### PR TITLE
fix(scout-for-lol): constrain Dare timeline event types to the ones Riot emits

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
@@ -9,6 +9,7 @@ import {
   type DiscordAccountId,
 } from "@scout-for-lol/data";
 import { DARE_ACCEPT_WINDOW_MS } from "#src/betting/constants.ts";
+import { dareSqlV3DomainIssues } from "#src/betting/dare-sql-v3-domains.ts";
 import { pendingDareV2CalloutRefresh } from "#src/betting/dare-callout-refresh-state-v2.ts";
 import {
   dareV2MoneyFactsInTransaction,
@@ -64,6 +65,34 @@ function contractCompilerVersion(revision: {
   return "dare-scoutql-2";
 }
 
+/**
+ * Domain problems that must stop a draft before it takes a stake.
+ *
+ * Draft-to-funded is the last moment a contract can still be fixed. Authoring
+ * enforces the value domains while stored plans read permissively so an
+ * already-funded dare stays readable — which leaves this transition as the only
+ * place a draft written before a rule existed can still be caught. Both contract
+ * versions need it: v3's domain check lives in its compiler, which is a drafting
+ * step, and activation re-runs neither.
+ */
+function fundingContractIssues(revision: {
+  compilerVersion: string;
+  compiledPlan: string;
+  scoutQlImmutableAst: string | null;
+}): string[] {
+  if (revision.compilerVersion === "dare-scoutql-3") {
+    return revision.scoutQlImmutableAst === null
+      ? []
+      : dareSqlV3DomainIssues(revision.scoutQlImmutableAst);
+  }
+  const authored = DareCompiledPlanV2Schema.safeParse(
+    JSON.parse(revision.compiledPlan),
+  );
+  return authored.success
+    ? []
+    : authored.error.issues.map((issue) => issue.message);
+}
+
 export async function fundDareV2InTransaction(
   tx: Db,
   input: {
@@ -86,16 +115,9 @@ export async function fundDareV2InTransaction(
   // already-funded dare stays readable, and this transition is what would
   // otherwise let a stale draft holding a value the allowlist now refuses take a
   // stake and settle as a real loss.
-  if (revision.compilerVersion !== "dare-scoutql-3") {
-    const authored = DareCompiledPlanV2Schema.safeParse(
-      JSON.parse(revision.compiledPlan),
-    );
-    if (!authored.success) {
-      return {
-        kind: "contract_invalid",
-        issues: authored.error.issues.map((issue) => issue.message),
-      } as const;
-    }
+  const contractIssues = fundingContractIssues(revision);
+  if (contractIssues.length > 0) {
+    return { kind: "contract_invalid", issues: contractIssues } as const;
   }
   const targets = parseDareV2Targets(revision.targetsJson);
   const deadlineSpec = parseDareV2Deadline(revision.deadlineSpecJson);

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
@@ -2,6 +2,7 @@ import {
   DARE_CONTRACT_VERSION,
   DareStoredPlanV2Schema,
   DareSqlV3CompilationSchema,
+  DareCompiledPlanV2Schema,
   DareContractV2Schema,
   DiscordAccountIdSchema,
   PlayerIdSchema,
@@ -79,6 +80,23 @@ export async function fundDareV2InTransaction(
     },
   });
   if (revision === null) return { kind: "stale_revision" } as const;
+  // Draft-to-funded is the last moment a contract can still be fixed, and the
+  // only place the authoring rules can still be applied to a draft that predates
+  // them. Activation deliberately parses with the permissive stored schema so an
+  // already-funded dare stays readable, and this transition is what would
+  // otherwise let a stale draft holding a value the allowlist now refuses take a
+  // stake and settle as a real loss.
+  if (revision.compilerVersion !== "dare-scoutql-3") {
+    const authored = DareCompiledPlanV2Schema.safeParse(
+      JSON.parse(revision.compiledPlan),
+    );
+    if (!authored.success) {
+      return {
+        kind: "contract_invalid",
+        issues: authored.error.issues.map((issue) => issue.message),
+      } as const;
+    }
+  }
   const targets = parseDareV2Targets(revision.targetsJson);
   const deadlineSpec = parseDareV2Deadline(revision.deadlineSpecJson);
   const absoluteDeadline =

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-preview-compiler-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-preview-compiler-v2.test.ts
@@ -39,7 +39,11 @@ describe("Dare v2 lake compiler", () => {
                 kind: "comparison",
                 value: {
                   kind: "timeline_event_count",
-                  eventType: hostile,
+                  // A real event type: the contract schema now constrains this
+                  // to the types Riot emits, so a hostile string cannot reach
+                  // the compiler here either. The puuid below still carries it,
+                  // which is what the binding assertions exercise.
+                  eventType: "ITEM_PURCHASED",
                   target: null,
                   role: "killer",
                   afterMs: 1000,
@@ -112,6 +116,47 @@ describe("Dare v2 lake compiler", () => {
     );
     expect(compiled.sql).not.toContain("tep.puuid");
     expect(compiled.sql).toContain("(p0.kills + p0.assists)");
+  });
+
+  test("rejects a hostile event type before it can reach the compiler", () => {
+    const hostile = "'); DROP TABLE timeline_events; --";
+    expect(
+      DareCompiledPlanV2Schema.safeParse({
+        version: 2,
+        maxEligibleGames: 100,
+        gameSets: [
+          {
+            name: "one_game",
+            targetKeys: ["target"],
+            relationship: "independent",
+            queues: ["solo"],
+            predicate: {
+              kind: "comparison",
+              value: {
+                kind: "timeline_event_count",
+                eventType: hostile,
+                target: "target",
+                role: "subject",
+                afterMs: null,
+                beforeMs: null,
+                itemId: null,
+              },
+              operator: "gte",
+              threshold: 1,
+            },
+            projections: [],
+            orderBy: "game_end_at_asc_match_id_asc",
+            limit: 10,
+          },
+        ],
+        result: {
+          kind: "matching_games",
+          gameSet: "one_game",
+          operator: "gte",
+          threshold: 1,
+        },
+      }).success,
+    ).toBe(false);
   });
 
   test("rejects a hostile champion before it can reach the compiler", () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-sql-v3-domains.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-sql-v3-domains.test.ts
@@ -123,3 +123,46 @@ describe("Dare SQL v3 value domains", () => {
     ).rejects.toThrow("MIDDLE");
   });
 });
+
+// Timeline reads must also read timeline_coverage, so missing data cannot be
+// treated as zero — the same failure class this domain check exists for.
+function timelineContract(predicate: string): string {
+  return `SELECT EXISTS (
+      SELECT 1 FROM timeline_coverage c
+        JOIN T1 p USING (match_id)
+        JOIN timeline_events e USING (match_id)
+      WHERE ${predicate}
+    ) AS achieved`;
+}
+
+describe("Dare SQL v3 timeline event types", () => {
+  // v3 exposes timeline_events as a source table rather than a macro, so an
+  // invented event type is an ordinary column comparison — and one that returns
+  // a count of zero, which reads as a lost dare rather than a broken contract.
+  test("rejects an event type Riot never emits", async () => {
+    await expect(
+      compileDareSqlV3({
+        queryText: timelineContract("e.event_type = 'DRAGON_KILL'"),
+        targetKeys: ["T1"],
+      }),
+    ).rejects.toThrow("not a timeline event type");
+  });
+
+  test("rejects BUILDING_DESTROYED, which an old docs table invented", async () => {
+    await expect(
+      compileDareSqlV3({
+        queryText: timelineContract("e.event_type = 'BUILDING_DESTROYED'"),
+        targetKeys: ["T1"],
+      }),
+    ).rejects.toThrow("not a timeline event type");
+  });
+
+  test("accepts the event type a dragon kill actually uses", async () => {
+    await expect(
+      compileDareSqlV3({
+        queryText: timelineContract("e.event_type = 'ELITE_MONSTER_KILL'"),
+        targetKeys: ["T1"],
+      }),
+    ).resolves.toMatchObject({ compilerVersion: "dare-scoutql-3" });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-language.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-language.ts
@@ -1,0 +1,61 @@
+import {
+  DARE_TEAM_POSITIONS,
+  DARE_TIMELINE_EVENT_TYPES,
+  DARE_V2_MAX_ELIGIBLE_GAMES,
+  DARE_V2_MAX_EXPRESSION_DEPTH,
+  DARE_V2_MAX_GAME_SETS,
+  DARE_V2_MAX_HORIZON_DAYS,
+  DARE_V2_MAX_JOINED_RELATIONS,
+  DARE_V2_MAX_PREDICATES,
+  DARE_V2_MAX_QUERY_LENGTH,
+  DARE_V2_MAX_TARGETS,
+} from "@scout-for-lol/data";
+import { dareSqlV3Catalog } from "#src/betting/dare-sql-v3-catalog.ts";
+
+/**
+ * Everything `get_dare_language` tells the model about the contract vocabulary.
+ *
+ * Split out of `dare-tools.ts` because it is a static description of the
+ * language rather than an executor: it reads no request state beyond the
+ * shortlist and the authoring version, so keeping it here lets the tool module
+ * stay a list of executors.
+ */
+export function dareLanguagePayload(input: {
+  sqlV3: boolean;
+  targets: readonly { key: string; alias: string }[];
+}) {
+  return {
+    authoringVersion: input.sqlV3 ? 3 : 2,
+    targets: input.targets.map((target) => ({
+      key: target.key,
+      alias: target.alias,
+    })),
+    limits: {
+      targets: DARE_V2_MAX_TARGETS,
+      gameSets: DARE_V2_MAX_GAME_SETS,
+      joinedRelations: DARE_V2_MAX_JOINED_RELATIONS,
+      predicates: DARE_V2_MAX_PREDICATES,
+      expressionDepth: DARE_V2_MAX_EXPRESSION_DEPTH,
+      queryCharacters: DARE_V2_MAX_QUERY_LENGTH,
+      eligibleGames: DARE_V2_MAX_ELIGIBLE_GAMES,
+      horizonDays: DARE_V2_MAX_HORIZON_DAYS,
+    },
+    defaults: {
+      queues: ["solo", "flex"],
+      relativeDeadlineDays: 7,
+      orderBy: "game_end_at_asc_match_id_asc",
+    },
+    // The closed value domains the contract schema enforces. The contract's own
+    // JSON Schema cannot carry them: `eventType` and `team_position` are checked
+    // in the authoring refinement rather than in the shared value shape, so that
+    // a dare already funded against a value we later drop stays readable in
+    // settlement. That leaves this tool as the only place the model can learn
+    // them before it guesses — and a guessed event type counts zero, which
+    // settles as a real loss rather than voiding.
+    domains: {
+      teamPosition: DARE_TEAM_POSITIONS,
+      timelineEventType: DARE_TIMELINE_EVENT_TYPES,
+    },
+    ...(input.sqlV3 ? { sql: dareSqlV3Catalog() } : {}),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-tools.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-tools.ts
@@ -1,20 +1,10 @@
-import {
-  DARE_V2_MAX_ELIGIBLE_GAMES,
-  DARE_V2_MAX_EXPRESSION_DEPTH,
-  DARE_V2_MAX_GAME_SETS,
-  DARE_V2_MAX_HORIZON_DAYS,
-  DARE_V2_MAX_JOINED_RELATIONS,
-  DARE_V2_MAX_PREDICATES,
-  DARE_V2_MAX_QUERY_LENGTH,
-  DARE_V2_MAX_TARGETS,
-} from "@scout-for-lol/data";
 import { buildDareShortlist } from "#src/betting/dare-shortlist.ts";
 import {
   createDareDraftV3,
   prepareDareDraftV3,
   reviseDareDraftV3,
 } from "#src/betting/dare-draft-v3.ts";
-import { dareSqlV3Catalog } from "#src/betting/dare-sql-v3-catalog.ts";
+import { dareLanguagePayload } from "#src/explore/dare-language.ts";
 import { compileDareSqlV3 } from "#src/betting/dare-sql-v3.ts";
 import { renderDareSqlV3SemanticProofPlan } from "#src/betting/dare-sql-v3-description.ts";
 import {
@@ -163,29 +153,7 @@ export function createDareToolExecutors(input: DareExploreToolsInput) {
           targets.length === 0
             ? "No eligible targets are currently linked in this guild."
             : "Use only these target keys and the closed contract schema.",
-          {
-            authoringVersion: sqlV3 ? 3 : 2,
-            targets: targets.map((target) => ({
-              key: target.key,
-              alias: target.alias,
-            })),
-            limits: {
-              targets: DARE_V2_MAX_TARGETS,
-              gameSets: DARE_V2_MAX_GAME_SETS,
-              joinedRelations: DARE_V2_MAX_JOINED_RELATIONS,
-              predicates: DARE_V2_MAX_PREDICATES,
-              expressionDepth: DARE_V2_MAX_EXPRESSION_DEPTH,
-              queryCharacters: DARE_V2_MAX_QUERY_LENGTH,
-              eligibleGames: DARE_V2_MAX_ELIGIBLE_GAMES,
-              horizonDays: DARE_V2_MAX_HORIZON_DAYS,
-            },
-            defaults: {
-              queues: ["solo", "flex"],
-              relativeDeadlineDays: 7,
-              orderBy: "game_end_at_asc_match_id_asc",
-            },
-            ...(sqlV3 ? { sql: dareSqlV3Catalog() } : {}),
-          },
+          dareLanguagePayload({ sqlV3, targets }),
         );
       }),
     validateScoutQl: (raw: unknown) =>

--- a/packages/scout-for-lol/packages/backend/src/explore/tool-inspection.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/tool-inspection.ts
@@ -265,6 +265,7 @@ export function inspectExploreToolResult(
         "forbidden",
         "feature_disabled",
         "stale_revision",
+        "contract_invalid",
       ].includes(parsed.kind),
       rawOutput: JsonValueSchema.parse(parsed),
       details: null,

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-domains.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-domains.test.ts
@@ -217,4 +217,68 @@ describe("Dare v2 timeline event types", () => {
       ).toBe(true);
     },
   );
+
+  // The allowlist belongs to the authoring schema, never to the shared value
+  // shape: an enum on `eventType` would reach `DareStoredPlanV2Schema` too, and
+  // a funded dare naming a type we later drop — or that Riot renames — would
+  // stop parsing in settlement, callouts, and progress views instead of paying
+  // out.
+  test("reads a stored plan whose event type is outside the allowlist", () => {
+    expect(
+      DareStoredPlanV2Schema.safeParse(timelinePlan("DRAGON_KILL")).success,
+    ).toBe(true);
+  });
+
+  test("still refuses to author that same event type", () => {
+    expect(
+      DareCompiledPlanV2Schema.safeParse(timelinePlan("DRAGON_KILL")).success,
+    ).toBe(false);
+  });
+
+  // The bound survives the move: an unbounded event type is a shape violation,
+  // not a domain one, so it must fail on the stored side as well.
+  test("still refuses a stored event type past the length bound", () => {
+    expect(
+      DareStoredPlanV2Schema.safeParse(timelinePlan("E".repeat(81))).success,
+    ).toBe(false);
+  });
+
+  test("names the legal event types when refusing one", () => {
+    const result = DareCompiledPlanV2Schema.safeParse(
+      timelinePlan("BUILDING_DESTROYED"),
+    );
+    expect(
+      result.error?.issues.map((issue) => issue.message).join(" "),
+    ).toContain("BUILDING_KILL");
+  });
+
+  // The event type is a filter the value applies, not a comparison threshold,
+  // so it is invisible to the column-resolving predicate walk. A projection has
+  // no threshold at all, which is where that gap shows up first.
+  test("rejects an unknown event type on a projection", () => {
+    expect(
+      DareCompiledPlanV2Schema.safeParse({
+        ...DARE_V2_TEST_PLAN,
+        gameSets: [
+          {
+            ...DARE_V2_TEST_GAME_SET,
+            projections: [
+              {
+                name: "dragons",
+                value: {
+                  kind: "timeline_event_count",
+                  eventType: "DRAGON_KILL",
+                  target: "T1",
+                  role: "killer",
+                  afterMs: null,
+                  beforeMs: null,
+                  itemId: null,
+                },
+              },
+            ],
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
 });

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-domains.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-domains.test.ts
@@ -175,3 +175,46 @@ describe("Dare v2 stored plans stay readable", () => {
     ).toBe(false);
   });
 });
+
+function timelinePlan(eventType: string) {
+  return planWithPredicate({
+    kind: "comparison",
+    value: {
+      kind: "timeline_event_count",
+      eventType,
+      target: "T1",
+      role: "killer",
+      afterMs: null,
+      beforeMs: null,
+      itemId: null,
+    },
+    operator: "gte",
+    threshold: 1,
+  });
+}
+
+describe("Dare v2 timeline event types", () => {
+  // An unrecognised event type counts zero rather than resolving unknown, so it
+  // reads as a definite failure and settles as a real loss.
+  test("rejects an event type Riot never emits", () => {
+    expect(
+      DareCompiledPlanV2Schema.safeParse(timelinePlan("DRAGON_KILL")).success,
+    ).toBe(false);
+  });
+
+  test("rejects BUILDING_DESTROYED, which an old docs table invented", () => {
+    expect(
+      DareCompiledPlanV2Schema.safeParse(timelinePlan("BUILDING_DESTROYED"))
+        .success,
+    ).toBe(false);
+  });
+
+  test.each(["CHAMPION_KILL", "ELITE_MONSTER_KILL", "ITEM_PURCHASED"])(
+    "accepts the real event type %s",
+    (eventType) => {
+      expect(
+        DareCompiledPlanV2Schema.safeParse(timelinePlan(eventType)).success,
+      ).toBe(true);
+    },
+  );
+});

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
@@ -1,10 +1,7 @@
 import { z } from "zod";
 import { BucksStakeSchema } from "#src/model/bryan-bucks.ts";
 import { QueueTypeSchema } from "#src/model/state.ts";
-import {
-  dareGameSetDomainIssuesV2,
-  DareTimelineEventTypeSchema,
-} from "#src/model/dare-domains.ts";
+import { dareGameSetDomainIssuesV2 } from "#src/model/dare-domains.ts";
 import {
   DareParticipantRateFieldV2Schema,
   DareParticipantValueFieldV2Schema,
@@ -121,7 +118,13 @@ export const DareValueV2Schema: z.ZodType<DareValueV2> = z.lazy(() =>
     }),
     z.strictObject({
       kind: z.literal("timeline_event_count"),
-      eventType: DareTimelineEventTypeSchema,
+      // A bounded string, not the `DARE_TIMELINE_EVENT_TYPES` enum, because this
+      // schema is shared by `DareStoredPlanV2Schema`: an enum here would make a
+      // dare funded against an event type we later dropped — or one Riot renames
+      // — unreadable in settlement, callouts, and progress views, stranding real
+      // money. The allowlist is enforced in `DareCompiledPlanV2Schema`'s
+      // refinement instead, exactly like every other value domain.
+      eventType: z.string().min(1).max(80),
       target: z.string().min(1).nullable(),
       role: z
         .enum(["subject", "killer", "victim", "assist", "creator"])

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 import { BucksStakeSchema } from "#src/model/bryan-bucks.ts";
 import { QueueTypeSchema } from "#src/model/state.ts";
-import { dareGameSetDomainIssuesV2 } from "#src/model/dare-domains.ts";
+import {
+  dareGameSetDomainIssuesV2,
+  DareTimelineEventTypeSchema,
+} from "#src/model/dare-domains.ts";
 import {
   DareParticipantRateFieldV2Schema,
   DareParticipantValueFieldV2Schema,
@@ -118,7 +121,7 @@ export const DareValueV2Schema: z.ZodType<DareValueV2> = z.lazy(() =>
     }),
     z.strictObject({
       kind: z.literal("timeline_event_count"),
-      eventType: z.string().min(1).max(80),
+      eventType: DareTimelineEventTypeSchema,
       target: z.string().min(1).nullable(),
       role: z
         .enum(["subject", "killer", "victim", "assist", "creator"])

--- a/packages/scout-for-lol/packages/data/src/model/dare-domains.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-domains.ts
@@ -156,7 +156,20 @@ function dareDomainColumnForValue(value: DareValueV2): DareDomainColumn | null {
   return value.kind === "game" && value.field === "queue" ? "queue" : null;
 }
 
-/** Domain issues carried by a value itself, independent of any threshold. */
+function issueList(issue: string | null): string[] {
+  return issue === null ? [] : [issue];
+}
+
+/**
+ * Domain issues carried by a value itself, independent of any threshold.
+ *
+ * A closed-domain field that lives *on* a value never reaches
+ * `dareBooleanDomainIssuesV2`: that walk resolves a column from what the
+ * comparison reads, so it only ever inspects the comparison's own threshold.
+ * `related_participant_count.championName` and `timeline_event_count.eventType`
+ * are filters the value applies before it produces a number, so they have to be
+ * checked here or they are not checked at all.
+ */
 export function dareValueDomainIssuesV2(value: DareValueV2): string[] {
   if (value.kind === "arithmetic") {
     return [
@@ -164,14 +177,15 @@ export function dareValueDomainIssuesV2(value: DareValueV2): string[] {
       ...dareValueDomainIssuesV2(value.right),
     ];
   }
-  if (
-    value.kind !== "related_participant_count" ||
-    value.championName === null
-  ) {
-    return [];
+  if (value.kind === "related_participant_count") {
+    return value.championName === null
+      ? []
+      : issueList(dareDomainIssue("champion_name", value.championName));
   }
-  const issue = dareDomainIssue("champion_name", value.championName);
-  return issue === null ? [] : [issue];
+  if (value.kind === "timeline_event_count") {
+    return issueList(dareDomainIssue("event_type", value.eventType));
+  }
+  return [];
 }
 
 /**

--- a/packages/scout-for-lol/packages/data/src/model/dare-domains.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-domains.ts
@@ -29,6 +29,49 @@ export const DareTeamPositionSchema = z.enum(DARE_TEAM_POSITIONS);
 export type DareTeamPosition = z.infer<typeof DareTeamPositionSchema>;
 
 /**
+ * Riot timeline event types a Dare contract may count.
+ *
+ * Derived from the beta report lake — every distinct `event_type` across ~1.5M
+ * events — not from memory: `PAUSE_START` and `FEAT_UPDATE` are real and easy to
+ * omit, while `BUILDING_DESTROYED` (named in an old docs table) does not exist.
+ * `DRAGON_KILL` does not exist either; a dragon is an `ELITE_MONSTER_KILL`.
+ *
+ * This list is deliberately an authoring-side constraint only. The wire schema
+ * (`raw-timeline.schema.ts`) and the lake column stay open strings, because a
+ * new Riot event type modelled as an enum at ingestion would fail the parse and
+ * take down timeline processing entirely — the argument already written down for
+ * tournament lobby events in `raw-tournament.schema.ts`. Recognising an event is
+ * a decision one layer up; here, at the point someone writes a contract, an
+ * unrecognised type can only ever produce a count of zero, which settles as a
+ * real loss.
+ */
+export const DARE_TIMELINE_EVENT_TYPES = [
+  "BUILDING_KILL",
+  "CHAMPION_KILL",
+  "CHAMPION_SPECIAL_KILL",
+  "CHAMPION_TRANSFORM",
+  "DRAGON_SOUL_GIVEN",
+  "ELITE_MONSTER_KILL",
+  "FEAT_UPDATE",
+  "GAME_END",
+  "ITEM_DESTROYED",
+  "ITEM_PURCHASED",
+  "ITEM_SOLD",
+  "ITEM_UNDO",
+  "LEVEL_UP",
+  "OBJECTIVE_BOUNTY_FINISH",
+  "OBJECTIVE_BOUNTY_PRESTART",
+  "PAUSE_END",
+  "PAUSE_START",
+  "SKILL_LEVEL_UP",
+  "TURRET_PLATE_DESTROYED",
+  "WARD_KILL",
+  "WARD_PLACED",
+] as const;
+export const DareTimelineEventTypeSchema = z.enum(DARE_TIMELINE_EVENT_TYPES);
+export type DareTimelineEventType = z.infer<typeof DareTimelineEventTypeSchema>;
+
+/**
  * Lake columns whose values are drawn from a closed set.
  *
  * Keyed by column name so one table serves both contract shapes: a v2 contract
@@ -41,6 +84,7 @@ export const DARE_DOMAIN_COLUMNS = [
   "champion_name",
   "team_position",
   "queue",
+  "event_type",
 ] as const;
 export const DareDomainColumnSchema = z.enum(DARE_DOMAIN_COLUMNS);
 export type DareDomainColumn = z.infer<typeof DareDomainColumnSchema>;
@@ -87,6 +131,11 @@ export function dareDomainIssue(
     return QueueTypeSchema.safeParse(threshold).success
       ? null
       : `"${threshold}" is not a queue. Use one of ${QueueTypeSchema.options.join(", ")}.`;
+  }
+  if (column === "event_type") {
+    return DareTimelineEventTypeSchema.safeParse(threshold).success
+      ? null
+      : `"${threshold}" is not a timeline event type. Use one of ${DARE_TIMELINE_EVENT_TYPES.join(", ")}.`;
   }
   return championResolves(threshold)
     ? null

--- a/packages/scout-for-lol/packages/data/src/model/dare-v2-paraphrase-corpus.schema.json
+++ b/packages/scout-for-lol/packages/data/src/model/dare-v2-paraphrase-corpus.schema.json
@@ -339,7 +339,32 @@
           "type": "object",
           "properties": {
             "kind": { "type": "string", "const": "timeline_event_count" },
-            "eventType": { "type": "string", "minLength": 1, "maxLength": 80 },
+            "eventType": {
+              "type": "string",
+              "enum": [
+                "BUILDING_KILL",
+                "CHAMPION_KILL",
+                "CHAMPION_SPECIAL_KILL",
+                "CHAMPION_TRANSFORM",
+                "DRAGON_SOUL_GIVEN",
+                "ELITE_MONSTER_KILL",
+                "FEAT_UPDATE",
+                "GAME_END",
+                "ITEM_DESTROYED",
+                "ITEM_PURCHASED",
+                "ITEM_SOLD",
+                "ITEM_UNDO",
+                "LEVEL_UP",
+                "OBJECTIVE_BOUNTY_FINISH",
+                "OBJECTIVE_BOUNTY_PRESTART",
+                "PAUSE_END",
+                "PAUSE_START",
+                "SKILL_LEVEL_UP",
+                "TURRET_PLATE_DESTROYED",
+                "WARD_KILL",
+                "WARD_PLACED"
+              ]
+            },
             "target": {
               "anyOf": [
                 { "type": "string", "minLength": 1 },

--- a/packages/scout-for-lol/packages/data/src/model/dare-v2-paraphrase-corpus.schema.json
+++ b/packages/scout-for-lol/packages/data/src/model/dare-v2-paraphrase-corpus.schema.json
@@ -339,32 +339,7 @@
           "type": "object",
           "properties": {
             "kind": { "type": "string", "const": "timeline_event_count" },
-            "eventType": {
-              "type": "string",
-              "enum": [
-                "BUILDING_KILL",
-                "CHAMPION_KILL",
-                "CHAMPION_SPECIAL_KILL",
-                "CHAMPION_TRANSFORM",
-                "DRAGON_SOUL_GIVEN",
-                "ELITE_MONSTER_KILL",
-                "FEAT_UPDATE",
-                "GAME_END",
-                "ITEM_DESTROYED",
-                "ITEM_PURCHASED",
-                "ITEM_SOLD",
-                "ITEM_UNDO",
-                "LEVEL_UP",
-                "OBJECTIVE_BOUNTY_FINISH",
-                "OBJECTIVE_BOUNTY_PRESTART",
-                "PAUSE_END",
-                "PAUSE_START",
-                "SKILL_LEVEL_UP",
-                "TURRET_PLATE_DESTROYED",
-                "WARD_KILL",
-                "WARD_PLACED"
-              ]
-            },
+            "eventType": { "type": "string", "minLength": 1, "maxLength": 80 },
             "target": {
               "anyOf": [
                 { "type": "string", "minLength": 1 },


### PR DESCRIPTION
Stacked on #2686.

## Why

`timeline_event_count.eventType` was an open `z.string().min(1).max(80)` — no enum at any layer, no `description`, and no prompt guidance anywhere. The model was inferring event types from pretraining plus two corpus examples, which is exactly the setup that produces a confident `DRAGON_KILL`.

An unrecognised event type is **worse** than an unrecognised lane. `timelineEventCount` returns `.length`, so an unknown type counts **zero** rather than resolving unknown. Zero is a definite `false`, which reaches finality through `monotone_failure` and settles `unachieved` — refunding **with** the house cut — where genuinely missing evidence would have voided with a full refund. A plausible-but-wrong event type therefore costs the players money and reads like an honestly lost dare.

## What

- **`DARE_TIMELINE_EVENT_TYPES`**, derived from the beta report lake — every distinct `event_type` across ~1.5M real events, not from memory:

  ```
  WARD_PLACED 331934 · ITEM_PURCHASED 293012 · ITEM_DESTROYED 242424
  SKILL_LEVEL_UP 216174 · LEVEL_UP 204377 · CHAMPION_KILL 91077
  WARD_KILL 38642 · TURRET_PLATE_DESTROYED 34871 · BUILDING_KILL 19291
  CHAMPION_SPECIAL_KILL 13380 · ELITE_MONSTER_KILL 13201 · ITEM_UNDO 11906
  ITEM_SOLD 10743 · FEAT_UPDATE 10347 · DRAGON_SOUL_GIVEN 1821
  OBJECTIVE_BOUNTY_PRESTART 1489 · PAUSE_END 1438 · GAME_END 1436
  OBJECTIVE_BOUNTY_FINISH 599 · CHAMPION_TRANSFORM 102 · PAUSE_START 2
  ```

  Grounding it mattered in both directions: `PAUSE_START` and `FEAT_UPDATE` are real and easy to omit (which would block legitimate dares), while `BUILDING_DESTROYED` — named in `docs/ai-review-system.md:133-141` — does not exist, and neither does `DRAGON_KILL`.

- Used for the v2 contract's `eventType`, and added `event_type` to the **shared domain table**, which covers v3 for free: v3 exposes `timeline_events` as a source table rather than a macro, so its event filter is an ordinary column comparison the #2686 AST walk already inspects.

- **Regenerated the committed paraphrase JSON Schema.** Unlike the plan-level `superRefine`, `z.enum` *does* emit its values, so the drift check failed and the model now sees the legal event types where it previously saw a bare string.

The constraint is deliberately **authoring-side only**. `raw-timeline.schema.ts` and the lake column stay open strings, because a new Riot event type modelled as an enum at ingestion would fail the parse and take down timeline processing entirely — the argument already written down for lobby events in `raw-tournament.schema.ts:145-157`.

## Verification

```
bunx turbo run typecheck test lint --filter=@scout-for-lol/data --filter=@scout-for-lol/backend
```

4,501 tests pass; typecheck and lint clean.

- 5 new v2 cases and 3 new v3 cases: `DRAGON_KILL` and `BUILDING_DESTROYED` rejected, `CHAMPION_KILL` / `ELITE_MONSTER_KILL` / `ITEM_PURCHASED` accepted.
- The v3 tests also exercise the pre-existing guard that timeline reads must join `timeline_coverage` so missing data is never treated as zero — the same failure class, already defended one layer over.
- The injection test keeps its binding coverage through the hostile `puuid`, and gains an assertion that a hostile event type is refused *before* it can reach the compiler.

**Not run:** live beta authoring, and the paid model eval.

## Known gap (follow-up)

This stops an invented event type from silently counting zero, but **"kill three dragons" is still inexpressible.** The evaluator reads only 4 of the 35 timeline columns the lake stores (`event_id, event_type, event_timestamp_ms, item_id`), so `ELITE_MONSTER_KILL` cannot be narrowed to a dragon. The real domains are in the lake already — `monster_type`: `DRAGON, HORDE, BARON_NASHOR, RIFTHERALD, ATAKHAN`; `building_type`: `TOWER_BUILDING, INHIBITOR_BUILDING` — with zero current consumers, so exposing them is additive. The one constraint is that `dare_timeline_event_count` is positional, so new arguments must be **appended** or stored contracts fail the plan-hash round-trip.