### PR TITLE
fix(scout-for-lol): reject out-of-domain Dare contract values

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/betting/dare-callout-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-callout-v2.ts
@@ -3,7 +3,7 @@ import type { MessageCreateOptions, MessageEditOptions } from "discord.js";
 import {
   BucksDareV2StateSchema,
   BucksMessageRefSchema,
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   DareSqlV3CompilationSchema,
   DiscordChannelIdSchema,
   DiscordGuildIdSchema,
@@ -135,9 +135,7 @@ export async function loadDareV2CalloutState(
           settledValue: dare.finalValue,
         })
       : deriveDareProgressV2({
-          plan: DareCompiledPlanV2Schema.parse(
-            JSON.parse(revision.compiledPlan),
-          ),
+          plan: DareStoredPlanV2Schema.parse(JSON.parse(revision.compiledPlan)),
           evidence: dare.evidence.map((row) => storedDareV2Evidence(row)),
           targetKeys,
           final,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-contract-compiler-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-contract-compiler-v2.ts
@@ -4,6 +4,7 @@ import {
   DARE_V2_MAX_JOINED_RELATIONS,
   DARE_V2_MAX_PREDICATES,
   DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   type DareBooleanExpressionV2,
   type DareCompiledPlanV2,
   type DareGameSetV2,
@@ -452,7 +453,9 @@ export function darePlanSemanticIssues(
 }
 
 export function formatDareScoutQlV2(planInput: DareCompiledPlanV2): string {
-  const plan = DareCompiledPlanV2Schema.parse(planInput);
+  // Structural parse: this renders a plan, it does not authorise one. A
+  // legacy draft still has to display its query.
+  const plan = DareStoredPlanV2Schema.parse(planInput);
   const eligibleUnion = plan.gameSets
     .map(
       (gameSet) =>

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-contract-compiler-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-contract-compiler-v2.ts
@@ -404,7 +404,15 @@ export function darePlanSemanticIssues(
   planInput: DareCompiledPlanV2,
   targets: readonly DareTargetBindingV2[],
 ): string[] {
-  const plan = DareCompiledPlanV2Schema.parse(planInput);
+  // safeParse, not parse: the schema's superRefine is the hard gate for plan
+  // limits and value domains, and this function's contract is to *return* the
+  // problems so the authoring loop can show them. Throwing here would turn a
+  // fixable contract into a provider error the model cannot act on.
+  const parsed = DareCompiledPlanV2Schema.safeParse(planInput);
+  if (!parsed.success) {
+    return parsed.error.issues.map((issue) => issue.message);
+  }
+  const plan = parsed.data;
   const issues: string[] = [];
   const targetKeys = new Set(targets.map((target) => target.key));
   if (targetKeys.size !== targets.length)

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-draft-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-draft-v2.ts
@@ -100,7 +100,14 @@ export function prepareDareDraftV2(
 ):
   | { kind: "valid"; draft: PreparedDareDraftV2 }
   | { kind: "invalid"; issues: string[] } {
-  const plan = DareCompiledPlanV2Schema.parse(definition.plan);
+  const planResult = DareCompiledPlanV2Schema.safeParse(definition.plan);
+  if (!planResult.success) {
+    return {
+      kind: "invalid",
+      issues: planResult.error.issues.map((issue) => issue.message),
+    };
+  }
+  const plan = planResult.data;
   const targets = DareTargetBindingV2Schema.array().parse(definition.targets);
   const deadlineSpec = DareDeadlineSpecV2Schema.parse(definition.deadlineSpec);
   const stake = BucksStakeSchema.safeParse(definition.openingStake);

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-evaluator-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-evaluator-v2.test.ts
@@ -2,6 +2,7 @@ import {
   DareCompiledPlanV2Schema,
   RawMatchSchema,
   RawParticipantSchema,
+  type DareCompiledPlanV2,
   type DareTargetBindingV2,
   type DareValueV2,
   type RawMatch,
@@ -344,6 +345,91 @@ describe("Dare evaluator v2 arithmetic and aggregates", () => {
         evidence: [aggregateEvidence],
       }),
     ).toBe(false);
+  });
+});
+
+// Typed as a valid plan on purpose: `threshold: string` accepts "MID" at
+// the type level, and only the schema's runtime domain check rejects it.
+function positionPlanInput(threshold: string): DareCompiledPlanV2 {
+  return {
+    version: 2,
+    maxEligibleGames: 100,
+    gameSets: [
+      {
+        name: "qualifying_game",
+        targetKeys: ["virmel"],
+        relationship: "independent",
+        queues: ["solo"],
+        predicate: {
+          kind: "comparison",
+          value: {
+            kind: "participant",
+            target: "virmel",
+            field: "team_position",
+          },
+          operator: "eq",
+          threshold,
+        },
+        projections: [],
+        orderBy: "game_end_at_asc_match_id_asc",
+        limit: 100,
+      },
+    ],
+    result: {
+      kind: "matching_games",
+      gameSet: "qualifying_game",
+      operator: "gte",
+      threshold: 1,
+    },
+  };
+}
+
+function positionEvidence(threshold: string, teamPosition: string) {
+  const plan = DareCompiledPlanV2Schema.parse(positionPlanInput(threshold));
+  const match = makeTwistedFateMatch(fixture, {
+    matchId: "NA1_position",
+    timePlayed: 1800,
+    creepScore: 200,
+    teamPosition,
+  });
+  return evaluateDareEvidenceV2({
+    plan,
+    evidence: [
+      evaluateDareMatchV2({
+        plan,
+        targets: [TARGET],
+        matchData: match,
+        queue: "solo",
+        timeline: { coverage: "missing", events: [], participants: [] },
+      }),
+    ],
+  });
+}
+
+describe("Dare evaluator v2 team position", () => {
+  // The end-to-end half of the MID/MIDDLE regression: the schema now refuses to
+  // author "MID", and the value Riot actually writes has to evaluate true here,
+  // or rejecting the wrong spelling would just move the silent failure.
+  test("counts a mid-lane game against the position Riot records", () => {
+    expect(positionEvidence("MIDDLE", "MIDDLE")).toBe(true);
+  });
+
+  test("does not count a different lane", () => {
+    expect(positionEvidence("MIDDLE", "UTILITY")).toBe(false);
+  });
+
+  test("refuses to compile a plan using the invented MID spelling", () => {
+    expect(
+      DareCompiledPlanV2Schema.safeParse(positionPlanInput("MID")).success,
+    ).toBe(false);
+  });
+
+  // The authoring loop must receive this as a fixable issue, not an exception:
+  // darePlanSemanticIssues re-parses, so it has to convert the rejection into
+  // text the model can act on.
+  test("reports the illegal position as a semantic issue for the author", () => {
+    const issues = darePlanSemanticIssues(positionPlanInput("MID"), [TARGET]);
+    expect(issues.join(" ")).toContain("MIDDLE");
   });
 });
 

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-evidence-view-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-evidence-view-v2.ts
@@ -1,6 +1,6 @@
 import {
   BucksDareV2StateSchema,
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   DareProgressSchema,
   DareSqlV3CompilationSchema,
   DareSqlV3EvidenceSchema,
@@ -178,7 +178,7 @@ export async function listDareEvidenceV2(
     });
     return evidencePage(rows, input.cursor, input.limit);
   }
-  const plan = DareCompiledPlanV2Schema.parse(rawPlan);
+  const plan = DareStoredPlanV2Schema.parse(rawPlan);
   const evidence = dare.evidence.map((row) => storedDareV2Evidence(row));
   const rows = evidence.map((row, index) => {
     const common = {

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
@@ -1,6 +1,6 @@
 import {
   DARE_CONTRACT_VERSION,
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   DareSqlV3CompilationSchema,
   DareContractV2Schema,
   DiscordAccountIdSchema,
@@ -345,7 +345,7 @@ export async function acceptDareV2InTransaction(
       : DareContractV2Schema.parse({
           version: DARE_CONTRACT_VERSION,
           canonicalScoutQl: revision.canonicalScoutQl,
-          compiledPlan: DareCompiledPlanV2Schema.parse(
+          compiledPlan: DareStoredPlanV2Schema.parse(
             JSON.parse(revision.compiledPlan),
           ),
           compilerVersion,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-plan-canonical-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-plan-canonical-v2.ts
@@ -1,5 +1,5 @@
 import {
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   type DareBooleanExpressionV2,
   type DareCompiledPlanV2,
   type DareResultExpressionV2,
@@ -87,7 +87,7 @@ function canonicalResult(
 export function canonicalDarePlanV2(
   input: DareCompiledPlanV2,
 ): DareCompiledPlanV2 {
-  const plan = DareCompiledPlanV2Schema.parse(input);
+  const plan = DareStoredPlanV2Schema.parse(input);
   const mappings = new Map(
     plan.gameSets.map((gameSet, setIndex) => [
       gameSet.name,
@@ -120,7 +120,7 @@ export function canonicalDarePlanV2(
       })),
     };
   });
-  return DareCompiledPlanV2Schema.parse({
+  return DareStoredPlanV2Schema.parse({
     version: plan.version,
     gameSets,
     result: canonicalResult(plan.result, mappings),

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-preview-compiler-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-preview-compiler-v2.test.ts
@@ -29,7 +29,11 @@ describe("Dare v2 lake compiler", () => {
                   field: "champion_name",
                 },
                 operator: "eq",
-                threshold: hostile,
+                // A real champion: a hostile string can no longer reach the
+                // compiler through this field, because the contract schema now
+                // rejects an unresolvable champion at authoring time. Binding is
+                // still exercised below by the eventType and puuid values.
+                threshold: "Ahri",
               },
               {
                 kind: "comparison",
@@ -108,5 +112,42 @@ describe("Dare v2 lake compiler", () => {
     );
     expect(compiled.sql).not.toContain("tep.puuid");
     expect(compiled.sql).toContain("(p0.kills + p0.assists)");
+  });
+
+  test("rejects a hostile champion before it can reach the compiler", () => {
+    const hostile = "'); DROP TABLE timeline_events; --";
+    expect(
+      DareCompiledPlanV2Schema.safeParse({
+        version: 2,
+        maxEligibleGames: 100,
+        gameSets: [
+          {
+            name: "one_game",
+            targetKeys: ["target"],
+            relationship: "independent",
+            queues: ["solo"],
+            predicate: {
+              kind: "comparison",
+              value: {
+                kind: "participant",
+                target: "target",
+                field: "champion_name",
+              },
+              operator: "eq",
+              threshold: hostile,
+            },
+            projections: [],
+            orderBy: "game_end_at_asc_match_id_asc",
+            limit: 10,
+          },
+        ],
+        result: {
+          kind: "matching_games",
+          gameSet: "one_game",
+          operator: "gte",
+          threshold: 1,
+        },
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.ts
@@ -326,17 +326,16 @@ export async function compileDareScoutQlPlanV2(input: {
       compilation: { ...relational.compilation, plan },
     };
   } catch (error) {
-    if (
-      error instanceof DareScoutQlProfileError ||
-      error instanceof z.ZodError
-    ) {
+    if (error instanceof DareScoutQlProfileError) {
+      return { kind: "invalid", issues: [error.message] };
+    }
+    // Surface the schema's own messages rather than one generic line: a domain
+    // rejection ("MID" is not a team position) is only actionable if the
+    // authoring loop is told which value was wrong and what is legal.
+    if (error instanceof z.ZodError) {
       return {
         kind: "invalid",
-        issues: [
-          error instanceof DareScoutQlProfileError
-            ? error.message
-            : "Dare ScoutQL contains a value outside the versioned contract profile.",
-        ],
+        issues: error.issues.map((issue) => issue.message),
       };
     }
     throw error;

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-settle-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-settle-v2.ts
@@ -1,5 +1,5 @@
 import {
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   type DareContractV2,
   type RawMatch,
 } from "@scout-for-lol/data";
@@ -366,7 +366,7 @@ export async function settleDaresV2ForMatch(
           now,
         });
       }
-      const plan = DareCompiledPlanV2Schema.parse(contract.compiledPlan);
+      const plan = DareStoredPlanV2Schema.parse(contract.compiledPlan);
       const evaluator = dareEvaluatorImplementationV2(
         contract.evaluatorVersion,
       );

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-v2-test-fixtures.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-v2-test-fixtures.ts
@@ -101,6 +101,7 @@ export function makeTwistedFateMatch(
     timePlayed: number;
     creepScore: number;
     gameStartTimestamp?: number | undefined;
+    teamPosition?: string | undefined;
   },
 ): RawMatch {
   const copy = RawMatchSchema.parse(structuredClone(fixture));
@@ -111,6 +112,9 @@ export function makeTwistedFateMatch(
     timePlayed: input.timePlayed,
     totalMinionsKilled: input.creepScore,
     neutralMinionsKilled: 0,
+    ...(input.teamPosition === undefined
+      ? {}
+      : { teamPosition: input.teamPosition }),
   });
   const timing =
     input.gameStartTimestamp === undefined

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-model-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-model-v2.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import { DareV2InspectionSchema } from "#src/betting/dare-view-model-v2.ts";
+import { TWISTED_FATE_SAME_GAME_PLAN } from "#src/betting/dare-v2-test-fixtures.ts";
+
+/**
+ * A plan holding a value that predates the domain rules — the shape both dares
+ * still active on beta are in (`team_position = 'SUPPORT'`).
+ */
+const LEGACY_PLAN = {
+  ...TWISTED_FATE_SAME_GAME_PLAN,
+  gameSets: [
+    {
+      ...TWISTED_FATE_SAME_GAME_PLAN.gameSets[0],
+      predicate: {
+        kind: "comparison",
+        value: {
+          kind: "participant",
+          target: "virmel",
+          field: "team_position",
+        },
+        operator: "eq",
+        threshold: "SUPPORT",
+      },
+    },
+  ],
+};
+
+describe("Dare v2 inspection response", () => {
+  // Tightening the authoring schema must not make an already-funded dare
+  // unreadable through the detail API. The response schema re-validates the
+  // plan, so it needs the stored variant as much as the parse sites do.
+  test("carries a plan whose value predates the domain rules", () => {
+    const parsed = DareV2InspectionSchema.shape.plan.safeParse(LEGACY_PLAN);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("still rejects a structurally invalid plan", () => {
+    expect(
+      DareV2InspectionSchema.shape.plan.safeParse({
+        ...LEGACY_PLAN,
+        gameSets: [],
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-model-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-model-v2.ts
@@ -1,6 +1,6 @@
 import {
   BucksDareV2StateSchema,
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   DareDeadlineSpecV2Schema,
   DarePollHealthSchema,
   DareProgressSchema,
@@ -70,7 +70,9 @@ export const DareV2InspectionSchema = DareV2ListItemSchema.extend({
   channelId: z.string().min(1),
   originConversationId: z.string().min(1).nullable(),
   canonicalScoutQl: z.string().min(1),
-  plan: z.union([DareCompiledPlanV2Schema, DareSqlV3CompilationSchema]),
+  // Stored, not authoring: this describes a plan being *read back*, and a
+  // revision written before a domain rule existed must still render.
+  plan: z.union([DareStoredPlanV2Schema, DareSqlV3CompilationSchema]),
   semanticProofPlan: z.string().min(1),
   originalText: z.string().min(1),
   deadlineSpec: DareDeadlineSpecV2Schema,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
@@ -1,6 +1,6 @@
 import {
   BucksDareV2StateSchema,
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   DareSqlV3CompilationSchema,
   DareDeadlineSpecV2Schema,
   DareTargetBindingV2Schema,
@@ -121,7 +121,7 @@ function parsedRevisionPlan(revision: VisibleDareRow["revisions"][number]) {
   const rawPlan: unknown = JSON.parse(revision.compiledPlan);
   return revision.compilerVersion === "dare-scoutql-3"
     ? DareSqlV3CompilationSchema.parse(rawPlan)
-    : DareCompiledPlanV2Schema.parse(rawPlan);
+    : DareStoredPlanV2Schema.parse(rawPlan);
 }
 
 function progressForRow(
@@ -215,7 +215,7 @@ function inspection(
         ? revision.canonicalScoutQl
         : visibleDareScoutQlV2({
             state,
-            plan: DareCompiledPlanV2Schema.parse(plan),
+            plan: DareStoredPlanV2Schema.parse(plan),
             storedCanonicalScoutQl: revision.canonicalScoutQl,
           }),
     plan,
@@ -274,7 +274,7 @@ function inspection(
 
 export function visibleDareScoutQlV2(input: {
   state: BucksDareV2State;
-  plan: z.infer<typeof DareCompiledPlanV2Schema>;
+  plan: z.infer<typeof DareStoredPlanV2Schema>;
   storedCanonicalScoutQl: string;
 }): string {
   return input.state === "draft"

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-dare-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-dare-v2.ts
@@ -7,7 +7,7 @@ import {
   MessageFlags,
 } from "discord.js";
 import {
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   DareDeadlineSpecV2Schema,
   DareSqlV3CompilationSchema,
   DareTargetBindingV2Schema,
@@ -117,9 +117,7 @@ function contractFields(revision: {
       },
     ];
   }
-  const plan = DareCompiledPlanV2Schema.parse(
-    JSON.parse(revision.compiledPlan),
-  );
+  const plan = DareStoredPlanV2Schema.parse(JSON.parse(revision.compiledPlan));
   const queues = [
     ...new Set(plan.gameSets.flatMap((gameSet) => gameSet.queues)),
   ];

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-tool-schemas.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-tool-schemas.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "vitest";
+import { prepareDareDraftV2 } from "#src/betting/dare-draft-v2.ts";
+import { DareDefinitionV2ToolInputSchema } from "#src/explore/dare-tool-schemas.ts";
+
+/** A contract whose lane spelling Riot never emits. */
+const INVALID_LANE_DEFINITION = {
+  originalText: "Play mid lane",
+  targetKeys: ["T1"],
+  plan: {
+    version: 2,
+    maxEligibleGames: 1,
+    gameSets: [
+      {
+        name: "games",
+        targetKeys: ["T1"],
+        relationship: "independent",
+        queues: ["solo"],
+        predicate: {
+          kind: "comparison",
+          value: { kind: "participant", target: "T1", field: "team_position" },
+          operator: "eq",
+          threshold: "MID",
+        },
+        projections: [],
+        orderBy: "game_end_at_asc_match_id_asc",
+        limit: 1,
+      },
+    ],
+    result: {
+      kind: "matching_games",
+      gameSet: "games",
+      operator: "gte",
+      threshold: 1,
+    },
+  },
+  deadlineSpec: { kind: "relative", days: 7 },
+  openingStake: 5,
+};
+
+describe("Dare v2 tool input schema", () => {
+  // The AI SDK validates tool input against this schema before the executor
+  // runs. If the value-domain refinement lived here, the SDK would reject the
+  // call itself and the model would see a generic invalid-tool-input error
+  // instead of the issue text naming MIDDLE — so the domain check has to be
+  // reachable, not pre-empted.
+  test("accepts an out-of-domain plan so the executor can answer it", () => {
+    expect(
+      DareDefinitionV2ToolInputSchema.safeParse(INVALID_LANE_DEFINITION)
+        .success,
+    ).toBe(true);
+  });
+
+  test("still rejects a structurally invalid plan at the tool boundary", () => {
+    expect(
+      DareDefinitionV2ToolInputSchema.safeParse({
+        ...INVALID_LANE_DEFINITION,
+        plan: { ...INVALID_LANE_DEFINITION.plan, gameSets: [] },
+      }).success,
+    ).toBe(false);
+  });
+
+  test("the executor returns the actionable domain issue", () => {
+    const parsed = DareDefinitionV2ToolInputSchema.parse(
+      INVALID_LANE_DEFINITION,
+    );
+    const prepared = prepareDareDraftV2({
+      originalText: parsed.originalText,
+      plan: parsed.plan,
+      targets: [
+        {
+          key: "T1",
+          discordId: "100000000000000001",
+          playerId: 1,
+          alias: "Virmel",
+          accounts: [
+            {
+              puuid: "frozen-puuid",
+              trackingStartedAt: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+        },
+      ],
+      deadlineSpec: parsed.deadlineSpec,
+      openingStake: parsed.openingStake,
+    });
+    expect(prepared.kind).toBe("invalid");
+    expect(
+      prepared.kind === "invalid" ? prepared.issues.join(" ") : "",
+    ).toContain("MIDDLE");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-tool-schemas.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-tool-schemas.ts
@@ -4,7 +4,7 @@ import {
   DARE_V2_MAX_HORIZON_DAYS,
   DARE_V2_MAX_QUERY_LENGTH,
   DARE_V2_MAX_TARGETS,
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   DareDeadlineSpecV2Schema,
   DareSqlV3CompetitionSchema,
   DareActivationV3Schema,
@@ -24,7 +24,14 @@ export const DareDefinitionV2ToolInputSchema = z.strictObject({
     .array(z.string().regex(/^T\d{1,2}$/))
     .min(1)
     .max(DARE_V2_MAX_TARGETS),
-  plan: DareCompiledPlanV2Schema,
+  // Structural, not authoring. The AI SDK validates tool input against this
+  // schema *before* the executor runs, so putting the value-domain refinement
+  // here would make the SDK reject the call itself — and the model would get a
+  // generic invalid-tool-input error instead of `prepareDareDraftV2`'s
+  // actionable `{ kind: "invalid", issues }`, which names the wrong value and
+  // the legal ones. The domains are still enforced, one layer in, where the
+  // model can act on the answer.
+  plan: DareStoredPlanV2Schema,
   deadlineSpec: DareDeadlineSpecV2Schema,
   openingStake: BucksStakeSchema,
 });

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-domains.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-domains.test.ts
@@ -3,7 +3,10 @@ import {
   DARE_V2_TEST_GAME_SET,
   DARE_V2_TEST_PLAN,
 } from "./dare-contract-v2.test-fixtures.ts";
-import { DareCompiledPlanV2Schema } from "./dare-contract-v2.ts";
+import {
+  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
+} from "./dare-contract-v2.ts";
 import type { DareBooleanExpressionV2 } from "./dare-expression-v2.ts";
 import { DARE_TEAM_POSITIONS } from "./dare-domains.ts";
 
@@ -145,5 +148,30 @@ describe("Dare v2 contract value domains", () => {
         threshold: 10,
       }).success,
     ).toBe(true);
+  });
+});
+
+describe("Dare v2 stored plans stay readable", () => {
+  // Tightening the authoring schema must not retroactively break dares already
+  // funded against a plan written before the rule existed. Both active dares on
+  // beta hold `team_position = 'SUPPORT'`; their callout, progress view, and
+  // settlement all re-parse that stored revision.
+  const legacyPlan = planWithPredicate(
+    participantComparison("team_position", "SUPPORT"),
+  );
+
+  test("reads a stored plan whose value predates the domain rule", () => {
+    expect(DareStoredPlanV2Schema.safeParse(legacyPlan).success).toBe(true);
+  });
+
+  test("still refuses to author that same plan", () => {
+    expect(DareCompiledPlanV2Schema.safeParse(legacyPlan).success).toBe(false);
+  });
+
+  test("still enforces structural limits when reading a stored plan", () => {
+    expect(
+      DareStoredPlanV2Schema.safeParse({ ...DARE_V2_TEST_PLAN, gameSets: [] })
+        .success,
+    ).toBe(false);
   });
 });

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-domains.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-domains.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "vitest";
+import {
+  DARE_V2_TEST_GAME_SET,
+  DARE_V2_TEST_PLAN,
+} from "./dare-contract-v2.test-fixtures.ts";
+import { DareCompiledPlanV2Schema } from "./dare-contract-v2.ts";
+import type { DareBooleanExpressionV2 } from "./dare-expression-v2.ts";
+import { DARE_TEAM_POSITIONS } from "./dare-domains.ts";
+
+/** A plan whose single game set carries `predicate`. */
+function planWithPredicate(predicate: DareBooleanExpressionV2) {
+  return {
+    ...DARE_V2_TEST_PLAN,
+    gameSets: [{ ...DARE_V2_TEST_GAME_SET, predicate }],
+  };
+}
+
+function participantComparison(
+  field: "team_position" | "champion_name",
+  threshold: string,
+): DareBooleanExpressionV2 {
+  return {
+    kind: "comparison",
+    value: { kind: "participant", target: "T1", field },
+    operator: "eq",
+    threshold,
+  };
+}
+
+function parsePlan(predicate: DareBooleanExpressionV2) {
+  return DareCompiledPlanV2Schema.safeParse(planWithPredicate(predicate));
+}
+
+describe("Dare v2 contract value domains", () => {
+  // The regression this whole module exists for: Riot writes MIDDLE, so a
+  // contract comparing team_position to "MID" was false for every game that
+  // could ever be played — and settled as a funded loss with a house cut.
+  test("rejects a team position Riot never emits", () => {
+    const result = parsePlan(participantComparison("team_position", "MID"));
+    expect(result.success).toBe(false);
+    expect(
+      result.error?.issues.map((issue) => issue.message).join(" "),
+    ).toContain("MIDDLE");
+  });
+
+  test("rejects SUPPORT, which Riot records as UTILITY", () => {
+    expect(
+      parsePlan(participantComparison("team_position", "SUPPORT")).success,
+    ).toBe(false);
+  });
+
+  test.each(DARE_TEAM_POSITIONS)("accepts the real position %s", (position) => {
+    expect(
+      parsePlan(participantComparison("team_position", position)).success,
+    ).toBe(true);
+  });
+
+  test("rejects an unknown champion", () => {
+    expect(
+      parsePlan(participantComparison("champion_name", "Ahriii")).success,
+    ).toBe(false);
+  });
+
+  // Both spellings must survive: the committed paraphrase corpus stores the
+  // punctuated display name, while the evaluator compares Data Dragon keys.
+  test.each(["Ahri", "Twisted Fate", "TwistedFate", "Wukong"])(
+    "accepts the resolvable champion %s",
+    (champion) => {
+      expect(
+        parsePlan(participantComparison("champion_name", champion)).success,
+      ).toBe(true);
+    },
+  );
+
+  // `normalizeChampionName` percent-decodes and throws URIError on a malformed
+  // escape; a throw must read as "unknown champion", not crash the parse.
+  test("rejects a champion with a malformed percent escape", () => {
+    expect(
+      parsePlan(participantComparison("champion_name", "100% crit Yasuo"))
+        .success,
+    ).toBe(false);
+  });
+
+  test("rejects a queue outside the queue catalog", () => {
+    expect(
+      parsePlan({
+        kind: "comparison",
+        value: { kind: "game", field: "queue" },
+        operator: "eq",
+        threshold: "RANKED_FLEX_SR",
+      }).success,
+    ).toBe(false);
+  });
+
+  test("accepts a real queue", () => {
+    expect(
+      parsePlan({
+        kind: "comparison",
+        value: { kind: "game", field: "queue" },
+        operator: "eq",
+        threshold: "flex",
+      }).success,
+    ).toBe(true);
+  });
+
+  // Domains must be checked wherever a value appears, not only at the top of a
+  // predicate — an unreachable-by-construction leaf nested under not/and is
+  // just as unsatisfiable.
+  test("rejects an out-of-domain value nested under not and and", () => {
+    expect(
+      parsePlan({
+        kind: "and",
+        operands: [
+          {
+            kind: "not",
+            operand: participantComparison("team_position", "JG"),
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
+  test("rejects an unknown champion on a related participant count", () => {
+    expect(
+      parsePlan({
+        kind: "comparison",
+        value: {
+          kind: "related_participant_count",
+          target: "T1",
+          relationship: "ally",
+          championName: "Ahriii",
+        },
+        operator: "gte",
+        threshold: 1,
+      }).success,
+    ).toBe(false);
+  });
+
+  test("leaves numeric comparisons alone", () => {
+    expect(
+      parsePlan({
+        kind: "comparison",
+        value: { kind: "participant", target: "T1", field: "kills" },
+        operator: "gte",
+        threshold: 10,
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-limits.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-limits.test.ts
@@ -11,8 +11,8 @@ import {
   DARE_V2_MAX_PREDICATES,
   DareCompiledPlanV2Schema,
   DareContractV2Schema,
-  type DareBooleanExpressionV2,
 } from "./dare-contract-v2.ts";
+import type { DareBooleanExpressionV2 } from "./dare-expression-v2.ts";
 
 const CONTRACT = {
   ...DARE_V2_TEST_CONTRACT_BASE,

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.test-fixtures.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.test-fixtures.ts
@@ -1,4 +1,4 @@
-import type { DareBooleanExpressionV2 } from "./dare-contract-v2.ts";
+import type { DareBooleanExpressionV2 } from "./dare-expression-v2.ts";
 
 export const DARE_V2_TEST_PREDICATE: DareBooleanExpressionV2 = {
   kind: "comparison",

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 import { BucksStakeSchema } from "#src/model/bryan-bucks.ts";
 import { QueueTypeSchema } from "#src/model/state.ts";
+import { dareGameSetDomainIssuesV2 } from "#src/model/dare-domains.ts";
+import {
+  DareParticipantRateFieldV2Schema,
+  DareParticipantValueFieldV2Schema,
+  type DareBooleanExpressionV2,
+  type DareValueV2,
+} from "#src/model/dare-expression-v2.ts";
 
 export const DARE_CONTRACT_VERSION = 2;
 export const DARE_SCOUTQL_COMPILER_VERSIONS = [
@@ -59,33 +66,6 @@ export const DareTargetBindingV2Schema = z.strictObject({
 });
 export type DareTargetBindingV2 = z.infer<typeof DareTargetBindingV2Schema>;
 
-export const DareParticipantValueFieldV2Schema = z.enum([
-  "champion_name",
-  "team_position",
-  "team_id",
-  "win",
-  "kills",
-  "deaths",
-  "assists",
-  "creep_score",
-  "gold_earned",
-  "vision_score",
-  "time_played",
-  "total_damage_dealt_to_champions",
-  "wards_placed",
-  "wards_killed",
-  "double_kills",
-  "triple_kills",
-  "quadra_kills",
-  "penta_kills",
-]);
-
-export const DareParticipantRateFieldV2Schema = z.enum([
-  "cs_per_minute",
-  "damage_per_minute",
-  "kda",
-]);
-
 export const DareComparisonOperatorV2Schema = z.enum([
   "eq",
   "neq",
@@ -109,40 +89,6 @@ export const DareAggregateFunctionV2Schema = z.enum([
   "minimum",
   "maximum",
 ]);
-
-export type DareValueV2 =
-  | {
-      kind: "participant";
-      target: string;
-      field: z.infer<typeof DareParticipantValueFieldV2Schema>;
-    }
-  | {
-      kind: "participant_rate";
-      target: string;
-      field: z.infer<typeof DareParticipantRateFieldV2Schema>;
-    }
-  | { kind: "game"; field: "duration_seconds" | "queue" }
-  | {
-      kind: "related_participant_count";
-      target: string;
-      relationship: "ally" | "opponent";
-      championName: string | null;
-    }
-  | {
-      kind: "timeline_event_count";
-      eventType: string;
-      target: string | null;
-      role: "subject" | "killer" | "victim" | "assist" | "creator" | null;
-      afterMs: number | null;
-      beforeMs: number | null;
-      itemId: number | null;
-    }
-  | {
-      kind: "arithmetic";
-      operator: "add" | "subtract" | "multiply" | "divide";
-      left: DareValueV2;
-      right: DareValueV2;
-    };
 
 // `z.union` deliberately emits JSON Schema `anyOf`. OpenAI rejects `oneOf`,
 // which Zod emits for `discriminatedUnion`, for both structured responses and
@@ -194,16 +140,6 @@ export const DareProjectionV2Schema = z.strictObject({
   name: z.string().regex(/^[a-z][a-z0-9_]{0,39}$/),
   value: DareValueV2Schema,
 });
-
-export type DareBooleanExpressionV2 =
-  | {
-      kind: "comparison";
-      value: DareValueV2;
-      operator: "eq" | "neq" | "gte" | "lte" | "gt" | "lt";
-      threshold: string | number | boolean;
-    }
-  | { kind: "and" | "or"; operands: DareBooleanExpressionV2[] }
-  | { kind: "not"; operand: DareBooleanExpressionV2 };
 
 export const DareBooleanExpressionV2Schema: z.ZodType<DareBooleanExpressionV2> =
   z.lazy(() =>
@@ -406,6 +342,13 @@ export const DareCompiledPlanV2Schema = z
     const facts: DarePlanComplexityV2 = { predicates: 0, maxDepth: 0 };
     for (const [index, gameSet] of plan.gameSets.entries()) {
       inspectDareBooleanComplexity(gameSet.predicate, 1, facts);
+      for (const message of dareGameSetDomainIssuesV2(gameSet)) {
+        context.addIssue({
+          code: "custom",
+          message,
+          path: ["gameSets", index],
+        });
+      }
       if (dareGameSetJoinedRelations(gameSet) > DARE_V2_MAX_JOINED_RELATIONS) {
         context.addIssue({
           code: "custom",

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
@@ -331,7 +331,19 @@ function dareGameSetJoinedRelations(gameSet: DareGameSetV2): number {
   return gameSet.targetKeys.length + timelineRelations + relatedRelations;
 }
 
-export const DareCompiledPlanV2Schema = z
+/**
+ * A compiled plan as it is *stored*: shape, references, and complexity limits,
+ * but no value-domain check.
+ *
+ * Reading a frozen plan and authoring a new one are different questions. A
+ * revision written before a domain rule existed is still exactly what its
+ * participants agreed to, and its callout, progress view, and settlement must
+ * keep rendering it faithfully — so the domain rule, which only ever applies to
+ * a value someone is choosing right now, lives on `DareCompiledPlanV2Schema`
+ * below. Tightening the authoring schema must never retroactively make an
+ * already-funded dare unreadable.
+ */
+export const DareStoredPlanV2Schema = z
   .strictObject({
     version: z.literal(DARE_CONTRACT_VERSION),
     gameSets: z.array(DareGameSetV2Schema).min(1).max(DARE_V2_MAX_GAME_SETS),
@@ -342,13 +354,6 @@ export const DareCompiledPlanV2Schema = z
     const facts: DarePlanComplexityV2 = { predicates: 0, maxDepth: 0 };
     for (const [index, gameSet] of plan.gameSets.entries()) {
       inspectDareBooleanComplexity(gameSet.predicate, 1, facts);
-      for (const message of dareGameSetDomainIssuesV2(gameSet)) {
-        context.addIssue({
-          code: "custom",
-          message,
-          path: ["gameSets", index],
-        });
-      }
       if (dareGameSetJoinedRelations(gameSet) > DARE_V2_MAX_JOINED_RELATIONS) {
         context.addIssue({
           code: "custom",
@@ -371,6 +376,26 @@ export const DareCompiledPlanV2Schema = z
       });
     }
   });
+
+/**
+ * A compiled plan being authored. Everything `DareStoredPlanV2Schema` checks,
+ * plus the value domains: a threshold naming a lane, champion, or queue that
+ * does not exist produces a predicate no game can satisfy, which would settle as
+ * a real loss rather than an error.
+ */
+export const DareCompiledPlanV2Schema = DareStoredPlanV2Schema.superRefine(
+  (plan, context) => {
+    for (const [index, gameSet] of plan.gameSets.entries()) {
+      for (const message of dareGameSetDomainIssuesV2(gameSet)) {
+        context.addIssue({
+          code: "custom",
+          message,
+          path: ["gameSets", index],
+        });
+      }
+    }
+  },
+);
 export type DareCompiledPlanV2 = z.infer<typeof DareCompiledPlanV2Schema>;
 
 export const DareDeadlineSpecV2Schema = z.union([
@@ -401,7 +426,7 @@ const DareContractV2BaseSchema = z
   .strictObject({
     version: z.literal(DARE_CONTRACT_VERSION),
     canonicalScoutQl: z.string().min(1).max(DARE_V2_MAX_QUERY_LENGTH),
-    compiledPlan: DareCompiledPlanV2Schema,
+    compiledPlan: DareStoredPlanV2Schema,
     evaluatorVersion: DareEvaluatorV2VersionSchema,
     plainLanguage: z.string().min(1),
     semanticProofPlan: z.string().min(1),

--- a/packages/scout-for-lol/packages/data/src/model/dare-domains.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-domains.ts
@@ -1,0 +1,168 @@
+import { z } from "zod";
+import {
+  getChampionByKey,
+  normalizeChampionName,
+} from "#src/model/champion-registry.ts";
+import { QueueTypeSchema } from "#src/model/state.ts";
+import type {
+  DareBooleanExpressionV2,
+  DareValueV2,
+} from "#src/model/dare-expression-v2.ts";
+
+/**
+ * Riot's `teamPosition` domain as it appears in match data and the report lake.
+ *
+ * Deliberately NOT `PositionSchema` (`#src/league/enums.ts`), which also admits
+ * `""` and `"Invalid"`. Those are real wire values — a participant in a mode
+ * without assigned roles carries them — but they must never be authored as a
+ * Dare threshold, because a dare on an empty position is unsatisfiable in
+ * exactly the way this module exists to prevent.
+ */
+export const DARE_TEAM_POSITIONS = [
+  "TOP",
+  "JUNGLE",
+  "MIDDLE",
+  "BOTTOM",
+  "UTILITY",
+] as const;
+export const DareTeamPositionSchema = z.enum(DARE_TEAM_POSITIONS);
+export type DareTeamPosition = z.infer<typeof DareTeamPositionSchema>;
+
+/**
+ * Lake columns whose values are drawn from a closed set.
+ *
+ * Keyed by column name so one table serves both contract shapes: a v2 contract
+ * compares a typed `DareValueV2` field, a v3 contract compares a SQL column in
+ * its frozen AST, and both resolve to the same report-lake column. Keeping the
+ * domains here rather than in either contract module is what stops the two
+ * enforcement points from disagreeing.
+ */
+export const DARE_DOMAIN_COLUMNS = [
+  "champion_name",
+  "team_position",
+  "queue",
+] as const;
+export const DareDomainColumnSchema = z.enum(DARE_DOMAIN_COLUMNS);
+export type DareDomainColumn = z.infer<typeof DareDomainColumnSchema>;
+
+/**
+ * A champion threshold may be written either as a Data Dragon key (`TwistedFate`)
+ * or as the punctuated display name (`Twisted Fate`) — the committed paraphrase
+ * corpus stores the latter, and the evaluator normalizes before comparing. So
+ * "valid" means "the registry resolves it", not "it is already canonical".
+ */
+function championResolves(champion: string): boolean {
+  // `normalizeChampionName` percent-decodes and throws a URIError on a malformed
+  // escape (a model champion such as "100% crit Yasuo"). Dare v1 documents the
+  // same trap in `dare-model-schema.ts`; a throw and an unresolved name are the
+  // same answer here.
+  try {
+    return getChampionByKey(normalizeChampionName(champion)) !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns a human-readable issue when `threshold` is outside `column`'s domain,
+ * or null when it is in-domain.
+ *
+ * This is the check whose absence let `team_position = 'MID'` compile, freeze,
+ * render in plain English, and settle as a funded loss: Riot writes `MIDDLE`, so
+ * the predicate was false for every game that could ever be played.
+ */
+export function dareDomainIssue(
+  column: DareDomainColumn,
+  threshold: string | number | boolean,
+): string | null {
+  if (typeof threshold !== "string") {
+    return `${column} must be compared against a string value.`;
+  }
+  if (column === "team_position") {
+    return DareTeamPositionSchema.safeParse(threshold).success
+      ? null
+      : `"${threshold}" is not a team position. Use one of ${DARE_TEAM_POSITIONS.join(", ")}.`;
+  }
+  if (column === "queue") {
+    return QueueTypeSchema.safeParse(threshold).success
+      ? null
+      : `"${threshold}" is not a queue. Use one of ${QueueTypeSchema.options.join(", ")}.`;
+  }
+  return championResolves(threshold)
+    ? null
+    : `"${threshold}" is not a known champion.`;
+}
+
+/**
+ * The report-lake column a value resolves to, or null when it has no closed
+ * domain. Participant field names are already the lake column names, so the
+ * only translation needed is the game-level `queue`.
+ */
+function dareDomainColumnForValue(value: DareValueV2): DareDomainColumn | null {
+  if (value.kind === "participant") {
+    return value.field === "champion_name" || value.field === "team_position"
+      ? value.field
+      : null;
+  }
+  return value.kind === "game" && value.field === "queue" ? "queue" : null;
+}
+
+/** Domain issues carried by a value itself, independent of any threshold. */
+export function dareValueDomainIssuesV2(value: DareValueV2): string[] {
+  if (value.kind === "arithmetic") {
+    return [
+      ...dareValueDomainIssuesV2(value.left),
+      ...dareValueDomainIssuesV2(value.right),
+    ];
+  }
+  if (
+    value.kind !== "related_participant_count" ||
+    value.championName === null
+  ) {
+    return [];
+  }
+  const issue = dareDomainIssue("champion_name", value.championName);
+  return issue === null ? [] : [issue];
+}
+
+/**
+ * Every domain violation in a predicate.
+ *
+ * Exported so the schema's hard gate and the compiler's friendly semantic pass
+ * run one implementation and cannot drift apart.
+ */
+export function dareBooleanDomainIssuesV2(
+  expression: DareBooleanExpressionV2,
+): string[] {
+  if (expression.kind === "comparison") {
+    const issues = dareValueDomainIssuesV2(expression.value);
+    const column = dareDomainColumnForValue(expression.value);
+    if (column === null) return issues;
+    const issue = dareDomainIssue(column, expression.threshold);
+    return issue === null ? issues : [...issues, issue];
+  }
+  if (expression.kind === "not") {
+    return dareBooleanDomainIssuesV2(expression.operand);
+  }
+  return expression.operands.flatMap((operand) =>
+    dareBooleanDomainIssuesV2(operand),
+  );
+}
+
+/**
+ * Domain issues across a game set's predicate and its projections.
+ *
+ * Takes the two members it reads rather than the whole game set, so this module
+ * stays independent of the contract schema that calls it.
+ */
+export function dareGameSetDomainIssuesV2(gameSet: {
+  predicate: DareBooleanExpressionV2;
+  projections: readonly { value: DareValueV2 }[];
+}): string[] {
+  return [
+    ...dareBooleanDomainIssuesV2(gameSet.predicate),
+    ...gameSet.projections.flatMap((projection) =>
+      dareValueDomainIssuesV2(projection.value),
+    ),
+  ];
+}

--- a/packages/scout-for-lol/packages/data/src/model/dare-expression-v2.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-expression-v2.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+
+/**
+ * The Dare v2 expression vocabulary: which participant and game fields a
+ * contract may read, and the recursive value/predicate shapes built from them.
+ *
+ * Split out from `dare-contract-v2.ts` so `dare-domains.ts` can validate the
+ * values these fields carry without importing the contract schema back — the
+ * schema needs the domain walk in its `superRefine`, so the dependency has to
+ * run one way only.
+ */
+export const DareParticipantValueFieldV2Schema = z.enum([
+  "champion_name",
+  "team_position",
+  "team_id",
+  "win",
+  "kills",
+  "deaths",
+  "assists",
+  "creep_score",
+  "gold_earned",
+  "vision_score",
+  "time_played",
+  "total_damage_dealt_to_champions",
+  "wards_placed",
+  "wards_killed",
+  "double_kills",
+  "triple_kills",
+  "quadra_kills",
+  "penta_kills",
+]);
+
+export const DareParticipantRateFieldV2Schema = z.enum([
+  "cs_per_minute",
+  "damage_per_minute",
+  "kda",
+]);
+
+export type DareValueV2 =
+  | {
+      kind: "participant";
+      target: string;
+      field: z.infer<typeof DareParticipantValueFieldV2Schema>;
+    }
+  | {
+      kind: "participant_rate";
+      target: string;
+      field: z.infer<typeof DareParticipantRateFieldV2Schema>;
+    }
+  | { kind: "game"; field: "duration_seconds" | "queue" }
+  | {
+      kind: "related_participant_count";
+      target: string;
+      relationship: "ally" | "opponent";
+      championName: string | null;
+    }
+  | {
+      kind: "timeline_event_count";
+      eventType: string;
+      target: string | null;
+      role: "subject" | "killer" | "victim" | "assist" | "creator" | null;
+      afterMs: number | null;
+      beforeMs: number | null;
+      itemId: number | null;
+    }
+  | {
+      kind: "arithmetic";
+      operator: "add" | "subtract" | "multiply" | "divide";
+      left: DareValueV2;
+      right: DareValueV2;
+    };
+
+export type DareBooleanExpressionV2 =
+  | {
+      kind: "comparison";
+      value: DareValueV2;
+      operator: "eq" | "neq" | "gte" | "lte" | "gt" | "lt";
+      threshold: string | number | boolean;
+    }
+  | { kind: "and" | "or"; operands: DareBooleanExpressionV2[] }
+  | { kind: "not"; operand: DareBooleanExpressionV2 };

--- a/packages/scout-for-lol/packages/data/src/model/index.ts
+++ b/packages/scout-for-lol/packages/data/src/model/index.ts
@@ -5,6 +5,8 @@ export * from "./competition-format.ts";
 export * from "./discord.ts";
 export * from "./division.ts";
 export * from "./dare-contract-v2.ts";
+export * from "./dare-domains.ts";
+export * from "./dare-expression-v2.ts";
 export * from "./dare-contract-v3.ts";
 export * from "./dare-progress.ts";
 export * from "./dare-paraphrase-corpus.ts";


### PR DESCRIPTION
## Why

A dare compiled as `team_position = 'MID'` is unsatisfiable by construction — Riot writes `MIDDLE` — but nothing rejected it. The contract froze, rendered in plain English, and settled `unachieved`, which refunds **with** the house cut, so an impossible dare cost the players a fee.

This is not hypothetical. Every lane-constrained dare ever created on beta is invalid:

| dare | threshold | real value | state |
| --- | --- | --- | --- |
| 4 | `team_position = 'SUPPORT'` | `UTILITY` | active, unwinnable |
| 5 | `team_position = 'SUPPORT'` | `UTILITY` | active, unwinnable |
| 6 | `team_position = 'MID'` | `MIDDLE` | settled as a loss, 2 BB fee taken |

Three for three — the model has never emitted a legal `team_position`. Validation only compared the JS primitive type (`typeof threshold !== expectedType`), so any string passed. `champion_name`, `game.queue`, and `related_participant_count.championName` share the hole; champion was merely *masked*, because `normalizeChampionName` returns its input unchanged when it cannot resolve, so `"Ahriii"` also silently never matches.

Dare v1 already did this correctly — `dare-model-schema.ts` resolves champions through the registry and returns `Unknown champion "X"` as a semantic issue so the model retries. The v2 rewrite dropped it. And no dare test referenced `team_position` at all, which is why 3/3 shipped broken.

## What

- **`dare-domains.ts`** — the closed value domains, keyed by **report-lake column name** rather than v2 field name so the follow-up v3 AST check consumes the same table instead of a parallel copy. Positions are the 5 real Riot values, deliberately *not* `PositionSchema`, which also admits `""` and `"Invalid"`. Champions resolve through the existing registry and accept display names (`"Twisted Fate"`), guarding the `URIError` a malformed percent escape throws (the trap v1 documents).
- **Hard gate** in `DareCompiledPlanV2Schema`'s `superRefine`, walking predicates, nested `not`/`and`/`or`, arithmetic operands, and projections.
- **Authoring paths made total** — `darePlanSemanticIssues` and `prepareDareDraftV2` now `safeParse` and return the schema's own messages instead of throwing, and the ScoutQL compiler surfaces the specific issues rather than collapsing a `ZodError` to one generic line. This matters: both previously threw, which would have turned every domain rejection into a provider error the model cannot act on. One implementation feeds both the hard gate and the friendly messages, so they cannot drift.
- **`dare-expression-v2.ts`** — the expression vocabulary split out so the domain module can validate values without importing the contract schema back. Dependency runs one way; the contract file drops 481 → 424 lines.

The emitted model-facing JSON Schema is unchanged: `superRefine` is invisible to `z.toJSONSchema`, so this adds no bytes to the tool schema shipped on every Explore turn.

## Verification

```
bunx turbo run typecheck test lint --filter=@scout-for-lol/data --filter=@scout-for-lol/backend
```

4,479 tests pass; typecheck and lint clean on both packages.

- 18 new domain cases (`dare-contract-v2-domains.test.ts`) and 4 evaluator cases covering the end-to-end pair: `MIDDLE` matches a `MIDDLE` participant, `MID` will not compile, and `darePlanSemanticIssues` reports it as text naming `MIDDLE` rather than throwing.
- The paraphrase corpus round-trip and the generated JSON Schema drift check both pass unchanged.
- The SQL-injection binding test keeps its coverage — the hostile string still reaches the parameter binder via `eventType` and `puuid` — plus a new case asserting a hostile champion is refused *before* it can reach the compiler.

**Not run:** live beta authoring through `/bb dare`, and the paid model eval (`test:dare-v2:model-eval`).

Non-visual change (schema/validation), so no media.

## Follow-ups in this stack

Dare **v3** (merged dark behind `dare_extended_contracts_enabled`, `default: false`, no overrides) abandons the typed plan for `canonicalSql` + `immutableAst`, so `darePlanSemanticIssues` never runs for it and `compileDareSqlV3` never inspects a comparison literal — the same bug with less structure. The next PR adds the AST-walking check over this same domain table, and must land before that flag is enabled anywhere.