### PR TITLE
fix(scout-for-lol): reject out-of-domain values in Dare v3 SQL

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/betting/dare-callout-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-callout-v2.ts
@@ -3,7 +3,7 @@ import type { MessageCreateOptions, MessageEditOptions } from "discord.js";
 import {
   BucksDareV2StateSchema,
   BucksMessageRefSchema,
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   DareSqlV3CompilationSchema,
   DiscordChannelIdSchema,
   DiscordGuildIdSchema,
@@ -135,9 +135,7 @@ export async function loadDareV2CalloutState(
           settledValue: dare.finalValue,
         })
       : deriveDareProgressV2({
-          plan: DareCompiledPlanV2Schema.parse(
-            JSON.parse(revision.compiledPlan),
-          ),
+          plan: DareStoredPlanV2Schema.parse(JSON.parse(revision.compiledPlan)),
           evidence: dare.evidence.map((row) => storedDareV2Evidence(row)),
           targetKeys,
           final,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-contract-compiler-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-contract-compiler-v2.ts
@@ -4,6 +4,7 @@ import {
   DARE_V2_MAX_JOINED_RELATIONS,
   DARE_V2_MAX_PREDICATES,
   DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   type DareBooleanExpressionV2,
   type DareCompiledPlanV2,
   type DareGameSetV2,
@@ -452,7 +453,9 @@ export function darePlanSemanticIssues(
 }
 
 export function formatDareScoutQlV2(planInput: DareCompiledPlanV2): string {
-  const plan = DareCompiledPlanV2Schema.parse(planInput);
+  // Structural parse: this renders a plan, it does not authorise one. A
+  // legacy draft still has to display its query.
+  const plan = DareStoredPlanV2Schema.parse(planInput);
   const eligibleUnion = plan.gameSets
     .map(
       (gameSet) =>

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-contract-compiler-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-contract-compiler-v2.ts
@@ -404,7 +404,15 @@ export function darePlanSemanticIssues(
   planInput: DareCompiledPlanV2,
   targets: readonly DareTargetBindingV2[],
 ): string[] {
-  const plan = DareCompiledPlanV2Schema.parse(planInput);
+  // safeParse, not parse: the schema's superRefine is the hard gate for plan
+  // limits and value domains, and this function's contract is to *return* the
+  // problems so the authoring loop can show them. Throwing here would turn a
+  // fixable contract into a provider error the model cannot act on.
+  const parsed = DareCompiledPlanV2Schema.safeParse(planInput);
+  if (!parsed.success) {
+    return parsed.error.issues.map((issue) => issue.message);
+  }
+  const plan = parsed.data;
   const issues: string[] = [];
   const targetKeys = new Set(targets.map((target) => target.key));
   if (targetKeys.size !== targets.length)

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-draft-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-draft-v2.ts
@@ -100,7 +100,14 @@ export function prepareDareDraftV2(
 ):
   | { kind: "valid"; draft: PreparedDareDraftV2 }
   | { kind: "invalid"; issues: string[] } {
-  const plan = DareCompiledPlanV2Schema.parse(definition.plan);
+  const planResult = DareCompiledPlanV2Schema.safeParse(definition.plan);
+  if (!planResult.success) {
+    return {
+      kind: "invalid",
+      issues: planResult.error.issues.map((issue) => issue.message),
+    };
+  }
+  const plan = planResult.data;
   const targets = DareTargetBindingV2Schema.array().parse(definition.targets);
   const deadlineSpec = DareDeadlineSpecV2Schema.parse(definition.deadlineSpec);
   const stake = BucksStakeSchema.safeParse(definition.openingStake);

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-evaluator-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-evaluator-v2.test.ts
@@ -2,6 +2,7 @@ import {
   DareCompiledPlanV2Schema,
   RawMatchSchema,
   RawParticipantSchema,
+  type DareCompiledPlanV2,
   type DareTargetBindingV2,
   type DareValueV2,
   type RawMatch,
@@ -344,6 +345,91 @@ describe("Dare evaluator v2 arithmetic and aggregates", () => {
         evidence: [aggregateEvidence],
       }),
     ).toBe(false);
+  });
+});
+
+// Typed as a valid plan on purpose: `threshold: string` accepts "MID" at
+// the type level, and only the schema's runtime domain check rejects it.
+function positionPlanInput(threshold: string): DareCompiledPlanV2 {
+  return {
+    version: 2,
+    maxEligibleGames: 100,
+    gameSets: [
+      {
+        name: "qualifying_game",
+        targetKeys: ["virmel"],
+        relationship: "independent",
+        queues: ["solo"],
+        predicate: {
+          kind: "comparison",
+          value: {
+            kind: "participant",
+            target: "virmel",
+            field: "team_position",
+          },
+          operator: "eq",
+          threshold,
+        },
+        projections: [],
+        orderBy: "game_end_at_asc_match_id_asc",
+        limit: 100,
+      },
+    ],
+    result: {
+      kind: "matching_games",
+      gameSet: "qualifying_game",
+      operator: "gte",
+      threshold: 1,
+    },
+  };
+}
+
+function positionEvidence(threshold: string, teamPosition: string) {
+  const plan = DareCompiledPlanV2Schema.parse(positionPlanInput(threshold));
+  const match = makeTwistedFateMatch(fixture, {
+    matchId: "NA1_position",
+    timePlayed: 1800,
+    creepScore: 200,
+    teamPosition,
+  });
+  return evaluateDareEvidenceV2({
+    plan,
+    evidence: [
+      evaluateDareMatchV2({
+        plan,
+        targets: [TARGET],
+        matchData: match,
+        queue: "solo",
+        timeline: { coverage: "missing", events: [], participants: [] },
+      }),
+    ],
+  });
+}
+
+describe("Dare evaluator v2 team position", () => {
+  // The end-to-end half of the MID/MIDDLE regression: the schema now refuses to
+  // author "MID", and the value Riot actually writes has to evaluate true here,
+  // or rejecting the wrong spelling would just move the silent failure.
+  test("counts a mid-lane game against the position Riot records", () => {
+    expect(positionEvidence("MIDDLE", "MIDDLE")).toBe(true);
+  });
+
+  test("does not count a different lane", () => {
+    expect(positionEvidence("MIDDLE", "UTILITY")).toBe(false);
+  });
+
+  test("refuses to compile a plan using the invented MID spelling", () => {
+    expect(
+      DareCompiledPlanV2Schema.safeParse(positionPlanInput("MID")).success,
+    ).toBe(false);
+  });
+
+  // The authoring loop must receive this as a fixable issue, not an exception:
+  // darePlanSemanticIssues re-parses, so it has to convert the rejection into
+  // text the model can act on.
+  test("reports the illegal position as a semantic issue for the author", () => {
+    const issues = darePlanSemanticIssues(positionPlanInput("MID"), [TARGET]);
+    expect(issues.join(" ")).toContain("MIDDLE");
   });
 });
 

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-evidence-view-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-evidence-view-v2.ts
@@ -1,6 +1,6 @@
 import {
   BucksDareV2StateSchema,
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   DareProgressSchema,
   DareSqlV3CompilationSchema,
   DareSqlV3EvidenceSchema,
@@ -178,7 +178,7 @@ export async function listDareEvidenceV2(
     });
     return evidencePage(rows, input.cursor, input.limit);
   }
-  const plan = DareCompiledPlanV2Schema.parse(rawPlan);
+  const plan = DareStoredPlanV2Schema.parse(rawPlan);
   const evidence = dare.evidence.map((row) => storedDareV2Evidence(row));
   const rows = evidence.map((row, index) => {
     const common = {

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
@@ -1,6 +1,6 @@
 import {
   DARE_CONTRACT_VERSION,
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   DareSqlV3CompilationSchema,
   DareContractV2Schema,
   DiscordAccountIdSchema,
@@ -345,7 +345,7 @@ export async function acceptDareV2InTransaction(
       : DareContractV2Schema.parse({
           version: DARE_CONTRACT_VERSION,
           canonicalScoutQl: revision.canonicalScoutQl,
-          compiledPlan: DareCompiledPlanV2Schema.parse(
+          compiledPlan: DareStoredPlanV2Schema.parse(
             JSON.parse(revision.compiledPlan),
           ),
           compilerVersion,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-plan-canonical-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-plan-canonical-v2.ts
@@ -1,5 +1,5 @@
 import {
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   type DareBooleanExpressionV2,
   type DareCompiledPlanV2,
   type DareResultExpressionV2,
@@ -87,7 +87,7 @@ function canonicalResult(
 export function canonicalDarePlanV2(
   input: DareCompiledPlanV2,
 ): DareCompiledPlanV2 {
-  const plan = DareCompiledPlanV2Schema.parse(input);
+  const plan = DareStoredPlanV2Schema.parse(input);
   const mappings = new Map(
     plan.gameSets.map((gameSet, setIndex) => [
       gameSet.name,
@@ -120,7 +120,7 @@ export function canonicalDarePlanV2(
       })),
     };
   });
-  return DareCompiledPlanV2Schema.parse({
+  return DareStoredPlanV2Schema.parse({
     version: plan.version,
     gameSets,
     result: canonicalResult(plan.result, mappings),

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-preview-compiler-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-preview-compiler-v2.test.ts
@@ -29,7 +29,11 @@ describe("Dare v2 lake compiler", () => {
                   field: "champion_name",
                 },
                 operator: "eq",
-                threshold: hostile,
+                // A real champion: a hostile string can no longer reach the
+                // compiler through this field, because the contract schema now
+                // rejects an unresolvable champion at authoring time. Binding is
+                // still exercised below by the eventType and puuid values.
+                threshold: "Ahri",
               },
               {
                 kind: "comparison",
@@ -108,5 +112,42 @@ describe("Dare v2 lake compiler", () => {
     );
     expect(compiled.sql).not.toContain("tep.puuid");
     expect(compiled.sql).toContain("(p0.kills + p0.assists)");
+  });
+
+  test("rejects a hostile champion before it can reach the compiler", () => {
+    const hostile = "'); DROP TABLE timeline_events; --";
+    expect(
+      DareCompiledPlanV2Schema.safeParse({
+        version: 2,
+        maxEligibleGames: 100,
+        gameSets: [
+          {
+            name: "one_game",
+            targetKeys: ["target"],
+            relationship: "independent",
+            queues: ["solo"],
+            predicate: {
+              kind: "comparison",
+              value: {
+                kind: "participant",
+                target: "target",
+                field: "champion_name",
+              },
+              operator: "eq",
+              threshold: hostile,
+            },
+            projections: [],
+            orderBy: "game_end_at_asc_match_id_asc",
+            limit: 10,
+          },
+        ],
+        result: {
+          kind: "matching_games",
+          gameSet: "one_game",
+          operator: "gte",
+          threshold: 1,
+        },
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.ts
@@ -326,17 +326,16 @@ export async function compileDareScoutQlPlanV2(input: {
       compilation: { ...relational.compilation, plan },
     };
   } catch (error) {
-    if (
-      error instanceof DareScoutQlProfileError ||
-      error instanceof z.ZodError
-    ) {
+    if (error instanceof DareScoutQlProfileError) {
+      return { kind: "invalid", issues: [error.message] };
+    }
+    // Surface the schema's own messages rather than one generic line: a domain
+    // rejection ("MID" is not a team position) is only actionable if the
+    // authoring loop is told which value was wrong and what is legal.
+    if (error instanceof z.ZodError) {
       return {
         kind: "invalid",
-        issues: [
-          error instanceof DareScoutQlProfileError
-            ? error.message
-            : "Dare ScoutQL contains a value outside the versioned contract profile.",
-        ],
+        issues: error.issues.map((issue) => issue.message),
       };
     }
     throw error;

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-settle-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-settle-v2.ts
@@ -1,5 +1,5 @@
 import {
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   type DareContractV2,
   type RawMatch,
 } from "@scout-for-lol/data";
@@ -366,7 +366,7 @@ export async function settleDaresV2ForMatch(
           now,
         });
       }
-      const plan = DareCompiledPlanV2Schema.parse(contract.compiledPlan);
+      const plan = DareStoredPlanV2Schema.parse(contract.compiledPlan);
       const evaluator = dareEvaluatorImplementationV2(
         contract.evaluatorVersion,
       );

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-sql-v3-column-origin.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-sql-v3-column-origin.ts
@@ -1,0 +1,294 @@
+import { DARE_SQL_V3_SOURCES } from "#src/reports/duckdb/dare-sql-v3-profile.ts";
+import {
+  relationalScoutQlArrayValue as arrayValue,
+  relationalScoutQlObjectValue as objectValue,
+  relationalScoutQlStringValue as stringValue,
+  type RelationalScoutQlJsonValue as JsonValue,
+} from "#src/reports/duckdb/relational-scoutql-json.ts";
+
+/**
+ * Where a column reference in a frozen Dare SQL AST gets its values.
+ *
+ * The lake's closed value domains describe lake columns, so a name alone cannot
+ * decide anything: `COUNT(*) AS queue` is a CTE's own integer and
+ * `queue >= 5` against it is a perfectly good contract. `unknown` is deliberately
+ * distinct from `derived` — it means the AST did not say, which is not a licence
+ * to guess in either direction.
+ */
+type DareSqlV3ColumnOrigin = "lake" | "derived" | "unknown";
+
+/** `absent` says the relation does not export the column at all, so keep looking. */
+type ColumnLookup = DareSqlV3ColumnOrigin | "absent";
+
+type AstObject = Record<string, JsonValue>;
+
+/** A relation's body plus the FROM-clause names its output columns were given. */
+type RelationDefinition = {
+  node: AstObject | null;
+  columnAliases: string[];
+};
+
+type Relation =
+  { kind: "lake" } | { kind: "derived"; definition: RelationDefinition };
+
+export type DareSqlV3Scope = {
+  relations: { name: string; relation: Relation }[];
+  ctes: Map<string, RelationDefinition>;
+  parent: DareSqlV3Scope | null;
+};
+
+// SQL identifiers are case-insensitive and the lake writes its columns in lower
+// case, so every name this module compares is folded once, on the way in.
+const LAKE_SOURCE_NAMES = new Set(
+  [...DARE_SQL_V3_SOURCES].map((source) => source.toLowerCase()),
+);
+
+function lowerString(value: JsonValue | undefined): string | null {
+  const text = stringValue(value);
+  return text === null ? null : text.toLowerCase();
+}
+
+function columnAliasList(value: JsonValue | undefined): string[] {
+  return arrayValue(value)
+    .map((alias) => lowerString(alias))
+    .filter((alias) => alias !== null);
+}
+
+/** The name a select-list entry publishes: its alias, else the column it names. */
+function projectedName(value: JsonValue | undefined): string | null {
+  const expression = objectValue(value);
+  if (expression === null) return null;
+  const alias = lowerString(expression["alias"]);
+  if (alias !== null && alias.length > 0) return alias;
+  return lowerString(arrayValue(expression["column_names"]).at(-1));
+}
+
+function cteDefinitions(
+  node: AstObject,
+  inherited: ReadonlyMap<string, RelationDefinition>,
+): Map<string, RelationDefinition> {
+  const ctes = new Map(inherited);
+  for (const entryValue of arrayValue(objectValue(node["cte_map"])?.["map"])) {
+    const entry = objectValue(entryValue);
+    const name = lowerString(entry?.["key"]);
+    if (name === null) continue;
+    const value = objectValue(entry?.["value"]);
+    ctes.set(name, {
+      node: objectValue(objectValue(value?.["query"])?.["node"]),
+      columnAliases: columnAliasList(value?.["aliases"]),
+    });
+  }
+  return ctes;
+}
+
+function addBaseTable(from: AstObject, scope: DareSqlV3Scope): void {
+  const table = lowerString(from["table_name"]);
+  if (table === null) return;
+  const alias = lowerString(from["alias"]);
+  const name = alias !== null && alias.length > 0 ? alias : table;
+  // A schema- or catalog-qualified name cannot be a CTE reference, matching how
+  // `collectAstFacts` decides which base tables count as physical sources.
+  const bare =
+    (stringValue(from["schema_name"]) ?? "") === "" &&
+    (stringValue(from["catalog_name"]) ?? "") === "";
+  const cte = bare ? scope.ctes.get(table) : undefined;
+  if (cte !== undefined) {
+    scope.relations.push({
+      name,
+      relation: { kind: "derived", definition: cte },
+    });
+    return;
+  }
+  // `FROM T1 AS t(a, b)` renames the lake's columns, so the names written in the
+  // query no longer address the lake columns the domain table describes.
+  const renamed = columnAliasList(from["column_name_alias"]).length > 0;
+  const relation: Relation =
+    !renamed && LAKE_SOURCE_NAMES.has(table)
+      ? { kind: "lake" }
+      : { kind: "derived", definition: { node: null, columnAliases: [] } };
+  scope.relations.push({ name, relation });
+}
+
+function addRelations(
+  fromValue: JsonValue | undefined,
+  scope: DareSqlV3Scope,
+): void {
+  const from = objectValue(fromValue);
+  if (from === null) return;
+  const type = stringValue(from["type"]);
+  if (type === "JOIN") {
+    addRelations(from["left"], scope);
+    addRelations(from["right"], scope);
+    return;
+  }
+  if (type === "BASE_TABLE") {
+    addBaseTable(from, scope);
+    return;
+  }
+  if (type !== "SUBQUERY") return;
+  const alias = lowerString(from["alias"]);
+  scope.relations.push({
+    name: alias ?? "",
+    relation: {
+      kind: "derived",
+      definition: {
+        node: objectValue(objectValue(from["subquery"])?.["node"]),
+        columnAliases: columnAliasList(from["column_name_alias"]),
+      },
+    },
+  });
+}
+
+/** The relations a SELECT node's expressions may name, over its enclosing query. */
+export function dareSqlV3QueryScope(
+  node: AstObject,
+  parent: DareSqlV3Scope | null,
+): DareSqlV3Scope {
+  const scope: DareSqlV3Scope = {
+    relations: [],
+    ctes: cteDefinitions(node, parent?.ctes ?? new Map()),
+    parent,
+  };
+  addRelations(node["from_table"], scope);
+  return scope;
+}
+
+function projectionOrigin(
+  projection: JsonValue | undefined,
+  scope: DareSqlV3Scope,
+  visited: ReadonlySet<AstObject>,
+): DareSqlV3ColumnOrigin {
+  const expression = objectValue(projection);
+  if (
+    expression === null ||
+    stringValue(expression["class"]) !== "COLUMN_REF"
+  ) {
+    return "derived";
+  }
+  // A projection that only forwards a column keeps that column's origin, which
+  // is what lets `WITH g AS (SELECT team_position FROM T1) … g.team_position`
+  // stay a lake column.
+  return columnOrigin(scope, arrayValue(expression["column_names"]), visited);
+}
+
+function derivedOrigin(
+  definition: RelationDefinition,
+  scope: DareSqlV3Scope,
+  column: string,
+  visited: ReadonlySet<AstObject>,
+): ColumnLookup {
+  const node = definition.node;
+  // A CTE naming itself parses even though it would never bind; refusing to
+  // re-enter a body already on the path keeps this walk finite either way.
+  if (
+    node === null ||
+    visited.has(node) ||
+    stringValue(node["type"]) !== "SELECT_NODE"
+  ) {
+    return "unknown";
+  }
+  const inner = dareSqlV3QueryScope(node, scope);
+  const nextVisited = new Set(visited).add(node);
+  const selectList = arrayValue(node["select_list"]);
+  if (definition.columnAliases.length > 0) {
+    const index = definition.columnAliases.indexOf(column);
+    return index === -1
+      ? "absent"
+      : projectionOrigin(selectList[index], inner, nextVisited);
+  }
+  const projection = selectList.find(
+    (entry) => projectedName(entry) === column,
+  );
+  if (projection !== undefined) {
+    return projectionOrigin(projection, inner, nextVisited);
+  }
+  const star = selectList.some(
+    (entry) => stringValue(objectValue(entry)?.["class"]) === "STAR",
+  );
+  return star ? unqualifiedOrigin(inner, column, nextVisited) : "absent";
+}
+
+function qualifiedOrigin(
+  scope: DareSqlV3Scope,
+  qualifier: string,
+  column: string,
+  visited: ReadonlySet<AstObject>,
+): DareSqlV3ColumnOrigin {
+  let current: DareSqlV3Scope | null = scope;
+  while (current !== null) {
+    const entry = current.relations.find(
+      (candidate) => candidate.name === qualifier,
+    );
+    if (entry !== undefined) {
+      const origin =
+        entry.relation.kind === "lake"
+          ? "lake"
+          : derivedOrigin(entry.relation.definition, current, column, visited);
+      return origin === "absent" ? "unknown" : origin;
+    }
+    current = current.parent;
+  }
+  return "unknown";
+}
+
+function unqualifiedOrigin(
+  scope: DareSqlV3Scope,
+  column: string,
+  visited: ReadonlySet<AstObject>,
+): DareSqlV3ColumnOrigin {
+  let current: DareSqlV3Scope | null = scope;
+  while (current !== null) {
+    // A derived relation answers first: it is the one that can rename a lake
+    // column out of its domain, and the lake relations carry no such surprise.
+    for (const entry of current.relations) {
+      if (entry.relation.kind === "lake") continue;
+      const origin = derivedOrigin(
+        entry.relation.definition,
+        current,
+        column,
+        visited,
+      );
+      if (origin !== "absent") return origin;
+    }
+    if (current.relations.some((entry) => entry.relation.kind === "lake")) {
+      return "lake";
+    }
+    current = current.parent;
+  }
+  return "unknown";
+}
+
+function columnOrigin(
+  scope: DareSqlV3Scope,
+  columnNames: readonly JsonValue[],
+  visited: ReadonlySet<AstObject>,
+): DareSqlV3ColumnOrigin {
+  const names = columnNames
+    .map((part) => lowerString(part))
+    .filter((part) => part !== null);
+  const column = names.at(-1);
+  // A part that is not a string means the AST said something this walk does not
+  // model, and a partly-read name would resolve against the wrong relation.
+  if (column === undefined || names.length !== columnNames.length) {
+    return "unknown";
+  }
+  const qualifier = names.at(-2);
+  return qualifier === undefined
+    ? unqualifiedOrigin(scope, column, visited)
+    : qualifiedOrigin(scope, qualifier, column, visited);
+}
+
+/**
+ * Where a `COLUMN_REF`'s dotted name parts resolve, read from the AST alone.
+ *
+ * Qualified names resolve through the FROM aliases of this scope and every
+ * enclosing one; unqualified names resolve against the derived relations in
+ * scope first, because only a derived relation can publish a lake column name
+ * that holds something else.
+ */
+export function dareSqlV3ColumnOrigin(
+  scope: DareSqlV3Scope,
+  columnNames: readonly JsonValue[],
+): DareSqlV3ColumnOrigin {
+  return columnOrigin(scope, columnNames, new Set());
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-sql-v3-domains.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-sql-v3-domains.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+import { compileDareSqlV3 } from "#src/betting/dare-sql-v3.ts";
+
+/** A one-game-set contract whose game set carries `predicate`. */
+function contract(predicate: string): string {
+  return `WITH qualifying_game AS (
+      SELECT match_id, game_end_at, (${predicate}) AS matched FROM T1
+    )
+    SELECT EXISTS (SELECT 1 FROM qualifying_game WHERE matched) AS achieved`;
+}
+
+function compile(predicate: string) {
+  return compileDareSqlV3({
+    queryText: contract(predicate),
+    targetKeys: ["T1"],
+  });
+}
+
+describe("Dare SQL v3 value domains", () => {
+  // v3 keeps no typed plan, so this AST walk is the only thing standing between
+  // an invented lane spelling and a funded, unwinnable contract.
+  test("rejects a team position Riot never emits", async () => {
+    await expect(compile("team_position = 'MID'")).rejects.toThrow("MIDDLE");
+  });
+
+  test("rejects SUPPORT, which Riot records as UTILITY", async () => {
+    await expect(compile("team_position = 'SUPPORT'")).rejects.toThrow(
+      "UTILITY",
+    );
+  });
+
+  test("accepts the position Riot actually writes", async () => {
+    await expect(compile("team_position = 'MIDDLE'")).resolves.toMatchObject({
+      compilerVersion: "dare-scoutql-3",
+    });
+  });
+
+  // `'MID' = p0.team_position` is the same authoring mistake written backwards.
+  test("rejects an out-of-domain literal on either side of the comparison", async () => {
+    await expect(compile("'MID' = team_position")).rejects.toThrow("MIDDLE");
+  });
+
+  test("rejects an unknown champion", async () => {
+    await expect(compile("champion_name = 'Ahriii'")).rejects.toThrow(
+      "not a known champion",
+    );
+  });
+
+  test("accepts a champion written as its display name", async () => {
+    await expect(
+      compile("champion_name = 'Twisted Fate'"),
+    ).resolves.toMatchObject({ compilerVersion: "dare-scoutql-3" });
+  });
+
+  test("rejects an out-of-domain queue in an IN list", async () => {
+    await expect(compile("queue IN ('RANKED_FLEX_SR')")).rejects.toThrow(
+      "not a queue",
+    );
+  });
+
+  test("accepts a real queue in an IN list", async () => {
+    await expect(compile("queue IN ('solo', 'flex')")).resolves.toMatchObject({
+      compilerVersion: "dare-scoutql-3",
+    });
+  });
+
+  // Columns without a closed domain must be left alone, or every numeric dare
+  // would start failing to compile.
+  test("leaves numeric comparisons alone", async () => {
+    await expect(compile("kills >= 5")).resolves.toMatchObject({
+      compilerVersion: "dare-scoutql-3",
+    });
+  });
+
+  test("ignores a comparison between two columns", async () => {
+    await expect(
+      compile("team_position = individual_position"),
+    ).resolves.toMatchObject({ compilerVersion: "dare-scoutql-3" });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-sql-v3-domains.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-sql-v3-domains.test.ts
@@ -77,4 +77,49 @@ describe("Dare SQL v3 value domains", () => {
       compile("team_position = individual_position"),
     ).resolves.toMatchObject({ compilerVersion: "dare-scoutql-3" });
   });
+
+  // A CTE may publish any name it likes, so a domain belongs to the lake column
+  // rather than to the spelling: `COUNT(*) AS queue` is an integer.
+  test("accepts a derived alias that reuses a lake domain column's name", async () => {
+    await expect(
+      compileDareSqlV3({
+        queryText: `WITH counts AS (SELECT COUNT(*) AS queue FROM T1)
+          SELECT queue >= 5 AS achieved FROM counts`,
+        targetKeys: ["T1"],
+      }),
+    ).resolves.toMatchObject({ compilerVersion: "dare-scoutql-3" });
+  });
+
+  // The relaxation above must not become an escape hatch: a CTE that merely
+  // forwards a lake column is still comparing the lake column.
+  test("rejects an out-of-domain literal on a column a CTE forwards from the lake", async () => {
+    await expect(
+      compileDareSqlV3({
+        queryText: `WITH lake_games AS (
+            SELECT match_id, game_end_at, team_position FROM T1
+          ), qualifying_game AS (
+            SELECT match_id, game_end_at, (team_position = 'MID') AS matched
+            FROM lake_games
+          )
+          SELECT EXISTS (SELECT 1 FROM qualifying_game WHERE matched) AS achieved`,
+        targetKeys: ["T1"],
+      }),
+    ).rejects.toThrow("MIDDLE");
+  });
+
+  // A qualifier that names a lake relation is the shape the model writes most
+  // often, and it stays checked whichever alias the FROM clause gave it.
+  test("rejects an out-of-domain literal behind a lake table alias", async () => {
+    await expect(
+      compileDareSqlV3({
+        queryText: `WITH qualifying_game AS (
+            SELECT p0.match_id, p0.game_end_at,
+              (p0.team_position = 'MID') AS matched
+            FROM T1 AS p0
+          )
+          SELECT EXISTS (SELECT 1 FROM qualifying_game WHERE matched) AS achieved`,
+        targetKeys: ["T1"],
+      }),
+    ).rejects.toThrow("MIDDLE");
+  });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-sql-v3-domains.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-sql-v3-domains.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 import { DareDomainColumnSchema, dareDomainIssue } from "@scout-for-lol/data";
+import {
+  dareSqlV3ColumnOrigin,
+  dareSqlV3QueryScope,
+  type DareSqlV3Scope,
+} from "#src/betting/dare-sql-v3-column-origin.ts";
 import { relationalScoutQlStatementFromImmutableAst } from "#src/reports/duckdb/relational-scoutql.ts";
 import {
   relationalScoutQlArrayValue as arrayValue,
@@ -23,15 +28,13 @@ import {
 /** The literal kinds a comparison threshold may hold. */
 const AstLiteralSchema = z.union([z.string(), z.number(), z.boolean()]);
 
-/** The unqualified column a COLUMN_REF names, or null for any other node. */
-function columnName(value: JsonValue | undefined): string | null {
+/** A COLUMN_REF's dotted name parts, or null for any other node. */
+function columnRefNames(value: JsonValue | undefined): JsonValue[] | null {
   const object = objectValue(value);
   if (object === null || stringValue(object["class"]) !== "COLUMN_REF") {
     return null;
   }
-  const names = arrayValue(object["column_names"]);
-  const last = names.at(-1);
-  return last === undefined ? null : stringValue(last);
+  return arrayValue(object["column_names"]);
 }
 
 /**
@@ -58,30 +61,37 @@ function literalValue(
 function checkPair(
   columnValue: JsonValue | undefined,
   literalNode: JsonValue | undefined,
+  scope: DareSqlV3Scope | null,
   issues: string[],
 ): void {
-  const name = columnName(columnValue);
-  if (name === null) return;
-  const column = DareDomainColumnSchema.safeParse(name);
+  const names = columnRefNames(columnValue);
+  const name = stringValue(names?.at(-1));
+  if (names === null || name === null || scope === null) return;
+  const column = DareDomainColumnSchema.safeParse(name.toLowerCase());
   if (!column.success) return;
   const literal = literalValue(literalNode);
   // A comparison against another column or a computed expression carries no
   // literal to validate; only a written-down value can be out of domain.
   if (literal === null) return;
+  // The domain belongs to the lake column, not to its name. A query is free to
+  // publish `COUNT(*) AS queue` from a CTE and compare it to 5, so the check
+  // runs only once the AST proves the reference reaches a lake relation.
+  if (dareSqlV3ColumnOrigin(scope, names) !== "lake") return;
   const issue = dareDomainIssue(column.data, literal);
   if (issue !== null) issues.push(issue);
 }
 
 function inspectNode(
   object: Record<string, JsonValue>,
+  scope: DareSqlV3Scope | null,
   issues: string[],
 ): void {
   const className = stringValue(object["class"]);
   if (className === "COMPARISON") {
     // Either operand may hold the column: `p0.team_position = 'MID'` and
     // `'MID' = p0.team_position` are the same mistake.
-    checkPair(object["left"], object["right"], issues);
-    checkPair(object["right"], object["left"], issues);
+    checkPair(object["left"], object["right"], scope, issues);
+    checkPair(object["right"], object["left"], scope, issues);
     return;
   }
   if (
@@ -90,20 +100,31 @@ function inspectNode(
   ) {
     const children = arrayValue(object["children"]);
     const [column, ...values] = children;
-    for (const value of values) checkPair(column, value, issues);
+    for (const value of values) checkPair(column, value, scope, issues);
   }
 }
 
-function collectDomainIssues(value: JsonValue, issues: string[]): void {
+function collectDomainIssues(
+  value: JsonValue,
+  scope: DareSqlV3Scope | null,
+  issues: string[],
+): void {
   if (Array.isArray(value)) {
-    for (const child of value) collectDomainIssues(child, issues);
+    for (const child of value) collectDomainIssues(child, scope, issues);
     return;
   }
   const object = objectValue(value);
   if (object === null) return;
-  inspectNode(object, issues);
+  // Each SELECT node introduces the relations its expressions may name; a CTE
+  // body and a subquery are reached as children, so they inherit this scope as
+  // their enclosing one exactly as SQL scoping says they should.
+  const inner =
+    stringValue(object["type"]) === "SELECT_NODE"
+      ? dareSqlV3QueryScope(object, scope)
+      : scope;
+  inspectNode(object, inner, issues);
   for (const child of Object.values(object)) {
-    collectDomainIssues(child, issues);
+    collectDomainIssues(child, inner, issues);
   }
 }
 
@@ -117,6 +138,7 @@ export function dareSqlV3DomainIssues(immutableAst: string): string[] {
   const issues: string[] = [];
   collectDomainIssues(
     relationalScoutQlStatementFromImmutableAst(immutableAst),
+    null,
     issues,
   );
   return [...new Set(issues)];

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-sql-v3-domains.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-sql-v3-domains.ts
@@ -1,0 +1,123 @@
+import { z } from "zod";
+import { DareDomainColumnSchema, dareDomainIssue } from "@scout-for-lol/data";
+import { relationalScoutQlStatementFromImmutableAst } from "#src/reports/duckdb/relational-scoutql.ts";
+import {
+  relationalScoutQlArrayValue as arrayValue,
+  relationalScoutQlObjectValue as objectValue,
+  relationalScoutQlStringValue as stringValue,
+  type RelationalScoutQlJsonValue as JsonValue,
+} from "#src/reports/duckdb/relational-scoutql-json.ts";
+
+/**
+ * Domain validation for Dare v3 contracts.
+ *
+ * v3 froze the SQL instead of a typed plan, so there is no `threshold` field to
+ * type and `darePlanSemanticIssues` never runs for it. A comparison against an
+ * impossible value — `team_position = 'MID'` when Riot writes `MIDDLE` — is just
+ * a literal that matches no row, which reads as an honestly-lost dare rather
+ * than a broken one. This walks the frozen AST and applies the same domain table
+ * the v2 contract schema uses, so the two contract shapes cannot disagree about
+ * which values exist.
+ */
+
+/** The literal kinds a comparison threshold may hold. */
+const AstLiteralSchema = z.union([z.string(), z.number(), z.boolean()]);
+
+/** The unqualified column a COLUMN_REF names, or null for any other node. */
+function columnName(value: JsonValue | undefined): string | null {
+  const object = objectValue(value);
+  if (object === null || stringValue(object["class"]) !== "COLUMN_REF") {
+    return null;
+  }
+  const names = arrayValue(object["column_names"]);
+  const last = names.at(-1);
+  return last === undefined ? null : stringValue(last);
+}
+
+/**
+ * A plain literal's value, or null when the node is not one. Casts are unwrapped
+ * because DuckDB wraps some constants; anything else (a column, an expression)
+ * has no domain to check.
+ */
+function literalValue(
+  value: JsonValue | undefined,
+): string | number | boolean | null {
+  const object = objectValue(value);
+  if (object === null) return null;
+  if (stringValue(object["class"]) === "CAST") {
+    return literalValue(object["child"]);
+  }
+  if (stringValue(object["class"]) !== "CONSTANT") return null;
+  const constant = objectValue(object["value"]);
+  if (constant === null || constant["is_null"] === true) return null;
+  const literal = AstLiteralSchema.safeParse(constant["value"]);
+  return literal.success ? literal.data : null;
+}
+
+/** Record an issue when `column` has a closed domain that `literal` violates. */
+function checkPair(
+  columnValue: JsonValue | undefined,
+  literalNode: JsonValue | undefined,
+  issues: string[],
+): void {
+  const name = columnName(columnValue);
+  if (name === null) return;
+  const column = DareDomainColumnSchema.safeParse(name);
+  if (!column.success) return;
+  const literal = literalValue(literalNode);
+  // A comparison against another column or a computed expression carries no
+  // literal to validate; only a written-down value can be out of domain.
+  if (literal === null) return;
+  const issue = dareDomainIssue(column.data, literal);
+  if (issue !== null) issues.push(issue);
+}
+
+function inspectNode(
+  object: Record<string, JsonValue>,
+  issues: string[],
+): void {
+  const className = stringValue(object["class"]);
+  if (className === "COMPARISON") {
+    // Either operand may hold the column: `p0.team_position = 'MID'` and
+    // `'MID' = p0.team_position` are the same mistake.
+    checkPair(object["left"], object["right"], issues);
+    checkPair(object["right"], object["left"], issues);
+    return;
+  }
+  if (
+    className === "OPERATOR" &&
+    stringValue(object["type"]) === "COMPARE_IN"
+  ) {
+    const children = arrayValue(object["children"]);
+    const [column, ...values] = children;
+    for (const value of values) checkPair(column, value, issues);
+  }
+}
+
+function collectDomainIssues(value: JsonValue, issues: string[]): void {
+  if (Array.isArray(value)) {
+    for (const child of value) collectDomainIssues(child, issues);
+    return;
+  }
+  const object = objectValue(value);
+  if (object === null) return;
+  inspectNode(object, issues);
+  for (const child of Object.values(object)) {
+    collectDomainIssues(child, issues);
+  }
+}
+
+/**
+ * Every domain violation written into a Dare v3 contract's frozen SQL.
+ *
+ * Deduplicated because one authoring mistake can appear in several CTEs of the
+ * generated query, and repeating the same sentence teaches the author nothing.
+ */
+export function dareSqlV3DomainIssues(immutableAst: string): string[] {
+  const issues: string[] = [];
+  collectDomainIssues(
+    relationalScoutQlStatementFromImmutableAst(immutableAst),
+    issues,
+  );
+  return [...new Set(issues)];
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-sql-v3.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-sql-v3.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { dareSqlV3DomainIssues } from "#src/betting/dare-sql-v3-domains.ts";
 import {
   DARE_SQL_V3_COMPILER_VERSION,
   DARE_V2_MAX_ELIGIBLE_GAMES,
@@ -88,6 +89,15 @@ export async function compileDareSqlV3(input: {
   });
   if (validated.kind === "invalid") {
     throw new Error(validated.issues.join(" "));
+  }
+  // The frozen SQL is the contract, so an out-of-domain literal has to be
+  // refused here: v3 keeps no typed plan for darePlanSemanticIssues to inspect,
+  // and an unsatisfiable comparison would otherwise settle as a real loss.
+  const domainIssues = dareSqlV3DomainIssues(
+    validated.compilation.immutableAst,
+  );
+  if (domainIssues.length > 0) {
+    throw new Error(domainIssues.join(" "));
   }
   const resultStructure = dareSqlV3ResultStructureFromAst(
     validated.compilation.immutableAst,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-v2-test-fixtures.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-v2-test-fixtures.ts
@@ -101,6 +101,7 @@ export function makeTwistedFateMatch(
     timePlayed: number;
     creepScore: number;
     gameStartTimestamp?: number | undefined;
+    teamPosition?: string | undefined;
   },
 ): RawMatch {
   const copy = RawMatchSchema.parse(structuredClone(fixture));
@@ -111,6 +112,9 @@ export function makeTwistedFateMatch(
     timePlayed: input.timePlayed,
     totalMinionsKilled: input.creepScore,
     neutralMinionsKilled: 0,
+    ...(input.teamPosition === undefined
+      ? {}
+      : { teamPosition: input.teamPosition }),
   });
   const timing =
     input.gameStartTimestamp === undefined

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-model-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-model-v2.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import { DareV2InspectionSchema } from "#src/betting/dare-view-model-v2.ts";
+import { TWISTED_FATE_SAME_GAME_PLAN } from "#src/betting/dare-v2-test-fixtures.ts";
+
+/**
+ * A plan holding a value that predates the domain rules — the shape both dares
+ * still active on beta are in (`team_position = 'SUPPORT'`).
+ */
+const LEGACY_PLAN = {
+  ...TWISTED_FATE_SAME_GAME_PLAN,
+  gameSets: [
+    {
+      ...TWISTED_FATE_SAME_GAME_PLAN.gameSets[0],
+      predicate: {
+        kind: "comparison",
+        value: {
+          kind: "participant",
+          target: "virmel",
+          field: "team_position",
+        },
+        operator: "eq",
+        threshold: "SUPPORT",
+      },
+    },
+  ],
+};
+
+describe("Dare v2 inspection response", () => {
+  // Tightening the authoring schema must not make an already-funded dare
+  // unreadable through the detail API. The response schema re-validates the
+  // plan, so it needs the stored variant as much as the parse sites do.
+  test("carries a plan whose value predates the domain rules", () => {
+    const parsed = DareV2InspectionSchema.shape.plan.safeParse(LEGACY_PLAN);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("still rejects a structurally invalid plan", () => {
+    expect(
+      DareV2InspectionSchema.shape.plan.safeParse({
+        ...LEGACY_PLAN,
+        gameSets: [],
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-model-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-model-v2.ts
@@ -1,6 +1,6 @@
 import {
   BucksDareV2StateSchema,
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   DareDeadlineSpecV2Schema,
   DarePollHealthSchema,
   DareProgressSchema,
@@ -70,7 +70,9 @@ export const DareV2InspectionSchema = DareV2ListItemSchema.extend({
   channelId: z.string().min(1),
   originConversationId: z.string().min(1).nullable(),
   canonicalScoutQl: z.string().min(1),
-  plan: z.union([DareCompiledPlanV2Schema, DareSqlV3CompilationSchema]),
+  // Stored, not authoring: this describes a plan being *read back*, and a
+  // revision written before a domain rule existed must still render.
+  plan: z.union([DareStoredPlanV2Schema, DareSqlV3CompilationSchema]),
   semanticProofPlan: z.string().min(1),
   originalText: z.string().min(1),
   deadlineSpec: DareDeadlineSpecV2Schema,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
@@ -1,6 +1,6 @@
 import {
   BucksDareV2StateSchema,
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   DareSqlV3CompilationSchema,
   DareDeadlineSpecV2Schema,
   DareTargetBindingV2Schema,
@@ -121,7 +121,7 @@ function parsedRevisionPlan(revision: VisibleDareRow["revisions"][number]) {
   const rawPlan: unknown = JSON.parse(revision.compiledPlan);
   return revision.compilerVersion === "dare-scoutql-3"
     ? DareSqlV3CompilationSchema.parse(rawPlan)
-    : DareCompiledPlanV2Schema.parse(rawPlan);
+    : DareStoredPlanV2Schema.parse(rawPlan);
 }
 
 function progressForRow(
@@ -215,7 +215,7 @@ function inspection(
         ? revision.canonicalScoutQl
         : visibleDareScoutQlV2({
             state,
-            plan: DareCompiledPlanV2Schema.parse(plan),
+            plan: DareStoredPlanV2Schema.parse(plan),
             storedCanonicalScoutQl: revision.canonicalScoutQl,
           }),
     plan,
@@ -274,7 +274,7 @@ function inspection(
 
 export function visibleDareScoutQlV2(input: {
   state: BucksDareV2State;
-  plan: z.infer<typeof DareCompiledPlanV2Schema>;
+  plan: z.infer<typeof DareStoredPlanV2Schema>;
   storedCanonicalScoutQl: string;
 }): string {
   return input.state === "draft"

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-dare-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-dare-v2.ts
@@ -7,7 +7,7 @@ import {
   MessageFlags,
 } from "discord.js";
 import {
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   DareDeadlineSpecV2Schema,
   DareSqlV3CompilationSchema,
   DareTargetBindingV2Schema,
@@ -117,9 +117,7 @@ function contractFields(revision: {
       },
     ];
   }
-  const plan = DareCompiledPlanV2Schema.parse(
-    JSON.parse(revision.compiledPlan),
-  );
+  const plan = DareStoredPlanV2Schema.parse(JSON.parse(revision.compiledPlan));
   const queues = [
     ...new Set(plan.gameSets.flatMap((gameSet) => gameSet.queues)),
   ];

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-tool-schemas.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-tool-schemas.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "vitest";
+import { prepareDareDraftV2 } from "#src/betting/dare-draft-v2.ts";
+import { DareDefinitionV2ToolInputSchema } from "#src/explore/dare-tool-schemas.ts";
+
+/** A contract whose lane spelling Riot never emits. */
+const INVALID_LANE_DEFINITION = {
+  originalText: "Play mid lane",
+  targetKeys: ["T1"],
+  plan: {
+    version: 2,
+    maxEligibleGames: 1,
+    gameSets: [
+      {
+        name: "games",
+        targetKeys: ["T1"],
+        relationship: "independent",
+        queues: ["solo"],
+        predicate: {
+          kind: "comparison",
+          value: { kind: "participant", target: "T1", field: "team_position" },
+          operator: "eq",
+          threshold: "MID",
+        },
+        projections: [],
+        orderBy: "game_end_at_asc_match_id_asc",
+        limit: 1,
+      },
+    ],
+    result: {
+      kind: "matching_games",
+      gameSet: "games",
+      operator: "gte",
+      threshold: 1,
+    },
+  },
+  deadlineSpec: { kind: "relative", days: 7 },
+  openingStake: 5,
+};
+
+describe("Dare v2 tool input schema", () => {
+  // The AI SDK validates tool input against this schema before the executor
+  // runs. If the value-domain refinement lived here, the SDK would reject the
+  // call itself and the model would see a generic invalid-tool-input error
+  // instead of the issue text naming MIDDLE — so the domain check has to be
+  // reachable, not pre-empted.
+  test("accepts an out-of-domain plan so the executor can answer it", () => {
+    expect(
+      DareDefinitionV2ToolInputSchema.safeParse(INVALID_LANE_DEFINITION)
+        .success,
+    ).toBe(true);
+  });
+
+  test("still rejects a structurally invalid plan at the tool boundary", () => {
+    expect(
+      DareDefinitionV2ToolInputSchema.safeParse({
+        ...INVALID_LANE_DEFINITION,
+        plan: { ...INVALID_LANE_DEFINITION.plan, gameSets: [] },
+      }).success,
+    ).toBe(false);
+  });
+
+  test("the executor returns the actionable domain issue", () => {
+    const parsed = DareDefinitionV2ToolInputSchema.parse(
+      INVALID_LANE_DEFINITION,
+    );
+    const prepared = prepareDareDraftV2({
+      originalText: parsed.originalText,
+      plan: parsed.plan,
+      targets: [
+        {
+          key: "T1",
+          discordId: "100000000000000001",
+          playerId: 1,
+          alias: "Virmel",
+          accounts: [
+            {
+              puuid: "frozen-puuid",
+              trackingStartedAt: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+        },
+      ],
+      deadlineSpec: parsed.deadlineSpec,
+      openingStake: parsed.openingStake,
+    });
+    expect(prepared.kind).toBe("invalid");
+    expect(
+      prepared.kind === "invalid" ? prepared.issues.join(" ") : "",
+    ).toContain("MIDDLE");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-tool-schemas.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-tool-schemas.ts
@@ -4,7 +4,7 @@ import {
   DARE_V2_MAX_HORIZON_DAYS,
   DARE_V2_MAX_QUERY_LENGTH,
   DARE_V2_MAX_TARGETS,
-  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
   DareDeadlineSpecV2Schema,
   DareSqlV3CompetitionSchema,
   DareActivationV3Schema,
@@ -24,7 +24,14 @@ export const DareDefinitionV2ToolInputSchema = z.strictObject({
     .array(z.string().regex(/^T\d{1,2}$/))
     .min(1)
     .max(DARE_V2_MAX_TARGETS),
-  plan: DareCompiledPlanV2Schema,
+  // Structural, not authoring. The AI SDK validates tool input against this
+  // schema *before* the executor runs, so putting the value-domain refinement
+  // here would make the SDK reject the call itself — and the model would get a
+  // generic invalid-tool-input error instead of `prepareDareDraftV2`'s
+  // actionable `{ kind: "invalid", issues }`, which names the wrong value and
+  // the legal ones. The domains are still enforced, one layer in, where the
+  // model can act on the answer.
+  plan: DareStoredPlanV2Schema,
   deadlineSpec: DareDeadlineSpecV2Schema,
   openingStake: BucksStakeSchema,
 });

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-domains.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-domains.test.ts
@@ -3,7 +3,10 @@ import {
   DARE_V2_TEST_GAME_SET,
   DARE_V2_TEST_PLAN,
 } from "./dare-contract-v2.test-fixtures.ts";
-import { DareCompiledPlanV2Schema } from "./dare-contract-v2.ts";
+import {
+  DareCompiledPlanV2Schema,
+  DareStoredPlanV2Schema,
+} from "./dare-contract-v2.ts";
 import type { DareBooleanExpressionV2 } from "./dare-expression-v2.ts";
 import { DARE_TEAM_POSITIONS } from "./dare-domains.ts";
 
@@ -145,5 +148,30 @@ describe("Dare v2 contract value domains", () => {
         threshold: 10,
       }).success,
     ).toBe(true);
+  });
+});
+
+describe("Dare v2 stored plans stay readable", () => {
+  // Tightening the authoring schema must not retroactively break dares already
+  // funded against a plan written before the rule existed. Both active dares on
+  // beta hold `team_position = 'SUPPORT'`; their callout, progress view, and
+  // settlement all re-parse that stored revision.
+  const legacyPlan = planWithPredicate(
+    participantComparison("team_position", "SUPPORT"),
+  );
+
+  test("reads a stored plan whose value predates the domain rule", () => {
+    expect(DareStoredPlanV2Schema.safeParse(legacyPlan).success).toBe(true);
+  });
+
+  test("still refuses to author that same plan", () => {
+    expect(DareCompiledPlanV2Schema.safeParse(legacyPlan).success).toBe(false);
+  });
+
+  test("still enforces structural limits when reading a stored plan", () => {
+    expect(
+      DareStoredPlanV2Schema.safeParse({ ...DARE_V2_TEST_PLAN, gameSets: [] })
+        .success,
+    ).toBe(false);
   });
 });

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-domains.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-domains.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "vitest";
+import {
+  DARE_V2_TEST_GAME_SET,
+  DARE_V2_TEST_PLAN,
+} from "./dare-contract-v2.test-fixtures.ts";
+import { DareCompiledPlanV2Schema } from "./dare-contract-v2.ts";
+import type { DareBooleanExpressionV2 } from "./dare-expression-v2.ts";
+import { DARE_TEAM_POSITIONS } from "./dare-domains.ts";
+
+/** A plan whose single game set carries `predicate`. */
+function planWithPredicate(predicate: DareBooleanExpressionV2) {
+  return {
+    ...DARE_V2_TEST_PLAN,
+    gameSets: [{ ...DARE_V2_TEST_GAME_SET, predicate }],
+  };
+}
+
+function participantComparison(
+  field: "team_position" | "champion_name",
+  threshold: string,
+): DareBooleanExpressionV2 {
+  return {
+    kind: "comparison",
+    value: { kind: "participant", target: "T1", field },
+    operator: "eq",
+    threshold,
+  };
+}
+
+function parsePlan(predicate: DareBooleanExpressionV2) {
+  return DareCompiledPlanV2Schema.safeParse(planWithPredicate(predicate));
+}
+
+describe("Dare v2 contract value domains", () => {
+  // The regression this whole module exists for: Riot writes MIDDLE, so a
+  // contract comparing team_position to "MID" was false for every game that
+  // could ever be played — and settled as a funded loss with a house cut.
+  test("rejects a team position Riot never emits", () => {
+    const result = parsePlan(participantComparison("team_position", "MID"));
+    expect(result.success).toBe(false);
+    expect(
+      result.error?.issues.map((issue) => issue.message).join(" "),
+    ).toContain("MIDDLE");
+  });
+
+  test("rejects SUPPORT, which Riot records as UTILITY", () => {
+    expect(
+      parsePlan(participantComparison("team_position", "SUPPORT")).success,
+    ).toBe(false);
+  });
+
+  test.each(DARE_TEAM_POSITIONS)("accepts the real position %s", (position) => {
+    expect(
+      parsePlan(participantComparison("team_position", position)).success,
+    ).toBe(true);
+  });
+
+  test("rejects an unknown champion", () => {
+    expect(
+      parsePlan(participantComparison("champion_name", "Ahriii")).success,
+    ).toBe(false);
+  });
+
+  // Both spellings must survive: the committed paraphrase corpus stores the
+  // punctuated display name, while the evaluator compares Data Dragon keys.
+  test.each(["Ahri", "Twisted Fate", "TwistedFate", "Wukong"])(
+    "accepts the resolvable champion %s",
+    (champion) => {
+      expect(
+        parsePlan(participantComparison("champion_name", champion)).success,
+      ).toBe(true);
+    },
+  );
+
+  // `normalizeChampionName` percent-decodes and throws URIError on a malformed
+  // escape; a throw must read as "unknown champion", not crash the parse.
+  test("rejects a champion with a malformed percent escape", () => {
+    expect(
+      parsePlan(participantComparison("champion_name", "100% crit Yasuo"))
+        .success,
+    ).toBe(false);
+  });
+
+  test("rejects a queue outside the queue catalog", () => {
+    expect(
+      parsePlan({
+        kind: "comparison",
+        value: { kind: "game", field: "queue" },
+        operator: "eq",
+        threshold: "RANKED_FLEX_SR",
+      }).success,
+    ).toBe(false);
+  });
+
+  test("accepts a real queue", () => {
+    expect(
+      parsePlan({
+        kind: "comparison",
+        value: { kind: "game", field: "queue" },
+        operator: "eq",
+        threshold: "flex",
+      }).success,
+    ).toBe(true);
+  });
+
+  // Domains must be checked wherever a value appears, not only at the top of a
+  // predicate — an unreachable-by-construction leaf nested under not/and is
+  // just as unsatisfiable.
+  test("rejects an out-of-domain value nested under not and and", () => {
+    expect(
+      parsePlan({
+        kind: "and",
+        operands: [
+          {
+            kind: "not",
+            operand: participantComparison("team_position", "JG"),
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
+  test("rejects an unknown champion on a related participant count", () => {
+    expect(
+      parsePlan({
+        kind: "comparison",
+        value: {
+          kind: "related_participant_count",
+          target: "T1",
+          relationship: "ally",
+          championName: "Ahriii",
+        },
+        operator: "gte",
+        threshold: 1,
+      }).success,
+    ).toBe(false);
+  });
+
+  test("leaves numeric comparisons alone", () => {
+    expect(
+      parsePlan({
+        kind: "comparison",
+        value: { kind: "participant", target: "T1", field: "kills" },
+        operator: "gte",
+        threshold: 10,
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-limits.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-limits.test.ts
@@ -11,8 +11,8 @@ import {
   DARE_V2_MAX_PREDICATES,
   DareCompiledPlanV2Schema,
   DareContractV2Schema,
-  type DareBooleanExpressionV2,
 } from "./dare-contract-v2.ts";
+import type { DareBooleanExpressionV2 } from "./dare-expression-v2.ts";
 
 const CONTRACT = {
   ...DARE_V2_TEST_CONTRACT_BASE,

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.test-fixtures.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.test-fixtures.ts
@@ -1,4 +1,4 @@
-import type { DareBooleanExpressionV2 } from "./dare-contract-v2.ts";
+import type { DareBooleanExpressionV2 } from "./dare-expression-v2.ts";
 
 export const DARE_V2_TEST_PREDICATE: DareBooleanExpressionV2 = {
   kind: "comparison",

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 import { BucksStakeSchema } from "#src/model/bryan-bucks.ts";
 import { QueueTypeSchema } from "#src/model/state.ts";
+import { dareGameSetDomainIssuesV2 } from "#src/model/dare-domains.ts";
+import {
+  DareParticipantRateFieldV2Schema,
+  DareParticipantValueFieldV2Schema,
+  type DareBooleanExpressionV2,
+  type DareValueV2,
+} from "#src/model/dare-expression-v2.ts";
 
 export const DARE_CONTRACT_VERSION = 2;
 export const DARE_SCOUTQL_COMPILER_VERSIONS = [
@@ -59,33 +66,6 @@ export const DareTargetBindingV2Schema = z.strictObject({
 });
 export type DareTargetBindingV2 = z.infer<typeof DareTargetBindingV2Schema>;
 
-export const DareParticipantValueFieldV2Schema = z.enum([
-  "champion_name",
-  "team_position",
-  "team_id",
-  "win",
-  "kills",
-  "deaths",
-  "assists",
-  "creep_score",
-  "gold_earned",
-  "vision_score",
-  "time_played",
-  "total_damage_dealt_to_champions",
-  "wards_placed",
-  "wards_killed",
-  "double_kills",
-  "triple_kills",
-  "quadra_kills",
-  "penta_kills",
-]);
-
-export const DareParticipantRateFieldV2Schema = z.enum([
-  "cs_per_minute",
-  "damage_per_minute",
-  "kda",
-]);
-
 export const DareComparisonOperatorV2Schema = z.enum([
   "eq",
   "neq",
@@ -109,40 +89,6 @@ export const DareAggregateFunctionV2Schema = z.enum([
   "minimum",
   "maximum",
 ]);
-
-export type DareValueV2 =
-  | {
-      kind: "participant";
-      target: string;
-      field: z.infer<typeof DareParticipantValueFieldV2Schema>;
-    }
-  | {
-      kind: "participant_rate";
-      target: string;
-      field: z.infer<typeof DareParticipantRateFieldV2Schema>;
-    }
-  | { kind: "game"; field: "duration_seconds" | "queue" }
-  | {
-      kind: "related_participant_count";
-      target: string;
-      relationship: "ally" | "opponent";
-      championName: string | null;
-    }
-  | {
-      kind: "timeline_event_count";
-      eventType: string;
-      target: string | null;
-      role: "subject" | "killer" | "victim" | "assist" | "creator" | null;
-      afterMs: number | null;
-      beforeMs: number | null;
-      itemId: number | null;
-    }
-  | {
-      kind: "arithmetic";
-      operator: "add" | "subtract" | "multiply" | "divide";
-      left: DareValueV2;
-      right: DareValueV2;
-    };
 
 // `z.union` deliberately emits JSON Schema `anyOf`. OpenAI rejects `oneOf`,
 // which Zod emits for `discriminatedUnion`, for both structured responses and
@@ -194,16 +140,6 @@ export const DareProjectionV2Schema = z.strictObject({
   name: z.string().regex(/^[a-z][a-z0-9_]{0,39}$/),
   value: DareValueV2Schema,
 });
-
-export type DareBooleanExpressionV2 =
-  | {
-      kind: "comparison";
-      value: DareValueV2;
-      operator: "eq" | "neq" | "gte" | "lte" | "gt" | "lt";
-      threshold: string | number | boolean;
-    }
-  | { kind: "and" | "or"; operands: DareBooleanExpressionV2[] }
-  | { kind: "not"; operand: DareBooleanExpressionV2 };
 
 export const DareBooleanExpressionV2Schema: z.ZodType<DareBooleanExpressionV2> =
   z.lazy(() =>
@@ -406,6 +342,13 @@ export const DareCompiledPlanV2Schema = z
     const facts: DarePlanComplexityV2 = { predicates: 0, maxDepth: 0 };
     for (const [index, gameSet] of plan.gameSets.entries()) {
       inspectDareBooleanComplexity(gameSet.predicate, 1, facts);
+      for (const message of dareGameSetDomainIssuesV2(gameSet)) {
+        context.addIssue({
+          code: "custom",
+          message,
+          path: ["gameSets", index],
+        });
+      }
       if (dareGameSetJoinedRelations(gameSet) > DARE_V2_MAX_JOINED_RELATIONS) {
         context.addIssue({
           code: "custom",

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
@@ -331,7 +331,19 @@ function dareGameSetJoinedRelations(gameSet: DareGameSetV2): number {
   return gameSet.targetKeys.length + timelineRelations + relatedRelations;
 }
 
-export const DareCompiledPlanV2Schema = z
+/**
+ * A compiled plan as it is *stored*: shape, references, and complexity limits,
+ * but no value-domain check.
+ *
+ * Reading a frozen plan and authoring a new one are different questions. A
+ * revision written before a domain rule existed is still exactly what its
+ * participants agreed to, and its callout, progress view, and settlement must
+ * keep rendering it faithfully — so the domain rule, which only ever applies to
+ * a value someone is choosing right now, lives on `DareCompiledPlanV2Schema`
+ * below. Tightening the authoring schema must never retroactively make an
+ * already-funded dare unreadable.
+ */
+export const DareStoredPlanV2Schema = z
   .strictObject({
     version: z.literal(DARE_CONTRACT_VERSION),
     gameSets: z.array(DareGameSetV2Schema).min(1).max(DARE_V2_MAX_GAME_SETS),
@@ -342,13 +354,6 @@ export const DareCompiledPlanV2Schema = z
     const facts: DarePlanComplexityV2 = { predicates: 0, maxDepth: 0 };
     for (const [index, gameSet] of plan.gameSets.entries()) {
       inspectDareBooleanComplexity(gameSet.predicate, 1, facts);
-      for (const message of dareGameSetDomainIssuesV2(gameSet)) {
-        context.addIssue({
-          code: "custom",
-          message,
-          path: ["gameSets", index],
-        });
-      }
       if (dareGameSetJoinedRelations(gameSet) > DARE_V2_MAX_JOINED_RELATIONS) {
         context.addIssue({
           code: "custom",
@@ -371,6 +376,26 @@ export const DareCompiledPlanV2Schema = z
       });
     }
   });
+
+/**
+ * A compiled plan being authored. Everything `DareStoredPlanV2Schema` checks,
+ * plus the value domains: a threshold naming a lane, champion, or queue that
+ * does not exist produces a predicate no game can satisfy, which would settle as
+ * a real loss rather than an error.
+ */
+export const DareCompiledPlanV2Schema = DareStoredPlanV2Schema.superRefine(
+  (plan, context) => {
+    for (const [index, gameSet] of plan.gameSets.entries()) {
+      for (const message of dareGameSetDomainIssuesV2(gameSet)) {
+        context.addIssue({
+          code: "custom",
+          message,
+          path: ["gameSets", index],
+        });
+      }
+    }
+  },
+);
 export type DareCompiledPlanV2 = z.infer<typeof DareCompiledPlanV2Schema>;
 
 export const DareDeadlineSpecV2Schema = z.union([
@@ -401,7 +426,7 @@ const DareContractV2BaseSchema = z
   .strictObject({
     version: z.literal(DARE_CONTRACT_VERSION),
     canonicalScoutQl: z.string().min(1).max(DARE_V2_MAX_QUERY_LENGTH),
-    compiledPlan: DareCompiledPlanV2Schema,
+    compiledPlan: DareStoredPlanV2Schema,
     evaluatorVersion: DareEvaluatorV2VersionSchema,
     plainLanguage: z.string().min(1),
     semanticProofPlan: z.string().min(1),

--- a/packages/scout-for-lol/packages/data/src/model/dare-domains.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-domains.ts
@@ -1,0 +1,168 @@
+import { z } from "zod";
+import {
+  getChampionByKey,
+  normalizeChampionName,
+} from "#src/model/champion-registry.ts";
+import { QueueTypeSchema } from "#src/model/state.ts";
+import type {
+  DareBooleanExpressionV2,
+  DareValueV2,
+} from "#src/model/dare-expression-v2.ts";
+
+/**
+ * Riot's `teamPosition` domain as it appears in match data and the report lake.
+ *
+ * Deliberately NOT `PositionSchema` (`#src/league/enums.ts`), which also admits
+ * `""` and `"Invalid"`. Those are real wire values — a participant in a mode
+ * without assigned roles carries them — but they must never be authored as a
+ * Dare threshold, because a dare on an empty position is unsatisfiable in
+ * exactly the way this module exists to prevent.
+ */
+export const DARE_TEAM_POSITIONS = [
+  "TOP",
+  "JUNGLE",
+  "MIDDLE",
+  "BOTTOM",
+  "UTILITY",
+] as const;
+export const DareTeamPositionSchema = z.enum(DARE_TEAM_POSITIONS);
+export type DareTeamPosition = z.infer<typeof DareTeamPositionSchema>;
+
+/**
+ * Lake columns whose values are drawn from a closed set.
+ *
+ * Keyed by column name so one table serves both contract shapes: a v2 contract
+ * compares a typed `DareValueV2` field, a v3 contract compares a SQL column in
+ * its frozen AST, and both resolve to the same report-lake column. Keeping the
+ * domains here rather than in either contract module is what stops the two
+ * enforcement points from disagreeing.
+ */
+export const DARE_DOMAIN_COLUMNS = [
+  "champion_name",
+  "team_position",
+  "queue",
+] as const;
+export const DareDomainColumnSchema = z.enum(DARE_DOMAIN_COLUMNS);
+export type DareDomainColumn = z.infer<typeof DareDomainColumnSchema>;
+
+/**
+ * A champion threshold may be written either as a Data Dragon key (`TwistedFate`)
+ * or as the punctuated display name (`Twisted Fate`) — the committed paraphrase
+ * corpus stores the latter, and the evaluator normalizes before comparing. So
+ * "valid" means "the registry resolves it", not "it is already canonical".
+ */
+function championResolves(champion: string): boolean {
+  // `normalizeChampionName` percent-decodes and throws a URIError on a malformed
+  // escape (a model champion such as "100% crit Yasuo"). Dare v1 documents the
+  // same trap in `dare-model-schema.ts`; a throw and an unresolved name are the
+  // same answer here.
+  try {
+    return getChampionByKey(normalizeChampionName(champion)) !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns a human-readable issue when `threshold` is outside `column`'s domain,
+ * or null when it is in-domain.
+ *
+ * This is the check whose absence let `team_position = 'MID'` compile, freeze,
+ * render in plain English, and settle as a funded loss: Riot writes `MIDDLE`, so
+ * the predicate was false for every game that could ever be played.
+ */
+export function dareDomainIssue(
+  column: DareDomainColumn,
+  threshold: string | number | boolean,
+): string | null {
+  if (typeof threshold !== "string") {
+    return `${column} must be compared against a string value.`;
+  }
+  if (column === "team_position") {
+    return DareTeamPositionSchema.safeParse(threshold).success
+      ? null
+      : `"${threshold}" is not a team position. Use one of ${DARE_TEAM_POSITIONS.join(", ")}.`;
+  }
+  if (column === "queue") {
+    return QueueTypeSchema.safeParse(threshold).success
+      ? null
+      : `"${threshold}" is not a queue. Use one of ${QueueTypeSchema.options.join(", ")}.`;
+  }
+  return championResolves(threshold)
+    ? null
+    : `"${threshold}" is not a known champion.`;
+}
+
+/**
+ * The report-lake column a value resolves to, or null when it has no closed
+ * domain. Participant field names are already the lake column names, so the
+ * only translation needed is the game-level `queue`.
+ */
+function dareDomainColumnForValue(value: DareValueV2): DareDomainColumn | null {
+  if (value.kind === "participant") {
+    return value.field === "champion_name" || value.field === "team_position"
+      ? value.field
+      : null;
+  }
+  return value.kind === "game" && value.field === "queue" ? "queue" : null;
+}
+
+/** Domain issues carried by a value itself, independent of any threshold. */
+export function dareValueDomainIssuesV2(value: DareValueV2): string[] {
+  if (value.kind === "arithmetic") {
+    return [
+      ...dareValueDomainIssuesV2(value.left),
+      ...dareValueDomainIssuesV2(value.right),
+    ];
+  }
+  if (
+    value.kind !== "related_participant_count" ||
+    value.championName === null
+  ) {
+    return [];
+  }
+  const issue = dareDomainIssue("champion_name", value.championName);
+  return issue === null ? [] : [issue];
+}
+
+/**
+ * Every domain violation in a predicate.
+ *
+ * Exported so the schema's hard gate and the compiler's friendly semantic pass
+ * run one implementation and cannot drift apart.
+ */
+export function dareBooleanDomainIssuesV2(
+  expression: DareBooleanExpressionV2,
+): string[] {
+  if (expression.kind === "comparison") {
+    const issues = dareValueDomainIssuesV2(expression.value);
+    const column = dareDomainColumnForValue(expression.value);
+    if (column === null) return issues;
+    const issue = dareDomainIssue(column, expression.threshold);
+    return issue === null ? issues : [...issues, issue];
+  }
+  if (expression.kind === "not") {
+    return dareBooleanDomainIssuesV2(expression.operand);
+  }
+  return expression.operands.flatMap((operand) =>
+    dareBooleanDomainIssuesV2(operand),
+  );
+}
+
+/**
+ * Domain issues across a game set's predicate and its projections.
+ *
+ * Takes the two members it reads rather than the whole game set, so this module
+ * stays independent of the contract schema that calls it.
+ */
+export function dareGameSetDomainIssuesV2(gameSet: {
+  predicate: DareBooleanExpressionV2;
+  projections: readonly { value: DareValueV2 }[];
+}): string[] {
+  return [
+    ...dareBooleanDomainIssuesV2(gameSet.predicate),
+    ...gameSet.projections.flatMap((projection) =>
+      dareValueDomainIssuesV2(projection.value),
+    ),
+  ];
+}

--- a/packages/scout-for-lol/packages/data/src/model/dare-expression-v2.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-expression-v2.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+
+/**
+ * The Dare v2 expression vocabulary: which participant and game fields a
+ * contract may read, and the recursive value/predicate shapes built from them.
+ *
+ * Split out from `dare-contract-v2.ts` so `dare-domains.ts` can validate the
+ * values these fields carry without importing the contract schema back — the
+ * schema needs the domain walk in its `superRefine`, so the dependency has to
+ * run one way only.
+ */
+export const DareParticipantValueFieldV2Schema = z.enum([
+  "champion_name",
+  "team_position",
+  "team_id",
+  "win",
+  "kills",
+  "deaths",
+  "assists",
+  "creep_score",
+  "gold_earned",
+  "vision_score",
+  "time_played",
+  "total_damage_dealt_to_champions",
+  "wards_placed",
+  "wards_killed",
+  "double_kills",
+  "triple_kills",
+  "quadra_kills",
+  "penta_kills",
+]);
+
+export const DareParticipantRateFieldV2Schema = z.enum([
+  "cs_per_minute",
+  "damage_per_minute",
+  "kda",
+]);
+
+export type DareValueV2 =
+  | {
+      kind: "participant";
+      target: string;
+      field: z.infer<typeof DareParticipantValueFieldV2Schema>;
+    }
+  | {
+      kind: "participant_rate";
+      target: string;
+      field: z.infer<typeof DareParticipantRateFieldV2Schema>;
+    }
+  | { kind: "game"; field: "duration_seconds" | "queue" }
+  | {
+      kind: "related_participant_count";
+      target: string;
+      relationship: "ally" | "opponent";
+      championName: string | null;
+    }
+  | {
+      kind: "timeline_event_count";
+      eventType: string;
+      target: string | null;
+      role: "subject" | "killer" | "victim" | "assist" | "creator" | null;
+      afterMs: number | null;
+      beforeMs: number | null;
+      itemId: number | null;
+    }
+  | {
+      kind: "arithmetic";
+      operator: "add" | "subtract" | "multiply" | "divide";
+      left: DareValueV2;
+      right: DareValueV2;
+    };
+
+export type DareBooleanExpressionV2 =
+  | {
+      kind: "comparison";
+      value: DareValueV2;
+      operator: "eq" | "neq" | "gte" | "lte" | "gt" | "lt";
+      threshold: string | number | boolean;
+    }
+  | { kind: "and" | "or"; operands: DareBooleanExpressionV2[] }
+  | { kind: "not"; operand: DareBooleanExpressionV2 };

--- a/packages/scout-for-lol/packages/data/src/model/index.ts
+++ b/packages/scout-for-lol/packages/data/src/model/index.ts
@@ -5,6 +5,8 @@ export * from "./competition-format.ts";
 export * from "./discord.ts";
 export * from "./division.ts";
 export * from "./dare-contract-v2.ts";
+export * from "./dare-domains.ts";
+export * from "./dare-expression-v2.ts";
 export * from "./dare-contract-v3.ts";
 export * from "./dare-progress.ts";
 export * from "./dare-paraphrase-corpus.ts";


### PR DESCRIPTION
Stacked on #2685, which adds the shared domain table this consumes.

## Why

Dare v3 froze the compiled SQL instead of a typed plan. `DareContractV3Schema` carries `canonicalSql` + `immutableAst` + `queryHash` and no `compiledPlan` — so there is no `threshold` field to type, and `darePlanSemanticIssues` never runs for it.

`compileDareSqlV3` validates target-key format, the source/function profile, result structure, and competition/activation. It never looks at a comparison literal. So v3 carries the same defect as v2 with *less* structure to catch it: `team_position = 'MID'` is just a literal that matches no row, and the dare settles `unachieved` — refunding **with** the house cut — which is indistinguishable from an honestly lost dare.

`enabledDareVersion` checks `dare_extended_contracts_enabled` *before* v2, so once that flag is on, this is the authoring path.

**This is the cheap moment.** The flag is `default: false` with no overrides and sits in `PRODUCTION_HARD_DISABLED_FLAGS`, so no v3 dare has ever been created. There is no migration and no compatibility path to write. Landing it after the flag is enabled would mean another round of funded, unwinnable contracts and stuck revisions.

## What

- **`dare-sql-v3-domains.ts`** — a recursive walk of the frozen `immutableAst` that resolves `COLUMN_REF` nodes to report-lake columns and applies the **same** `dareDomainIssue` table the v2 contract schema uses. Keying the shared table by lake column name (in #2685) is what makes this reuse possible, so the two contract shapes cannot disagree about which values exist.
- Handles **both operand orders** — `'MID' = p0.team_position` is the same mistake written backwards — and **`COMPARE_IN` lists**, since that is how the queue filter is expressed.
- Comparisons against another column or a computed expression are deliberately left alone; only a written-down literal can be out of domain.
- Called from `compileDareSqlV3` before the result-structure walk. Throwing matches the surrounding convention — `prepareDareDraftV3` already converts a thrown error into `{kind: "invalid", issues}`, so this reaches the authoring loop as fixable text without a new error path.

`compileDareSqlV3` is the only v3 authoring chokepoint: `dare-contract-v3-build.ts` constructs a contract from a stored revision rather than recompiling, so validating here covers both creation and revision.

## Verification

```
bunx turbo run typecheck test lint --filter=@scout-for-lol/backend
```

3,100 tests pass; typecheck and lint clean.

10 new cases in `dare-sql-v3-domains.test.ts`:

- rejects `MID`, `SUPPORT`, an unknown champion, and an out-of-domain queue in an `IN` list — each asserting the message names the legal values
- accepts `MIDDLE`, a display-name champion (`Twisted Fate`), and a real queue
- rejects the reversed operand order
- **two negative controls** — `kills >= 5` and a column-to-column comparison both still compile, so the walk cannot false-positive on ordinary contracts

**Not run:** live beta authoring with `dare_extended_contracts_enabled` turned on.

Non-visual change (validation), so no media.