### PR TITLE
feat(feature-flags): enable Dare SQL v3 for the beta guild

### DIFF
--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -1062,7 +1062,31 @@
   "environments": [
     {
       "key": "beta",
-      "overrides": []
+      "overrides": [
+        {
+          "key": "dare_extended_contracts_enabled",
+          "type": "boolean",
+          "default": false,
+          "rollouts": [
+            {
+              "segmentKey": "scout-guild-1337623164146155593",
+              "segmentOperator": "OR_SEGMENT_OPERATOR",
+              "matchType": "ALL_SEGMENT_MATCH_TYPE",
+              "constraints": [
+                {
+                  "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+                  "property": "server",
+                  "operator": "eq",
+                  "value": "1337623164146155593"
+                }
+              ],
+              "result": true
+            }
+          ],
+          "rules": [],
+          "thresholdRollouts": []
+        }
+      ]
     },
     {
       "key": "prod",

--- a/packages/feature-flags/src/managed-flag-inventory.test.ts
+++ b/packages/feature-flags/src/managed-flag-inventory.test.ts
@@ -55,6 +55,17 @@ function exploreModel(environment: string) {
   ).find((flag) => flag.key === "scout-explore-model")?.default;
 }
 
+function dareExtendedContractsFlag(environment: string) {
+  const flag = materializeManagedNamespaceEnvironment(
+    managedFlagInventory,
+    environment,
+    "scout",
+  ).find((candidate) => candidate.key === "dare_extended_contracts_enabled");
+  if (flag === undefined)
+    throw new Error("Dare extended contracts flag missing");
+  return flag;
+}
+
 describe("ManagedFlagInventorySchema", () => {
   test("uses Luna in both managed environments", () => {
     expect(exploreModel("beta")).toBe("gpt-5.6-luna");
@@ -88,6 +99,21 @@ describe("ManagedFlagInventorySchema", () => {
         "temporal",
       ).map((flag) => flag.key),
     ).toContain("temporal-call-graph-tracing");
+  });
+
+  test("enables extended Dare contracts only for the beta guild", () => {
+    const betaFlag = dareExtendedContractsFlag("beta");
+    expect(betaFlag.default).toBe(false);
+    expect(betaFlag.rollouts).toEqual([
+      expect.objectContaining({
+        segmentKey: "scout-guild-1337623164146155593",
+        result: true,
+      }),
+    ]);
+
+    const prodFlag = dareExtendedContractsFlag("prod");
+    expect(prodFlag.default).toBe(false);
+    expect(prodFlag.rollouts).toEqual([]);
   });
 
   test("materializes a full-state environment override", () => {


### PR DESCRIPTION
## Why

Dare SQL v3 was merged and deployed behind `dare_extended_contracts_enabled`, but the live beta Flipt repository did not contain the flag and the managed inventory had no beta rollout.

## What

- add a full-state beta environment override for `dare_extended_contracts_enabled`
- keep the default false and enable only `scout-guild-1337623164146155593`
- assert beta receives the rollout while production remains disabled

## Verification

- `bunx turbo run test typecheck lint --filter=@shepherdjerred/feature-flags`
- `bunx lefthook run pre-commit`
- live beta evaluation: target guild is true and a control guild is false for both `dare_extended_contracts_enabled` and `scoutql_relational_enabled`
- live beta resource matches the managed contract
- full beta/scout drift check remains red only for two unrelated existing differences: missing `dare_notifications_enabled` and `scout-consumer-player-profiles-enabled` live true vs declared false
- production was not mutated; the Dare flag remains absent there

## Rollout

The live beta flag was created at Flipt revision `3f331c29f218bb51ce74bae2a330f197e1ee37fd`. Production remains untouched.