### PR TITLE
feat(scout-for-lol): expand player profiles with comparisons and match details

### DIFF
--- a/packages/scout-for-lol/packages/app/src/components/champion-comparison-table.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/champion-comparison-table.tsx
@@ -1,0 +1,127 @@
+import { Link } from "react-router";
+import { Button } from "@scout-for-lol/design-system/components/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@scout-for-lol/design-system/components/table";
+
+export type ChampionComparisonRow = {
+  playerId: number;
+  alias: string;
+  guild: { guildId: string; name: string };
+  viewerLinked: boolean;
+  games: number;
+  wins: number;
+  losses: number;
+  winRate: number;
+  kda: number;
+  csPerMinute: number;
+  damagePerMinute: number;
+  goldPerMinute: number;
+  visionPerMinute: number;
+};
+
+function rate(value: number): string {
+  return `${Math.round(value * 100).toString()}%`;
+}
+
+export function ChampionComparisonTable(props: {
+  rows: ChampionComparisonRow[];
+  profileSearch: string;
+  page: number;
+  hasNextPage: boolean;
+  pending: boolean;
+  empty: string;
+  onPrevious: () => void;
+  onNext: () => void;
+}) {
+  if (!props.pending && props.rows.length === 0) {
+    return <p className="text-sm text-scout-subtle">{props.empty}</p>;
+  }
+  return (
+    <div className="space-y-3 overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Player</TableHead>
+            <TableHead>Guild</TableHead>
+            <TableHead className="text-right">W-L</TableHead>
+            <TableHead className="text-right">Win rate</TableHead>
+            <TableHead className="text-right">KDA</TableHead>
+            <TableHead className="text-right">CS/min</TableHead>
+            <TableHead className="text-right">Damage/min</TableHead>
+            <TableHead className="text-right">Gold/min</TableHead>
+            <TableHead className="text-right">Vision/min</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {props.rows.map((row) => (
+            <TableRow
+              key={`${row.guild.guildId}:${row.playerId.toString()}`}
+              className={row.viewerLinked ? "bg-primary/10" : undefined}
+            >
+              <TableCell className="font-medium">
+                <Link
+                  className="underline-offset-4 hover:underline"
+                  to={`/players/${row.playerId.toString()}${props.profileSearch}`}
+                >
+                  {row.alias}
+                </Link>
+                {row.viewerLinked && (
+                  <span className="ml-2 text-xs text-primary">You</span>
+                )}
+              </TableCell>
+              <TableCell>{row.guild.name}</TableCell>
+              <TableCell className="text-right">
+                {row.wins.toString()}-{row.losses.toString()}
+              </TableCell>
+              <TableCell className="text-right">{rate(row.winRate)}</TableCell>
+              <TableCell className="text-right">{row.kda.toFixed(2)}</TableCell>
+              <TableCell className="text-right">
+                {row.csPerMinute.toFixed(1)}
+              </TableCell>
+              <TableCell className="text-right">
+                {row.damagePerMinute.toFixed(0)}
+              </TableCell>
+              <TableCell className="text-right">
+                {row.goldPerMinute.toFixed(0)}
+              </TableCell>
+              <TableCell className="text-right">
+                {row.visionPerMinute.toFixed(1)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-scout-subtle">
+          Page {(props.page + 1).toString()}
+        </p>
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={props.page === 0 || props.pending}
+            onClick={props.onPrevious}
+          >
+            Previous
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={!props.hasNextPage || props.pending}
+            onClick={props.onNext}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/consumer-profile-details.test.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/consumer-profile-details.test.tsx
@@ -1,0 +1,190 @@
+import { describe, expect, test, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import { ChampionComparisonTable } from "#src/components/champion-comparison-table.tsx";
+import { MatchScoreboards } from "#src/components/match-scoreboard.tsx";
+import { retainedEventFields } from "#src/components/match-timeline.tsx";
+import { FRAME_COLUMNS } from "#src/components/timeline-frame-table.tsx";
+import {
+  ChampionPoolTable,
+  MatchHistoryList,
+  RankValue,
+} from "#src/components/player-profile-sections.tsx";
+
+function router(children: React.ReactNode): React.ReactNode {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+describe("player profile details", () => {
+  test("renders an existing crest and paginates champion links ten at a time", () => {
+    const rank = renderToStaticMarkup(
+      <RankValue
+        rank={{ tier: "platinum", division: 1, lp: 44, wins: 10, losses: 8 }}
+      />,
+    );
+    expect(rank).toContain("Rank=Platinum.png");
+    expect(rank).toContain("Platinum I");
+    expect(rank).toContain("44 LP");
+
+    const champions = renderToStaticMarkup(
+      router(
+        <ChampionPoolTable
+          rows={Array.from({ length: 11 }, (_, index) => ({
+            championId: index + 1,
+            championName: `Champion${index.toString()}`,
+            games: 12,
+            wins: 7,
+            winRate: 7 / 12,
+            kda: 3,
+            csPerMinute: 7,
+            lowSample: false,
+          }))}
+          minGamesForRate={10}
+          profileSearch="?games=50&amp;queue=solo"
+        />,
+      ),
+    );
+    expect(champions.match(/\/champions\//g)).toHaveLength(10);
+    expect(champions).toContain("Next");
+  });
+
+  test("links match cards to details while preserving profile filters", () => {
+    const html = renderToStaticMarkup(
+      router(
+        <MatchHistoryList
+          playerId={7}
+          profileSearch="?games=all&amp;queue=flex"
+          entries={[
+            {
+              matchId: "NA1_123",
+              gameCreationMs: Date.now(),
+              gameDurationSeconds: 1800,
+              queue: "flex",
+              championName: "Ashe",
+              teamPosition: "BOTTOM",
+              win: true,
+              kills: 5,
+              deaths: 2,
+              assists: 8,
+              creepScore: 180,
+              csPerMinute: 6,
+              killParticipation: 0.6,
+              leaguePointsDelta: 20,
+              account: { gameName: "Player", tagLine: "NA1", region: "NA" },
+            },
+          ]}
+        />,
+      ),
+    );
+    expect(html).toContain("/players/7/matches/NA1_123");
+    expect(html).toContain("games=all");
+  });
+});
+
+describe("champion comparison and match timeline", () => {
+  test("shows viewer highlighting, guild labels, and accessible profile links", () => {
+    const html = renderToStaticMarkup(
+      router(
+        <ChampionComparisonTable
+          rows={[
+            {
+              playerId: 4,
+              alias: "Me",
+              guild: { guildId: "guild", name: "Friends" },
+              viewerLinked: true,
+              games: 20,
+              wins: 12,
+              losses: 8,
+              winRate: 0.6,
+              kda: 3,
+              csPerMinute: 7,
+              damagePerMinute: 600,
+              goldPerMinute: 420,
+              visionPerMinute: 1.2,
+            },
+          ]}
+          profileSearch="?queue=solo"
+          page={0}
+          hasNextPage={false}
+          pending={false}
+          empty="Empty"
+          onPrevious={vi.fn()}
+          onNext={vi.fn()}
+        />,
+      ),
+    );
+    expect(html).toContain("Friends");
+    expect(html).toContain("You");
+    expect(html).toContain("/players/4?queue=solo");
+  });
+
+  test("keeps unknown event fields and enumerates every frame field", () => {
+    expect(
+      retainedEventFields({
+        event_id: "event",
+        event_type: "NEW_RIOT_EVENT",
+        event_timestamp_ms: 100,
+        gold_gain: 42,
+        monster_type: null,
+      }),
+    ).toContainEqual(["gold gain", "42"]);
+    expect(FRAME_COLUMNS).toContain("total_damage_done_to_champions");
+    expect(FRAME_COLUMNS).toHaveLength(28);
+  });
+
+  test("renders both team scoreboards and marks the launching player", () => {
+    const participant = {
+      participantId: 1,
+      teamId: 100,
+      selectedPlayer: true,
+      riotId: { gameName: "Launch", tagLine: "NA1" },
+      championId: 22,
+      championName: "Ashe",
+      position: "BOTTOM",
+      win: true,
+      kills: 5,
+      deaths: 2,
+      assists: 8,
+      creepScore: 180,
+      goldEarned: 12_000,
+      visionScore: 22,
+      damageToChampions: 20_000,
+      killParticipation: 0.6,
+      damageShare: 0.4,
+      objectives: { turrets: 1, inhibitors: 0, barons: 0, dragons: 0 },
+      scoutAliases: [{ playerId: 4, alias: "Me", guildName: "Friends" }],
+    };
+    const html = renderToStaticMarkup(
+      router(
+        <MatchScoreboards
+          teams={[
+            {
+              teamId: 100,
+              win: true,
+              participants: [participant],
+              objectives: { turrets: 1, inhibitors: 0, barons: 0, dragons: 0 },
+            },
+            {
+              teamId: 200,
+              win: false,
+              participants: [
+                {
+                  ...participant,
+                  participantId: 2,
+                  teamId: 200,
+                  selectedPlayer: false,
+                  win: false,
+                },
+              ],
+              objectives: { turrets: 0, inhibitors: 0, barons: 0, dragons: 0 },
+            },
+          ]}
+        />,
+      ),
+    );
+    expect(html).toContain("Team 100");
+    expect(html).toContain("Team 200");
+    expect(html).toContain("Selected");
+    expect(html).toContain("Me (Friends)");
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/components/match-scoreboard.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/match-scoreboard.tsx
@@ -1,0 +1,193 @@
+import { Link } from "react-router";
+import { championNameToDisplayName } from "@scout-for-lol/data";
+import { Badge } from "@scout-for-lol/design-system/components/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@scout-for-lol/design-system/components/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@scout-for-lol/design-system/components/table";
+import { ChampionIcon } from "#src/components/champion-icon.tsx";
+import { formatRiotId } from "#src/lib/riot-id-format.ts";
+
+type MatchParticipant = {
+  participantId: number;
+  teamId: number;
+  selectedPlayer: boolean;
+  riotId: { gameName: string | null; tagLine: string | null };
+  championId: number;
+  championName: string;
+  position: string;
+  win: boolean;
+  kills: number;
+  deaths: number;
+  assists: number;
+  creepScore: number;
+  goldEarned: number;
+  visionScore: number;
+  damageToChampions: number;
+  killParticipation: number | null;
+  damageShare: number | null;
+  objectives: {
+    turrets: number;
+    inhibitors: number;
+    barons: number;
+    dragons: number;
+  };
+  scoutAliases: { playerId: number; alias: string; guildName: string }[];
+};
+
+type MatchTeam = {
+  teamId: number;
+  win: boolean;
+  participants: MatchParticipant[];
+  objectives: {
+    turrets: number;
+    inhibitors: number;
+    barons: number;
+    dragons: number;
+  };
+};
+
+function percent(value: number | null): string {
+  return value === null ? "—" : `${Math.round(value * 100).toString()}%`;
+}
+
+function kda(participant: MatchParticipant): string {
+  const value =
+    participant.deaths === 0
+      ? participant.kills + participant.assists
+      : (participant.kills + participant.assists) / participant.deaths;
+  return value.toFixed(2);
+}
+
+export function MatchScoreboards(props: { teams: MatchTeam[] }) {
+  return (
+    <div className="space-y-5">
+      {props.teams.map((team) => (
+        <Card key={team.teamId}>
+          <CardHeader>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <CardTitle className="flex items-center gap-2">
+                Team {team.teamId.toString()}
+                <Badge variant={team.win ? "default" : "outline"}>
+                  {team.win ? "Victory" : "Defeat"}
+                </Badge>
+              </CardTitle>
+              <p className="text-xs text-scout-subtle">
+                {team.objectives.turrets.toString()} turrets ·{" "}
+                {team.objectives.inhibitors.toString()} inhibitors ·{" "}
+                {team.objectives.dragons.toString()} dragons ·{" "}
+                {team.objectives.barons.toString()} barons
+              </p>
+            </div>
+          </CardHeader>
+          <CardContent className="overflow-x-auto p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Player</TableHead>
+                  <TableHead>Position</TableHead>
+                  <TableHead className="text-right">K / D / A</TableHead>
+                  <TableHead className="text-right">KDA</TableHead>
+                  <TableHead className="text-right">CS</TableHead>
+                  <TableHead className="text-right">Gold</TableHead>
+                  <TableHead className="text-right">Vision</TableHead>
+                  <TableHead className="text-right">Damage</TableHead>
+                  <TableHead className="text-right">KP</TableHead>
+                  <TableHead className="text-right">Damage share</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {team.participants.map((participant) => (
+                  <TableRow
+                    key={participant.participantId}
+                    className={
+                      participant.selectedPlayer ? "bg-primary/10" : undefined
+                    }
+                  >
+                    <TableCell>
+                      <div className="flex min-w-48 items-center gap-2">
+                        <ChampionIcon championName={participant.championName} />
+                        <div>
+                          <p className="font-medium">
+                            {formatRiotId(
+                              participant.riotId,
+                              "Unknown Riot ID",
+                            )}
+                            {participant.selectedPlayer && (
+                              <span className="ml-2 text-xs text-primary">
+                                Selected
+                              </span>
+                            )}
+                          </p>
+                          <p className="text-xs text-scout-subtle">
+                            {championNameToDisplayName(
+                              participant.championName,
+                            )}
+                          </p>
+                          {participant.scoutAliases.length > 0 && (
+                            <p className="text-xs text-scout-subtle">
+                              {participant.scoutAliases.map((alias, index) => (
+                                <span
+                                  key={`${alias.guildName}:${alias.playerId.toString()}`}
+                                >
+                                  {index > 0 ? " · " : ""}
+                                  <Link
+                                    className="hover:underline"
+                                    to={`/players/${alias.playerId.toString()}`}
+                                  >
+                                    {alias.alias} ({alias.guildName})
+                                  </Link>
+                                </span>
+                              ))}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell>{participant.position || "—"}</TableCell>
+                    <TableCell className="text-right">
+                      {participant.kills.toString()} /{" "}
+                      {participant.deaths.toString()} /{" "}
+                      {participant.assists.toString()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {kda(participant)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {participant.creepScore.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {participant.goldEarned.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {participant.visionScore.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {participant.damageToChampions.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {percent(participant.killParticipation)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {percent(participant.damageShare)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/match-timeline.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/match-timeline.tsx
@@ -1,0 +1,395 @@
+import { useEffect, useRef, useState } from "react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import * as echarts from "echarts";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@scout-for-lol/design-system/components/card";
+import { TimelineFrameTable } from "#src/components/timeline-frame-table.tsx";
+import {
+  TimelinePagination,
+  type TimelineCursor,
+} from "#src/components/timeline-pagination.tsx";
+import { useTRPC, type RouterOutputs } from "#src/lib/trpc.ts";
+
+type Coverage =
+  RouterOutputs["consumerMatch"]["detail"]["timeline"]["coverage"];
+type TimelineEvent = RouterOutputs["consumerMatch"]["events"]["rows"][number];
+type ChartPoint =
+  RouterOutputs["consumerMatch"]["chartSeries"]["points"][number];
+
+const EVENT_TYPES = [
+  "CHAMPION_KILL",
+  "ELITE_MONSTER_KILL",
+  "BUILDING_KILL",
+  "ITEM_PURCHASED",
+  "ITEM_SOLD",
+  "ITEM_UNDO",
+  "SKILL_LEVEL_UP",
+  "WARD_PLACED",
+  "WARD_KILL",
+  "GAME_END",
+];
+
+function eventTitle(event: TimelineEvent): string {
+  const minute = Math.floor(event.event_timestamp_ms / 60_000);
+  const seconds = Math.floor((event.event_timestamp_ms % 60_000) / 1000);
+  return `${minute.toString()}:${seconds.toString().padStart(2, "0")} · ${event.event_type.replaceAll("_", " ")}`;
+}
+
+export function retainedEventFields(event: object): [string, string][] {
+  return Object.entries(event)
+    .filter(
+      ([key, value]) =>
+        value !== null &&
+        ![
+          "event_id",
+          "event_type",
+          "event_timestamp_ms",
+          "frame_timestamp_ms",
+        ].includes(key),
+    )
+    .map(([key, value]) => [key.replaceAll("_", " "), String(value)]);
+}
+
+export function MatchTimeline(props: {
+  playerId: number;
+  matchId: string;
+  coverage: Coverage;
+  keyEvents: TimelineEvent[];
+  participantIds: number[];
+}) {
+  const trpc = useTRPC();
+  const [eventType, setEventType] = useState<string | undefined>();
+  const [participantId, setParticipantId] = useState<number | undefined>();
+  const [eventCursors, setEventCursors] = useState<
+    (TimelineCursor | undefined)[]
+  >([undefined]);
+  const [frameCursors, setFrameCursors] = useState<
+    (TimelineCursor | undefined)[]
+  >([undefined]);
+  const [eventPage, setEventPage] = useState(0);
+  const [framePage, setFramePage] = useState(0);
+  const baseInput = { playerId: props.playerId, matchId: props.matchId };
+  const events = useQuery(
+    trpc.consumerMatch.events.queryOptions(
+      {
+        ...baseInput,
+        ...(eventType === undefined ? {} : { eventTypes: [eventType] }),
+        ...(participantId === undefined
+          ? {}
+          : { participantIds: [participantId] }),
+        ...(eventCursors[eventPage] === undefined
+          ? {}
+          : { cursor: eventCursors[eventPage] }),
+      },
+      {
+        enabled: props.coverage !== null,
+        placeholderData: keepPreviousData,
+      },
+    ),
+  );
+  const frames = useQuery(
+    trpc.consumerMatch.frames.queryOptions(
+      {
+        ...baseInput,
+        ...(participantId === undefined
+          ? {}
+          : { participantIds: [participantId] }),
+        ...(frameCursors[framePage] === undefined
+          ? {}
+          : { cursor: frameCursors[framePage] }),
+      },
+      {
+        enabled: props.coverage !== null,
+        placeholderData: keepPreviousData,
+      },
+    ),
+  );
+  const chart = useQuery(
+    trpc.consumerMatch.chartSeries.queryOptions(baseInput, {
+      enabled: props.coverage !== null,
+    }),
+  );
+
+  if (props.coverage === null) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Timeline not captured</CardTitle>
+          <CardDescription>
+            Scout retained the match overview, but no normalized timeline was
+            captured for this game. Opening this page never requests it from
+            Riot.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  function resetPages(): void {
+    setEventCursors([undefined]);
+    setFrameCursors([undefined]);
+    setEventPage(0);
+    setFramePage(0);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold">Timeline</h2>
+        <p className="text-sm text-scout-subtle">
+          {props.coverage.frame_count.toLocaleString()} frames and{" "}
+          {props.coverage.event_count.toLocaleString()} events retained by
+          Scout.
+        </p>
+      </div>
+
+      {chart.isError ? (
+        <p className="text-sm text-scout-danger">
+          Timeline charts did not load.
+        </p>
+      ) : chart.data === undefined ? (
+        <p className="text-sm text-scout-subtle">Loading timeline charts…</p>
+      ) : (
+        <TimelineCharts points={chart.data.points} />
+      )}
+
+      <section className="space-y-3">
+        <h3 className="text-xl font-semibold">Key events</h3>
+        {props.keyEvents.length === 0 ? (
+          <p className="text-sm text-scout-subtle">
+            No categorized key events were retained.
+          </p>
+        ) : (
+          <ol className="space-y-2 border-l pl-5">
+            {props.keyEvents.map((event) => (
+              <li key={event.event_id} className="text-sm">
+                <strong>{eventTitle(event)}</strong>
+                <span className="ml-2 text-scout-subtle">
+                  {event.monster_type ??
+                    event.building_type ??
+                    (event.killer_id === null
+                      ? ""
+                      : `Participant ${event.killer_id.toString()}`)}
+                </span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      <div className="flex flex-wrap gap-4 rounded-lg border bg-card p-4">
+        <label className="space-y-1 text-sm font-medium">
+          <span className="block">Event type</span>
+          <select
+            name="eventType"
+            value={eventType ?? ""}
+            className="h-9 rounded-md border border-input bg-background px-3"
+            onChange={(event) => {
+              setEventType(event.currentTarget.value || undefined);
+              resetPages();
+            }}
+          >
+            <option value="">All event types</option>
+            {EVENT_TYPES.map((type) => (
+              <option key={type} value={type}>
+                {type.replaceAll("_", " ")}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="space-y-1 text-sm font-medium">
+          <span className="block">Participant</span>
+          <select
+            name="participant"
+            value={participantId?.toString() ?? ""}
+            className="h-9 rounded-md border border-input bg-background px-3"
+            onChange={(event) => {
+              setParticipantId(
+                event.currentTarget.value === ""
+                  ? undefined
+                  : Number(event.currentTarget.value),
+              );
+              resetPages();
+            }}
+          >
+            <option value="">Everyone</option>
+            {props.participantIds.map((id) => (
+              <option key={id} value={id}>
+                Participant {id.toString()}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <section className="space-y-3">
+        <h3 className="text-xl font-semibold">Event explorer</h3>
+        <p className="text-sm text-scout-subtle">
+          Every retained event is available in chronological 100-row pages.
+          Unfamiliar Riot types show all non-null retained fields.
+        </p>
+        {events.isError ? (
+          <p className="text-sm text-scout-danger">Events did not load.</p>
+        ) : (
+          <div className="space-y-2">
+            {(events.data?.rows ?? []).map((event) => (
+              <details key={event.event_id} className="rounded-md border p-3">
+                <summary className="cursor-pointer text-sm font-medium">
+                  {eventTitle(event)}
+                </summary>
+                <dl className="mt-3 grid gap-x-4 gap-y-1 text-xs sm:grid-cols-2 lg:grid-cols-4">
+                  {retainedEventFields(event).map(([label, value]) => (
+                    <div key={label}>
+                      <dt className="text-scout-subtle">{label}</dt>
+                      <dd>{value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </details>
+            ))}
+            <TimelinePagination
+              page={eventPage}
+              pending={events.isFetching}
+              nextCursor={events.data?.nextCursor}
+              onPrevious={() => {
+                setEventPage((page) => page - 1);
+              }}
+              onNext={(cursor) => {
+                setEventCursors((cursors) => [
+                  ...cursors.slice(0, eventPage + 1),
+                  cursor,
+                ]);
+                setEventPage((page) => page + 1);
+              }}
+            />
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-xl font-semibold">Frame table</h3>
+        <p className="text-sm text-scout-subtle">
+          Every retained frame field is shown in chronological 100-row pages.
+        </p>
+        <TimelineFrameTable
+          rows={frames.data?.rows ?? []}
+          error={frames.isError}
+          pending={frames.isFetching}
+          page={framePage}
+          nextCursor={frames.data?.nextCursor}
+          onPrevious={() => {
+            setFramePage((page) => page - 1);
+          }}
+          onNext={(cursor) => {
+            setFrameCursors((cursors) => [
+              ...cursors.slice(0, framePage + 1),
+              cursor,
+            ]);
+            setFramePage((page) => page + 1);
+          }}
+        />
+      </section>
+    </div>
+  );
+}
+
+function TimelineCharts(props: { points: ChartPoint[] }) {
+  const teamIds = [
+    ...new Set(
+      props.points.flatMap((point) =>
+        point.teamGold.map((team) => team.teamId),
+      ),
+    ),
+  ];
+  const timeLabels = props.points.map((point) =>
+    Math.round(point.timestampMs / 60_000),
+  );
+  const teamSeries = teamIds.map((teamId) => ({
+    name: `Team ${teamId.toString()}`,
+    type: "line" as const,
+    showSymbol: false,
+    data: props.points.map(
+      (point) =>
+        point.teamGold.find((team) => team.teamId === teamId)?.gold ?? null,
+    ),
+  }));
+  const playerSeries = [
+    {
+      name: "Gold",
+      type: "line" as const,
+      showSymbol: false,
+      data: props.points.map((point) => point.selectedGold),
+    },
+    {
+      name: "XP",
+      type: "line" as const,
+      showSymbol: false,
+      data: props.points.map((point) => point.selectedXp),
+    },
+  ];
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <TimelineChart
+        title="Team gold"
+        labels={timeLabels}
+        series={teamSeries}
+      />
+      <TimelineChart
+        title="Selected-player progression"
+        labels={timeLabels}
+        series={playerSeries}
+      />
+    </div>
+  );
+}
+
+function TimelineChart(props: {
+  title: string;
+  labels: number[];
+  series: {
+    name: string;
+    type: "line";
+    showSymbol: boolean;
+    data: (number | null)[];
+  }[];
+}) {
+  const container = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (container.current === null) return;
+    const chart = echarts.init(container.current);
+    chart.setOption({
+      title: {
+        text: props.title,
+        left: 12,
+        top: 8,
+        textStyle: { fontSize: 14 },
+      },
+      tooltip: { trigger: "axis" },
+      legend: { top: 34 },
+      grid: { top: 70, left: 52, right: 18, bottom: 36 },
+      xAxis: { type: "category", name: "min", data: props.labels },
+      yAxis: { type: "value" },
+      series: props.series,
+    });
+    const observer = new ResizeObserver(() => {
+      chart.resize();
+    });
+    observer.observe(container.current);
+    return () => {
+      observer.disconnect();
+      chart.dispose();
+    };
+  }, [props.labels, props.series, props.title]);
+  return (
+    <div
+      ref={container}
+      className="h-72 rounded-md border bg-card"
+      role="img"
+      aria-label={props.title}
+    />
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/page-section-heading.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/page-section-heading.tsx
@@ -1,0 +1,11 @@
+export function PageSectionHeading(props: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div>
+      <h2 className="text-xl font-semibold">{props.title}</h2>
+      <p className="text-sm text-scout-subtle">{props.description}</p>
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/player-profile-filter-bar.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/player-profile-filter-bar.tsx
@@ -1,0 +1,155 @@
+import {
+  PLAYER_PROFILE_QUEUE_GROUPS,
+  PLAYER_PROFILE_QUEUE_PRESETS,
+  queueTypeToDisplayString,
+  type PlayerProfileGameWindow,
+  type QueueType,
+} from "@scout-for-lol/data";
+import { Button } from "@scout-for-lol/design-system/components/button";
+import { Badge } from "@scout-for-lol/design-system/components/badge";
+import type { PlayerProfileFilters } from "#src/lib/player-profile-filters.ts";
+
+function sameQueues(
+  selected: QueueType[] | undefined,
+  preset: readonly QueueType[] | undefined,
+): boolean {
+  if (selected === undefined || preset === undefined) {
+    return selected === undefined && preset === undefined;
+  }
+  return (
+    selected.length === preset.length &&
+    selected.every((queue) => preset.includes(queue))
+  );
+}
+
+const PRESETS: readonly {
+  id: string;
+  label: string;
+  queues?: readonly QueueType[];
+}[] = [
+  { id: "all", label: "All games" },
+  {
+    id: "competitive",
+    label: "Competitive",
+    queues: PLAYER_PROFILE_QUEUE_PRESETS.competitive,
+  },
+  {
+    id: "solo",
+    label: "Solo / duo",
+    queues: PLAYER_PROFILE_QUEUE_PRESETS.solo,
+  },
+  { id: "flex", label: "Flex", queues: PLAYER_PROFILE_QUEUE_PRESETS.flex },
+  { id: "clash", label: "Clash", queues: PLAYER_PROFILE_QUEUE_PRESETS.clash },
+];
+
+export function PlayerProfileFilterBar(props: {
+  filters: PlayerProfileFilters;
+  onChange: (filters: PlayerProfileFilters, kind: "games" | "queues") => void;
+}) {
+  const activePreset = PRESETS.find((preset) =>
+    sameQueues(props.filters.queues, preset.queues),
+  );
+
+  function toggleQueue(queue: QueueType, checked: boolean): void {
+    const selected = props.filters.queues ?? [];
+    const queues = checked
+      ? [...selected, queue]
+      : selected.filter((selectedQueue) => selectedQueue !== queue);
+    props.onChange(
+      {
+        games: props.filters.games,
+        ...(queues.length === 0 ? {} : { queues }),
+      },
+      "queues",
+    );
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border bg-card p-4">
+      <div className="flex flex-wrap items-end gap-4">
+        <label className="space-y-1 text-sm font-medium">
+          <span className="block">Game window</span>
+          <select
+            name="games"
+            value={props.filters.games.toString()}
+            className="h-9 rounded-md border border-input bg-background px-3"
+            onChange={(event) => {
+              const value = event.currentTarget.value;
+              const games: PlayerProfileGameWindow =
+                value === "50" ? 50 : value === "all" ? "all" : 20;
+              props.onChange({ ...props.filters, games }, "games");
+            }}
+          >
+            <option value="20">Last 20</option>
+            <option value="50">Last 50</option>
+            <option value="all">All time</option>
+          </select>
+        </label>
+
+        <fieldset className="min-w-0 space-y-2">
+          <legend className="text-sm font-medium">Queue preset</legend>
+          <div className="flex flex-wrap gap-2">
+            {PRESETS.map((preset) => (
+              <Button
+                key={preset.id}
+                type="button"
+                size="sm"
+                variant={activePreset?.id === preset.id ? "default" : "outline"}
+                onClick={() => {
+                  props.onChange(
+                    {
+                      games: props.filters.games,
+                      ...(preset.queues === undefined
+                        ? {}
+                        : { queues: [...preset.queues] }),
+                    },
+                    "queues",
+                  );
+                }}
+              >
+                {preset.label}
+              </Button>
+            ))}
+            {activePreset === undefined && (
+              <Badge className="h-8 px-3">Custom</Badge>
+            )}
+          </div>
+        </fieldset>
+      </div>
+
+      <details>
+        <summary className="cursor-pointer text-sm font-medium">
+          Choose queues
+          <span className="ml-2 font-normal text-scout-subtle">
+            {props.filters.queues === undefined
+              ? "Every recorded queue, including unmapped history"
+              : `${props.filters.queues.length.toString()} selected`}
+          </span>
+        </summary>
+        <div className="mt-3 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {PLAYER_PROFILE_QUEUE_GROUPS.map((group) => (
+            <fieldset key={group.label} className="space-y-2">
+              <legend className="text-xs font-semibold uppercase tracking-wide text-scout-subtle">
+                {group.label}
+              </legend>
+              {group.queues.map((queue) => (
+                <label key={queue} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    name="queue"
+                    value={queue}
+                    checked={props.filters.queues?.includes(queue) ?? false}
+                    onChange={(event) => {
+                      toggleQueue(queue, event.currentTarget.checked);
+                    }}
+                  />
+                  {queueTypeToDisplayString(queue)}
+                </label>
+              ))}
+            </fieldset>
+          ))}
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/player-profile-sections.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/player-profile-sections.tsx
@@ -1,9 +1,13 @@
 import {
   championNameToDisplayName,
-  rankToString,
+  divisionToString,
   type Rank,
 } from "@scout-for-lol/data";
+import { SCOUT_RANKS } from "@scout-for-lol/design-system/assets";
+import { useState } from "react";
+import { Link } from "react-router";
 import { Badge } from "@scout-for-lol/design-system/components/badge";
+import { Button } from "@scout-for-lol/design-system/components/button";
 import {
   Card,
   CardContent,
@@ -20,6 +24,7 @@ import {
 } from "@scout-for-lol/design-system/components/table";
 import { ChampionIcon } from "#src/components/champion-icon.tsx";
 import { formatRiotId } from "#src/lib/riot-id-format.ts";
+import { RankDisplay } from "@scout-for-lol/design-system/domain/rank-display";
 
 export function formatPercent(value: number | null): string {
   return value === null ? "—" : `${Math.round(value * 100).toString()}%`;
@@ -47,11 +52,37 @@ export function RankCard(props: { label: string; rank: Rank | undefined }) {
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <p className="text-lg font-semibold">
-          {props.rank === undefined ? "Unranked" : rankToString(props.rank)}
-        </p>
+        <RankValue rank={props.rank} />
       </CardContent>
     </Card>
+  );
+}
+
+function scoutRank(rank: Rank) {
+  const display = SCOUT_RANKS.find(
+    (candidate) => candidate.toLowerCase() === rank.tier,
+  );
+  if (display === undefined) {
+    throw new Error(`No crest exists for rank tier ${rank.tier}`);
+  }
+  return display;
+}
+
+export function RankValue(props: {
+  rank: Rank | undefined;
+  compact?: boolean;
+}) {
+  if (props.rank === undefined) {
+    return <p className="text-lg font-semibold">Unranked</p>;
+  }
+  return (
+    <RankDisplay
+      rank={scoutRank(props.rank)}
+      division={divisionToString(props.rank.division)}
+      leaguePoints={props.rank.lp}
+      {...(props.compact === undefined ? {} : { compact: props.compact })}
+      className="text-scout-ink"
+    />
   );
 }
 
@@ -120,7 +151,9 @@ type ChampionRow = {
 export function ChampionPoolTable(props: {
   rows: ChampionRow[];
   minGamesForRate: number;
+  profileSearch: string;
 }) {
+  const [page, setPage] = useState(0);
   if (props.rows.length === 0) {
     return (
       <p className="text-sm text-muted-foreground">
@@ -142,12 +175,17 @@ export function ChampionPoolTable(props: {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {props.rows.map((row) => (
+          {props.rows.slice(page * 10, page * 10 + 10).map((row) => (
             <TableRow key={row.championId}>
               <TableCell>
                 <span className="flex items-center gap-2">
                   <ChampionIcon championName={row.championName} decorative />
-                  {championNameToDisplayName(row.championName)}
+                  <Link
+                    className="font-medium underline-offset-4 hover:underline"
+                    to={`/champions/${row.championId.toString()}${props.profileSearch}`}
+                  >
+                    {championNameToDisplayName(row.championName)}
+                  </Link>
                 </span>
               </TableCell>
               <TableCell className="text-right">
@@ -172,6 +210,38 @@ export function ChampionPoolTable(props: {
           ))}
         </TableBody>
       </Table>
+      {props.rows.length > 10 && (
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs text-muted-foreground">
+            Page {(page + 1).toString()} of{" "}
+            {Math.ceil(props.rows.length / 10).toString()}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page === 0}
+              onClick={() => {
+                setPage((current) => current - 1);
+              }}
+            >
+              Previous
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={(page + 1) * 10 >= props.rows.length}
+              onClick={() => {
+                setPage((current) => current + 1);
+              }}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
       {props.rows.some((row) => row.lowSample) && (
         <p className="text-xs text-muted-foreground">
           * Fewer than {props.minGamesForRate.toString()} games — treat the rate
@@ -225,7 +295,11 @@ function LeaguePointsBadge(props: { delta: number | null }) {
   );
 }
 
-export function MatchHistoryList(props: { entries: MatchEntry[] }) {
+export function MatchHistoryList(props: {
+  entries: MatchEntry[];
+  playerId?: number;
+  profileSearch: string;
+}) {
   if (props.entries.length === 0) {
     return (
       <p className="text-sm text-muted-foreground">
@@ -248,7 +322,20 @@ export function MatchHistoryList(props: { entries: MatchEntry[] }) {
           <ChampionIcon championName={entry.championName} size="md" />
           <div className="min-w-32">
             <p className="text-sm font-medium text-scout-ink">
-              {entry.win ? "Victory" : "Defeat"}
+              {props.playerId === undefined ? (
+                entry.win ? (
+                  "Victory"
+                ) : (
+                  "Defeat"
+                )
+              ) : (
+                <Link
+                  className="underline-offset-4 hover:underline"
+                  to={`/players/${props.playerId.toString()}/matches/${encodeURIComponent(entry.matchId)}${props.profileSearch}`}
+                >
+                  {entry.win ? "Victory" : "Defeat"}
+                </Link>
+              )}
             </p>
             <p className="text-xs text-scout-ink">
               {entry.queue ?? "Unknown queue"} ·{" "}

--- a/packages/scout-for-lol/packages/app/src/components/timeline-frame-table.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/timeline-frame-table.tsx
@@ -1,0 +1,101 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@scout-for-lol/design-system/components/table";
+import {
+  TimelinePagination,
+  type TimelineCursor,
+} from "#src/components/timeline-pagination.tsx";
+import type { RouterOutputs } from "#src/lib/trpc.ts";
+
+type TimelineFrame = RouterOutputs["consumerMatch"]["frames"]["rows"][number];
+
+export const FRAME_COLUMNS: readonly (keyof TimelineFrame)[] = [
+  "frame_index",
+  "frame_timestamp_ms",
+  "participant_id",
+  "puuid",
+  "position_x",
+  "position_y",
+  "current_gold",
+  "total_gold",
+  "gold_per_second",
+  "minions_killed",
+  "jungle_minions_killed",
+  "level",
+  "xp",
+  "time_enemy_spent_controlled",
+  "ability_haste",
+  "ability_power",
+  "armor",
+  "attack_damage",
+  "attack_speed",
+  "health",
+  "health_max",
+  "magic_resist",
+  "movement_speed",
+  "power",
+  "power_max",
+  "total_damage_done",
+  "total_damage_done_to_champions",
+  "total_damage_taken",
+];
+
+function displayCell(value: TimelineFrame[keyof TimelineFrame]): string {
+  return value === null ? "—" : String(value);
+}
+
+export function TimelineFrameTable(props: {
+  rows: TimelineFrame[];
+  error: boolean;
+  pending: boolean;
+  page: number;
+  nextCursor: TimelineCursor | null | undefined;
+  onPrevious: () => void;
+  onNext: (cursor: TimelineCursor) => void;
+}) {
+  if (props.error) {
+    return <p className="text-sm text-scout-danger">Frames did not load.</p>;
+  }
+  return (
+    <>
+      <div className="overflow-x-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {FRAME_COLUMNS.map((column) => (
+                <TableHead key={column}>
+                  {column.replaceAll("_", " ")}
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {props.rows.map((frame) => (
+              <TableRow
+                key={`${frame.frame_index.toString()}:${frame.participant_id.toString()}`}
+              >
+                {FRAME_COLUMNS.map((column) => (
+                  <TableCell key={column}>
+                    {displayCell(frame[column])}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <TimelinePagination
+        page={props.page}
+        pending={props.pending}
+        nextCursor={props.nextCursor}
+        onPrevious={props.onPrevious}
+        onNext={props.onNext}
+      />
+    </>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/timeline-pagination.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/timeline-pagination.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@scout-for-lol/design-system/components/button";
+
+export type TimelineCursor = { offset: number };
+
+export function TimelinePagination(props: {
+  page: number;
+  pending: boolean;
+  nextCursor: TimelineCursor | null | undefined;
+  onPrevious: () => void;
+  onNext: (cursor: TimelineCursor) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <p className="text-xs text-scout-subtle">
+        Page {(props.page + 1).toString()}
+      </p>
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={props.page === 0 || props.pending}
+          onClick={props.onPrevious}
+        >
+          Previous
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={
+            props.nextCursor === null ||
+            props.nextCursor === undefined ||
+            props.pending
+          }
+          onClick={() => {
+            if (props.nextCursor !== null && props.nextCursor !== undefined)
+              props.onNext(props.nextCursor);
+          }}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/lib/analytics-events.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/analytics-events.ts
@@ -45,6 +45,10 @@ const SCOUT_ANALYTICS_EVENTS = [
   "player_deleted",
   "player_search_performed",
   "player_profile_opened",
+  "player_profile_filter_changed",
+  "champion_comparison_opened",
+  "match_detail_opened",
+  "match_timeline_viewed",
   // Competitions
   "competition_created",
   "competition_edited",

--- a/packages/scout-for-lol/packages/app/src/lib/analytics.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/analytics.test.ts
@@ -171,6 +171,10 @@ describe("normalizePath", () => {
       "/g/:guildId/competitions/:competitionId",
     );
     expect(normalizePath("/players/42")).toBe("/players/:playerId");
+    expect(normalizePath("/players/42/matches/NA1_123456789")).toBe(
+      "/players/:playerId/matches/:matchId",
+    );
+    expect(normalizePath("/champions/22")).toBe("/champions/:championId");
   });
 
   test("preserves known static routes and rejects unknown routes", () => {
@@ -509,6 +513,13 @@ describe("track", () => {
       outcome: "succeeded",
       surface: "search_results",
     });
+    track("player_profile_filter_changed", {
+      kind: "queues",
+      action: "explicit_selection",
+    });
+    track("champion_comparison_opened", { outcome: "succeeded" });
+    track("match_detail_opened", { outcome: "succeeded" });
+    track("match_timeline_viewed", { outcome: "not_captured" });
 
     expect(calls).toEqual([
       {
@@ -526,6 +537,43 @@ describe("track", () => {
         properties: {
           outcome: "succeeded",
           surface: "search_results",
+          site_key: "scout-beta",
+          site_hostname: "beta.scout-for-lol.com",
+        },
+        options: undefined,
+      },
+      {
+        event: "player_profile_filter_changed",
+        properties: {
+          kind: "queues",
+          action: "explicit_selection",
+          site_key: "scout-beta",
+          site_hostname: "beta.scout-for-lol.com",
+        },
+        options: undefined,
+      },
+      {
+        event: "champion_comparison_opened",
+        properties: {
+          outcome: "succeeded",
+          site_key: "scout-beta",
+          site_hostname: "beta.scout-for-lol.com",
+        },
+        options: undefined,
+      },
+      {
+        event: "match_detail_opened",
+        properties: {
+          outcome: "succeeded",
+          site_key: "scout-beta",
+          site_hostname: "beta.scout-for-lol.com",
+        },
+        options: undefined,
+      },
+      {
+        event: "match_timeline_viewed",
+        properties: {
+          outcome: "not_captured",
           site_key: "scout-beta",
           site_hostname: "beta.scout-for-lol.com",
         },

--- a/packages/scout-for-lol/packages/app/src/lib/analytics.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/analytics.ts
@@ -444,6 +444,11 @@ export function stopAnalyticsCapture(): void {
 export function normalizePath(pathname: string): string {
   const normalized = pathname
     .replace(/^\/players\/[^/]+/, "/players/:playerId")
+    .replace(
+      /^\/players\/:playerId\/matches\/[^/]+/,
+      "/players/:playerId/matches/:matchId",
+    )
+    .replace(/^\/champions\/[^/]+/, "/champions/:championId")
     .replace(/^\/g\/[^/]+/, "/g/:guildId")
     .replace(/^\/g\/:guildId\/players\/[^/]+/, "/g/:guildId/players/:alias")
     .replace(
@@ -461,7 +466,7 @@ export function normalizePath(pathname: string): string {
     .replace(/^\/explore\/s\/[^/]+/, "/explore/s/:shareToken")
     .replace(/^\/explore\/(?!s(?:\/|$))[^/]+/, "/explore/:conversationId");
   const knownRoute =
-    /^(?:\/|\/(?:login|welcome|installed|manage)|\/explore(?:\/(?::conversationId|s\/:shareToken))?|\/players(?:\/:playerId)?|\/bucks(?:\/(?:dares(?:\/:dareId)?|history|leaderboard|settings))?|\/g\/:guildId(?:\/(?:access|audit|subscriptions|players(?:\/:alias(?:\/manage)?)?|competitions(?:\/(?:new|:competitionId(?:\/edit)?))?|reports(?:\/(?:new|help|:reportId(?:\/edit)?))?)?)?)$/;
+    /^(?:\/|\/(?:login|welcome|installed|manage)|\/explore(?:\/(?::conversationId|s\/:shareToken))?|\/players(?:\/:playerId(?:\/matches\/:matchId)?)?|\/champions\/:championId|\/bucks(?:\/(?:dares(?:\/:dareId)?|history|leaderboard|settings))?|\/g\/:guildId(?:\/(?:access|audit|subscriptions|players(?:\/:alias(?:\/manage)?)?|competitions(?:\/(?:new|:competitionId(?:\/edit)?))?|reports(?:\/(?:new|help|:reportId(?:\/edit)?))?)?)?)$/;
   return knownRoute.test(normalized) ? normalized : "/not-found";
 }
 

--- a/packages/scout-for-lol/packages/app/src/lib/player-profile-filters.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/player-profile-filters.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+import {
+  filterKey,
+  parsePlayerProfileFilters,
+  playerProfileSearch,
+} from "#src/lib/player-profile-filters.ts";
+
+describe("player profile URL state", () => {
+  test("uses omitted parameters for Last 20 and All games", () => {
+    const filters = parsePlayerProfileFilters(new URLSearchParams());
+    expect(filters).toEqual({ games: 20 });
+    expect(playerProfileSearch(filters)).toBe("");
+  });
+
+  test("parses and canonicalizes repeated queue parameters", () => {
+    const filters = parsePlayerProfileFilters(
+      new URLSearchParams("queue=flex&games=50&queue=solo"),
+    );
+    expect(filters).toEqual({ games: 50, queues: ["flex", "solo"] });
+    expect(playerProfileSearch(filters)).toBe(
+      "?games=50&queue=solo&queue=flex",
+    );
+    expect(filterKey(filters)).toBe("50:flex,solo");
+    expect(filterKey(filters)).not.toBe(filterKey({ games: 20 }));
+  });
+
+  test("drops invalid or duplicate queue selections at the URL boundary", () => {
+    expect(
+      parsePlayerProfileFilters(new URLSearchParams("queue=solo&queue=solo")),
+    ).toEqual({ games: 20 });
+    expect(
+      parsePlayerProfileFilters(new URLSearchParams("queue=not-real")),
+    ).toEqual({ games: 20 });
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/lib/player-profile-filters.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/player-profile-filters.ts
@@ -1,0 +1,75 @@
+import {
+  PlayerProfileFilterSchema,
+  QueueTypeSchema,
+  type PlayerProfileGameWindow,
+  type QueueType,
+} from "@scout-for-lol/data";
+
+export type PlayerProfileFilters = {
+  games: PlayerProfileGameWindow;
+  queues?: QueueType[];
+};
+
+function queueOrder(order: ReadonlyMap<QueueType, number>, queue: QueueType) {
+  const index = order.get(queue);
+  if (index === undefined) {
+    throw new Error(`Queue ${queue} is missing from the canonical order`);
+  }
+  return index;
+}
+
+export function parsePlayerProfileFilters(
+  searchParams: URLSearchParams,
+): PlayerProfileFilters {
+  const gamesValue = searchParams.get("games");
+  const games: PlayerProfileGameWindow =
+    gamesValue === "50" ? 50 : gamesValue === "all" ? "all" : 20;
+  const rawQueues = searchParams.getAll("queue");
+  if (rawQueues.length === 0) return { games };
+  const queues = rawQueues.map((queue) => QueueTypeSchema.safeParse(queue));
+  if (queues.some((queue) => !queue.success)) return { games };
+  const parsed = PlayerProfileFilterSchema.safeParse({
+    games,
+    queues: queues.map((queue) => {
+      if (!queue.success) {
+        throw new Error("Invalid queue survived profile filter validation");
+      }
+      return queue.data;
+    }),
+  });
+  if (!parsed.success) return { games };
+  return {
+    games: parsed.data.games,
+    ...(parsed.data.queues === undefined ? {} : { queues: parsed.data.queues }),
+  };
+}
+
+export function playerProfileSearchParams(
+  filters: PlayerProfileFilters,
+): URLSearchParams {
+  const parsed = PlayerProfileFilterSchema.parse(filters);
+  const searchParams = new URLSearchParams();
+  if (parsed.games !== 20) {
+    searchParams.set("games", parsed.games.toString());
+  }
+  if (parsed.queues !== undefined) {
+    const order = new Map(
+      QueueTypeSchema.options.map((queue, index) => [queue, index] as const),
+    );
+    for (const queue of parsed.queues.toSorted(
+      (left, right) => queueOrder(order, left) - queueOrder(order, right),
+    )) {
+      searchParams.append("queue", queue);
+    }
+  }
+  return searchParams;
+}
+
+export function playerProfileSearch(filters: PlayerProfileFilters): string {
+  const query = playerProfileSearchParams(filters).toString();
+  return query.length === 0 ? "" : `?${query}`;
+}
+
+export function filterKey(filters: PlayerProfileFilters): string {
+  return `${filters.games.toString()}:${filters.queues?.join(",") ?? "all"}`;
+}

--- a/packages/scout-for-lol/packages/app/src/lib/route-loaders.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/route-loaders.ts
@@ -67,6 +67,9 @@ export function consumerPlayersLoader(): null {
   void preloadQuery(
     queryClient.query(trpcOptions.consumerPlayer.status.queryOptions()),
   );
+  void preloadQuery(
+    queryClient.query(trpcOptions.consumerPlayer.home.queryOptions()),
+  );
   return null;
 }
 

--- a/packages/scout-for-lol/packages/app/src/lib/route-params.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/route-params.ts
@@ -2,7 +2,9 @@ import { useParams } from "react-router";
 import { z } from "zod";
 import {
   CompetitionIdSchema,
+  ChampionIdSchema,
   ExploreConversationIdSchema,
+  MatchIdSchema,
   PlayerIdSchema,
   ReportIdSchema,
 } from "@scout-for-lol/data";
@@ -24,6 +26,15 @@ export const PlayerParamsSchema = z.object({
 
 export const ConsumerPlayerParamsSchema = z.object({
   playerId: z.coerce.number().pipe(PlayerIdSchema),
+});
+
+export const ConsumerChampionParamsSchema = z.object({
+  championId: z.coerce.number().pipe(ChampionIdSchema),
+});
+
+export const ConsumerMatchParamsSchema = z.object({
+  playerId: z.coerce.number().pipe(PlayerIdSchema),
+  matchId: MatchIdSchema,
 });
 
 export const CompetitionParamsSchema = z.object({
@@ -76,6 +87,18 @@ export function useConsumerPlayerParams(): z.infer<
   typeof ConsumerPlayerParamsSchema
 > {
   return parseRouteParams(ConsumerPlayerParamsSchema, useParams());
+}
+
+export function useConsumerChampionParams(): z.infer<
+  typeof ConsumerChampionParamsSchema
+> {
+  return parseRouteParams(ConsumerChampionParamsSchema, useParams());
+}
+
+export function useConsumerMatchParams(): z.infer<
+  typeof ConsumerMatchParamsSchema
+> {
+  return parseRouteParams(ConsumerMatchParamsSchema, useParams());
 }
 
 export function useCompetitionParams(): z.infer<

--- a/packages/scout-for-lol/packages/app/src/lib/trpc.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/trpc.ts
@@ -1,6 +1,12 @@
 import { createTRPCClient, httpBatchLink, splitLink } from "@trpc/client";
 import { createTRPCContext } from "@trpc/tanstack-react-query";
-import type { AppRouter } from "@scout-for-lol/backend/trpc/router/index.ts";
+import type {
+  AppRouter,
+  AppRouterOutputs,
+} from "@scout-for-lol/backend/trpc/router/index.ts";
+
+type LocalType<T> = T;
+export type RouterOutputs = LocalType<AppRouterOutputs>;
 
 const CSRF_COOKIE = "scout_csrf";
 

--- a/packages/scout-for-lol/packages/app/src/lib/use-player-profile-url-state.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/use-player-profile-url-state.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useSearchParams } from "react-router";
+import {
+  parsePlayerProfileFilters,
+  playerProfileSearchParams,
+  type PlayerProfileFilters,
+} from "#src/lib/player-profile-filters.ts";
+
+export function usePlayerProfileUrlState(): {
+  filters: PlayerProfileFilters;
+  setFilters: (filters: PlayerProfileFilters) => void;
+} {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = parsePlayerProfileFilters(searchParams);
+  const canonical = playerProfileSearchParams(filters).toString();
+
+  useEffect(() => {
+    if (searchParams.toString() === canonical) return;
+    setSearchParams(canonical, { replace: true });
+  }, [canonical, searchParams, setSearchParams]);
+
+  return {
+    filters,
+    setFilters(nextFilters) {
+      setSearchParams(playerProfileSearchParams(nextFilters), {
+        replace: true,
+      });
+    },
+  };
+}

--- a/packages/scout-for-lol/packages/app/src/router.tsx
+++ b/packages/scout-for-lol/packages/app/src/router.tsx
@@ -25,6 +25,8 @@ import { Explore } from "#src/routes/explore.tsx";
 import { ExploreShared } from "#src/routes/explore-shared.tsx";
 import { ConsumerPlayerSearch } from "#src/routes/consumer-player-search.tsx";
 import { ConsumerPlayerProfile } from "#src/routes/consumer-player-profile.tsx";
+import { ConsumerChampion } from "#src/routes/consumer-champion.tsx";
+import { ConsumerMatch } from "#src/routes/consumer-match.tsx";
 import { ConsumerWorkspace } from "#src/routes/consumer-workspace.tsx";
 import { BucksWorkspace } from "#src/routes/bucks-workspace.tsx";
 import { BucksOverview } from "#src/routes/bucks-overview.tsx";
@@ -216,6 +218,16 @@ export const routes: RouteObject[] = [
                 path: "players/:playerId",
                 element: <ConsumerPlayerProfile />,
                 loader: consumerPlayerLoader,
+                errorElement: <RouteErrorPanel />,
+              },
+              {
+                path: "players/:playerId/matches/:matchId",
+                element: <ConsumerMatch />,
+                errorElement: <RouteErrorPanel />,
+              },
+              {
+                path: "champions/:championId",
+                element: <ConsumerChampion />,
                 errorElement: <RouteErrorPanel />,
               },
               {

--- a/packages/scout-for-lol/packages/app/src/routes/consumer-champion.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/consumer-champion.tsx
@@ -1,0 +1,349 @@
+import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import {
+  ChampionComparisonSortSchema,
+  type ChampionComparisonSort,
+} from "@scout-for-lol/data";
+import { Button } from "@scout-for-lol/design-system/components/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@scout-for-lol/design-system/components/card";
+import { ChampionIcon } from "#src/components/champion-icon.tsx";
+import {
+  ChampionComparisonTable,
+  type ChampionComparisonRow,
+} from "#src/components/champion-comparison-table.tsx";
+import { PageSectionHeading } from "#src/components/page-section-heading.tsx";
+import { PlayerProfileFilterBar } from "#src/components/player-profile-filter-bar.tsx";
+import { track } from "#src/lib/analytics.ts";
+import {
+  playerProfileSearch,
+  type PlayerProfileFilters,
+} from "#src/lib/player-profile-filters.ts";
+import { useConsumerChampionParams } from "#src/lib/route-params.ts";
+import { useTRPC, type RouterOutputs } from "#src/lib/trpc.ts";
+import { usePlayerProfileUrlState } from "#src/lib/use-player-profile-url-state.ts";
+
+type Cursor = { offset: number };
+type ComparisonOutput = RouterOutputs["consumerChampion"]["compare"];
+
+function parseComparisonSort(value: string): ChampionComparisonSort {
+  const parsed = ChampionComparisonSortSchema.safeParse(value);
+  return parsed.success ? parsed.data : "win_rate";
+}
+
+function comparisonInput(options: {
+  championId: number;
+  filters: PlayerProfileFilters;
+  sort: ChampionComparisonSort;
+  guildIds: string[] | undefined;
+}) {
+  return {
+    championId: options.championId,
+    games: options.filters.games,
+    sort: options.sort,
+    ...(options.filters.queues === undefined
+      ? {}
+      : { queues: options.filters.queues }),
+    ...(options.guildIds === undefined ? {} : { guildIds: options.guildIds }),
+  };
+}
+
+function cohortInput<T extends ReturnType<typeof comparisonInput>>(
+  common: T,
+  cohort: "qualified" | "small_sample",
+  cursor: Cursor | undefined,
+) {
+  return {
+    ...common,
+    cohort,
+    ...(cursor === undefined ? {} : { cursor }),
+  };
+}
+
+function useComparisonOpenTracking(isSuccess: boolean, isError: boolean): void {
+  const tracked = useRef(false);
+  useEffect(() => {
+    if (tracked.current || (!isSuccess && !isError)) return;
+    tracked.current = true;
+    track("champion_comparison_opened", {
+      outcome: isSuccess ? "succeeded" : "failed",
+    });
+  }, [isError, isSuccess]);
+}
+
+function comparisonPage(data: ComparisonOutput | undefined) {
+  return {
+    rows: data?.rows ?? [],
+    nextCursor: data?.nextCursor,
+  };
+}
+
+function comparisonHeader(options: {
+  qualified: ComparisonOutput | undefined;
+  small: ComparisonOutput | undefined;
+  guildIds: string[] | undefined;
+}) {
+  const data = options.qualified ?? options.small;
+  const availableGuilds = data?.availableGuilds ?? [];
+  return {
+    champion: data?.champion,
+    availableGuilds,
+    selectedGuilds:
+      options.guildIds ?? availableGuilds.map((guild) => guild.guildId),
+  };
+}
+
+export function ConsumerChampion() {
+  const { championId } = useConsumerChampionParams();
+  const { filters, setFilters } = usePlayerProfileUrlState();
+  const trpc = useTRPC();
+  const [sort, setSort] = useState<ChampionComparisonSort>("win_rate");
+  const [guildIds, setGuildIds] = useState<string[] | undefined>();
+  const [qualifiedCursors, setQualifiedCursors] = useState<
+    (Cursor | undefined)[]
+  >([undefined]);
+  const [smallCursors, setSmallCursors] = useState<(Cursor | undefined)[]>([
+    undefined,
+  ]);
+  const [qualifiedPage, setQualifiedPage] = useState(0);
+  const [smallPage, setSmallPage] = useState(0);
+  const commonInput = comparisonInput({
+    championId,
+    filters,
+    sort,
+    guildIds,
+  });
+  const qualified = useQuery(
+    trpc.consumerChampion.compare.queryOptions(
+      cohortInput(commonInput, "qualified", qualifiedCursors[qualifiedPage]),
+      { placeholderData: keepPreviousData },
+    ),
+  );
+  const small = useQuery(
+    trpc.consumerChampion.compare.queryOptions(
+      cohortInput(commonInput, "small_sample", smallCursors[smallPage]),
+      { placeholderData: keepPreviousData },
+    ),
+  );
+  useComparisonOpenTracking(qualified.isSuccess, qualified.isError);
+
+  function resetPagination(): void {
+    setQualifiedCursors([undefined]);
+    setSmallCursors([undefined]);
+    setQualifiedPage(0);
+    setSmallPage(0);
+  }
+
+  if (qualified.isError || small.isError) {
+    return (
+      <PageShell>
+        <Card>
+          <CardHeader>
+            <CardTitle>Champion comparison unavailable</CardTitle>
+            <CardDescription>
+              Scout could not verify this champion against your currently
+              enabled shared servers.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex gap-2">
+            <Button onClick={() => void qualified.refetch()}>Retry</Button>
+            <Button asChild variant="outline">
+              <Link to="/players">Players</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </PageShell>
+    );
+  }
+
+  const { champion, availableGuilds, selectedGuilds } = comparisonHeader({
+    qualified: qualified.data,
+    small: small.data,
+    guildIds,
+  });
+  const qualifiedResult = comparisonPage(qualified.data);
+  const smallResult = comparisonPage(small.data);
+  const profileSearch = playerProfileSearch(filters);
+
+  return (
+    <PageShell>
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          {champion === undefined ? null : (
+            <ChampionIcon
+              championName={champion.name}
+              size="md"
+              className="h-14 w-14"
+            />
+          )}
+          <div>
+            <p className="text-sm font-medium text-primary">
+              Champion comparison
+            </p>
+            <h1 className="text-3xl font-semibold tracking-tight">
+              {champion?.name ?? "Loading champion…"}
+            </h1>
+            <p className="text-sm text-scout-subtle">
+              Each guild registration stays a distinct leaderboard entry.
+            </p>
+          </div>
+        </div>
+        <Button asChild variant="outline">
+          <Link to="/players">Player hub</Link>
+        </Button>
+      </div>
+
+      <PlayerProfileFilterBar
+        filters={filters}
+        onChange={(nextFilters, kind) => {
+          resetPagination();
+          setFilters(nextFilters);
+          track("player_profile_filter_changed", {
+            kind,
+            action: "champion_comparison",
+          });
+        }}
+      />
+
+      <div className="flex flex-wrap items-end gap-6 rounded-lg border bg-card p-4">
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium">Guilds</legend>
+          <div className="flex flex-wrap gap-3">
+            {availableGuilds.map((guild) => (
+              <label
+                key={guild.guildId}
+                className="flex items-center gap-2 text-sm"
+              >
+                <input
+                  type="checkbox"
+                  name="guild"
+                  value={guild.guildId}
+                  checked={selectedGuilds.includes(guild.guildId)}
+                  onChange={(event) => {
+                    const next = event.currentTarget.checked
+                      ? [...selectedGuilds, guild.guildId]
+                      : selectedGuilds.filter((id) => id !== guild.guildId);
+                    if (next.length === 0) return;
+                    setGuildIds(next);
+                    resetPagination();
+                  }}
+                />
+                {guild.name}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+        <label className="space-y-1 text-sm font-medium">
+          <span className="block">Sort by</span>
+          <select
+            name="sort"
+            value={sort}
+            className="h-9 rounded-md border border-input bg-background px-3"
+            onChange={(event) => {
+              setSort(parseComparisonSort(event.currentTarget.value));
+              resetPagination();
+            }}
+          >
+            <option value="win_rate">Win rate</option>
+            <option value="games">Games</option>
+            <option value="kda">KDA</option>
+            <option value="cs_per_minute">CS/min</option>
+            <option value="damage_per_minute">Damage/min</option>
+            <option value="gold_per_minute">Gold/min</option>
+            <option value="vision_per_minute">Vision/min</option>
+            <option value="alias">Alias</option>
+          </select>
+        </label>
+      </div>
+
+      <ComparisonSection
+        title="Leaderboard"
+        description="Players with at least 10 matching games."
+        rows={qualifiedResult.rows}
+        profileSearch={profileSearch}
+        page={qualifiedPage}
+        nextCursor={qualifiedResult.nextCursor}
+        pending={qualified.isPending || qualified.isFetching}
+        empty="No player has ten matching games on this champion yet."
+        onPrevious={() => {
+          setQualifiedPage((page) => page - 1);
+        }}
+        onNext={(cursor) => {
+          setQualifiedCursors((cursors) => [
+            ...cursors.slice(0, qualifiedPage + 1),
+            cursor,
+          ]);
+          setQualifiedPage((page) => page + 1);
+        }}
+      />
+      <ComparisonSection
+        title="Smaller samples"
+        description="Useful context, kept separate from the ranked leaderboard."
+        rows={smallResult.rows}
+        profileSearch={profileSearch}
+        page={smallPage}
+        nextCursor={smallResult.nextCursor}
+        pending={small.isPending || small.isFetching}
+        empty="No smaller samples match these filters."
+        onPrevious={() => {
+          setSmallPage((page) => page - 1);
+        }}
+        onNext={(cursor) => {
+          setSmallCursors((cursors) => [
+            ...cursors.slice(0, smallPage + 1),
+            cursor,
+          ]);
+          setSmallPage((page) => page + 1);
+        }}
+      />
+    </PageShell>
+  );
+}
+
+function ComparisonSection(props: {
+  title: string;
+  description: string;
+  rows: ChampionComparisonRow[];
+  profileSearch: string;
+  page: number;
+  nextCursor: Cursor | null | undefined;
+  pending: boolean;
+  empty: string;
+  onPrevious: () => void;
+  onNext: (cursor: Cursor) => void;
+}) {
+  return (
+    <section className="space-y-3">
+      <PageSectionHeading title={props.title} description={props.description} />
+      <ChampionComparisonTable
+        rows={props.rows}
+        profileSearch={props.profileSearch}
+        page={props.page}
+        hasNextPage={
+          props.nextCursor !== null && props.nextCursor !== undefined
+        }
+        pending={props.pending}
+        empty={props.empty}
+        onPrevious={props.onPrevious}
+        onNext={() => {
+          if (props.nextCursor !== null && props.nextCursor !== undefined)
+            props.onNext(props.nextCursor);
+        }}
+      />
+    </section>
+  );
+}
+
+function PageShell(props: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:py-12">
+      {props.children}
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/routes/consumer-match.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/consumer-match.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef } from "react";
+import { Link, useSearchParams } from "react-router";
+import { useQuery } from "@tanstack/react-query";
+import { Badge } from "@scout-for-lol/design-system/components/badge";
+import { Button } from "@scout-for-lol/design-system/components/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@scout-for-lol/design-system/components/card";
+import { MatchScoreboards } from "#src/components/match-scoreboard.tsx";
+import { MatchTimeline } from "#src/components/match-timeline.tsx";
+import { track } from "#src/lib/analytics.ts";
+import {
+  parsePlayerProfileFilters,
+  playerProfileSearch,
+} from "#src/lib/player-profile-filters.ts";
+import { useConsumerMatchParams } from "#src/lib/route-params.ts";
+import { useTRPC } from "#src/lib/trpc.ts";
+
+function duration(seconds: number): string {
+  return `${Math.floor(seconds / 60).toString()}m ${(seconds % 60).toString()}s`;
+}
+
+export function ConsumerMatch() {
+  const { playerId, matchId } = useConsumerMatchParams();
+  const [searchParams] = useSearchParams();
+  const profileSearch = playerProfileSearch(
+    parsePlayerProfileFilters(searchParams),
+  );
+  const trpc = useTRPC();
+  const detail = useQuery(
+    trpc.consumerMatch.detail.queryOptions({ playerId, matchId }),
+  );
+  const tracked = useRef(false);
+
+  useEffect(() => {
+    if (tracked.current || (!detail.isSuccess && !detail.isError)) return;
+    tracked.current = true;
+    track("match_detail_opened", {
+      outcome: detail.isSuccess ? "succeeded" : "failed",
+    });
+    if (detail.isSuccess) {
+      track("match_timeline_viewed", {
+        outcome:
+          detail.data.timeline.coverage === null ? "not_captured" : "available",
+      });
+    }
+  }, [detail.data, detail.isError, detail.isSuccess]);
+
+  if (detail.isPending) {
+    return (
+      <PageShell>
+        <p className="text-sm text-scout-subtle">Loading match details…</p>
+      </PageShell>
+    );
+  }
+  if (detail.isError) {
+    return (
+      <PageShell>
+        <Card>
+          <CardHeader>
+            <CardTitle>Match unavailable</CardTitle>
+            <CardDescription>
+              The selected accessible Scout player did not participate in this
+              match, or Scout could not reverify your current server access.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex gap-2">
+            <Button onClick={() => void detail.refetch()}>Retry</Button>
+            <Button asChild variant="outline">
+              <Link to={`/players/${playerId.toString()}${profileSearch}`}>
+                Back to profile
+              </Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </PageShell>
+    );
+  }
+
+  const match = detail.data.match;
+  const participantIds = match.teams.flatMap((team) =>
+    team.participants.map((participant) => participant.participantId),
+  );
+  return (
+    <PageShell>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-primary">Recorded match</p>
+          <h1 className="text-3xl font-semibold tracking-tight">
+            {match.queue ?? `Queue ${match.queueId.toString()}`}
+          </h1>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-scout-subtle">
+            <span>{new Date(match.gameCreationMs).toLocaleString()}</span>
+            <span>·</span>
+            <span>{duration(match.gameDurationSeconds)}</span>
+            <span>·</span>
+            <span>Patch {match.gameVersion}</span>
+            <Badge variant="outline">Map {match.mapId.toString()}</Badge>
+          </div>
+        </div>
+        <Button asChild variant="outline">
+          <Link to={`/players/${playerId.toString()}${profileSearch}`}>
+            Back to profile
+          </Link>
+        </Button>
+      </div>
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-2xl font-semibold">Team scoreboards</h2>
+          <p className="text-sm text-scout-subtle">
+            All public Riot match participants are shown. Scout aliases appear
+            only from your currently accessible guilds.
+          </p>
+        </div>
+        <MatchScoreboards teams={match.teams} />
+      </section>
+
+      <MatchTimeline
+        playerId={playerId}
+        matchId={matchId}
+        coverage={detail.data.timeline.coverage}
+        keyEvents={detail.data.timeline.keyEvents}
+        participantIds={participantIds}
+      />
+    </PageShell>
+  );
+}
+
+function PageShell(props: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto max-w-7xl space-y-7 px-4 py-8 sm:py-12">
+      {props.children}
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/routes/consumer-player-profile.test.ts
+++ b/packages/scout-for-lol/packages/app/src/routes/consumer-player-profile.test.ts
@@ -2,16 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   isFreshConsumerProfileAccess,
   PROTECTED_CONSUMER_PROFILE_QUERY_OPTIONS,
-  queueValue,
 } from "#src/routes/consumer-player-profile.tsx";
-
-describe("consumer profile queue filter", () => {
-  test("maps member labels to report-lake queue values", () => {
-    expect(queueValue("all")).toBeUndefined();
-    expect(queueValue("solo")).toBe("solo");
-    expect(queueValue("flex")).toBe("flex");
-  });
-});
 
 describe("consumer profile authorization cache", () => {
   test("does not render a cached access success during its membership recheck", () => {

--- a/packages/scout-for-lol/packages/app/src/routes/consumer-player-profile.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/consumer-player-profile.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router";
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
-import { rankToString, type Rank } from "@scout-for-lol/data";
 import { Badge } from "@scout-for-lol/design-system/components/badge";
 import { Button } from "@scout-for-lol/design-system/components/button";
 import {
@@ -18,18 +17,23 @@ import {
   ChampionPoolTable,
   MatchHistoryList,
   PlayerSummaryCards,
+  RankValue,
 } from "#src/components/player-profile-sections.tsx";
-import { LoadMore } from "#src/components/load-more.tsx";
+import { PlayerProfileFilterBar } from "#src/components/player-profile-filter-bar.tsx";
 import { track } from "#src/lib/analytics.ts";
 import { formatRiotId } from "#src/lib/riot-id-format.ts";
 import { useConsumerPlayerParams } from "#src/lib/route-params.ts";
 import { useTRPC } from "#src/lib/trpc.ts";
+import {
+  filterKey,
+  playerProfileSearch,
+  type PlayerProfileFilters,
+} from "#src/lib/player-profile-filters.ts";
+import { usePlayerProfileUrlState } from "#src/lib/use-player-profile-url-state.ts";
 
 const EntryStateSchema = z.object({
   entrySurface: z.enum(["search_results", "direct_link"]),
 });
-
-type QueueFilter = "all" | "solo" | "flex";
 
 export const PROTECTED_CONSUMER_PROFILE_QUERY_OPTIONS = {
   staleTime: 0,
@@ -45,16 +49,45 @@ export function isFreshConsumerProfileAccess(
   return isSuccess && !isFetching && state === "available";
 }
 
-export function queueValue(queue: QueueFilter): string | undefined {
-  if (queue === "solo") return "solo";
-  if (queue === "flex") return "flex";
-  return undefined;
+function playerProfileOutcome(options: {
+  summarySuccess: boolean;
+  summaryError: boolean;
+  accessError: boolean;
+  accessSuccess: boolean;
+  accessState: "available" | "feature_disabled" | "no_shared_guild" | undefined;
+}): "succeeded" | "failed" | null {
+  if (options.summarySuccess) return "succeeded";
+  if (
+    options.summaryError ||
+    options.accessError ||
+    (options.accessSuccess && options.accessState !== "available")
+  ) {
+    return "failed";
+  }
+  return null;
 }
 
-function queueLabel(queue: QueueFilter): string {
-  if (queue === "solo") return "Solo / duo";
-  if (queue === "flex") return "Flex";
-  return "All queues";
+function profileFilterInput(filters: PlayerProfileFilters) {
+  return {
+    games: filters.games,
+    ...(filters.queues === undefined ? {} : { queues: filters.queues }),
+  };
+}
+
+function shouldLoadHistory(
+  accessIsFresh: boolean,
+  summarySuccess: boolean,
+  summaryFetching: boolean,
+): boolean {
+  return accessIsFresh && summarySuccess && !summaryFetching;
+}
+
+function profileUnavailable(
+  accessError: boolean,
+  accessState: "available" | "feature_disabled" | "no_shared_guild" | undefined,
+  summaryError: boolean,
+): boolean {
+  return accessError || accessState !== "available" || summaryError;
 }
 
 function observedAt(value: Date | string | null): string {
@@ -62,11 +95,37 @@ function observedAt(value: Date | string | null): string {
   return new Date(value).toLocaleString();
 }
 
-function rankLabel(rank: Rank | undefined): string {
-  return rank === undefined ? "Unranked" : rankToString(rank);
+export function ConsumerPlayerProfile() {
+  const { filters, setFilters } = usePlayerProfileUrlState();
+  return (
+    <ConsumerPlayerProfileContent
+      key={filterKey(filters)}
+      filters={filters}
+      onFiltersChange={(nextFilters, kind) => {
+        setFilters(nextFilters);
+        track("player_profile_filter_changed", {
+          kind,
+          action:
+            nextFilters.queues === undefined ? "all" : "explicit_selection",
+        });
+      }}
+    />
+  );
 }
 
-export function ConsumerPlayerProfile() {
+type HistoryCursor = {
+  gameCreationMs: number;
+  matchId: string;
+  consumed?: number | undefined;
+};
+
+function ConsumerPlayerProfileContent(props: {
+  filters: PlayerProfileFilters;
+  onFiltersChange: (
+    filters: PlayerProfileFilters,
+    kind: "games" | "queues",
+  ) => void;
+}) {
   const { playerId } = useConsumerPlayerParams();
   const trpc = useTRPC();
   const location = useLocation();
@@ -74,10 +133,12 @@ export function ConsumerPlayerProfile() {
   const entrySurface = parsedEntry.success
     ? parsedEntry.data.entrySurface
     : "direct_link";
-  const [queue, setQueue] = useState<QueueFilter>("all");
-  const selectedQueue = queueValue(queue);
-  const queueInput =
-    selectedQueue === undefined ? {} : { queue: selectedQueue };
+  const [historyCursors, setHistoryCursors] = useState<
+    (HistoryCursor | undefined)[]
+  >([undefined]);
+  const [historyPage, setHistoryPage] = useState(0);
+  const currentHistoryCursor = historyCursors[historyPage];
+  const filterInput = profileFilterInput(props.filters);
   const trackedOutcome = useRef<string | null>(null);
 
   const accessQuery = useQuery(
@@ -91,11 +152,12 @@ export function ConsumerPlayerProfile() {
     accessQuery.isSuccess,
     accessQuery.isFetching,
   );
+  const accessState = accessQuery.data?.state;
   const summaryQuery = useQuery(
     trpc.consumerPlayer.profileSummary.queryOptions(
       {
         playerId,
-        ...queueInput,
+        ...filterInput,
       },
       {
         enabled: accessIsFresh,
@@ -103,14 +165,23 @@ export function ConsumerPlayerProfile() {
       },
     ),
   );
-  const historyQuery = useInfiniteQuery(
-    trpc.consumerPlayer.matchHistory.infiniteQueryOptions(
-      { playerId, limit: 20, ...queueInput },
+  const historyQuery = useQuery(
+    trpc.consumerPlayer.matchHistory.queryOptions(
       {
-        enabled:
-          accessIsFresh && summaryQuery.isSuccess && !summaryQuery.isFetching,
+        playerId,
+        limit: 20,
+        ...filterInput,
+        ...(currentHistoryCursor === undefined
+          ? {}
+          : { cursor: currentHistoryCursor }),
+      },
+      {
+        enabled: shouldLoadHistory(
+          accessIsFresh,
+          summaryQuery.isSuccess,
+          summaryQuery.isFetching,
+        ),
         ...PROTECTED_CONSUMER_PROFILE_QUERY_OPTIONS,
-        getNextPageParam: (lastPage) => lastPage.nextCursor,
       },
     ),
   );
@@ -120,13 +191,13 @@ export function ConsumerPlayerProfile() {
   }, [playerId]);
 
   useEffect(() => {
-    const outcome = summaryQuery.isSuccess
-      ? "succeeded"
-      : summaryQuery.isError ||
-          accessQuery.isError ||
-          (accessQuery.isSuccess && accessQuery.data.state !== "available")
-        ? "failed"
-        : null;
+    const outcome = playerProfileOutcome({
+      summarySuccess: summaryQuery.isSuccess,
+      summaryError: summaryQuery.isError,
+      accessError: accessQuery.isError,
+      accessSuccess: accessQuery.isSuccess,
+      accessState,
+    });
     if (outcome === null || trackedOutcome.current === outcome) return;
     trackedOutcome.current = outcome;
     track("player_profile_opened", {
@@ -134,7 +205,7 @@ export function ConsumerPlayerProfile() {
       surface: entrySurface,
     });
   }, [
-    accessQuery.data,
+    accessState,
     accessQuery.isError,
     accessQuery.isSuccess,
     entrySurface,
@@ -151,9 +222,7 @@ export function ConsumerPlayerProfile() {
   }
 
   if (
-    accessQuery.isError ||
-    accessQuery.data.state !== "available" ||
-    summaryQuery.isError
+    profileUnavailable(accessQuery.isError, accessState, summaryQuery.isError)
   ) {
     return (
       <ProfileShell>
@@ -169,10 +238,7 @@ export function ConsumerPlayerProfile() {
           <CardContent className="flex flex-wrap gap-2">
             <Button
               onClick={() => {
-                if (
-                  accessQuery.isError ||
-                  accessQuery.data.state !== "available"
-                ) {
+                if (accessState !== "available" || accessQuery.isError) {
                   void accessQuery.refetch();
                 } else {
                   void summaryQuery.refetch();
@@ -199,8 +265,11 @@ export function ConsumerPlayerProfile() {
   }
 
   const summary = summaryQuery.data;
-  const entries =
-    historyQuery.data?.pages.flatMap((page) => page.entries) ?? [];
+  if (summary === undefined) {
+    throw new Error("Successful player profile query returned no summary");
+  }
+  const entries = historyQuery.data?.entries ?? [];
+  const profileSearch = playerProfileSearch(props.filters);
 
   return (
     <ProfileShell>
@@ -226,8 +295,10 @@ export function ConsumerPlayerProfile() {
       </div>
 
       <div className="grid gap-3 lg:grid-cols-2">
-        {summary.accounts.map((account) => (
-          <Card key={`${account.region}:${account.gameName ?? "pending"}`}>
+        {summary.accounts.map((account, index) => (
+          <Card
+            key={`${account.region}:${account.gameName ?? "pending"}:${account.tagLine ?? "pending"}:${index.toString()}`}
+          >
             <CardHeader className="pb-3">
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <CardTitle className="text-lg">
@@ -241,21 +312,25 @@ export function ConsumerPlayerProfile() {
                 Last checked by Scout: {observedAt(account.lastCheckedAt)}
               </CardDescription>
             </CardHeader>
-            <CardContent className="grid grid-cols-2 gap-3 text-sm">
+            <CardContent className="grid gap-3 text-sm sm:grid-cols-3">
               <div>
                 <p className="text-scout-subtle">Solo / duo</p>
-                <p className="font-medium">{rankLabel(account.ranks.solo)}</p>
+                <RankValue rank={account.ranks.solo} compact />
               </div>
               <div>
                 <p className="text-scout-subtle">Flex</p>
-                <p className="font-medium">{rankLabel(account.ranks.flex)}</p>
+                <RankValue rank={account.ranks.flex} compact />
+              </div>
+              <div>
+                <p className="text-scout-subtle">Ranked 5s</p>
+                <RankValue rank={account.ranks.ranked5s} compact />
               </div>
             </CardContent>
           </Card>
         ))}
       </div>
 
-      <div className="flex flex-wrap items-center justify-between gap-3">
+      <div>
         <div>
           <h2 className="text-xl font-semibold">Combined performance</h2>
           <p className="text-sm text-scout-subtle">
@@ -263,22 +338,12 @@ export function ConsumerPlayerProfile() {
             Scout player.
           </p>
         </div>
-        <div className="flex gap-2" role="group" aria-label="Queue filter">
-          {(["all", "solo", "flex"] as const).map((value) => (
-            <Button
-              key={value}
-              type="button"
-              size="sm"
-              variant={queue === value ? "default" : "outline"}
-              onClick={() => {
-                setQueue(value);
-              }}
-            >
-              {queueLabel(value)}
-            </Button>
-          ))}
-        </div>
       </div>
+
+      <PlayerProfileFilterBar
+        filters={props.filters}
+        onChange={props.onFiltersChange}
+      />
 
       <PlayerSummaryCards
         ranks={summary.ranks}
@@ -287,8 +352,10 @@ export function ConsumerPlayerProfile() {
 
       <Section title="Champion performance">
         <ChampionPoolTable
+          key={filterKey(props.filters)}
           rows={summary.championPool}
           minGamesForRate={summary.minGamesForRate}
+          profileSearch={profileSearch}
         />
       </Section>
 
@@ -316,14 +383,49 @@ export function ConsumerPlayerProfile() {
           </div>
         ) : (
           <div className="space-y-3">
-            <MatchHistoryList entries={entries} />
-            <LoadMore
-              hasNextPage={historyQuery.hasNextPage}
-              isFetchingNextPage={historyQuery.isFetchingNextPage}
-              onLoadMore={() => {
-                void historyQuery.fetchNextPage();
-              }}
+            <MatchHistoryList
+              entries={entries}
+              playerId={playerId}
+              profileSearch={profileSearch}
             />
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-xs text-scout-subtle">
+                Page {(historyPage + 1).toString()}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={historyPage === 0 || historyQuery.isFetching}
+                  onClick={() => {
+                    setHistoryPage((page) => page - 1);
+                  }}
+                >
+                  Previous
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={
+                    historyQuery.data.nextCursor === null ||
+                    historyQuery.isFetching
+                  }
+                  onClick={() => {
+                    const next = historyQuery.data.nextCursor;
+                    if (next === null) return;
+                    setHistoryCursors((cursors) => [
+                      ...cursors.slice(0, historyPage + 1),
+                      next,
+                    ]);
+                    setHistoryPage((page) => page + 1);
+                  }}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
           </div>
         )}
       </Section>

--- a/packages/scout-for-lol/packages/app/src/routes/consumer-player-search.test.ts
+++ b/packages/scout-for-lol/packages/app/src/routes/consumer-player-search.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
 import {
   isConsumerTypeaheadReady,
+  PlayerHome,
   PROTECTED_CONSUMER_SEARCH_QUERY_OPTIONS,
   shouldHideConsumerSuggestions,
 } from "#src/routes/consumer-player-search.tsx";
@@ -37,6 +41,48 @@ describe("consumer player typeahead", () => {
         isPlaceholderData: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe("consumer player hub states", () => {
+  test("renders loading, error, and both empty explanations", () => {
+    const loading = renderToStaticMarkup(
+      createElement(PlayerHome, {
+        yourProfiles: undefined,
+        recentPlayers: undefined,
+        pending: true,
+        error: false,
+        onRetry: vi.fn(),
+      }),
+    );
+    expect(loading).toContain("Loading your player hub");
+
+    const error = renderToStaticMarkup(
+      createElement(PlayerHome, {
+        yourProfiles: undefined,
+        recentPlayers: undefined,
+        pending: false,
+        error: true,
+        onRetry: vi.fn(),
+      }),
+    );
+    expect(error).toContain("didn&#x27;t load");
+
+    const empty = renderToStaticMarkup(
+      createElement(
+        MemoryRouter,
+        undefined,
+        createElement(PlayerHome, {
+          yourProfiles: [],
+          recentPlayers: [],
+          pending: false,
+          error: false,
+          onRetry: vi.fn(),
+        }),
+      ),
+    );
+    expect(empty).toContain("No Scout player is linked");
+    expect(empty).toContain("No other recently active players");
   });
 });
 

--- a/packages/scout-for-lol/packages/app/src/routes/consumer-player-search.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/consumer-player-search.tsx
@@ -11,6 +11,7 @@ import {
   CardTitle,
 } from "@scout-for-lol/design-system/components/card";
 import { ConsumerGuildAvatar } from "#src/components/consumer-guild-avatar.tsx";
+import { PageSectionHeading } from "#src/components/page-section-heading.tsx";
 import { useDebouncedValue } from "#src/hooks/use-debounced-value.ts";
 import { track } from "#src/lib/analytics.ts";
 import { formatRiotId } from "#src/lib/riot-id-format.ts";
@@ -48,6 +49,10 @@ type SearchResult = {
   }[];
 };
 
+export type HomePlayer = SearchResult & {
+  lastMatchTime: Date | string | null;
+};
+
 export function ConsumerPlayerSearch() {
   const trpc = useTRPC();
   const navigate = useNavigate();
@@ -72,6 +77,12 @@ export function ConsumerPlayerSearch() {
         ...PROTECTED_CONSUMER_SEARCH_QUERY_OPTIONS,
       },
     ),
+  );
+  const homeQuery = useQuery(
+    trpc.consumerPlayer.home.queryOptions(undefined, {
+      enabled: statusQuery.data?.state === "available",
+      ...PROTECTED_CONSUMER_SEARCH_QUERY_OPTIONS,
+    }),
   );
   const suggestionsHidden = shouldHideConsumerSuggestions({
     query,
@@ -136,6 +147,16 @@ export function ConsumerPlayerSearch() {
         renderStatusContent(
           statusQuery.data.state,
           <>
+            <PlayerHome
+              yourProfiles={homeQuery.data?.yourProfiles}
+              recentPlayers={homeQuery.data?.recentPlayers}
+              pending={homeQuery.isPending || homeQuery.isFetching}
+              error={homeQuery.isError}
+              onRetry={() => {
+                void homeQuery.refetch();
+              }}
+            />
+
             <div className="space-y-2">
               <label
                 className="text-sm font-medium"
@@ -182,6 +203,106 @@ export function ConsumerPlayerSearch() {
         )
       )}
     </div>
+  );
+}
+
+export function PlayerHome(props: {
+  yourProfiles: HomePlayer[] | undefined;
+  recentPlayers: HomePlayer[] | undefined;
+  pending: boolean;
+  error: boolean;
+  onRetry: () => void;
+}) {
+  if (props.pending) {
+    return (
+      <p className="text-sm text-scout-subtle" aria-live="polite">
+        Loading your player hub…
+      </p>
+    );
+  }
+  if (props.error) {
+    return (
+      <RetryCard
+        title="Your player hub didn't load"
+        description="Scout rechecks your shared servers for this list. Retry without reloading the page."
+        onRetry={props.onRetry}
+      />
+    );
+  }
+  return (
+    <div className="space-y-6">
+      <PlayerHomeSection
+        title="Your profiles"
+        description="Every Scout profile linked to your Discord account across enabled shared servers."
+        players={props.yourProfiles ?? []}
+        empty="No Scout player is linked to your Discord account yet. You can still search everyone you share access to."
+      />
+      <PlayerHomeSection
+        title="Recently active"
+        description="Six other players with the newest matches Scout recorded."
+        players={props.recentPlayers ?? []}
+        empty="No other recently active players are in Scout's stored coverage yet."
+      />
+    </div>
+  );
+}
+
+function PlayerHomeSection(props: {
+  title: string;
+  description: string;
+  players: HomePlayer[];
+  empty: string;
+}) {
+  return (
+    <section className="space-y-3">
+      <PageSectionHeading title={props.title} description={props.description} />
+      {props.players.length === 0 ? (
+        <Card>
+          <CardContent className="pt-6 text-sm text-scout-subtle">
+            {props.empty}
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {props.players.map((player) => (
+            <Card key={player.playerId}>
+              <CardHeader className="pb-3">
+                <div className="flex items-start gap-3">
+                  <ConsumerGuildAvatar
+                    name={player.guild.name}
+                    size="compact"
+                  />
+                  <div className="min-w-0">
+                    <CardTitle className="truncate text-base">
+                      <Link
+                        className="underline-offset-4 hover:underline"
+                        to={`/players/${player.playerId.toString()}`}
+                        state={{ entrySurface: "direct_link" }}
+                      >
+                        {player.alias}
+                      </Link>
+                    </CardTitle>
+                    <CardDescription className="truncate">
+                      {player.guild.name}
+                    </CardDescription>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="text-xs text-scout-subtle">
+                {player.accounts
+                  .map((account) => formatRiotId(account, "Riot ID pending"))
+                  .join(" · ") || "No Riot ID observed yet"}
+                {player.lastMatchTime === null ? null : (
+                  <span className="mt-2 block">
+                    Last game {new Date(player.lastMatchTime).toLocaleString()}
+                  </span>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/packages/scout-for-lol/packages/app/src/routes/player-profile.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-profile.tsx
@@ -54,6 +54,7 @@ export function PlayerProfile() {
         <ChampionPoolTable
           rows={summary.championPool}
           minGamesForRate={summary.minGamesForRate}
+          profileSearch=""
         />
       </Section>
 
@@ -65,7 +66,10 @@ export function PlayerProfile() {
             Couldn&apos;t load match history.
           </p>
         ) : (
-          <MatchHistoryList entries={historyQuery.data.entries} />
+          <MatchHistoryList
+            entries={historyQuery.data.entries}
+            profileSearch=""
+          />
         )}
       </Section>
     </div>

--- a/packages/scout-for-lol/packages/backend/src/lib/player-profile/profile-resolution.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-profile/profile-resolution.ts
@@ -1,0 +1,140 @@
+import {
+  RankSchema,
+  type DiscordGuildId,
+  type PlayerId,
+  type Rank,
+} from "@scout-for-lol/data";
+import { prisma } from "#src/database/index.ts";
+import { getPlayerOrThrow, notFound } from "#src/lib/player-admin/shared.ts";
+
+export type ProfileAccount = {
+  puuid: string;
+  region: string;
+  riotGameName: string | null;
+  riotTagLine: string | null;
+  riotIdUpdatedAt: Date | null;
+  lastMatchTime: Date | null;
+  lastCheckedAt: Date | null;
+};
+
+export type ResolvedPlayerProfile = {
+  playerId: number;
+  alias: string;
+  puuids: string[];
+  accounts: ProfileAccount[];
+};
+
+export type ResolvedGuildPlayerProfile = ResolvedPlayerProfile & {
+  discordId: string | null;
+};
+
+function profileAccount(account: ProfileAccount): ProfileAccount {
+  return {
+    puuid: account.puuid,
+    region: account.region,
+    riotGameName: account.riotGameName,
+    riotTagLine: account.riotTagLine,
+    riotIdUpdatedAt: account.riotIdUpdatedAt,
+    lastMatchTime: account.lastMatchTime,
+    lastCheckedAt: account.lastCheckedAt,
+  };
+}
+
+export async function resolveGuildPuuids(input: {
+  guildId: string;
+  alias: string;
+}): Promise<ResolvedGuildPlayerProfile> {
+  const player = await getPlayerOrThrow(input);
+  return {
+    playerId: player.id,
+    alias: player.alias,
+    discordId: player.discordId,
+    puuids: player.accounts.map((account) => account.puuid),
+    accounts: player.accounts.map((account) => profileAccount(account)),
+  };
+}
+
+export async function resolveConsumerPlayerPuuids(input: {
+  playerId: PlayerId;
+  guildIds: DiscordGuildId[];
+}): Promise<ResolvedPlayerProfile & { guildId: string }> {
+  const player = await prisma.player.findFirst({
+    where: { id: input.playerId, serverId: { in: input.guildIds } },
+    include: { accounts: true },
+  });
+  if (player === null) {
+    throw notFound("Player was not found");
+  }
+  return {
+    playerId: player.id,
+    alias: player.alias,
+    guildId: player.serverId,
+    puuids: player.accounts.map((account) => account.puuid),
+    accounts: player.accounts.map((account) => profileAccount(account)),
+  };
+}
+
+export function parseRank(serialized: string | null): Rank | undefined {
+  if (serialized === null) return undefined;
+  const parsed = RankSchema.safeParse(JSON.parse(serialized));
+  return parsed.success ? parsed.data : undefined;
+}
+
+/** Latest known rank per queue, newest game first. */
+export async function latestRanks(puuids: string[]): Promise<{
+  solo: Rank | undefined;
+  flex: Rank | undefined;
+  ranked5s: Rank | undefined;
+}> {
+  const [rankHistory, current] = await Promise.all([
+    Promise.all(
+      (["solo", "flex", "ranked 5s"] as const).map(async (queueType) =>
+        prisma.matchRankHistory.findFirst({
+          where: {
+            puuid: { in: puuids },
+            queueType,
+            rankAfter: { not: null },
+          },
+          orderBy: [
+            { matchGameEndAt: { sort: "desc", nulls: "last" } },
+            { capturedAt: "desc" },
+          ],
+        }),
+      ),
+    ),
+    prisma.currentRankSnapshot.findMany({
+      where: { puuid: { in: puuids } },
+      orderBy: { fetchedAt: "desc" },
+    }),
+  ]);
+
+  function newestRank(
+    live: (typeof rankHistory)[number] | undefined,
+    queueType: "solo" | "flex" | "ranked 5s",
+  ): Rank | undefined {
+    const snapshot = current.find((entry) => {
+      if (queueType === "solo") return entry.soloRank !== null;
+      if (queueType === "flex") return entry.flexRank !== null;
+      return entry.ranked5sRank !== null;
+    });
+    const snapshotValue =
+      queueType === "solo"
+        ? snapshot?.soloRank
+        : queueType === "flex"
+          ? snapshot?.flexRank
+          : snapshot?.ranked5sRank;
+    if (
+      snapshot !== undefined &&
+      (live == null || snapshot.fetchedAt > live.capturedAt)
+    ) {
+      return parseRank(snapshotValue ?? null);
+    }
+    return parseRank(live?.rankAfter ?? null);
+  }
+
+  return {
+    solo: newestRank(rankHistory[0], "solo"),
+    flex: newestRank(rankHistory[1], "flex"),
+    ranked5s: newestRank(rankHistory[2], "ranked 5s"),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/player-profile/queries.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-profile/queries.ts
@@ -1,18 +1,25 @@
 import { z } from "zod";
 import {
   LOW_SAMPLE_GAME_THRESHOLD,
-  RankSchema,
+  PlayerProfileGameWindowSchema,
+  PlayerProfileQueueSelectionSchema,
+  QueueTypeSchema,
   leaguePointsDelta,
   type DiscordGuildId,
   type PlayerId,
-  type Rank,
+  type PlayerProfileGameWindow,
+  type QueueType,
 } from "@scout-for-lol/data";
 import { prisma } from "#src/database/index.ts";
+import { PlayerLookupInput } from "#src/lib/player-admin/shared.ts";
 import {
-  PlayerLookupInput,
-  getPlayerOrThrow,
-  notFound,
-} from "#src/lib/player-admin/shared.ts";
+  latestRanks,
+  parseRank,
+  resolveConsumerPlayerPuuids,
+  resolveGuildPuuids,
+  type ProfileAccount,
+  type ResolvedPlayerProfile,
+} from "#src/lib/player-profile/profile-resolution.ts";
 import {
   fetchPlayerChampionPool,
   fetchPlayerMatchHistory,
@@ -44,149 +51,18 @@ const RECENT_FORM_GAMES = 20;
 const MatchHistoryCursorSchema = z.object({
   gameCreationMs: z.number().int(),
   matchId: z.string().min(1),
+  consumed: z.number().int().nonnegative().optional(),
 });
 
 export const PlayerProfileInput = PlayerLookupInput.extend({
-  queue: z.string().trim().min(1).max(50).optional(),
+  queue: QueueTypeSchema.optional(),
 });
 
 export const PlayerMatchHistoryInput = PlayerLookupInput.extend({
   limit: z.number().int().min(1).max(50).default(RECENT_FORM_GAMES),
   cursor: MatchHistoryCursorSchema.optional(),
-  queue: z.string().trim().min(1).max(50).optional(),
+  queue: QueueTypeSchema.optional(),
 });
-
-type ProfileAccount = {
-  puuid: string;
-  region: string;
-  riotGameName: string | null;
-  riotTagLine: string | null;
-  riotIdUpdatedAt: Date | null;
-  lastMatchTime: Date | null;
-  lastCheckedAt: Date | null;
-};
-
-type ResolvedPlayerProfile = {
-  playerId: number;
-  alias: string;
-  puuids: string[];
-  accounts: ProfileAccount[];
-};
-
-type ResolvedGuildPlayerProfile = ResolvedPlayerProfile & {
-  discordId: string | null;
-};
-
-function profileAccount(account: ProfileAccount): ProfileAccount {
-  return {
-    puuid: account.puuid,
-    region: account.region,
-    riotGameName: account.riotGameName,
-    riotTagLine: account.riotTagLine,
-    riotIdUpdatedAt: account.riotIdUpdatedAt,
-    lastMatchTime: account.lastMatchTime,
-    lastCheckedAt: account.lastCheckedAt,
-  };
-}
-
-async function resolveGuildPuuids(input: {
-  guildId: string;
-  alias: string;
-}): Promise<ResolvedGuildPlayerProfile> {
-  const player = await getPlayerOrThrow(input);
-  return {
-    playerId: player.id,
-    alias: player.alias,
-    discordId: player.discordId,
-    puuids: player.accounts.map((account) => account.puuid),
-    accounts: player.accounts.map((account) => profileAccount(account)),
-  };
-}
-
-async function resolveConsumerPlayerPuuids(input: {
-  playerId: PlayerId;
-  guildIds: DiscordGuildId[];
-}): Promise<ResolvedPlayerProfile & { guildId: string }> {
-  const player = await prisma.player.findFirst({
-    where: { id: input.playerId, serverId: { in: input.guildIds } },
-    include: { accounts: true },
-  });
-  if (player === null) {
-    throw notFound("Player was not found");
-  }
-  return {
-    playerId: player.id,
-    alias: player.alias,
-    guildId: player.serverId,
-    puuids: player.accounts.map((account) => account.puuid),
-    accounts: player.accounts.map((account) => profileAccount(account)),
-  };
-}
-
-function parseRank(serialized: string | null): Rank | undefined {
-  if (serialized === null) return undefined;
-  const parsed = RankSchema.safeParse(JSON.parse(serialized));
-  return parsed.success ? parsed.data : undefined;
-}
-
-/** Latest known rank per queue, newest game first. */
-async function latestRanks(puuids: string[]): Promise<{
-  solo: Rank | undefined;
-  flex: Rank | undefined;
-  ranked5s: Rank | undefined;
-}> {
-  const [rankHistory, current] = await Promise.all([
-    Promise.all(
-      (["solo", "flex", "ranked 5s"] as const).map(async (queueType) =>
-        prisma.matchRankHistory.findFirst({
-          where: {
-            puuid: { in: puuids },
-            queueType,
-            rankAfter: { not: null },
-          },
-          orderBy: [
-            { matchGameEndAt: { sort: "desc", nulls: "last" } },
-            { capturedAt: "desc" },
-          ],
-        }),
-      ),
-    ),
-    prisma.currentRankSnapshot.findMany({
-      where: { puuid: { in: puuids } },
-      orderBy: { fetchedAt: "desc" },
-    }),
-  ]);
-
-  function newestRank(
-    live: (typeof rankHistory)[number] | undefined,
-    queueType: "solo" | "flex" | "ranked 5s",
-  ): Rank | undefined {
-    const snapshot = current.find((entry) => {
-      if (queueType === "solo") return entry.soloRank !== null;
-      if (queueType === "flex") return entry.flexRank !== null;
-      return entry.ranked5sRank !== null;
-    });
-    const snapshotValue =
-      queueType === "solo"
-        ? snapshot?.soloRank
-        : queueType === "flex"
-          ? snapshot?.flexRank
-          : snapshot?.ranked5sRank;
-    if (
-      snapshot !== undefined &&
-      (live == null || snapshot.fetchedAt > live.capturedAt)
-    ) {
-      return parseRank(snapshotValue ?? null);
-    }
-    return parseRank(live?.rankAfter ?? null);
-  }
-
-  return {
-    solo: newestRank(rankHistory[0], "solo"),
-    flex: newestRank(rankHistory[1], "flex"),
-    ranked5s: newestRank(rankHistory[2], "ranked 5s"),
-  };
-}
 
 export type MatchHistoryEntry = {
   matchId: string;
@@ -311,6 +187,8 @@ async function matchHistoryForPlayer(
     limit: number;
     cursor?: MatchHistoryCursor;
     queue?: string;
+    queues?: QueueType[];
+    games?: PlayerProfileGameWindow;
   },
 ): Promise<{
   entries: MatchHistoryEntry[];
@@ -320,21 +198,41 @@ async function matchHistoryForPlayer(
     return { entries: [], nextCursor: null };
   }
 
+  const consumed = input.cursor?.consumed ?? 0;
+  const remaining =
+    input.games === 20 || input.games === 50
+      ? Math.max(0, input.games - consumed)
+      : input.limit;
+  if (remaining === 0) {
+    return { entries: [], nextCursor: null };
+  }
+  const pageLimit = Math.min(input.limit, remaining);
   const rows = await fetchPlayerMatchHistory({
     puuids: player.puuids,
-    limit: input.limit + 1,
+    limit: pageLimit + 1,
     ...(input.cursor === undefined ? {} : { cursor: input.cursor }),
     ...(input.queue === undefined ? {} : { queue: input.queue }),
+    ...(input.queues === undefined ? {} : { queues: input.queues }),
   });
-  const page = rows.slice(0, input.limit);
-  const last = rows.length > input.limit ? page.at(-1) : undefined;
+  const page = rows.slice(0, pageLimit);
+  const last =
+    rows.length > pageLimit &&
+    (input.games === "all" ||
+      input.games === undefined ||
+      page.length < remaining)
+      ? page.at(-1)
+      : undefined;
 
   return {
     entries: await decorateHistoryRows(page, player.accounts),
     nextCursor:
       last === undefined
         ? null
-        : { gameCreationMs: last.game_creation_ms, matchId: last.match_id },
+        : {
+            gameCreationMs: last.game_creation_ms,
+            matchId: last.match_id,
+            consumed: consumed + page.length,
+          },
   };
 }
 
@@ -347,6 +245,7 @@ export async function getPlayerMatchHistory(
   const player = await resolveGuildPuuids(input);
   return matchHistoryForPlayer(player, {
     limit: input.limit,
+    games: "all",
     ...(input.cursor === undefined ? {} : { cursor: input.cursor }),
     ...(input.queue === undefined ? {} : { queue: input.queue }),
   });
@@ -357,7 +256,8 @@ export async function getConsumerPlayerMatchHistory(input: {
   guildIds: DiscordGuildId[];
   limit: number;
   cursor?: MatchHistoryCursor;
-  queue?: string;
+  queues?: QueueType[];
+  games: PlayerProfileGameWindow;
 }) {
   const player = await resolveConsumerPlayerPuuids(input);
   return matchHistoryForPlayer(player, input);
@@ -391,7 +291,12 @@ async function accountSummaries(accounts: ProfileAccount[]) {
 
 async function profileSummaryForPlayer(
   player: ResolvedPlayerProfile,
-  queue: string | undefined,
+  filters: {
+    queue?: QueueType;
+    queues?: QueueType[];
+    games: PlayerProfileGameWindow;
+    championGames?: PlayerProfileGameWindow;
+  },
 ) {
   const accounts = await accountSummaries(player.accounts);
   if (player.puuids.length === 0) {
@@ -411,12 +316,15 @@ async function profileSummaryForPlayer(
     latestRanks(player.puuids),
     fetchPlayerMatchHistory({
       puuids: player.puuids,
-      limit: RECENT_FORM_GAMES,
-      ...(queue === undefined ? {} : { queue }),
+      ...(filters.games === "all" ? {} : { limit: filters.games }),
+      ...(filters.queue === undefined ? {} : { queue: filters.queue }),
+      ...(filters.queues === undefined ? {} : { queues: filters.queues }),
     }),
     fetchPlayerChampionPool({
       puuids: player.puuids,
-      ...(queue === undefined ? {} : { queue }),
+      games: filters.championGames ?? filters.games,
+      ...(filters.queue === undefined ? {} : { queue: filters.queue }),
+      ...(filters.queues === undefined ? {} : { queues: filters.queues }),
     }),
   ]);
 
@@ -475,7 +383,11 @@ export async function getPlayerProfileSummary(
   input: z.infer<typeof PlayerProfileInput>,
 ) {
   const player = await resolveGuildPuuids(input);
-  const summary = await profileSummaryForPlayer(player, input.queue);
+  const summary = await profileSummaryForPlayer(player, {
+    games: RECENT_FORM_GAMES,
+    championGames: "all",
+    ...(input.queue === undefined ? {} : { queue: input.queue }),
+  });
   return {
     discordId: player.discordId,
     ...summary,
@@ -485,11 +397,17 @@ export async function getPlayerProfileSummary(
 export async function getConsumerPlayerProfileSummary(input: {
   playerId: PlayerId;
   guildIds: DiscordGuildId[];
-  queue?: string;
+  queues?: QueueType[];
+  games: PlayerProfileGameWindow;
 }) {
   const player = await resolveConsumerPlayerPuuids(input);
   return {
     guildId: player.guildId,
-    ...(await profileSummaryForPlayer(player, input.queue)),
+    ...(await profileSummaryForPlayer(player, {
+      games: PlayerProfileGameWindowSchema.parse(input.games),
+      ...(input.queues === undefined
+        ? {}
+        : { queues: PlayerProfileQueueSelectionSchema.parse(input.queues) }),
+    })),
   };
 }

--- a/packages/scout-for-lol/packages/backend/src/reports/duckdb/consumer-profile-lake-reads.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/duckdb/consumer-profile-lake-reads.test.ts
@@ -1,0 +1,304 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type {
+  TimelineCoverageLakeRow,
+  TimelineEventParticipantLakeRow,
+  TimelineEventLakeRow,
+  TimelineParticipantFrameLakeRow,
+} from "@scout-for-lol/data";
+import {
+  fetchChampionComparisons,
+  fetchFullMatch,
+  fetchTimelineCoverage,
+  fetchTimelineEventPage,
+  fetchTimelineFramePage,
+} from "#src/reports/duckdb/consumer-profile-lake-reads.ts";
+import { resetTestLake, writeTestLake } from "#src/testing/test-report-lake.ts";
+import { testPuuid } from "#src/testing/test-ids.ts";
+
+const lakeDir = await mkdtemp(path.join(tmpdir(), "scout-consumer-lake-"));
+const playerOne = testPuuid("comparison-one");
+const playerTwo = testPuuid("comparison-two");
+const matchId = "NA1_timeline_detail";
+
+function event(options: {
+  id: string;
+  timestamp: number;
+  type: string;
+  participantId?: number;
+  goldGain?: number;
+}): TimelineEventLakeRow {
+  return {
+    event_id: options.id,
+    match_id: matchId,
+    month: "2026-08",
+    observed_at: "2026-08-20 12:30:00.000",
+    frame_index: Math.floor(options.timestamp / 60_000),
+    event_index: options.timestamp,
+    frame_timestamp_ms: options.timestamp,
+    event_timestamp_ms: options.timestamp,
+    event_type: options.type,
+    participant_id: options.participantId ?? null,
+    killer_id: null,
+    victim_id: null,
+    creator_id: null,
+    team_id: null,
+    killer_team_id: null,
+    item_id: null,
+    after_id: null,
+    before_id: null,
+    skill_slot: null,
+    level: null,
+    bounty: null,
+    shutdown_bounty: null,
+    kill_streak_length: null,
+    gold_gain: options.goldGain ?? null,
+    position_x: null,
+    position_y: null,
+    ward_type: null,
+    building_type: null,
+    lane_type: null,
+    tower_type: null,
+    monster_type: null,
+    monster_sub_type: null,
+    level_up_type: null,
+    winning_team_id: null,
+    real_timestamp_ms: null,
+  };
+}
+
+function frame(options: {
+  index: number;
+  timestamp: number;
+  participantId: number;
+  puuid: string;
+}): TimelineParticipantFrameLakeRow {
+  return {
+    match_id: matchId,
+    month: "2026-08",
+    observed_at: "2026-08-20 12:30:00.000",
+    frame_index: options.index,
+    frame_timestamp_ms: options.timestamp,
+    participant_id: options.participantId,
+    puuid: options.puuid,
+    position_x: 100,
+    position_y: 200,
+    current_gold: 300,
+    total_gold: 1000 + options.timestamp,
+    gold_per_second: 20,
+    minions_killed: 10,
+    jungle_minions_killed: 2,
+    level: 3,
+    xp: 500 + options.timestamp,
+    time_enemy_spent_controlled: 1.5,
+    ability_haste: 0,
+    ability_power: 0,
+    armor: 30,
+    attack_damage: 60,
+    attack_speed: 0.7,
+    health: 700,
+    health_max: 800,
+    magic_resist: 30,
+    movement_speed: 340,
+    power: 300,
+    power_max: 400,
+    total_damage_done: 2000,
+    total_damage_done_to_champions: 300,
+    total_damage_taken: 250,
+  };
+}
+
+function eventParticipant(options: {
+  eventId: string;
+  participantId: number;
+  role: TimelineEventParticipantLakeRow["role"];
+}): TimelineEventParticipantLakeRow {
+  return {
+    event_id: options.eventId,
+    match_id: matchId,
+    month: "2026-08",
+    observed_at: "2026-08-20 12:30:00.000",
+    participant_id: options.participantId,
+    puuid: options.participantId === 1 ? playerOne : playerTwo,
+    role: options.role,
+    role_index: 0,
+  };
+}
+
+const coverage: TimelineCoverageLakeRow = {
+  match_id: matchId,
+  month: "2026-08",
+  observed_at: "2026-08-20 12:30:00.000",
+  coverage_state: "complete",
+  data_version: "2",
+  frame_interval_ms: 60_000,
+  frame_count: 2,
+  event_count: 3,
+  participant_count: 2,
+  first_frame_timestamp_ms: 60_000,
+  last_frame_timestamp_ms: 120_000,
+};
+
+beforeAll(async () => {
+  await resetTestLake(lakeDir);
+  const created = new Date("2026-08-20T12:00:00.000Z");
+  await writeTestLake(lakeDir, {
+    serverId: "100000000000000041",
+    matchFacts: Array.from({ length: 22 }, (_, index) => ({
+      playerId: 1,
+      playerAlias: "One",
+      matchId: index === 0 ? matchId : `NA1_one_${index.toString()}`,
+      puuid: playerOne,
+      queue: index === 21 ? null : index % 2 === 0 ? "solo" : "flex",
+      win: index % 2 === 0,
+      surrendered: false,
+      kills: 4,
+      deaths: 2,
+      assists: 6,
+      championId: 22,
+      championName: "Ashe",
+      gameCreationAt: new Date(created.getTime() - index * 60_000),
+    })),
+    untrackedMatchFacts: [
+      {
+        playerId: 2,
+        playerAlias: "Two",
+        matchId,
+        puuid: playerTwo,
+        queue: "solo",
+        win: false,
+        surrendered: false,
+        kills: 2,
+        deaths: 4,
+        assists: 3,
+        teamId: 200,
+        championId: 86,
+        championName: "Garen",
+        gameCreationAt: created,
+      },
+    ],
+    timelineEvents: [
+      event({ id: "late", timestamp: 180_000, type: "CHAMPION_KILL" }),
+      event({
+        id: "early",
+        timestamp: 60_000,
+        type: "ITEM_PURCHASED",
+        participantId: 1,
+      }),
+      event({
+        id: "unknown",
+        timestamp: 120_000,
+        type: "RIFT_HERALD_DANCE",
+        goldGain: 17,
+      }),
+    ],
+    timelineEventParticipants: [
+      eventParticipant({ eventId: "early", participantId: 1, role: "subject" }),
+      eventParticipant({
+        eventId: "unknown",
+        participantId: 1,
+        role: "assist",
+      }),
+    ],
+    timelineFrames: [
+      frame({
+        index: 1,
+        timestamp: 120_000,
+        participantId: 2,
+        puuid: playerTwo,
+      }),
+      frame({
+        index: 0,
+        timestamp: 60_000,
+        participantId: 1,
+        puuid: playerOne,
+      }),
+    ],
+    timelineCoverage: [coverage],
+  });
+});
+
+afterAll(async () => {
+  await rm(lakeDir, { recursive: true, force: true });
+});
+
+describe("consumer profile lake reads", () => {
+  test("applies multi-queue and newest-N champion scopes without excluding null from all games", async () => {
+    const lastTwenty = await fetchChampionComparisons({
+      championId: 22,
+      entries: [{ entryKey: "one", puuids: [playerOne] }],
+      games: 20,
+      queues: ["solo", "flex"],
+      lakeDir,
+    });
+    expect(lastTwenty[0]?.games).toBe(20);
+
+    const all = await fetchChampionComparisons({
+      championId: 22,
+      entries: [{ entryKey: "one", puuids: [playerOne] }],
+      games: "all",
+      lakeDir,
+    });
+    expect(all[0]?.games).toBe(22);
+  });
+
+  test("returns the complete stored scoreboard", async () => {
+    const rows = await fetchFullMatch({ matchId, lakeDir });
+    expect(rows.map((row) => row.champion_name)).toEqual(["Ashe", "Garen"]);
+  });
+
+  test("keeps chronological event and frame pages, filters, and unknown event fields", async () => {
+    expect(await fetchTimelineCoverage({ matchId, lakeDir })).toMatchObject({
+      event_count: 3,
+      frame_count: 2,
+    });
+    const events = await fetchTimelineEventPage({
+      matchId,
+      offset: 0,
+      limit: 2,
+      lakeDir,
+    });
+    expect(events.map((row) => row.event_id)).toEqual(["early", "unknown"]);
+    expect(events[1]).toMatchObject({
+      event_type: "RIFT_HERALD_DANCE",
+      gold_gain: 17,
+    });
+    const laterEvents = await fetchTimelineEventPage({
+      matchId,
+      offset: 2,
+      limit: 2,
+      lakeDir,
+    });
+    expect(laterEvents.map((row) => row.event_id)).toEqual(["late"]);
+    const filtered = await fetchTimelineEventPage({
+      matchId,
+      offset: 0,
+      limit: 100,
+      participantIds: [1],
+      lakeDir,
+    });
+    expect(filtered.map((row) => row.event_id)).toEqual(["early", "unknown"]);
+    const frames = await fetchTimelineFramePage({
+      matchId,
+      offset: 0,
+      limit: 1,
+      lakeDir,
+    });
+    expect(frames.map((row) => row.participant_id)).toEqual([1]);
+    const laterFrames = await fetchTimelineFramePage({
+      matchId,
+      offset: 1,
+      limit: 1,
+      lakeDir,
+    });
+    expect(laterFrames.map((row) => row.participant_id)).toEqual([2]);
+  });
+
+  test("returns null when Scout never retained timeline coverage", async () => {
+    expect(
+      await fetchTimelineCoverage({ matchId: "NA1_missing", lakeDir }),
+    ).toBeNull();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/reports/duckdb/consumer-profile-lake-reads.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/duckdb/consumer-profile-lake-reads.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
-import type {
-  PlayerProfileGameWindow,
-  QueueType,
-  TimelineEventLakeRow,
-  TimelineParticipantFrameLakeRow,
+import {
+  TimelineEventLakeRowSchema,
+  TimelineParticipantFrameLakeRowSchema,
+  type PlayerProfileGameWindow,
+  type QueueType,
+  type TimelineEventLakeRow,
+  type TimelineParticipantFrameLakeRow,
 } from "@scout-for-lol/data";
 import { resolveLakeDir } from "#src/report-lake/paths.ts";
 import { withDuckDBConnection } from "#src/reports/duckdb/instance.ts";
@@ -231,13 +233,15 @@ export async function fetchTimelineCoverage(options: {
   return rows[0] ?? null;
 }
 
-const TimelineEventReadSchema = z.object({
-  event_id: z.string(),
+const TimelineEventReadSchema = TimelineEventLakeRowSchema.omit({
+  match_id: true,
+  month: true,
+  observed_at: true,
+}).extend({
   frame_index: LakeIntSchema,
   event_index: LakeIntSchema,
   frame_timestamp_ms: LakeIntSchema,
   event_timestamp_ms: LakeIntSchema,
-  event_type: z.string(),
   participant_id: LakeIntSchema.nullable(),
   killer_id: LakeIntSchema.nullable(),
   victim_id: LakeIntSchema.nullable(),
@@ -255,13 +259,6 @@ const TimelineEventReadSchema = z.object({
   gold_gain: LakeIntSchema.nullable(),
   position_x: LakeIntSchema.nullable(),
   position_y: LakeIntSchema.nullable(),
-  ward_type: z.string().nullable(),
-  building_type: z.string().nullable(),
-  lane_type: z.string().nullable(),
-  tower_type: z.string().nullable(),
-  monster_type: z.string().nullable(),
-  monster_sub_type: z.string().nullable(),
-  level_up_type: z.string().nullable(),
   winning_team_id: LakeIntSchema.nullable(),
   real_timestamp_ms: LakeIntSchema.nullable(),
 });
@@ -326,11 +323,14 @@ export async function fetchTimelineEventPage(options: {
   });
 }
 
-const TimelineFrameReadSchema = z.object({
+const TimelineFrameReadSchema = TimelineParticipantFrameLakeRowSchema.omit({
+  match_id: true,
+  month: true,
+  observed_at: true,
+}).extend({
   frame_index: LakeIntSchema,
   frame_timestamp_ms: LakeIntSchema,
   participant_id: LakeIntSchema,
-  puuid: z.string().nullable(),
   position_x: LakeIntSchema,
   position_y: LakeIntSchema,
   current_gold: LakeIntSchema,
@@ -340,21 +340,6 @@ const TimelineFrameReadSchema = z.object({
   jungle_minions_killed: LakeIntSchema,
   level: LakeIntSchema,
   xp: LakeIntSchema,
-  time_enemy_spent_controlled: z.number(),
-  ability_haste: z.number().nullable(),
-  ability_power: z.number().nullable(),
-  armor: z.number().nullable(),
-  attack_damage: z.number().nullable(),
-  attack_speed: z.number().nullable(),
-  health: z.number().nullable(),
-  health_max: z.number().nullable(),
-  magic_resist: z.number().nullable(),
-  movement_speed: z.number().nullable(),
-  power: z.number().nullable(),
-  power_max: z.number().nullable(),
-  total_damage_done: z.number().nullable(),
-  total_damage_done_to_champions: z.number().nullable(),
-  total_damage_taken: z.number().nullable(),
 });
 
 export type TimelineFrameRead = Omit<

--- a/packages/scout-for-lol/packages/backend/src/reports/duckdb/consumer-profile-lake-reads.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/duckdb/consumer-profile-lake-reads.ts
@@ -1,0 +1,427 @@
+import { z } from "zod";
+import type {
+  PlayerProfileGameWindow,
+  QueueType,
+  TimelineEventLakeRow,
+  TimelineParticipantFrameLakeRow,
+} from "@scout-for-lol/data";
+import { resolveLakeDir } from "#src/report-lake/paths.ts";
+import { withDuckDBConnection } from "#src/reports/duckdb/instance.ts";
+import { bindParams } from "#src/reports/duckdb/lake-reads.ts";
+import {
+  buildMatchesSource,
+  buildTimelineCoverageSource,
+  buildTimelineEventParticipantsSource,
+  buildTimelineEventsSource,
+  buildTimelineParticipantFramesSource,
+  listParam,
+  resolveLakeFiles,
+  scalarParam,
+  type BoundParam,
+  type SqlFragment,
+} from "#src/reports/duckdb/lake.ts";
+
+const LakeIntSchema = z.union([z.bigint(), z.number()]).transform(Number);
+
+async function runSource<T>(options: {
+  source: SqlFragment;
+  sql: string;
+  leadingParams?: BoundParam[];
+  trailingParams?: BoundParam[];
+  schema: z.ZodType<T>;
+}): Promise<T[]> {
+  return await withDuckDBConnection(async (session) => {
+    const rows = await session.run(
+      options.sql,
+      bindParams(session, [
+        ...(options.leadingParams ?? []),
+        ...options.source.params,
+        ...(options.trailingParams ?? []),
+      ]),
+    );
+    return rows.map((row) => options.schema.parse(row));
+  });
+}
+
+function queuePredicate(queues: QueueType[] | undefined): {
+  sql: string;
+  params: BoundParam[];
+} {
+  return queues === undefined
+    ? { sql: "", params: [] }
+    : {
+        sql: "queue IN (SELECT unnest(?))",
+        params: [listParam(queues)],
+      };
+}
+
+export type ChampionComparisonEntry = {
+  entryKey: string;
+  puuids: string[];
+};
+
+const ChampionComparisonRowSchema = z.object({
+  entry_key: z.string(),
+  champion_name: z.string(),
+  games: LakeIntSchema,
+  wins: LakeIntSchema,
+  kills: LakeIntSchema,
+  deaths: LakeIntSchema,
+  assists: LakeIntSchema,
+  creep_score: LakeIntSchema,
+  gold_earned: LakeIntSchema,
+  vision_score: LakeIntSchema,
+  damage_to_champions: LakeIntSchema,
+  time_played: LakeIntSchema,
+});
+
+export type LakeChampionComparisonRow = z.infer<
+  typeof ChampionComparisonRowSchema
+>;
+
+export async function fetchChampionComparisons(options: {
+  championId: number;
+  entries: ChampionComparisonEntry[];
+  games: PlayerProfileGameWindow;
+  queues?: QueueType[];
+  lakeDir?: string;
+}): Promise<LakeChampionComparisonRow[]> {
+  const pairs = options.entries.flatMap((entry) =>
+    entry.puuids.map((puuid) => ({ entryKey: entry.entryKey, puuid })),
+  );
+  if (pairs.length === 0) return [];
+  const files = await resolveLakeFiles(options.lakeDir ?? resolveLakeDir());
+  const allPuuids = [...new Set(pairs.map((pair) => pair.puuid))];
+  const queues = queuePredicate(options.queues);
+  const source = buildMatchesSource(files, {
+    sql: ["puuid IN (SELECT unnest(?))", "champion_id = ?", queues.sql]
+      .filter((part) => part.length > 0)
+      .join(" AND "),
+    params: [
+      listParam(allPuuids),
+      scalarParam(options.championId),
+      ...queues.params,
+    ],
+  });
+  if (source === undefined) return [];
+  const requestedSql = pairs.map(() => "(?, ?)").join(", ");
+  const requestedParams = pairs.flatMap((pair) => [
+    scalarParam(pair.entryKey),
+    scalarParam(pair.puuid),
+  ]);
+  const windowClause =
+    options.games === "all" ? "" : "WHERE player_game_rank <= ?";
+  const windowParams =
+    options.games === "all" ? [] : [scalarParam(options.games)];
+  return await runSource({
+    source,
+    leadingParams: requestedParams,
+    trailingParams: windowParams,
+    sql:
+      `WITH requested(entry_key, puuid) AS (VALUES ${requestedSql}), ` +
+      `deduped AS (` +
+      `SELECT requested.entry_key, matches.* FROM (${source.sql}) AS matches ` +
+      `INNER JOIN requested ON requested.puuid = matches.puuid ` +
+      `QUALIFY row_number() OVER (` +
+      `PARTITION BY requested.entry_key, matches.match_id ORDER BY matches.puuid) = 1), ` +
+      `ranked AS (` +
+      `SELECT *, row_number() OVER (` +
+      `PARTITION BY entry_key ORDER BY game_creation_at DESC, match_id DESC) AS player_game_rank ` +
+      `FROM deduped), scoped AS (SELECT * FROM ranked ${windowClause}) ` +
+      `SELECT entry_key, min(champion_name) AS champion_name, count(*)::BIGINT AS games, ` +
+      `sum(CASE WHEN win THEN 1 ELSE 0 END)::BIGINT AS wins, ` +
+      `sum(kills)::BIGINT AS kills, sum(deaths)::BIGINT AS deaths, ` +
+      `sum(assists)::BIGINT AS assists, sum(creep_score)::BIGINT AS creep_score, ` +
+      `sum(gold_earned)::BIGINT AS gold_earned, sum(vision_score)::BIGINT AS vision_score, ` +
+      `sum(total_damage_dealt_to_champions)::BIGINT AS damage_to_champions, ` +
+      `sum(time_played)::BIGINT AS time_played FROM scoped GROUP BY entry_key`,
+    schema: ChampionComparisonRowSchema,
+  });
+}
+
+const MatchParticipantRowSchema = z.object({
+  match_id: z.string(),
+  game_creation_ms: LakeIntSchema,
+  game_duration_seconds: LakeIntSchema,
+  queue: z.string().nullable(),
+  queue_id: LakeIntSchema,
+  game_mode: z.string(),
+  game_type: z.string(),
+  game_version: z.string(),
+  map_id: LakeIntSchema,
+  puuid: z.string(),
+  participant_id: LakeIntSchema,
+  team_id: LakeIntSchema,
+  riot_id_game_name: z.string().nullable(),
+  riot_id_tagline: z.string(),
+  champion_id: LakeIntSchema,
+  champion_name: z.string(),
+  team_position: z.string(),
+  win: z.boolean(),
+  kills: LakeIntSchema,
+  deaths: LakeIntSchema,
+  assists: LakeIntSchema,
+  creep_score: LakeIntSchema,
+  gold_earned: LakeIntSchema,
+  vision_score: LakeIntSchema,
+  total_damage_dealt_to_champions: LakeIntSchema,
+  turret_kills: LakeIntSchema,
+  inhibitor_kills: LakeIntSchema,
+  baron_kills: LakeIntSchema,
+  dragon_kills: LakeIntSchema,
+});
+
+export type LakeMatchParticipantRow = z.infer<typeof MatchParticipantRowSchema>;
+
+export async function fetchFullMatch(options: {
+  matchId: string;
+  lakeDir?: string;
+}): Promise<LakeMatchParticipantRow[]> {
+  const files = await resolveLakeFiles(options.lakeDir ?? resolveLakeDir());
+  const source = buildMatchesSource(files, {
+    sql: "match_id = ?",
+    params: [scalarParam(options.matchId)],
+  });
+  if (source === undefined) return [];
+  return await runSource({
+    source,
+    sql:
+      `SELECT match_id, epoch_ms(game_creation_at)::BIGINT AS game_creation_ms, ` +
+      `game_duration_seconds, queue, queue_id, game_mode, game_type, game_version, map_id, ` +
+      `puuid, participant_id, team_id, riot_id_game_name, riot_id_tagline, ` +
+      `champion_id, champion_name, team_position, win, kills, deaths, assists, creep_score, ` +
+      `gold_earned, vision_score, total_damage_dealt_to_champions, turret_kills, ` +
+      `inhibitor_kills, baron_kills, dragon_kills FROM (${source.sql}) ` +
+      `ORDER BY team_id, participant_id`,
+    schema: MatchParticipantRowSchema,
+  });
+}
+
+const TimelineCoverageRowSchema = z.object({
+  coverage_state: z.literal("complete"),
+  data_version: z.string(),
+  frame_interval_ms: LakeIntSchema,
+  frame_count: LakeIntSchema,
+  event_count: LakeIntSchema,
+  participant_count: LakeIntSchema,
+  first_frame_timestamp_ms: LakeIntSchema.nullable(),
+  last_frame_timestamp_ms: LakeIntSchema.nullable(),
+});
+
+export type LakeTimelineCoverage = z.infer<typeof TimelineCoverageRowSchema>;
+
+export async function fetchTimelineCoverage(options: {
+  matchId: string;
+  lakeDir?: string;
+}): Promise<LakeTimelineCoverage | null> {
+  const files = await resolveLakeFiles(options.lakeDir ?? resolveLakeDir());
+  const source = buildTimelineCoverageSource(files, {
+    sql: "match_id = ?",
+    params: [scalarParam(options.matchId)],
+  });
+  if (source === undefined) return null;
+  const rows = await runSource({
+    source,
+    sql:
+      `SELECT coverage_state, data_version, frame_interval_ms, frame_count, event_count, ` +
+      `participant_count, first_frame_timestamp_ms, last_frame_timestamp_ms ` +
+      `FROM (${source.sql}) LIMIT 1`,
+    schema: TimelineCoverageRowSchema,
+  });
+  return rows[0] ?? null;
+}
+
+const TimelineEventReadSchema = z.object({
+  event_id: z.string(),
+  frame_index: LakeIntSchema,
+  event_index: LakeIntSchema,
+  frame_timestamp_ms: LakeIntSchema,
+  event_timestamp_ms: LakeIntSchema,
+  event_type: z.string(),
+  participant_id: LakeIntSchema.nullable(),
+  killer_id: LakeIntSchema.nullable(),
+  victim_id: LakeIntSchema.nullable(),
+  creator_id: LakeIntSchema.nullable(),
+  team_id: LakeIntSchema.nullable(),
+  killer_team_id: LakeIntSchema.nullable(),
+  item_id: LakeIntSchema.nullable(),
+  after_id: LakeIntSchema.nullable(),
+  before_id: LakeIntSchema.nullable(),
+  skill_slot: LakeIntSchema.nullable(),
+  level: LakeIntSchema.nullable(),
+  bounty: LakeIntSchema.nullable(),
+  shutdown_bounty: LakeIntSchema.nullable(),
+  kill_streak_length: LakeIntSchema.nullable(),
+  gold_gain: LakeIntSchema.nullable(),
+  position_x: LakeIntSchema.nullable(),
+  position_y: LakeIntSchema.nullable(),
+  ward_type: z.string().nullable(),
+  building_type: z.string().nullable(),
+  lane_type: z.string().nullable(),
+  tower_type: z.string().nullable(),
+  monster_type: z.string().nullable(),
+  monster_sub_type: z.string().nullable(),
+  level_up_type: z.string().nullable(),
+  winning_team_id: LakeIntSchema.nullable(),
+  real_timestamp_ms: LakeIntSchema.nullable(),
+});
+
+export type TimelineEventRead = Omit<
+  TimelineEventLakeRow,
+  "match_id" | "month" | "observed_at"
+>;
+
+const TIMELINE_EVENT_COLUMNS = Object.keys(TimelineEventReadSchema.shape).join(
+  ", ",
+);
+
+export async function fetchTimelineEventPage(options: {
+  matchId: string;
+  offset: number;
+  limit: number;
+  eventTypes?: string[];
+  participantIds?: number[];
+  lakeDir?: string;
+}): Promise<TimelineEventRead[]> {
+  const files = await resolveLakeFiles(options.lakeDir ?? resolveLakeDir());
+  const clauses = ["match_id = ?"];
+  const params: BoundParam[] = [scalarParam(options.matchId)];
+  if (options.eventTypes !== undefined) {
+    clauses.push("event_type IN (SELECT unnest(?))");
+    params.push(listParam(options.eventTypes));
+  }
+  const source = buildTimelineEventsSource(files, {
+    sql: clauses.join(" AND "),
+    params,
+  });
+  if (source === undefined) return [];
+  const participantSource =
+    options.participantIds === undefined
+      ? undefined
+      : buildTimelineEventParticipantsSource(files, {
+          sql: "match_id = ? AND participant_id IN (SELECT unnest(?))",
+          params: [
+            scalarParam(options.matchId),
+            listParam(options.participantIds),
+          ],
+        });
+  if (participantSource === undefined && options.participantIds !== undefined) {
+    return [];
+  }
+  const participantClause =
+    participantSource === undefined
+      ? ""
+      : `WHERE event_id IN (SELECT event_id FROM (${participantSource.sql}))`;
+  return await runSource({
+    source,
+    trailingParams: [
+      ...(participantSource?.params ?? []),
+      scalarParam(Math.floor(options.limit)),
+      scalarParam(Math.floor(options.offset)),
+    ],
+    sql:
+      `SELECT ${TIMELINE_EVENT_COLUMNS} FROM (${source.sql}) ${participantClause} ` +
+      `ORDER BY event_timestamp_ms, frame_index, event_index, event_id LIMIT ? OFFSET ?`,
+    schema: TimelineEventReadSchema,
+  });
+}
+
+const TimelineFrameReadSchema = z.object({
+  frame_index: LakeIntSchema,
+  frame_timestamp_ms: LakeIntSchema,
+  participant_id: LakeIntSchema,
+  puuid: z.string().nullable(),
+  position_x: LakeIntSchema,
+  position_y: LakeIntSchema,
+  current_gold: LakeIntSchema,
+  total_gold: LakeIntSchema,
+  gold_per_second: LakeIntSchema,
+  minions_killed: LakeIntSchema,
+  jungle_minions_killed: LakeIntSchema,
+  level: LakeIntSchema,
+  xp: LakeIntSchema,
+  time_enemy_spent_controlled: z.number(),
+  ability_haste: z.number().nullable(),
+  ability_power: z.number().nullable(),
+  armor: z.number().nullable(),
+  attack_damage: z.number().nullable(),
+  attack_speed: z.number().nullable(),
+  health: z.number().nullable(),
+  health_max: z.number().nullable(),
+  magic_resist: z.number().nullable(),
+  movement_speed: z.number().nullable(),
+  power: z.number().nullable(),
+  power_max: z.number().nullable(),
+  total_damage_done: z.number().nullable(),
+  total_damage_done_to_champions: z.number().nullable(),
+  total_damage_taken: z.number().nullable(),
+});
+
+export type TimelineFrameRead = Omit<
+  TimelineParticipantFrameLakeRow,
+  "match_id" | "month" | "observed_at"
+>;
+
+const TIMELINE_FRAME_COLUMNS = Object.keys(TimelineFrameReadSchema.shape).join(
+  ", ",
+);
+
+export async function fetchTimelineFramePage(options: {
+  matchId: string;
+  offset: number;
+  limit: number;
+  participantIds?: number[];
+  lakeDir?: string;
+}): Promise<TimelineFrameRead[]> {
+  const files = await resolveLakeFiles(options.lakeDir ?? resolveLakeDir());
+  const clauses = ["match_id = ?"];
+  const params: BoundParam[] = [scalarParam(options.matchId)];
+  if (options.participantIds !== undefined) {
+    clauses.push("participant_id IN (SELECT unnest(?))");
+    params.push(listParam(options.participantIds));
+  }
+  const source = buildTimelineParticipantFramesSource(files, {
+    sql: clauses.join(" AND "),
+    params,
+  });
+  if (source === undefined) return [];
+  return await runSource({
+    source,
+    trailingParams: [
+      scalarParam(Math.floor(options.limit)),
+      scalarParam(Math.floor(options.offset)),
+    ],
+    sql:
+      `SELECT ${TIMELINE_FRAME_COLUMNS} FROM (${source.sql}) ` +
+      `ORDER BY frame_timestamp_ms, participant_id LIMIT ? OFFSET ?`,
+    schema: TimelineFrameReadSchema,
+  });
+}
+
+const TimelineChartFrameSchema = z.object({
+  frame_timestamp_ms: LakeIntSchema,
+  participant_id: LakeIntSchema,
+  total_gold: LakeIntSchema,
+  xp: LakeIntSchema,
+});
+
+export type TimelineChartFrame = z.infer<typeof TimelineChartFrameSchema>;
+
+export async function fetchTimelineChartFrames(options: {
+  matchId: string;
+  lakeDir?: string;
+}): Promise<TimelineChartFrame[]> {
+  const files = await resolveLakeFiles(options.lakeDir ?? resolveLakeDir());
+  const source = buildTimelineParticipantFramesSource(files, {
+    sql: "match_id = ?",
+    params: [scalarParam(options.matchId)],
+  });
+  if (source === undefined) return [];
+  return await runSource({
+    source,
+    sql:
+      `SELECT frame_timestamp_ms, participant_id, total_gold, xp FROM (${source.sql}) ` +
+      `ORDER BY frame_timestamp_ms, participant_id`,
+    schema: TimelineChartFrameSchema,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/reports/duckdb/lake-reads.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/duckdb/lake-reads.ts
@@ -1,5 +1,7 @@
 import {
   CachedLeaderboardSchema,
+  type PlayerProfileGameWindow,
+  type QueueType,
   type CachedLeaderboard,
   type CompetitionId,
 } from "@scout-for-lol/data";
@@ -237,12 +239,17 @@ async function runLakeQuery<T>(options: {
 function playerPredicate(options: {
   puuids: string[];
   queue?: string;
+  queues?: QueueType[];
 }): SqlFragment {
   const sql = ["puuid IN (SELECT unnest(?))"];
   const params: BoundParam[] = [listParam(options.puuids)];
   if (options.queue !== undefined) {
     sql.push("queue = ?");
     params.push(scalarParam(options.queue));
+  }
+  if (options.queues !== undefined) {
+    sql.push("queue IN (SELECT unnest(?))");
+    params.push(listParam(options.queues));
   }
   return { sql: sql.join(" AND "), params };
 }
@@ -288,6 +295,7 @@ const DEDUPE_TO_ONE_ROW_PER_MATCH =
 export type MatchHistoryCursor = {
   gameCreationMs: number;
   matchId: string;
+  consumed?: number | undefined;
 };
 
 /**
@@ -303,9 +311,10 @@ export type MatchHistoryCursor = {
  */
 export async function fetchPlayerMatchHistory(options: {
   puuids: string[];
-  limit: number;
+  limit?: number;
   cursor?: MatchHistoryCursor;
   queue?: string;
+  queues?: QueueType[];
   lakeDir?: string;
 }): Promise<LakePlayerMatchHistoryRow[]> {
   if (options.puuids.length === 0) {
@@ -332,6 +341,7 @@ export async function fetchPlayerMatchHistory(options: {
   if (source === undefined) {
     return [];
   }
+  const limitSql = options.limit === undefined ? "" : "LIMIT ?";
   return await runLakeQuery({
     source,
     sql:
@@ -340,8 +350,11 @@ export async function fetchPlayerMatchHistory(options: {
       `team_position, team_id, win, kills, deaths, assists, creep_score, ` +
       `gold_earned, total_damage_dealt_to_champions, vision_score, time_played ` +
       `FROM (${source.sql}) ${DEDUPE_TO_ONE_ROW_PER_MATCH} ` +
-      `ORDER BY game_creation_ms DESC, match_id DESC LIMIT ?`,
-    extraParams: [scalarParam(Math.floor(options.limit))],
+      `ORDER BY game_creation_ms DESC, match_id DESC ${limitSql}`,
+    extraParams:
+      options.limit === undefined
+        ? []
+        : [scalarParam(Math.floor(options.limit))],
     schema: PlayerMatchHistoryRowSchema,
   });
 }
@@ -372,6 +385,8 @@ export type LakeChampionPoolRow = z.infer<typeof ChampionPoolRowSchema>;
 export async function fetchPlayerChampionPool(options: {
   puuids: string[];
   queue?: string;
+  queues?: QueueType[];
+  games?: PlayerProfileGameWindow;
   lakeDir?: string;
 }): Promise<LakeChampionPoolRow[]> {
   if (options.puuids.length === 0) {
@@ -384,16 +399,25 @@ export async function fetchPlayerChampionPool(options: {
   if (source === undefined) {
     return [];
   }
+  const limitSql =
+    options.games === 20 || options.games === 50 ? "LIMIT ?" : "";
   return await runLakeQuery({
     source,
     sql:
+      `WITH player_matches AS (` +
+      `SELECT * FROM (${source.sql}) ${DEDUPE_TO_ONE_ROW_PER_MATCH} ` +
+      `ORDER BY game_creation_at DESC, match_id DESC ${limitSql}) ` +
       `SELECT champion_id, champion_name, count(*) AS games, ` +
       `sum(CASE WHEN win THEN 1 ELSE 0 END)::BIGINT AS wins, ` +
       `sum(kills)::BIGINT AS kills, sum(deaths)::BIGINT AS deaths, ` +
       `sum(assists)::BIGINT AS assists, sum(creep_score)::BIGINT AS creep_score, ` +
       `sum(time_played)::BIGINT AS time_played ` +
-      `FROM (SELECT * FROM (${source.sql}) ${DEDUPE_TO_ONE_ROW_PER_MATCH}) ` +
+      `FROM player_matches ` +
       `GROUP BY champion_id, champion_name ORDER BY games DESC, champion_name ASC`,
+    extraParams:
+      options.games === 20 || options.games === 50
+        ? [scalarParam(options.games)]
+        : [],
     schema: ChampionPoolRowSchema,
   });
 }

--- a/packages/scout-for-lol/packages/backend/src/testing/consumer-profile-feature-test.ts
+++ b/packages/scout-for-lol/packages/backend/src/testing/consumer-profile-feature-test.ts
@@ -1,0 +1,79 @@
+import type { DiscordGuildId } from "@scout-for-lol/data";
+import { afterAll, beforeAll, beforeEach } from "vitest";
+import {
+  initFeatureFlags,
+  shutdownFeatureFlags,
+} from "@shepherdjerred/feature-flags";
+import { resetConfigurationForTests } from "#src/configuration.ts";
+import {
+  addFlagOverride,
+  resetFlagOverrides,
+} from "#src/configuration/flags.ts";
+import { resolveLakeDir } from "#src/report-lake/paths.ts";
+import { resetTestLake } from "#src/testing/test-report-lake.ts";
+
+const PLAYER_PROFILE_FLAG = "scout-consumer-player-profiles-enabled";
+
+export function configureConsumerProfileFeatureTest(
+  guildIds: DiscordGuildId[],
+) {
+  const previousEnvironment = Bun.env["ENVIRONMENT"];
+  const previousAllowlist = Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+  Bun.env["ENVIRONMENT"] = "beta";
+  Bun.env["EXPLORE_GUILD_ALLOWLIST"] = guildIds.join(",");
+  resetConfigurationForTests();
+  const lakeDir = resolveLakeDir();
+
+  return {
+    lakeDir,
+    initialize: async () => {
+      await initFeatureFlags({
+        environment: { FEATURE_FLAGS_MODE: "disabled" },
+      });
+    },
+    enable: (...enabledGuildIds: DiscordGuildId[]) => {
+      for (const server of enabledGuildIds) {
+        addFlagOverride(PLAYER_PROFILE_FLAG, true, { server });
+      }
+    },
+    reset: () => {
+      resetFlagOverrides(PLAYER_PROFILE_FLAG);
+    },
+    resetLake: async () => {
+      await resetTestLake(lakeDir);
+    },
+    restore: async () => {
+      resetFlagOverrides(PLAYER_PROFILE_FLAG);
+      await shutdownFeatureFlags();
+      if (previousEnvironment === undefined) delete Bun.env["ENVIRONMENT"];
+      else Bun.env["ENVIRONMENT"] = previousEnvironment;
+      if (previousAllowlist === undefined)
+        delete Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+      else Bun.env["EXPLORE_GUILD_ALLOWLIST"] = previousAllowlist;
+      resetConfigurationForTests();
+    },
+  };
+}
+
+type ConsumerProfileFeatureTest = ReturnType<
+  typeof configureConsumerProfileFeatureTest
+>;
+
+export function registerConsumerProfileFeatureTestLifecycle(options: {
+  feature: ConsumerProfileFeatureTest;
+  prepare: () => Promise<void>;
+  cleanup: () => Promise<void>;
+}): void {
+  beforeAll(options.feature.initialize);
+  beforeEach(async () => {
+    options.feature.reset();
+    await options.prepare();
+  });
+  afterAll(async () => {
+    try {
+      await options.cleanup();
+    } finally {
+      await options.feature.restore();
+    }
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/testing/test-report-lake.ts
+++ b/packages/scout-for-lol/packages/backend/src/testing/test-report-lake.ts
@@ -5,6 +5,10 @@ import {
   type AccountLakeRow,
   type MatchLakeRow,
   type PrematchLakeRow,
+  type TimelineCoverageLakeRow,
+  type TimelineEventParticipantLakeRow,
+  type TimelineEventLakeRow,
+  type TimelineParticipantFrameLakeRow,
 } from "@scout-for-lol/data";
 import {
   duckDbColumnsSpec,
@@ -19,6 +23,7 @@ import {
 import {
   matchStagingFilePath,
   prematchStagingFilePath,
+  timelineStagingFilePath,
 } from "#src/report-lake/staging.ts";
 import { withDuckDBConnection } from "#src/reports/duckdb/instance.ts";
 
@@ -223,29 +228,24 @@ export async function resetTestLake(lakeDir: string): Promise<void> {
   await ensureLakeScaffold(lakeDir);
 }
 
-export async function writeTestLake(
-  lakeDir: string,
-  input: {
-    serverId: string;
-    matchFacts?: TestLakeMatchFact[];
-    prematchFacts?: TestLakePrematchFact[];
-    /**
-     * Additional servers that also track every account above, producing a
-     * second accounts row per (server, account) exactly as the compactor does.
-     * This is the shape that makes an unscoped accounts join double-count, so
-     * global-scope tests need it to be meaningful.
-     */
-    alsoTrackedBy?: string[];
-    /**
-     * Match facts written to the lake but deliberately absent from the accounts
-     * dimension — the other nine participants of a game Scout ingested for one
-     * tracked player. Guild scope must not see them; global scope must.
-     */
-    untrackedMatchFacts?: TestLakeMatchFact[];
-  },
-): Promise<void> {
-  await ensureLakeScaffold(lakeDir);
+type TestLakeInput = {
+  serverId: string;
+  matchFacts?: TestLakeMatchFact[];
+  prematchFacts?: TestLakePrematchFact[];
+  /** Additional servers that also track every account above. */
+  alsoTrackedBy?: string[];
+  /** Full-match participants deliberately absent from the accounts dimension. */
+  untrackedMatchFacts?: TestLakeMatchFact[];
+  timelineEvents?: TimelineEventLakeRow[];
+  timelineEventParticipants?: TimelineEventParticipantLakeRow[];
+  timelineFrames?: TimelineParticipantFrameLakeRow[];
+  timelineCoverage?: TimelineCoverageLakeRow[];
+};
 
+async function writeTestAccounts(
+  lakeDir: string,
+  input: TestLakeInput,
+): Promise<void> {
   // Accounts dimension: one account per distinct (server, playerId, puuid).
   const accountsByKey = new Map<string, AccountLakeRow>();
   const allFacts = [
@@ -289,7 +289,12 @@ export async function writeTestLake(
   });
   await rm(accountsNdjson);
   await publishBuild(lakeDir, buildId);
+}
 
+async function writeTestMatches(
+  lakeDir: string,
+  input: TestLakeInput,
+): Promise<void> {
   // Match rows: one staging file per matchId (exercises the union path).
   // Untracked facts are written alongside tracked ones — the lake makes no
   // distinction; only the accounts dimension above does.
@@ -308,7 +313,12 @@ export async function writeTestLake(
       rows.map((row) => JSON.stringify(row)).join("\n") + "\n",
     );
   }
+}
 
+async function writeTestPrematches(
+  lakeDir: string,
+  input: TestLakeInput,
+): Promise<void> {
   const byPrematch = new Map<string, PrematchLakeRow[]>();
   for (const fact of input.prematchFacts ?? []) {
     const rows = byPrematch.get(fact.dedupeKey) ?? [];
@@ -321,4 +331,57 @@ export async function writeTestLake(
       rows.map((row) => JSON.stringify(row)).join("\n") + "\n",
     );
   }
+}
+
+async function writeTestTimelineRows(
+  lakeDir: string,
+  table:
+    | "timeline_events"
+    | "timeline_event_participants"
+    | "timeline_participant_frames"
+    | "timeline_coverage",
+  rows: { match_id: string }[],
+): Promise<void> {
+  const rowsByMatch = new Map<string, { match_id: string }[]>();
+  for (const row of rows) {
+    const matchRows = rowsByMatch.get(row.match_id) ?? [];
+    matchRows.push(row);
+    rowsByMatch.set(row.match_id, matchRows);
+  }
+  for (const [matchId, matchRows] of rowsByMatch) {
+    await Bun.write(
+      timelineStagingFilePath(lakeDir, table, matchId),
+      matchRows.map((row) => JSON.stringify(row)).join("\n") + "\n",
+    );
+  }
+}
+
+export async function writeTestLake(
+  lakeDir: string,
+  input: TestLakeInput,
+): Promise<void> {
+  await ensureLakeScaffold(lakeDir);
+  await writeTestAccounts(lakeDir, input);
+  await writeTestMatches(lakeDir, input);
+  await writeTestPrematches(lakeDir, input);
+  await writeTestTimelineRows(
+    lakeDir,
+    "timeline_events",
+    input.timelineEvents ?? [],
+  );
+  await writeTestTimelineRows(
+    lakeDir,
+    "timeline_event_participants",
+    input.timelineEventParticipants ?? [],
+  );
+  await writeTestTimelineRows(
+    lakeDir,
+    "timeline_participant_frames",
+    input.timelineFrames ?? [],
+  );
+  await writeTestTimelineRows(
+    lakeDir,
+    "timeline_coverage",
+    input.timelineCoverage ?? [],
+  );
 }

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/consumer-champion.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/consumer-champion.router.ts
@@ -1,0 +1,200 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import {
+  ChampionComparisonCohortSchema,
+  ChampionComparisonCursorSchema,
+  ChampionComparisonSortSchema,
+  ChampionIdSchema,
+  DiscordGuildIdSchema,
+  PlayerProfileGameWindowSchema,
+  PlayerProfileQueueSelectionSchema,
+  getChampionDisplayName,
+  type ChampionComparisonSort,
+} from "@scout-for-lol/data";
+import { prisma } from "#src/database/index.ts";
+import { assertConsumerPlayerScope } from "#src/consumer/player-access.ts";
+import { fetchChampionComparisons } from "#src/reports/duckdb/consumer-profile-lake-reads.ts";
+import { protectedProcedure, router } from "#src/trpc/trpc.ts";
+
+const PAGE_SIZE = 25;
+const QUALIFYING_GAMES = 10;
+
+const GuildSelectionSchema = z
+  .array(DiscordGuildIdSchema)
+  .min(1)
+  .superRefine((guildIds, context) => {
+    if (new Set(guildIds).size !== guildIds.length) {
+      context.addIssue({ code: "custom", message: "Guilds must be unique" });
+    }
+  });
+
+const ComparisonInput = z.object({
+  championId: ChampionIdSchema,
+  games: PlayerProfileGameWindowSchema.default(20),
+  queues: PlayerProfileQueueSelectionSchema.optional(),
+  guildIds: GuildSelectionSchema.optional(),
+  cohort: ChampionComparisonCohortSchema.default("qualified"),
+  sort: ChampionComparisonSortSchema.default("win_rate"),
+  cursor: ChampionComparisonCursorSchema.optional(),
+});
+
+type ComparisonRow = {
+  playerId: number;
+  alias: string;
+  guild: { guildId: string; name: string };
+  viewerLinked: boolean;
+  games: number;
+  wins: number;
+  losses: number;
+  winRate: number;
+  kda: number;
+  csPerMinute: number;
+  damagePerMinute: number;
+  goldPerMinute: number;
+  visionPerMinute: number;
+};
+
+function metric(row: ComparisonRow, sort: ChampionComparisonSort): number {
+  switch (sort) {
+    case "win_rate":
+      return row.winRate;
+    case "games":
+      return row.games;
+    case "kda":
+      return row.kda;
+    case "cs_per_minute":
+      return row.csPerMinute;
+    case "damage_per_minute":
+      return row.damagePerMinute;
+    case "gold_per_minute":
+      return row.goldPerMinute;
+    case "vision_per_minute":
+      return row.visionPerMinute;
+    case "alias":
+      return 0;
+  }
+}
+
+function comparisonOrder(
+  sort: ChampionComparisonSort,
+): (left: ComparisonRow, right: ComparisonRow) => number {
+  return (left, right) => {
+    if (sort === "alias") {
+      const alias = left.alias.localeCompare(right.alias);
+      if (alias !== 0) return alias;
+    } else {
+      const selected = metric(right, sort) - metric(left, sort);
+      if (selected !== 0) return selected;
+    }
+    if (sort !== "games" && right.games !== left.games) {
+      return right.games - left.games;
+    }
+    if (sort !== "kda" && right.kda !== left.kda) {
+      return right.kda - left.kda;
+    }
+    if (sort !== "alias") {
+      const alias = left.alias.localeCompare(right.alias);
+      if (alias !== 0) return alias;
+    }
+    const guild = left.guild.name.localeCompare(right.guild.name);
+    if (guild !== 0) return guild;
+    return left.playerId - right.playerId;
+  };
+}
+
+export const consumerChampionRouter = router({
+  compare: protectedProcedure
+    .input(ComparisonInput)
+    .query(async ({ ctx, input }) => {
+      const accessibleGuilds = await assertConsumerPlayerScope(ctx.user);
+      const accessibleIds = new Set(accessibleGuilds.map((guild) => guild.id));
+      const selectedGuildIds =
+        input.guildIds ??
+        accessibleGuilds.map((guild) => DiscordGuildIdSchema.parse(guild.id));
+      if (selectedGuildIds.some((guildId) => !accessibleIds.has(guildId))) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Requested guild is outside the current player scope",
+        });
+      }
+      const players = await prisma.player.findMany({
+        where: { serverId: { in: selectedGuildIds } },
+        select: {
+          id: true,
+          alias: true,
+          serverId: true,
+          discordId: true,
+          accounts: { select: { puuid: true } },
+        },
+      });
+      const lakeRows = await fetchChampionComparisons({
+        championId: input.championId,
+        games: input.games,
+        entries: players.map((player) => ({
+          entryKey: player.id.toString(),
+          puuids: player.accounts.map((account) => account.puuid),
+        })),
+        ...(input.queues === undefined ? {} : { queues: input.queues }),
+      });
+      const playerById = new Map(
+        players.map((player) => [player.id.toString(), player] as const),
+      );
+      const guildById = new Map(
+        accessibleGuilds.map((guild) => [guild.id, guild] as const),
+      );
+      const rows = lakeRows.map((lakeRow): ComparisonRow => {
+        const player = playerById.get(lakeRow.entry_key);
+        if (player === undefined) {
+          throw new Error("Champion comparison returned an unrequested player");
+        }
+        const guild = guildById.get(player.serverId);
+        if (guild === undefined) {
+          throw new Error("Champion comparison returned an unscoped guild");
+        }
+        const minutes = lakeRow.time_played / 60;
+        return {
+          playerId: player.id,
+          alias: player.alias,
+          guild: { guildId: guild.id, name: guild.name },
+          viewerLinked: player.discordId === ctx.user.discordId,
+          games: lakeRow.games,
+          wins: lakeRow.wins,
+          losses: lakeRow.games - lakeRow.wins,
+          winRate: lakeRow.wins / lakeRow.games,
+          kda:
+            lakeRow.deaths === 0
+              ? lakeRow.kills + lakeRow.assists
+              : (lakeRow.kills + lakeRow.assists) / lakeRow.deaths,
+          csPerMinute: minutes > 0 ? lakeRow.creep_score / minutes : 0,
+          damagePerMinute:
+            minutes > 0 ? lakeRow.damage_to_champions / minutes : 0,
+          goldPerMinute: minutes > 0 ? lakeRow.gold_earned / minutes : 0,
+          visionPerMinute: minutes > 0 ? lakeRow.vision_score / minutes : 0,
+        };
+      });
+      const cohortRows = rows
+        .filter((row) =>
+          input.cohort === "qualified"
+            ? row.games >= QUALIFYING_GAMES
+            : row.games < QUALIFYING_GAMES,
+        )
+        .toSorted(comparisonOrder(input.sort));
+      const offset = input.cursor?.offset ?? 0;
+      const page = cohortRows.slice(offset, offset + PAGE_SIZE);
+      const nextOffset = offset + page.length;
+      return {
+        champion: {
+          championId: input.championId,
+          name: getChampionDisplayName(input.championId),
+        },
+        qualifyingGames: QUALIFYING_GAMES,
+        availableGuilds: accessibleGuilds.map((guild) => ({
+          guildId: guild.id,
+          name: guild.name,
+        })),
+        rows: page,
+        nextCursor:
+          nextOffset < cohortRows.length ? { offset: nextOffset } : null,
+      };
+    }),
+});

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/consumer-match.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/consumer-match.router.ts
@@ -1,0 +1,321 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import {
+  MatchIdSchema,
+  PlayerIdSchema,
+  TimelineCursorSchema,
+  TimelineEventFilterSchema,
+} from "@scout-for-lol/data";
+import type { User } from "#generated/prisma/client/index.js";
+import { assertConsumerPlayerScope } from "#src/consumer/player-access.ts";
+import { prisma } from "#src/database/index.ts";
+import {
+  fetchFullMatch,
+  fetchTimelineChartFrames,
+  fetchTimelineCoverage,
+  fetchTimelineEventPage,
+  fetchTimelineFramePage,
+  type LakeMatchParticipantRow,
+} from "#src/reports/duckdb/consumer-profile-lake-reads.ts";
+import { protectedProcedure, router } from "#src/trpc/trpc.ts";
+
+const PAGE_SIZE = 100;
+const KEY_EVENT_TYPES = [
+  "CHAMPION_KILL",
+  "ELITE_MONSTER_KILL",
+  "BUILDING_KILL",
+  "GAME_END",
+];
+
+const MatchInput = z.object({
+  playerId: PlayerIdSchema,
+  matchId: MatchIdSchema,
+});
+
+const TimelinePageInput = MatchInput.extend({
+  participantIds: TimelineEventFilterSchema.shape.participantIds,
+  cursor: TimelineCursorSchema.optional(),
+});
+
+const TimelineEventPageInput = TimelinePageInput.extend({
+  eventTypes: TimelineEventFilterSchema.shape.eventTypes,
+});
+
+type AuthorizedMatch = {
+  player: { id: number; puuids: Set<string> };
+  rows: LakeMatchParticipantRow[];
+  aliasesByPuuid: Map<
+    string,
+    { playerId: number; alias: string; guildName: string }[]
+  >;
+};
+
+async function authorizeMatch(
+  user: User,
+  input: z.infer<typeof MatchInput>,
+): Promise<AuthorizedMatch> {
+  const guilds = await assertConsumerPlayerScope(user);
+  const guildIds = guilds.map((guild) => guild.id);
+  const player = await prisma.player.findFirst({
+    where: { id: input.playerId, serverId: { in: guildIds } },
+    select: { id: true, accounts: { select: { puuid: true } } },
+  });
+  if (player === null) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Match was not found" });
+  }
+  const rows = await fetchFullMatch({ matchId: input.matchId });
+  const playerPuuids = new Set<string>(
+    player.accounts.map((account) => account.puuid),
+  );
+  if (!rows.some((row) => playerPuuids.has(row.puuid))) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Match was not found" });
+  }
+  const trackedAccounts = await prisma.account.findMany({
+    where: {
+      puuid: { in: rows.map((row) => row.puuid) },
+      player: { serverId: { in: guildIds } },
+    },
+    select: {
+      puuid: true,
+      player: { select: { id: true, alias: true, serverId: true } },
+    },
+  });
+  const guildNameById = new Map(
+    guilds.map((guild) => [guild.id, guild.name] as const),
+  );
+  const aliasesByPuuid = new Map<
+    string,
+    { playerId: number; alias: string; guildName: string }[]
+  >();
+  for (const account of trackedAccounts) {
+    const guildName = guildNameById.get(account.player.serverId);
+    if (guildName === undefined) {
+      throw new Error("Tracked match alias resolved outside its request scope");
+    }
+    const aliases = aliasesByPuuid.get(account.puuid) ?? [];
+    aliases.push({
+      playerId: account.player.id,
+      alias: account.player.alias,
+      guildName,
+    });
+    aliasesByPuuid.set(account.puuid, aliases);
+  }
+  return {
+    player: { id: player.id, puuids: playerPuuids },
+    rows,
+    aliasesByPuuid,
+  };
+}
+
+function teamTotals(rows: LakeMatchParticipantRow[]) {
+  const totals = new Map<number, { kills: number; damage: number }>();
+  for (const row of rows) {
+    const current = totals.get(row.team_id) ?? { kills: 0, damage: 0 };
+    current.kills += row.kills;
+    current.damage += row.total_damage_dealt_to_champions;
+    totals.set(row.team_id, current);
+  }
+  return totals;
+}
+
+function ratio(part: number, total: number): number | null {
+  return total > 0 ? part / total : null;
+}
+
+function matchView(match: AuthorizedMatch) {
+  const first = match.rows[0];
+  if (first === undefined) {
+    throw new Error("Authorized match has no participants");
+  }
+  const totals = teamTotals(match.rows);
+  const participants = match.rows.map((row) => {
+    const team = totals.get(row.team_id);
+    if (team === undefined) {
+      throw new Error("Match participant has no team totals");
+    }
+    return {
+      participantId: row.participant_id,
+      teamId: row.team_id,
+      selectedPlayer: match.player.puuids.has(row.puuid),
+      riotId: {
+        gameName: row.riot_id_game_name,
+        tagLine: row.riot_id_tagline,
+      },
+      championId: row.champion_id,
+      championName: row.champion_name,
+      position: row.team_position,
+      win: row.win,
+      kills: row.kills,
+      deaths: row.deaths,
+      assists: row.assists,
+      creepScore: row.creep_score,
+      goldEarned: row.gold_earned,
+      visionScore: row.vision_score,
+      damageToChampions: row.total_damage_dealt_to_champions,
+      killParticipation: ratio(row.kills + row.assists, team.kills),
+      damageShare: ratio(row.total_damage_dealt_to_champions, team.damage),
+      objectives: {
+        turrets: row.turret_kills,
+        inhibitors: row.inhibitor_kills,
+        barons: row.baron_kills,
+        dragons: row.dragon_kills,
+      },
+      scoutAliases: match.aliasesByPuuid.get(row.puuid) ?? [],
+    };
+  });
+  const teams = [...new Set(match.rows.map((row) => row.team_id))].map(
+    (teamId) => {
+      const teamRows = participants.filter(
+        (participant) => participant.teamId === teamId,
+      );
+      const teamFirst = teamRows[0];
+      if (teamFirst === undefined) {
+        throw new Error("Match team has no participants");
+      }
+      return {
+        teamId,
+        win: teamFirst.win,
+        participants: teamRows,
+        objectives: teamRows.reduce(
+          (sum, participant) => ({
+            turrets: sum.turrets + participant.objectives.turrets,
+            inhibitors: sum.inhibitors + participant.objectives.inhibitors,
+            barons: sum.barons + participant.objectives.barons,
+            dragons: sum.dragons + participant.objectives.dragons,
+          }),
+          { turrets: 0, inhibitors: 0, barons: 0, dragons: 0 },
+        ),
+      };
+    },
+  );
+  return {
+    matchId: first.match_id,
+    gameCreationMs: first.game_creation_ms,
+    gameDurationSeconds: first.game_duration_seconds,
+    queue: first.queue,
+    queueId: first.queue_id,
+    gameMode: first.game_mode,
+    gameType: first.game_type,
+    gameVersion: first.game_version,
+    mapId: first.map_id,
+    teams,
+  };
+}
+
+function pageResult<T>(rows: T[], offset: number) {
+  const page = rows.slice(0, PAGE_SIZE);
+  return {
+    rows: page,
+    nextCursor: rows.length > PAGE_SIZE ? { offset: offset + PAGE_SIZE } : null,
+  };
+}
+
+function participantFilter(participantIds: number[] | undefined) {
+  return participantIds === undefined ? {} : { participantIds };
+}
+
+export const consumerMatchRouter = router({
+  detail: protectedProcedure.input(MatchInput).query(async ({ ctx, input }) => {
+    const authorized = await authorizeMatch(ctx.user, input);
+    const [coverage, keyEvents] = await Promise.all([
+      fetchTimelineCoverage({ matchId: input.matchId }),
+      fetchTimelineEventPage({
+        matchId: input.matchId,
+        offset: 0,
+        limit: 40,
+        eventTypes: KEY_EVENT_TYPES,
+      }),
+    ]);
+    return { match: matchView(authorized), timeline: { coverage, keyEvents } };
+  }),
+
+  events: protectedProcedure
+    .input(TimelineEventPageInput)
+    .query(async ({ ctx, input }) => {
+      await authorizeMatch(ctx.user, input);
+      const offset = input.cursor?.offset ?? 0;
+      const rows = await fetchTimelineEventPage({
+        matchId: input.matchId,
+        offset,
+        limit: PAGE_SIZE + 1,
+        ...(input.eventTypes === undefined
+          ? {}
+          : { eventTypes: input.eventTypes }),
+        ...participantFilter(input.participantIds),
+      });
+      return pageResult(rows, offset);
+    }),
+
+  frames: protectedProcedure
+    .input(TimelinePageInput)
+    .query(async ({ ctx, input }) => {
+      await authorizeMatch(ctx.user, input);
+      const offset = input.cursor?.offset ?? 0;
+      const rows = await fetchTimelineFramePage({
+        matchId: input.matchId,
+        offset,
+        limit: PAGE_SIZE + 1,
+        ...participantFilter(input.participantIds),
+      });
+      return pageResult(rows, offset);
+    }),
+
+  chartSeries: protectedProcedure
+    .input(MatchInput)
+    .query(async ({ ctx, input }) => {
+      const authorized = await authorizeMatch(ctx.user, input);
+      const frames = await fetchTimelineChartFrames({
+        matchId: input.matchId,
+      });
+      const teamByParticipant = new Map(
+        authorized.rows.map(
+          (row) => [row.participant_id, row.team_id] as const,
+        ),
+      );
+      const selectedParticipants = new Set(
+        authorized.rows
+          .filter((row) => authorized.player.puuids.has(row.puuid))
+          .map((row) => row.participant_id),
+      );
+      const points = new Map<
+        number,
+        {
+          teamGold: Map<number, number>;
+          selectedGold: number | null;
+          selectedXp: number | null;
+        }
+      >();
+      for (const frame of frames) {
+        const teamId = teamByParticipant.get(frame.participant_id);
+        if (teamId === undefined) {
+          throw new Error("Timeline frame references an unknown participant");
+        }
+        const point = points.get(frame.frame_timestamp_ms) ?? {
+          teamGold: new Map<number, number>(),
+          selectedGold: null,
+          selectedXp: null,
+        };
+        point.teamGold.set(
+          teamId,
+          (point.teamGold.get(teamId) ?? 0) + frame.total_gold,
+        );
+        if (selectedParticipants.has(frame.participant_id)) {
+          point.selectedGold = frame.total_gold;
+          point.selectedXp = frame.xp;
+        }
+        points.set(frame.frame_timestamp_ms, point);
+      }
+      return {
+        points: [...points.entries()]
+          .toSorted(([left], [right]) => left - right)
+          .map(([timestampMs, point]) => ({
+            timestampMs,
+            teamGold: [...point.teamGold.entries()]
+              .toSorted(([left], [right]) => left - right)
+              .map(([teamId, gold]) => ({ teamId, gold })),
+            selectedGold: point.selectedGold,
+            selectedXp: point.selectedXp,
+          })),
+      };
+    }),
+});

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/consumer-player.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/consumer-player.router.test.ts
@@ -50,6 +50,7 @@ async function seedPlayer(options: {
   alias: string;
   discordId?: DiscordAccountId;
   puuids: LeaguePuuid[];
+  lastMatchTime?: Date | null;
 }) {
   const now = new Date();
   const player = await testPrisma.player.create({
@@ -75,7 +76,8 @@ async function seedPlayer(options: {
       riotGameName: `${options.alias} Riot ${index.toString()}`,
       riotTagLine: "NA1",
       riotIdUpdatedAt: now,
-      lastMatchTime: now,
+      lastMatchTime:
+        options.lastMatchTime === undefined ? now : options.lastMatchTime,
       lastCheckedAt: now,
       createdTime: now,
       updatedTime: now,
@@ -88,21 +90,22 @@ function matchFact(options: {
   matchId: string;
   puuid: string;
   playerId: number;
-  queue?: string;
+  queue?: string | null;
+  gameCreationAt?: Date;
 }) {
   return {
     playerId: options.playerId,
     playerAlias: "Consumer Player",
     matchId: options.matchId,
     puuid: options.puuid,
-    queue: options.queue ?? "solo",
+    queue: options.queue === undefined ? "solo" : options.queue,
     win: true,
     surrendered: false,
     kills: 7,
     deaths: 2,
     assists: 5,
     teamId: 100,
-    gameCreationAt: gameCreatedAt,
+    gameCreationAt: options.gameCreationAt ?? gameCreatedAt,
   };
 }
 
@@ -320,6 +323,61 @@ describe("consumerPlayer search and direct lookup", () => {
   });
 });
 
+describe("consumerPlayer.home", () => {
+  test("returns every viewer-linked profile and six newest non-self players", async () => {
+    enableProfiles(guildId, otherGuildId);
+    trpc.setMembership([
+      { guildId, asAdmin: false },
+      { guildId: otherGuildId, asAdmin: false },
+    ]);
+    const mineOne = await seedPlayer({
+      serverId: guildId,
+      alias: "Mine One",
+      discordId: actorDiscordId,
+      puuids: [testPuuid("home-mine-one")],
+    });
+    const mineTwo = await seedPlayer({
+      serverId: otherGuildId,
+      alias: "Mine Two",
+      discordId: actorDiscordId,
+      puuids: [testPuuid("home-mine-two")],
+    });
+    const recent: number[] = [];
+    for (let index = 0; index < 8; index += 1) {
+      const player = await seedPlayer({
+        serverId: guildId,
+        alias: `Recent ${index.toString()}`,
+        puuids: [testPuuid(`home-recent-${index.toString()}`)],
+        lastMatchTime: new Date(gameCreatedAt.getTime() - index * 60_000),
+      });
+      recent.push(player.id);
+    }
+    await seedPlayer({
+      serverId: guildId,
+      alias: "Never active",
+      puuids: [testPuuid("home-never")],
+      lastMatchTime: null,
+    });
+
+    const home = await trpc.authedCaller(actorDiscordId).consumerPlayer.home();
+    expect(
+      home.yourProfiles
+        .map((player) => player.playerId)
+        .toSorted((left, right) => left - right),
+    ).toEqual([mineOne.id, mineTwo.id].toSorted((left, right) => left - right));
+    expect(home.recentPlayers.map((player) => player.playerId)).toEqual(
+      recent.slice(0, 6),
+    );
+    expect(JSON.stringify(home)).not.toContain(actorDiscordId);
+  });
+
+  test("rechecks the feature flag for the home request", async () => {
+    await expect(trpc.authedCaller().consumerPlayer.home()).rejects.toThrow(
+      /not available/i,
+    );
+  });
+});
+
 describe("consumerPlayer combined profile", () => {
   test("returns safe account freshness, ranks, and match attribution", async () => {
     enableProfiles(guildId);
@@ -398,10 +456,65 @@ describe("consumerPlayer combined profile", () => {
     const flexHistory = await caller.consumerPlayer.matchHistory({
       playerId: player.id,
       limit: 20,
-      queue: "flex",
+      queues: ["flex"],
     });
     expect(flexHistory.entries.map((entry) => entry.matchId)).toEqual([
       "NA1_alt",
     ]);
+  });
+
+  test("combines queues, preserves all-game null queues, and stops at the selected window", async () => {
+    enableProfiles(guildId);
+    const player = await seedPlayer({
+      serverId: guildId,
+      alias: "Windowed Player",
+      puuids: [MAIN],
+    });
+    const facts = Array.from({ length: 55 }, (_, index) =>
+      matchFact({
+        matchId: `NA1_window_${index.toString().padStart(2, "0")}`,
+        puuid: MAIN,
+        playerId: player.id,
+        queue: index === 54 ? null : index % 2 === 0 ? "solo" : "flex",
+        gameCreationAt: new Date(gameCreatedAt.getTime() - index * 60_000),
+      }),
+    );
+    await writeTestLake(lakeDir, { serverId: guildId, matchFacts: facts });
+
+    const caller = trpc.authedCaller();
+    const lastTwenty = await caller.consumerPlayer.matchHistory({
+      playerId: player.id,
+      limit: 50,
+    });
+    expect(lastTwenty.entries).toHaveLength(20);
+    expect(lastTwenty.nextCursor).toBeNull();
+
+    const lastFifty = await caller.consumerPlayer.matchHistory({
+      playerId: player.id,
+      games: 50,
+      limit: 50,
+      queues: ["solo", "flex"],
+    });
+    expect(lastFifty.entries).toHaveLength(50);
+    expect(lastFifty.nextCursor).toBeNull();
+
+    const allTime = await caller.consumerPlayer.matchHistory({
+      playerId: player.id,
+      games: "all",
+      limit: 50,
+    });
+    expect(allTime.entries).toHaveLength(50);
+    expect(allTime.nextCursor).not.toBeNull();
+    if (allTime.nextCursor === null) {
+      throw new Error("All-time history should have another page");
+    }
+    const finalPage = await caller.consumerPlayer.matchHistory({
+      playerId: player.id,
+      games: "all",
+      limit: 50,
+      cursor: allTime.nextCursor,
+    });
+    expect(finalPage.entries).toHaveLength(5);
+    expect(finalPage.entries.at(-1)?.queue).toBeNull();
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/consumer-player.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/consumer-player.router.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from "vitest";
+import { describe, expect, test } from "vitest";
 import {
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
@@ -14,32 +7,24 @@ import {
   type LeaguePuuid,
 } from "@scout-for-lol/data";
 import {
-  initFeatureFlags,
-  shutdownFeatureFlags,
-} from "@shepherdjerred/feature-flags";
-import { resetConfigurationForTests } from "#src/configuration.ts";
-import {
-  addFlagOverride,
-  resetFlagOverrides,
-} from "#src/configuration/flags.ts";
-import { resolveLakeDir } from "#src/report-lake/paths.ts";
+  configureConsumerProfileFeatureTest,
+  registerConsumerProfileFeatureTestLifecycle,
+} from "#src/testing/consumer-profile-feature-test.ts";
 import { createOfflineTrpcHarness } from "#src/testing/test-trpc-caller.ts";
 import { testPuuid } from "#src/testing/test-ids.ts";
-import { resetTestLake, writeTestLake } from "#src/testing/test-report-lake.ts";
-
-const originalEnvironment = Bun.env["ENVIRONMENT"];
-const originalAllowlist = Bun.env["EXPLORE_GUILD_ALLOWLIST"];
-Bun.env["ENVIRONMENT"] = "beta";
+import { writeTestLake } from "#src/testing/test-report-lake.ts";
 
 const guildId = DiscordGuildIdSchema.parse("100000000000000041");
 const otherGuildId = DiscordGuildIdSchema.parse("100000000000000042");
-Bun.env["EXPLORE_GUILD_ALLOWLIST"] = `${guildId},${otherGuildId}`;
-resetConfigurationForTests();
+const profileFeature = configureConsumerProfileFeatureTest([
+  guildId,
+  otherGuildId,
+]);
 
 const trpc = await createOfflineTrpcHarness("trpc-consumer-player-test");
 const { prisma: testPrisma } = trpc;
 const actorDiscordId = DiscordAccountIdSchema.parse("300000000000000041");
-const lakeDir = resolveLakeDir();
+const { lakeDir } = profileFeature;
 const MAIN = testPuuid("consumer-main");
 const ALT = testPuuid("consumer-alt");
 const OTHER = testPuuid("consumer-other");
@@ -110,43 +95,21 @@ function matchFact(options: {
 }
 
 function enableProfiles(...guildIds: DiscordGuildId[]): void {
-  for (const server of guildIds) {
-    addFlagOverride("scout-consumer-player-profiles-enabled", true, {
-      server,
-    });
-  }
+  profileFeature.enable(...guildIds);
 }
 
-beforeAll(async () => {
-  await initFeatureFlags({
-    environment: { FEATURE_FLAGS_MODE: "disabled" },
-  });
-});
-
-beforeEach(async () => {
-  resetFlagOverrides("scout-consumer-player-profiles-enabled");
-  trpc.setMembership([{ guildId, asAdmin: false }]);
-  await testPrisma.matchRankHistory.deleteMany();
-  await testPrisma.account.deleteMany();
-  await testPrisma.player.deleteMany();
-  await resetTestLake(lakeDir);
-});
-
-afterAll(async () => {
-  resetFlagOverrides("scout-consumer-player-profiles-enabled");
-  await shutdownFeatureFlags();
-  await testPrisma.$disconnect();
-  if (originalEnvironment === undefined) {
-    delete Bun.env["ENVIRONMENT"];
-  } else {
-    Bun.env["ENVIRONMENT"] = originalEnvironment;
-  }
-  if (originalAllowlist === undefined) {
-    delete Bun.env["EXPLORE_GUILD_ALLOWLIST"];
-  } else {
-    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = originalAllowlist;
-  }
-  resetConfigurationForTests();
+registerConsumerProfileFeatureTestLifecycle({
+  feature: profileFeature,
+  prepare: async () => {
+    trpc.setMembership([{ guildId, asAdmin: false }]);
+    await testPrisma.matchRankHistory.deleteMany();
+    await testPrisma.account.deleteMany();
+    await testPrisma.player.deleteMany();
+    await profileFeature.resetLake();
+  },
+  cleanup: async () => {
+    await testPrisma.$disconnect();
+  },
 });
 
 describe("consumerPlayer.status", () => {

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/consumer-player.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/consumer-player.router.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
-import { DiscordGuildIdSchema, PlayerIdSchema } from "@scout-for-lol/data";
+import {
+  DiscordGuildIdSchema,
+  PlayerIdSchema,
+  PlayerProfileGameWindowSchema,
+  PlayerProfileQueueSelectionSchema,
+} from "@scout-for-lol/data";
 import { Prisma } from "#generated/prisma/client/index.js";
 import { prisma } from "#src/database/index.ts";
 import {
@@ -17,13 +22,15 @@ const ConsumerPlayerInput = z.object({
   playerId: PlayerIdSchema,
 });
 
-const QueueInput = z.object({
-  queue: z.string().trim().min(1).max(50).optional(),
+const FilterInput = z.object({
+  games: PlayerProfileGameWindowSchema.default(20),
+  queues: PlayerProfileQueueSelectionSchema.optional(),
 });
 
 const MatchHistoryCursorSchema = z.object({
   gameCreationMs: z.number().int(),
   matchId: z.string().min(1),
+  consumed: z.number().int().nonnegative().optional(),
 });
 
 const SearchInput = z.object({
@@ -139,6 +146,45 @@ function guildDisplay(
   };
 }
 
+type HomePlayer = {
+  id: number;
+  alias: string;
+  serverId: string;
+  discordId: string | null;
+  accounts: {
+    riotGameName: string | null;
+    riotTagLine: string | null;
+    region: string;
+    lastMatchTime: Date | null;
+  }[];
+};
+
+function latestMatch(player: HomePlayer): Date | null {
+  return player.accounts.reduce<Date | null>((latest, account) => {
+    if (account.lastMatchTime === null) return latest;
+    return latest === null || account.lastMatchTime > latest
+      ? account.lastMatchTime
+      : latest;
+  }, null);
+}
+
+function homePlayer(
+  player: HomePlayer,
+  guilds: { id: string; name: string; icon: string | null }[],
+) {
+  return {
+    playerId: player.id,
+    alias: player.alias,
+    guild: guildDisplay(guilds, player.serverId),
+    lastMatchTime: latestMatch(player),
+    accounts: player.accounts.map((account) => ({
+      gameName: account.riotGameName,
+      tagLine: account.riotTagLine,
+      region: account.region,
+    })),
+  };
+}
+
 export const consumerPlayerRouter = router({
   status: protectedProcedure.query(async ({ ctx }) => {
     const scope = await resolveConsumerPlayerScope(ctx.user);
@@ -153,6 +199,59 @@ export const consumerPlayerRouter = router({
       return { state: scope.reason } as const;
     }
     return { state: "available", guildCount: scope.guilds.length } as const;
+  }),
+
+  home: protectedProcedure.query(async ({ ctx }) => {
+    const guilds = await assertConsumerPlayerScope(ctx.user);
+    const guildIds = guilds.map((guild) =>
+      DiscordGuildIdSchema.parse(guild.id),
+    );
+    const players = await prisma.player.findMany({
+      where: { serverId: { in: guildIds } },
+      select: {
+        id: true,
+        alias: true,
+        serverId: true,
+        discordId: true,
+        accounts: {
+          select: {
+            riotGameName: true,
+            riotTagLine: true,
+            region: true,
+            lastMatchTime: true,
+          },
+        },
+      },
+    });
+    const yourProfiles = players
+      .filter((player) => player.discordId === ctx.user.discordId)
+      .toSorted((left, right) => {
+        const recent =
+          (latestMatch(right)?.getTime() ?? 0) -
+          (latestMatch(left)?.getTime() ?? 0);
+        return recent === 0 ? left.alias.localeCompare(right.alias) : recent;
+      })
+      .map((player) => homePlayer(player, guilds));
+    const recentPlayers = players
+      .filter(
+        (player) =>
+          player.discordId !== ctx.user.discordId &&
+          latestMatch(player) !== null,
+      )
+      .toSorted((left, right) => {
+        const leftMatch = latestMatch(left);
+        const rightMatch = latestMatch(right);
+        if (leftMatch === null || rightMatch === null) {
+          throw new Error("Recently active player is missing activity");
+        }
+        const recent = rightMatch.getTime() - leftMatch.getTime();
+        if (recent !== 0) return recent;
+        const alias = left.alias.localeCompare(right.alias);
+        return alias === 0 ? left.id - right.id : alias;
+      })
+      .slice(0, 6)
+      .map((player) => homePlayer(player, guilds));
+    return { yourProfiles, recentPlayers };
   }),
 
   search: protectedProcedure
@@ -212,13 +311,14 @@ export const consumerPlayerRouter = router({
     }),
 
   profileSummary: protectedProcedure
-    .input(ConsumerPlayerInput.extend(QueueInput.shape))
+    .input(ConsumerPlayerInput.extend(FilterInput.shape))
     .query(async ({ ctx, input }) => {
       const guilds = await assertConsumerPlayerScope(ctx.user);
       const summary = await getConsumerPlayerProfileSummary({
         playerId: input.playerId,
         guildIds: guilds.map((guild) => DiscordGuildIdSchema.parse(guild.id)),
-        ...(input.queue === undefined ? {} : { queue: input.queue }),
+        games: input.games,
+        ...(input.queues === undefined ? {} : { queues: input.queues }),
       });
       const { guildId, ...profile } = summary;
       return { ...profile, guild: guildDisplay(guilds, guildId) };
@@ -226,7 +326,7 @@ export const consumerPlayerRouter = router({
 
   matchHistory: protectedProcedure
     .input(
-      ConsumerPlayerInput.extend(QueueInput.shape).extend({
+      ConsumerPlayerInput.extend(FilterInput.shape).extend({
         limit: z.number().int().min(1).max(50).default(20),
         cursor: MatchHistoryCursorSchema.optional(),
       }),
@@ -237,8 +337,9 @@ export const consumerPlayerRouter = router({
         playerId: input.playerId,
         guildIds: guilds.map((guild) => DiscordGuildIdSchema.parse(guild.id)),
         limit: input.limit,
+        games: input.games,
         ...(input.cursor === undefined ? {} : { cursor: input.cursor }),
-        ...(input.queue === undefined ? {} : { queue: input.queue }),
+        ...(input.queues === undefined ? {} : { queues: input.queues }),
       });
     }),
 });

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/consumer-profile-details.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/consumer-profile-details.router.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from "vitest";
+import { describe, expect, test } from "vitest";
 import {
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
@@ -14,30 +7,23 @@ import {
   type LeaguePuuid,
 } from "@scout-for-lol/data";
 import {
-  initFeatureFlags,
-  shutdownFeatureFlags,
-} from "@shepherdjerred/feature-flags";
-import { resetConfigurationForTests } from "#src/configuration.ts";
-import {
-  addFlagOverride,
-  resetFlagOverrides,
-} from "#src/configuration/flags.ts";
-import { resolveLakeDir } from "#src/report-lake/paths.ts";
+  configureConsumerProfileFeatureTest,
+  registerConsumerProfileFeatureTestLifecycle,
+} from "#src/testing/consumer-profile-feature-test.ts";
 import { createOfflineTrpcHarness } from "#src/testing/test-trpc-caller.ts";
 import { testPuuid } from "#src/testing/test-ids.ts";
-import { resetTestLake, writeTestLake } from "#src/testing/test-report-lake.ts";
+import { writeTestLake } from "#src/testing/test-report-lake.ts";
 
-const previousEnvironment = Bun.env["ENVIRONMENT"];
-const previousAllowlist = Bun.env["EXPLORE_GUILD_ALLOWLIST"];
-Bun.env["ENVIRONMENT"] = "beta";
 const guildOne = DiscordGuildIdSchema.parse("100000000000000061");
 const guildTwo = DiscordGuildIdSchema.parse("100000000000000062");
-Bun.env["EXPLORE_GUILD_ALLOWLIST"] = `${guildOne},${guildTwo}`;
-resetConfigurationForTests();
+const profileFeature = configureConsumerProfileFeatureTest([
+  guildOne,
+  guildTwo,
+]);
 
 const trpc = await createOfflineTrpcHarness("consumer-profile-details-test");
 const actor = DiscordAccountIdSchema.parse("300000000000000061");
-const lakeDir = resolveLakeDir();
+const { lakeDir } = profileFeature;
 const created = new Date("2026-08-25T12:00:00.000Z");
 
 async function player(options: {
@@ -104,37 +90,21 @@ function fact(options: {
   };
 }
 
-beforeAll(async () => {
-  await initFeatureFlags({ environment: { FEATURE_FLAGS_MODE: "disabled" } });
-});
-
-beforeEach(async () => {
-  resetFlagOverrides("scout-consumer-player-profiles-enabled");
-  addFlagOverride("scout-consumer-player-profiles-enabled", true, {
-    server: guildOne,
-  });
-  addFlagOverride("scout-consumer-player-profiles-enabled", true, {
-    server: guildTwo,
-  });
-  trpc.setMembership([
-    { guildId: guildOne, asAdmin: false },
-    { guildId: guildTwo, asAdmin: false },
-  ]);
-  await trpc.prisma.account.deleteMany();
-  await trpc.prisma.player.deleteMany();
-  await resetTestLake(lakeDir);
-});
-
-afterAll(async () => {
-  resetFlagOverrides("scout-consumer-player-profiles-enabled");
-  await shutdownFeatureFlags();
-  await trpc.prisma.$disconnect();
-  if (previousEnvironment === undefined) delete Bun.env["ENVIRONMENT"];
-  else Bun.env["ENVIRONMENT"] = previousEnvironment;
-  if (previousAllowlist === undefined)
-    delete Bun.env["EXPLORE_GUILD_ALLOWLIST"];
-  else Bun.env["EXPLORE_GUILD_ALLOWLIST"] = previousAllowlist;
-  resetConfigurationForTests();
+registerConsumerProfileFeatureTestLifecycle({
+  feature: profileFeature,
+  prepare: async () => {
+    profileFeature.enable(guildOne, guildTwo);
+    trpc.setMembership([
+      { guildId: guildOne, asAdmin: false },
+      { guildId: guildTwo, asAdmin: false },
+    ]);
+    await trpc.prisma.account.deleteMany();
+    await trpc.prisma.player.deleteMany();
+    await profileFeature.resetLake();
+  },
+  cleanup: async () => {
+    await trpc.prisma.$disconnect();
+  },
 });
 
 describe("consumerChampion.compare", () => {

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/consumer-profile-details.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/consumer-profile-details.router.test.ts
@@ -1,0 +1,368 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+  type DiscordAccountId,
+  type DiscordGuildId,
+  type LeaguePuuid,
+} from "@scout-for-lol/data";
+import {
+  initFeatureFlags,
+  shutdownFeatureFlags,
+} from "@shepherdjerred/feature-flags";
+import { resetConfigurationForTests } from "#src/configuration.ts";
+import {
+  addFlagOverride,
+  resetFlagOverrides,
+} from "#src/configuration/flags.ts";
+import { resolveLakeDir } from "#src/report-lake/paths.ts";
+import { createOfflineTrpcHarness } from "#src/testing/test-trpc-caller.ts";
+import { testPuuid } from "#src/testing/test-ids.ts";
+import { resetTestLake, writeTestLake } from "#src/testing/test-report-lake.ts";
+
+const previousEnvironment = Bun.env["ENVIRONMENT"];
+const previousAllowlist = Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+Bun.env["ENVIRONMENT"] = "beta";
+const guildOne = DiscordGuildIdSchema.parse("100000000000000061");
+const guildTwo = DiscordGuildIdSchema.parse("100000000000000062");
+Bun.env["EXPLORE_GUILD_ALLOWLIST"] = `${guildOne},${guildTwo}`;
+resetConfigurationForTests();
+
+const trpc = await createOfflineTrpcHarness("consumer-profile-details-test");
+const actor = DiscordAccountIdSchema.parse("300000000000000061");
+const lakeDir = resolveLakeDir();
+const created = new Date("2026-08-25T12:00:00.000Z");
+
+async function player(options: {
+  guildId: DiscordGuildId;
+  alias: string;
+  puuid: LeaguePuuid;
+  discordId?: DiscordAccountId;
+}) {
+  const row = await trpc.prisma.player.create({
+    data: {
+      serverId: options.guildId,
+      alias: options.alias,
+      creatorDiscordId: actor,
+      ...(options.discordId === undefined
+        ? {}
+        : { discordId: options.discordId }),
+      createdTime: created,
+      updatedTime: created,
+    },
+  });
+  await trpc.prisma.account.create({
+    data: {
+      serverId: options.guildId,
+      playerId: row.id,
+      alias: `${options.alias} account`,
+      puuid: options.puuid,
+      region: "AMERICA_NORTH",
+      creatorDiscordId: actor,
+      riotGameName: options.alias,
+      riotTagLine: "NA1",
+      createdTime: created,
+      updatedTime: created,
+    },
+  });
+  return row;
+}
+
+function fact(options: {
+  playerId: number;
+  alias: string;
+  puuid: string;
+  matchId: string;
+  win: boolean;
+  championId?: number;
+  championName?: string;
+  teamId?: number;
+  index?: number;
+}) {
+  return {
+    playerId: options.playerId,
+    playerAlias: options.alias,
+    puuid: options.puuid,
+    matchId: options.matchId,
+    queue: "solo",
+    win: options.win,
+    surrendered: false,
+    kills: options.win ? 8 : 2,
+    deaths: options.win ? 2 : 6,
+    assists: 6,
+    championId: options.championId ?? 22,
+    championName: options.championName ?? "Ashe",
+    teamId: options.teamId ?? 100,
+    gameCreationAt: new Date(created.getTime() - (options.index ?? 0) * 60_000),
+  };
+}
+
+beforeAll(async () => {
+  await initFeatureFlags({ environment: { FEATURE_FLAGS_MODE: "disabled" } });
+});
+
+beforeEach(async () => {
+  resetFlagOverrides("scout-consumer-player-profiles-enabled");
+  addFlagOverride("scout-consumer-player-profiles-enabled", true, {
+    server: guildOne,
+  });
+  addFlagOverride("scout-consumer-player-profiles-enabled", true, {
+    server: guildTwo,
+  });
+  trpc.setMembership([
+    { guildId: guildOne, asAdmin: false },
+    { guildId: guildTwo, asAdmin: false },
+  ]);
+  await trpc.prisma.account.deleteMany();
+  await trpc.prisma.player.deleteMany();
+  await resetTestLake(lakeDir);
+});
+
+afterAll(async () => {
+  resetFlagOverrides("scout-consumer-player-profiles-enabled");
+  await shutdownFeatureFlags();
+  await trpc.prisma.$disconnect();
+  if (previousEnvironment === undefined) delete Bun.env["ENVIRONMENT"];
+  else Bun.env["ENVIRONMENT"] = previousEnvironment;
+  if (previousAllowlist === undefined)
+    delete Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+  else Bun.env["EXPLORE_GUILD_ALLOWLIST"] = previousAllowlist;
+  resetConfigurationForTests();
+});
+
+describe("consumerChampion.compare", () => {
+  test("separates qualifying samples, keeps guild registrations distinct, and marks the viewer without an ID", async () => {
+    const onePuuid = testPuuid("champion-one");
+    const twoPuuid = testPuuid("champion-two");
+    const smallPuuid = testPuuid("champion-small");
+    const one = await player({
+      guildId: guildOne,
+      alias: "Shared Alias",
+      puuid: onePuuid,
+      discordId: actor,
+    });
+    const two = await player({
+      guildId: guildTwo,
+      alias: "Shared Alias",
+      puuid: twoPuuid,
+    });
+    const small = await player({
+      guildId: guildOne,
+      alias: "Small Sample",
+      puuid: smallPuuid,
+    });
+    const matches = [
+      ...Array.from({ length: 10 }, (_, index) =>
+        fact({
+          playerId: one.id,
+          alias: one.alias,
+          puuid: onePuuid,
+          matchId: `NA1_champion_one_${index.toString()}`,
+          win: index < 7,
+          index,
+        }),
+      ),
+      ...Array.from({ length: 10 }, (_, index) =>
+        fact({
+          playerId: two.id,
+          alias: two.alias,
+          puuid: twoPuuid,
+          matchId: `NA1_champion_two_${index.toString()}`,
+          win: index < 6,
+          index,
+        }),
+      ),
+      ...Array.from({ length: 9 }, (_, index) =>
+        fact({
+          playerId: small.id,
+          alias: small.alias,
+          puuid: smallPuuid,
+          matchId: `NA1_champion_small_${index.toString()}`,
+          win: true,
+          index,
+        }),
+      ),
+    ];
+    await writeTestLake(lakeDir, { serverId: guildOne, matchFacts: matches });
+
+    const caller = trpc.authedCaller(actor);
+    const qualified = await caller.consumerChampion.compare({
+      championId: 22,
+      games: "all",
+      cohort: "qualified",
+      sort: "win_rate",
+    });
+    expect(qualified.rows.map((row) => row.playerId)).toEqual([one.id, two.id]);
+    expect(qualified.rows.map((row) => row.guild.guildId)).toEqual([
+      guildOne,
+      guildTwo,
+    ]);
+    expect(qualified.rows[0]?.viewerLinked).toBe(true);
+    expect(JSON.stringify(qualified.rows)).not.toContain(actor);
+
+    const lowSample = await caller.consumerChampion.compare({
+      championId: 22,
+      cohort: "small_sample",
+    });
+    expect(lowSample.rows.map((row) => row.playerId)).toEqual([small.id]);
+  });
+
+  test("rejects a guild outside the freshly authorized subset", async () => {
+    await expect(
+      trpc.authedCaller().consumerChampion.compare({
+        championId: 22,
+        guildIds: [DiscordGuildIdSchema.parse("100000000000000099")],
+      }),
+    ).rejects.toThrow(/outside/i);
+  });
+
+  test("paginates comparison results at 25 rows with a stable server cursor", async () => {
+    const players = await Promise.all(
+      Array.from({ length: 26 }, async (_, index) => {
+        const puuid = testPuuid(`champion-page-${index.toString()}`);
+        const entry = await player({
+          guildId: guildOne,
+          alias: `Player ${index.toString().padStart(2, "0")}`,
+          puuid,
+        });
+        return { entry, puuid, index };
+      }),
+    );
+    await writeTestLake(lakeDir, {
+      serverId: guildOne,
+      matchFacts: players.flatMap(({ entry, puuid, index }) =>
+        Array.from({ length: 10 }, (_, gameIndex) =>
+          fact({
+            playerId: entry.id,
+            alias: entry.alias,
+            puuid,
+            matchId: `NA1_page_${index.toString()}_${gameIndex.toString()}`,
+            win: gameIndex < 5,
+            index: gameIndex,
+          }),
+        ),
+      ),
+    });
+
+    const caller = trpc.authedCaller(actor);
+    const first = await caller.consumerChampion.compare({
+      championId: 22,
+      games: "all",
+      cohort: "qualified",
+      sort: "win_rate",
+    });
+    expect(first.rows).toHaveLength(25);
+    expect(first.rows[0]?.alias).toBe("Player 00");
+    expect(first.nextCursor).toEqual({ offset: 25 });
+    if (first.nextCursor === null) {
+      throw new Error("The first comparison page must have a cursor");
+    }
+    const second = await caller.consumerChampion.compare({
+      championId: 22,
+      games: "all",
+      cohort: "qualified",
+      sort: "win_rate",
+      cursor: first.nextCursor,
+    });
+    expect(second.rows.map((row) => row.alias)).toEqual(["Player 25"]);
+    expect(second.nextCursor).toBeNull();
+  });
+});
+
+describe("consumerMatch", () => {
+  test("authorizes through the launching player and returns a full scoreboard with scoped aliases", async () => {
+    const launchPuuid = testPuuid("match-launch");
+    const teammatePuuid = testPuuid("match-teammate");
+    const launch = await player({
+      guildId: guildOne,
+      alias: "Launching Player",
+      puuid: launchPuuid,
+    });
+    const teammate = await player({
+      guildId: guildOne,
+      alias: "Known Teammate",
+      puuid: teammatePuuid,
+    });
+    await writeTestLake(lakeDir, {
+      serverId: guildOne,
+      matchFacts: [
+        fact({
+          playerId: launch.id,
+          alias: launch.alias,
+          puuid: launchPuuid,
+          matchId: "NA1_detail",
+          win: true,
+        }),
+        fact({
+          playerId: teammate.id,
+          alias: teammate.alias,
+          puuid: teammatePuuid,
+          matchId: "NA1_detail",
+          win: false,
+          championId: 86,
+          championName: "Garen",
+          teamId: 200,
+        }),
+      ],
+    });
+
+    const detail = await trpc.authedCaller().consumerMatch.detail({
+      playerId: launch.id,
+      matchId: "NA1_detail",
+    });
+    expect(detail.match.teams).toHaveLength(2);
+    expect(detail.match.teams.flatMap((team) => team.participants)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ selectedPlayer: true }),
+        expect.objectContaining({
+          scoutAliases: [
+            expect.objectContaining({
+              playerId: teammate.id,
+              alias: "Known Teammate",
+            }),
+          ],
+        }),
+      ]),
+    );
+    expect(detail.timeline.coverage).toBeNull();
+    expect(JSON.stringify(detail)).not.toContain(actor);
+  });
+
+  test("does not authorize a match the named player did not play", async () => {
+    const launch = await player({
+      guildId: guildOne,
+      alias: "Launch",
+      puuid: testPuuid("match-denied-launch"),
+    });
+    const other = await player({
+      guildId: guildOne,
+      alias: "Other",
+      puuid: testPuuid("match-denied-other"),
+    });
+    await writeTestLake(lakeDir, {
+      serverId: guildOne,
+      matchFacts: [
+        fact({
+          playerId: other.id,
+          alias: other.alias,
+          puuid: testPuuid("match-denied-other"),
+          matchId: "NA1_not_yours",
+          win: true,
+        }),
+      ],
+    });
+    await expect(
+      trpc.authedCaller().consumerMatch.detail({
+        playerId: launch.id,
+        matchId: "NA1_not_yours",
+      }),
+    ).rejects.toThrow("Match was not found");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/index.ts
@@ -5,6 +5,7 @@
  */
 
 import { router } from "#src/trpc/trpc.ts";
+import type { AnyRouter, inferRouterOutputs } from "@trpc/server";
 import { authRouter } from "#src/trpc/router/auth.router.ts";
 import { telemetryRouter } from "#src/trpc/router/telemetry.router.ts";
 import { installAttributionRouter } from "#src/trpc/router/install-attribution.router.ts";
@@ -22,6 +23,8 @@ import { discordRouter } from "#src/trpc/router/discord.router.ts";
 import { riotRouter } from "#src/trpc/router/riot.router.ts";
 import { rolesRouter } from "#src/trpc/router/roles.router.ts";
 import { consumerPlayerRouter } from "#src/trpc/router/consumer-player.router.ts";
+import { consumerChampionRouter } from "#src/trpc/router/consumer-champion.router.ts";
+import { consumerMatchRouter } from "#src/trpc/router/consumer-match.router.ts";
 import { bucksRouter } from "#src/trpc/router/bucks.router.ts";
 import { customsRouter } from "#src/trpc/router/customs.router.ts";
 import { customsHistoryRouter } from "#src/trpc/router/customs-history.router.ts";
@@ -44,9 +47,13 @@ export const appRouter = router({
   riot: riotRouter,
   roles: rolesRouter,
   consumerPlayer: consumerPlayerRouter,
+  consumerChampion: consumerChampionRouter,
+  consumerMatch: consumerMatchRouter,
   bucks: bucksRouter,
   customs: customsRouter,
   customsHistory: customsHistoryRouter,
 });
 
 export type AppRouter = typeof appRouter;
+type OutputsFor<TRouter extends AnyRouter> = inferRouterOutputs<TRouter>;
+export type AppRouterOutputs = OutputsFor<AppRouter>;

--- a/packages/scout-for-lol/packages/data/src/model/index.ts
+++ b/packages/scout-for-lol/packages/data/src/model/index.ts
@@ -19,6 +19,7 @@ export * from "./match.ts";
 export * from "./match-helpers.ts";
 export * from "./player.ts";
 export * from "./player-config.ts";
+export * from "./player-profile.ts";
 export * from "./queue-availability.ts";
 export * from "./queue-windows.schema.ts";
 export * from "./queue-window-drift.ts";

--- a/packages/scout-for-lol/packages/data/src/model/player-profile.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/player-profile.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import {
+  PLAYER_PROFILE_QUEUE_GROUPS,
+  PLAYER_PROFILE_QUEUE_PRESETS,
+  PlayerProfileFilterSchema,
+  PlayerProfileQueueSelectionSchema,
+  QueueTypeSchema,
+} from "#src/index.ts";
+
+describe("player profile filters", () => {
+  test("defaults to the newest 20 games and no queue predicate", () => {
+    expect(PlayerProfileFilterSchema.parse({})).toEqual({ games: 20 });
+  });
+
+  test("accepts typed windows and unique non-empty queue selections", () => {
+    expect(
+      PlayerProfileFilterSchema.parse({
+        games: "all",
+        queues: ["solo", "flex"],
+      }),
+    ).toEqual({ games: "all", queues: ["solo", "flex"] });
+    expect(PlayerProfileQueueSelectionSchema.safeParse([]).success).toBe(false);
+    expect(
+      PlayerProfileQueueSelectionSchema.safeParse(["solo", "solo"]).success,
+    ).toBe(false);
+    expect(
+      PlayerProfileQueueSelectionSchema.safeParse(["not-a-queue"]).success,
+    ).toBe(false);
+  });
+
+  test("groups expose every queue exactly once and presets remain valid", () => {
+    const grouped = PLAYER_PROFILE_QUEUE_GROUPS.flatMap(
+      (group) => group.queues,
+    );
+    expect(grouped.toSorted()).toEqual(QueueTypeSchema.options.toSorted());
+    expect(new Set(grouped).size).toBe(grouped.length);
+    for (const queues of Object.values(PLAYER_PROFILE_QUEUE_PRESETS)) {
+      expect(PlayerProfileQueueSelectionSchema.safeParse(queues).success).toBe(
+        true,
+      );
+    }
+  });
+});

--- a/packages/scout-for-lol/packages/data/src/model/player-profile.ts
+++ b/packages/scout-for-lol/packages/data/src/model/player-profile.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+import { QueueTypeSchema, type QueueType } from "#src/model/state.ts";
+
+export const PlayerProfileGameWindowSchema = z.union([
+  z.literal(20),
+  z.literal(50),
+  z.literal("all"),
+]);
+export type PlayerProfileGameWindow = z.infer<
+  typeof PlayerProfileGameWindowSchema
+>;
+
+export const PlayerProfileQueueSelectionSchema = z
+  .array(QueueTypeSchema)
+  .min(1)
+  .max(QueueTypeSchema.options.length)
+  .superRefine((queues, context) => {
+    if (new Set(queues).size !== queues.length) {
+      context.addIssue({
+        code: "custom",
+        message: "Queue selections must be unique",
+      });
+    }
+  });
+export type PlayerProfileQueueSelection = z.infer<
+  typeof PlayerProfileQueueSelectionSchema
+>;
+
+export const PlayerProfileFilterSchema = z.object({
+  games: PlayerProfileGameWindowSchema.default(20),
+  queues: PlayerProfileQueueSelectionSchema.optional(),
+});
+
+export const PLAYER_PROFILE_QUEUE_PRESETS = {
+  competitive: ["solo", "flex", "ranked 5s", "clash"],
+  solo: ["solo"],
+  flex: ["flex"],
+  clash: ["clash", "aram clash"],
+} satisfies Record<string, readonly QueueType[]>;
+
+export const PLAYER_PROFILE_QUEUE_GROUPS = [
+  {
+    label: "Competitive",
+    queues: ["solo", "flex", "ranked 5s", "clash", "aram clash"],
+  },
+  {
+    label: "Standard",
+    queues: ["normal", "draft pick", "quickplay", "swiftplay", "aram"],
+  },
+  {
+    label: "Rotating",
+    queues: [
+      "arena",
+      "arurf",
+      "urf",
+      "brawl",
+      "aram mayhem",
+      "classic",
+      "classic aram mayhem",
+      "custom",
+    ],
+  },
+  {
+    label: "PvE",
+    queues: ["easy doom bots", "normal doom bots", "hard doom bots"],
+  },
+] satisfies readonly { label: string; queues: readonly QueueType[] }[];
+
+const groupedQueues = PLAYER_PROFILE_QUEUE_GROUPS.flatMap(
+  (group) => group.queues,
+);
+if (
+  groupedQueues.length !== QueueTypeSchema.options.length ||
+  new Set(groupedQueues).size !== QueueTypeSchema.options.length
+) {
+  throw new Error("Player profile queue groups must cover every queue once");
+}
+
+export const ChampionComparisonSortSchema = z.enum([
+  "win_rate",
+  "games",
+  "kda",
+  "cs_per_minute",
+  "damage_per_minute",
+  "gold_per_minute",
+  "vision_per_minute",
+  "alias",
+]);
+export type ChampionComparisonSort = z.infer<
+  typeof ChampionComparisonSortSchema
+>;
+
+export const ChampionComparisonCohortSchema = z.enum([
+  "qualified",
+  "small_sample",
+]);
+export type ChampionComparisonCohort = z.infer<
+  typeof ChampionComparisonCohortSchema
+>;
+
+export const ChampionComparisonCursorSchema = z.object({
+  offset: z.number().int().nonnegative(),
+});
+
+export const TimelineEventFilterSchema = z.object({
+  eventTypes: z.array(z.string().trim().min(1).max(100)).max(30).optional(),
+  participantIds: z
+    .array(z.number().int().positive().max(100))
+    .max(20)
+    .optional(),
+});
+
+export const TimelineCursorSchema = z.object({
+  offset: z.number().int().nonnegative(),
+});

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/how-to/find-player-profile.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/how-to/find-player-profile.md
@@ -1,6 +1,6 @@
 ---
 title: Find and interpret a player profile
-description: Search a shared server's configured players, distinguish combined Riot accounts, and read ranks, recent form, champion samples, and recorded match cards.
+description: Use the personalized player hub, filter recorded games, compare champion performance, and inspect match scoreboards and timelines.
 sidebar:
   order: 0
 ---
@@ -10,12 +10,16 @@ player. Profiles require Discord sign-in and only appear for enabled servers
 that you and Scout currently share. You do not need server administrator
 permission.
 
-## Find the player
+## Start from the player hub
 
 1. Open [Player Profiles](/app/players).
-2. Search the player's Scout alias or a Riot ID in `Name#Tag` form.
-3. Use the server name on each result to choose the intended player.
-4. Open the result.
+2. Under **Your profiles**, open any configured player linked to your Discord
+   account. A profile can appear more than once when different shared servers
+   register you separately.
+3. Or choose one of the six **Recently active** players, ordered by the newest
+   match Scout recorded.
+4. To find someone else, search their Scout alias or Riot ID in `Name#Tag`
+   form, use the server name to choose the intended registration, and open it.
 
 No result means Scout has no matching configured player inside your enabled
 shared servers. It does not reveal whether the same alias or Riot ID exists in
@@ -25,7 +29,9 @@ another server.
 
 The profile header shows the server alias and how many Riot accounts Scout
 combines. Each account card identifies its Riot ID, region, last observed
-match, last check time, and last observed solo and flex ranks.
+match, last check time, and last observed solo, flex, and ranked-5s ranks.
+Ranked queues use the same crest, division, and league-points treatment as a
+post-match report. An unranked queue stays text-only.
 
 Scout combines those accounts because the server configured them as one
 player. It does not infer that relationship from similar names. Ask a server
@@ -42,23 +48,77 @@ Use both timestamps:
 Opening the profile does not contact Riot or refresh either value. Scout's
 normal polling and ingest pipeline remains the source of new data.
 
+## Choose the games to compare
+
+The summary, champion table, and match history share one filter:
+
+1. Choose **Last 20**, **Last 50**, or **All time**.
+2. Choose **All games**, **Competitive**, **Solo / duo**, **Flex**, or
+   **Clash** for a common queue grouping.
+3. Expand **Choose queues** when you need an exact combination. Queues are
+   grouped into Competitive, Standard, Rotating, and PvE sections.
+
+**All games** does not add a queue predicate. Use it when older stored games
+may have a queue Riot had not mapped at ingest time. A custom selection includes
+only the checked queues. The address bar keeps the selected window and queues,
+so you can bookmark or share the same view.
+
 ## Read combined performance
 
-The summary combines games from every account in the profile. Use the queue
-buttons to compare all recorded queues, ranked solo/duo, and ranked flex.
+The summary combines matching games from every Riot account in the profile.
+Current rank does not change with the game filters: it is always Scout's newest
+known rank.
 
 Champion rows marked with an asterisk have fewer than the displayed minimum
 number of games. Treat their win rates as early evidence, not a stable
 performance claim.
 
+Use **Previous** and **Next** below the champion table to move through ten
+champions at a time.
+
+## Compare players on a champion
+
+1. Select the game window and queues you want on a player profile.
+2. Open a champion name in the champion-performance table. The comparison keeps
+   those filters.
+3. Check or clear accessible servers to change the comparison cohort.
+4. Sort by win rate, games, KDA, CS, damage, gold, vision, or alias.
+
+The main leaderboard includes player registrations with at least ten matching
+games. Smaller samples stay in a separate table. A player configured in two
+servers appears as two labeled entries, and rows linked to your Discord account
+are marked **You**.
+
 ## Trace a match to an account
 
 Every recorded match card names the Riot account Scout observed for that game.
-Use that label when a rank change, champion result, or queue entry appears to
-come from the wrong account.
+Use **Previous** and **Next** to move through twenty matches at a time. The
+selected Last 20 or Last 50 window is also the end of the list.
 
-The list is paginated and includes only games Scout recorded. It is not a
-complete Riot match history, and viewing it never starts a manual refresh.
+Open a victory or defeat label to inspect the match. The match page shows both
+complete team scoreboards and highlights the player whose profile you opened.
+Use the Riot ID, position, KDA, CS, gold, vision, damage, team-relative shares,
+objectives, and any accessible Scout aliases to interpret each participant.
+
+## Explore a captured timeline
+
+When Scout retained the timeline, the match page also provides:
+
+- team-gold and selected-player progression charts;
+- a chronological key-event summary;
+- a filterable event explorer with 100 rows per page; and
+- a frame table with 100 rows per page and every retained frame field.
+
+Choose an event type or participant to narrow the explorer. Open an event to
+see every non-empty retained field; this also works for Riot event types Scout
+does not recognize by name yet.
+
+If the page says **Timeline not captured**, the scoreboards are still complete
+for Scout's stored match row. Scout never contacts Riot from the page to fill
+the historical gap.
+
+Every list and detail includes only data Scout retained. It is not a complete
+Riot match history, and viewing it never starts a manual refresh.
 
 ## If access disappears
 


### PR DESCRIPTION
## Why

The signed-in player surface previously began and ended with search even though Scout already retains enough scoped data for personalized discovery, configurable analysis, social champion comparisons, and inspectable match details.

## What

- Replace `/players` with a personalized hub containing search, every viewer-linked profile, and six recently active non-self players.
- Add canonical Last 20 / Last 50 / All time and repeated multi-queue URL filters, presets, rank crests, 10-row champion pagination, and 20-row stable-keyset match pagination.
- Add per-guild champion leaderboards with guild filtering, qualification cohorts, server-side sorting, pagination, and viewer-linked highlighting without browser-visible Discord IDs.
- Add authorized full-match scoreboards plus retained timeline charts, key events, exhaustive 100-row event/frame pagination, filters, generic unknown-event rendering, and an explicit no-coverage state without on-demand Riot requests.
- Add browser-safe contracts, fresh membership/flag authorization on every request, DuckDB reads over the existing report lake, and low-cardinality analytics.
- Update the task-oriented player-profile how-to.

## Verification

- Scout data: typecheck, focused schema tests, lint, and build passed.
- Scout backend: generated the current Prisma client; typecheck, build, lint, architecture (1,010 modules), and 29 focused router/DuckDB/profile tests passed.
- Scout app: typecheck, all 60 test files / 403 tests, lint, architecture (292 modules), and production build passed.
- Scout docs: typecheck, prod and beta flavor tests/builds, lint, and production build passed.
- Repository duplication ratchet passed with 688 clones across the 448 allowed file pairs, down from the baseline checked by the first CI run.
- `bunx lefthook run pre-commit` and `git diff --check` passed.
- Local end-to-end acceptance used a beta-only PostgreSQL snapshot and the current beta report lake through `dev:web --no-discord-gateway`. Hub, profile, champion, and retained-timeline pages rendered without browser console/page errors in mobile/desktop and dark/light modes.
- Exact-head Buildkite is running on the final restacked head; this PR remains draft until that result is available.

## Visual proof

Mobile dark hub — viewer-linked profiles and recently active scoped players:

![player-hub-mobile-dark.png](https://public.sjer.red/pr/assets/2682/player-hub-mobile-dark.png)

Desktop light profile — rank crests, presets, shared filters, recent form, and paginated champion performance:

![player-profile-light.png](https://public.sjer.red/pr/assets/2682/player-profile-light.png)

Desktop dark champion comparison — guild filters, qualified leaderboard, small-sample cohort, and viewer highlight:

![champion-comparison-dark.png](https://public.sjer.red/pr/assets/2682/champion-comparison-dark.png)

Desktop light match timeline — full scoreboard context, team-gold and selected-player progression, and retained key events:

![match-timeline-light.png](https://public.sjer.red/pr/assets/2682/match-timeline-light.png)

## Rollout

The existing `scout-consumer-player-profiles-enabled` flag remains default-off and is re-evaluated per guild on every request. Beta deployment, authorized/unauthorized direct-link acceptance, stored PostHog-event verification, and per-guild ramp happen after this revision is deployable; they were not claimed by the local acceptance run.
