### PR TITLE
feat(scout-for-lol): add queue-scoped Hall of Fame records

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1154,7 +1154,7 @@
     },
     "packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.test.ts|packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.test.ts": {
       "clones": 2,
-      "tokens": 305
+      "tokens": 248
     },
     "packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.ts|packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.ts": {
       "clones": 1,

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/prune-players.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/prune-players.test.ts
@@ -111,6 +111,53 @@ function setupTestDatabase(): {
   return { prisma, testDir, testDbPath };
 }
 
+async function seedConflictingHallBaseline(
+  prisma: ExtendedPrismaClient,
+  now: Date,
+) {
+  const guildId = testGuildId("1000000001");
+  const actorId = testAccountId("1000000000000");
+  await prisma.player.create({
+    data: {
+      alias: "hall-holder",
+      serverId: guildId,
+      creatorDiscordId: actorId,
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+  await prisma.hallSettings.create({
+    data: {
+      guildId,
+      catalogVersion: 1,
+      enabledQueueFamilies: '["aram"]',
+      enabledRecords: '["kills"]',
+      updatedByDiscordId: actorId,
+    },
+  });
+  await prisma.hallBaselineRun.create({
+    data: {
+      guildId,
+      revision: 1,
+      baselineState: "ready",
+      requestedByDiscordId: actorId,
+      workflowId: "conflicting-hall-baseline",
+    },
+  });
+  return guildId;
+}
+
+async function expectHallIntentFailureRollsBack(
+  prisma: ExtendedPrismaClient,
+): Promise<void> {
+  const guildId = await seedConflictingHallBaseline(prisma, new Date());
+  await expect(pruneOrphanedPlayers(prisma, false, null)).rejects.toThrow();
+  expect(await prisma.player.count({ where: { serverId: guildId } })).toBe(1);
+  expect(
+    await prisma.hallSettings.findUniqueOrThrow({ where: { guildId } }),
+  ).toMatchObject({ baselineRevision: 0 });
+}
+
 describe("pruneOrphanedPlayers", () => {
   let prisma: ExtendedPrismaClient;
   let testDir: string;
@@ -286,6 +333,10 @@ describe("pruneOrphanedPlayers", () => {
     expect(result.totalAccountsDeleted).toBe(2);
     const afterAccountCount = await prisma.account.count();
     expect(afterAccountCount).toBe(0);
+  });
+
+  it("rolls back player deletion when the Hall rebuild intent cannot persist", async () => {
+    await expectHallIntentFailureRollsBack(prisma);
   });
 
   it("should handle mixed scenarios correctly", async () => {

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/prune-players.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/prune-players.ts
@@ -14,6 +14,8 @@ import {
 } from "@scout-for-lol/data";
 import { sendDM } from "#src/discord/utils/dm.ts";
 import { createLogger } from "#src/logger.ts";
+import configuration from "#src/configuration.ts";
+import { queueHallRosterRebaseline } from "#src/progression/hall/roster-change.ts";
 
 const logger = createLogger("cleanup-prune-players");
 
@@ -242,58 +244,6 @@ export async function pruneOrphanedPlayers(
       logger.info(`[PlayerPruning]   └─ Status: ELIGIBLE FOR PRUNING`);
     }
 
-    // Delete orphaned players and their related data
-    logger.info(`[PlayerPruning] 🗑️  Starting deletion process...`);
-    const playerIds = orphanedPlayers.map(
-      (player: PlayerWithRelations) => player.id,
-    );
-
-    // Delete in order: accounts first, then competition data, then players
-    const accountsDeleted = await prismaClient.account.deleteMany({
-      where: {
-        playerId: {
-          in: playerIds,
-        },
-      },
-    });
-    logger.info(
-      `[PlayerPruning]   ✓ Deleted ${accountsDeleted.count.toString()} accounts`,
-    );
-
-    const participantsDeleted =
-      await prismaClient.competitionParticipant.deleteMany({
-        where: {
-          playerId: {
-            in: playerIds,
-          },
-        },
-      });
-    logger.info(
-      `[PlayerPruning]   ✓ Deleted ${participantsDeleted.count.toString()} competition participants`,
-    );
-
-    const snapshotsDeleted = await prismaClient.competitionSnapshot.deleteMany({
-      where: {
-        playerId: {
-          in: playerIds,
-        },
-      },
-    });
-    logger.info(
-      `[PlayerPruning]   ✓ Deleted ${snapshotsDeleted.count.toString()} competition snapshots`,
-    );
-
-    const playersDeleted = await prismaClient.player.deleteMany({
-      where: {
-        id: {
-          in: playerIds,
-        },
-      },
-    });
-    logger.info(
-      `[PlayerPruning]   ✓ Deleted ${playersDeleted.count.toString()} players`,
-    );
-
     // Prepare server summaries
     const serverSummaries = Object.entries(playersByServer).map(
       ([serverId, players]) => {
@@ -322,6 +272,54 @@ export async function pruneOrphanedPlayers(
       },
     );
 
+    // Delete orphaned players and durably queue every affected Hall rebuild in
+    // one transaction. A committed roster change must never leave ready Hall
+    // cells pointing at an account that no longer exists.
+    logger.info(`[PlayerPruning] 🗑️  Starting deletion process...`);
+    const playerIds = orphanedPlayers.map(
+      (player: PlayerWithRelations) => player.id,
+    );
+    const deletion = await prismaClient.$transaction(async (tx) => {
+      const accountsDeleted = await tx.account.deleteMany({
+        where: { playerId: { in: playerIds } },
+      });
+      const participantsDeleted = await tx.competitionParticipant.deleteMany({
+        where: { playerId: { in: playerIds } },
+      });
+      const snapshotsDeleted = await tx.competitionSnapshot.deleteMany({
+        where: { playerId: { in: playerIds } },
+      });
+      const playersDeleted = await tx.player.deleteMany({
+        where: { id: { in: playerIds } },
+      });
+      for (const summary of serverSummaries) {
+        await queueHallRosterRebaseline({
+          guildId: summary.serverId,
+          actorDiscordId: "system:player-pruning",
+          stage: configuration.environment,
+          db: tx,
+        });
+      }
+      return {
+        accountsDeleted,
+        participantsDeleted,
+        snapshotsDeleted,
+        playersDeleted,
+      };
+    });
+    logger.info(
+      `[PlayerPruning]   ✓ Deleted ${deletion.accountsDeleted.count.toString()} accounts`,
+    );
+    logger.info(
+      `[PlayerPruning]   ✓ Deleted ${deletion.participantsDeleted.count.toString()} competition participants`,
+    );
+    logger.info(
+      `[PlayerPruning]   ✓ Deleted ${deletion.snapshotsDeleted.count.toString()} competition snapshots`,
+    );
+    logger.info(
+      `[PlayerPruning]   ✓ Deleted ${deletion.playersDeleted.count.toString()} players`,
+    );
+
     // Notify server owners
     if (notifyOwners && discordClient) {
       logger.info(
@@ -345,16 +343,16 @@ export async function pruneOrphanedPlayers(
     logger.info(`[PlayerPruning] ✅ PRUNING COMPLETE`);
     logger.info(`[PlayerPruning]   - Duration: ${duration.toString()}ms`);
     logger.info(
-      `[PlayerPruning]   - Players pruned: ${playersDeleted.count.toString()}`,
+      `[PlayerPruning]   - Players pruned: ${deletion.playersDeleted.count.toString()}`,
     );
     logger.info(
-      `[PlayerPruning]   - Accounts deleted: ${accountsDeleted.count.toString()}`,
+      `[PlayerPruning]   - Accounts deleted: ${deletion.accountsDeleted.count.toString()}`,
     );
     logger.info(
-      `[PlayerPruning]   - Participants deleted: ${participantsDeleted.count.toString()}`,
+      `[PlayerPruning]   - Participants deleted: ${deletion.participantsDeleted.count.toString()}`,
     );
     logger.info(
-      `[PlayerPruning]   - Snapshots deleted: ${snapshotsDeleted.count.toString()}`,
+      `[PlayerPruning]   - Snapshots deleted: ${deletion.snapshotsDeleted.count.toString()}`,
     );
     logger.info(
       `[PlayerPruning]   - Servers affected: ${serverSummaries.length.toString()}`,
@@ -365,10 +363,10 @@ export async function pruneOrphanedPlayers(
     logger.info(`[PlayerPruning] ============================================`);
 
     return {
-      totalPlayersPruned: playersDeleted.count,
-      totalAccountsDeleted: accountsDeleted.count,
-      totalParticipantsDeleted: participantsDeleted.count,
-      totalSnapshotsDeleted: snapshotsDeleted.count,
+      totalPlayersPruned: deletion.playersDeleted.count,
+      totalAccountsDeleted: deletion.accountsDeleted.count,
+      totalParticipantsDeleted: deletion.participantsDeleted.count,
+      totalSnapshotsDeleted: deletion.snapshotsDeleted.count,
       serverSummaries,
     };
   } catch (error) {

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/remove-guild.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/remove-guild.test.ts
@@ -126,6 +126,42 @@ async function seedGuild(
     errorType: "channel_missing",
   });
 
+  await db.hallSettings.create({
+    data: {
+      guildId: serverId,
+      catalogVersion: 1,
+      channelId,
+      enabledQueueFamilies: '["aram"]',
+      enabledRecords: '["kills"]',
+      baselineRevision: 1,
+      updatedByDiscordId: creator,
+      recordCells: {
+        create: {
+          queueFamilyId: "aram",
+          recordId: "kills",
+          baselineStatus: "ready",
+          baselineRevision: 1,
+        },
+      },
+      baselineRuns: {
+        create: {
+          revision: 1,
+          baselineState: "ready",
+          requestedByDiscordId: creator,
+          workflowId: `hall-cleanup-${serverId}`,
+        },
+      },
+    },
+  });
+  await db.hallRecordBreakOutbox.create({
+    data: {
+      guildId: serverId,
+      matchId: `match-${serverId}`,
+      channelId,
+      payloadJson: "[]",
+    },
+  });
+
   return player.id;
 }
 
@@ -146,6 +182,12 @@ async function countGuild(
     permissionErrors: await db.guildPermissionError.count({
       where: { serverId },
     }),
+    hallSettings: await db.hallSettings.count({
+      where: { guildId: serverId },
+    }),
+    hallRecordBreakOutbox: await db.hallRecordBreakOutbox.count({
+      where: { guildId: serverId },
+    }),
   };
 }
 
@@ -160,6 +202,8 @@ beforeEach(async () => {
   await prisma.reportRun.deleteMany();
   await prisma.report.deleteMany();
   await prisma.subscription.deleteMany();
+  await prisma.hallRecordBreakOutbox.deleteMany();
+  await prisma.hallSettings.deleteMany();
   await prisma.account.deleteMany();
   await prisma.player.deleteMany();
   await prisma.serverPermission.deleteMany();
@@ -188,6 +232,8 @@ describe("cleanupRemovedGuild", () => {
       accounts: 1,
       players: 1,
       permissionErrors: 1,
+      hallSettings: 1,
+      hallRecordBreakOutbox: 1,
     });
 
     // ...and actually gone from the database.
@@ -201,6 +247,8 @@ describe("cleanupRemovedGuild", () => {
       notificationPreferences: 0,
       serverPermissions: 0,
       permissionErrors: 0,
+      hallSettings: 0,
+      hallRecordBreakOutbox: 0,
     });
 
     // The cascade removed the competition participant too.
@@ -217,6 +265,8 @@ describe("cleanupRemovedGuild", () => {
       notificationPreferences: 1,
       serverPermissions: 1,
       permissionErrors: 1,
+      hallSettings: 1,
+      hallRecordBreakOutbox: 1,
     });
   });
 
@@ -231,6 +281,8 @@ describe("cleanupRemovedGuild", () => {
       accounts: 0,
       players: 0,
       permissionErrors: 0,
+      hallSettings: 0,
+      hallRecordBreakOutbox: 0,
     });
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/remove-guild.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/remove-guild.ts
@@ -33,6 +33,8 @@ export type RemovedGuildCleanupSummary = {
   accounts: number;
   players: number;
   permissionErrors: number;
+  hallSettings: number;
+  hallRecordBreakOutbox: number;
 };
 
 /**
@@ -123,6 +125,12 @@ export async function cleanupRemovedGuild(
       const serverPermissions = await tx.serverPermission.deleteMany({
         where: { serverId },
       });
+      const hallRecordBreakOutbox = await tx.hallRecordBreakOutbox.deleteMany({
+        where: { guildId: serverId },
+      });
+      const hallSettings = await tx.hallSettings.deleteMany({
+        where: { guildId: serverId },
+      });
       const accounts = await tx.account.deleteMany({ where: { serverId } });
       const players = await tx.player.deleteMany({ where: { serverId } });
       const permissionErrors = await tx.guildPermissionError.deleteMany({
@@ -138,6 +146,8 @@ export async function cleanupRemovedGuild(
         accounts: accounts.count,
         players: players.count,
         permissionErrors: permissionErrors.count,
+        hallSettings: hallSettings.count,
+        hallRecordBreakOutbox: hallRecordBreakOutbox.count,
       };
     },
   );

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
@@ -209,6 +209,14 @@ export async function processMatchAndUpdatePlayers(
   // therefore leaves the cursors in place and retries the same match.
   await finalizeAndPublishTournamentResult(prisma, matchData);
 
+  const { processCompetitiveProgressionMatch } =
+    await import("#src/progression/postmatch.ts");
+  await processCompetitiveProgressionMatch({
+    match: matchData,
+    timeline: prefetchedTimeline,
+    trackedPlayers: allTrackedPlayers,
+  });
+
   // Mark as processed
   processedMatchIds.add(matchId);
 

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.test.ts
@@ -1,12 +1,10 @@
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import type {
-  DiscordAccountId,
   LeaguePuuid,
   PlayerId,
   Region,
   RiotId,
 } from "@scout-for-lol/data";
-import type { User } from "#generated/prisma/client/index.js";
 import {
   createTestDatabase,
   deleteIfExists,
@@ -16,6 +14,7 @@ import {
   testGuildId,
   testPuuid,
 } from "#src/testing/test-ids.ts";
+import { createTestUser } from "#src/testing/test-user.ts";
 import {
   addFlagOverride,
   resetFlagOverrides,
@@ -51,7 +50,7 @@ const { addAccount, deleteAccount, transferAccount } =
 const guildId = testGuildId("9931");
 const actorDiscordId = testAccountId("9932");
 const ctx = {
-  user: createUser(actorDiscordId),
+  user: createTestUser(actorDiscordId),
   webSession: { ipAddress: "127.0.0.1", userAgent: "bun-test" },
 };
 
@@ -152,21 +151,6 @@ describe("account admin mutations", () => {
     expect(await prisma.auditLog.count()).toBe(0);
   });
 });
-
-function createUser(discordId: DiscordAccountId): User {
-  return {
-    discordId,
-    discordUsername: "Test Admin",
-    discordAvatar: null,
-    discordAccessToken: "access",
-    discordRefreshToken: "refresh",
-    tokenExpiresAt: null,
-    analyticsUserId: `analytics-${discordId}`,
-    lastSeenAt: null,
-    createdAt: new Date(0),
-    updatedAt: new Date(0),
-  };
-}
 
 async function createPlayer(alias: string) {
   const now = new Date();

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.ts
@@ -15,6 +15,8 @@ import { backfillLastMatchTime } from "#src/league/api/backfill-match-history.ts
 import { getRiotIdByPuuid } from "#src/lib/riot/account-riot-id.ts";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
 import { enqueueInitialMatchHistoryImport } from "#src/league/initial-history/enqueue.ts";
+import configuration from "#src/configuration.ts";
+import { queueHallRosterRebaseline } from "#src/progression/hall/roster-change.ts";
 import {
   conflict,
   GuildIdInput,
@@ -151,6 +153,12 @@ export async function addAccount(ctx: WebCtx, input: AddAccountInputData) {
         },
         tx,
       );
+      await queueHallRosterRebaseline({
+        guildId: input.guildId,
+        actorDiscordId: ctx.user.discordId,
+        stage: configuration.environment,
+        db: tx,
+      });
       return account;
     })
     .catch((error: unknown) => {
@@ -222,6 +230,12 @@ export async function deleteAccount(ctx: WebCtx, input: RiotAccountInputData) {
       },
       tx,
     );
+    await queueHallRosterRebaseline({
+      guildId: input.guildId,
+      actorDiscordId: ctx.user.discordId,
+      stage: configuration.environment,
+      db: tx,
+    });
     return {
       accountId: currentAccount.id,
       playerAlias: currentAccount.player.alias,
@@ -300,6 +314,12 @@ export async function transferAccount(
       },
       tx,
     );
+    await queueHallRosterRebaseline({
+      guildId: input.guildId,
+      actorDiscordId: ctx.user.discordId,
+      stage: configuration.environment,
+      db: tx,
+    });
     return {
       accountId: account.id,
       fromPlayerAlias: currentAccount.player.alias,
@@ -382,9 +402,14 @@ export async function updateAccount(
       },
       tx,
     );
+    await queueHallRosterRebaseline({
+      guildId: input.guildId,
+      actorDiscordId: ctx.user.discordId,
+      stage: configuration.environment,
+      db: tx,
+    });
     return result;
   });
-
   return {
     accountId: updated.id,
     alias: updated.alias,

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.test.ts
@@ -1,11 +1,10 @@
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
-import type {
-  DiscordAccountId,
-  DiscordChannelId,
-  LeaguePuuid,
-  PlayerId,
+import {
+  COMPETITIVE_PROGRESSION_CATALOG_VERSION,
+  type DiscordChannelId,
+  type LeaguePuuid,
+  type PlayerId,
 } from "@scout-for-lol/data";
-import type { User } from "#generated/prisma/client/index.js";
 import {
   createTestDatabase,
   deleteIfExists,
@@ -16,6 +15,7 @@ import {
   testGuildId,
   testPuuid,
 } from "#src/testing/test-ids.ts";
+import { createTestUser } from "#src/testing/test-user.ts";
 
 const { prisma } = createTestDatabase("player-admin-mutations");
 
@@ -35,11 +35,12 @@ const { deletePlayer, linkDiscord, mergePlayers, renamePlayer, unlinkDiscord } =
 const guildId = testGuildId("9901");
 const actorDiscordId = testAccountId("9902");
 const ctx = {
-  user: createUser(actorDiscordId),
+  user: createTestUser(actorDiscordId),
   webSession: { ipAddress: "127.0.0.1", userAgent: "bun-test" },
 };
 
 beforeEach(async () => {
+  await deleteIfExists(() => prisma.hallSettings.deleteMany());
   await deleteIfExists(() => prisma.auditLog.deleteMany());
   await deleteIfExists(() => prisma.subscription.deleteMany());
   await deleteIfExists(() => prisma.account.deleteMany());
@@ -127,6 +128,29 @@ describe("player admin mutations", () => {
     ]);
   });
 
+  test("rolls back deletion when its Hall re-baseline cannot be persisted", async () => {
+    const player = await createPlayer("KeepMe");
+    await prisma.hallSettings.create({
+      data: {
+        guildId,
+        catalogVersion: COMPETITIVE_PROGRESSION_CATALOG_VERSION,
+        channelId: null,
+        enabledQueueFamilies: '["unknown-family"]',
+        enabledRecords: '["kills"]',
+        updatedByDiscordId: actorDiscordId,
+      },
+    });
+
+    await expect(
+      deletePlayer(ctx, { guildId, alias: player.alias }),
+    ).rejects.toThrow();
+
+    expect(
+      await prisma.player.findUnique({ where: { id: player.id } }),
+    ).not.toBeNull();
+    expect(await prisma.auditLog.count()).toBe(0);
+  });
+
   test("merges accounts and non-duplicate subscriptions into the target player", async () => {
     const source = await createPlayer("Source");
     const target = await createPlayer("Target");
@@ -171,21 +195,6 @@ describe("player admin mutations", () => {
     ]);
   });
 });
-
-function createUser(discordId: DiscordAccountId): User {
-  return {
-    discordId,
-    discordUsername: "Test Admin",
-    discordAvatar: null,
-    discordAccessToken: "access",
-    discordRefreshToken: "refresh",
-    tokenExpiresAt: null,
-    analyticsUserId: `analytics-${discordId}`,
-    lastSeenAt: null,
-    createdAt: new Date(0),
-    updatedAt: new Date(0),
-  };
-}
 
 async function createPlayer(alias: string) {
   const now = new Date();

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.ts
@@ -5,7 +5,9 @@ import {
   type PlayerId,
 } from "@scout-for-lol/data";
 import { prisma, type Db } from "#src/database/index.ts";
+import configuration from "#src/configuration.ts";
 import { recordAudit } from "#src/lib/audit/index.ts";
+import { queueHallRosterRebaseline } from "#src/progression/hall/roster-change.ts";
 import {
   GuildIdInput,
   conflict,
@@ -47,7 +49,7 @@ export async function renamePlayer(ctx: WebCtx, input: RenamePlayerInputData) {
   });
   const now = new Date();
   try {
-    return await prisma.$transaction(async (tx) => {
+    const renamed = await prisma.$transaction(async (tx) => {
       const existing = await tx.player.findUnique({
         where: {
           serverId_alias: { serverId: input.guildId, alias: input.newAlias },
@@ -81,8 +83,15 @@ export async function renamePlayer(ctx: WebCtx, input: RenamePlayerInputData) {
         },
         tx,
       );
+      await queueHallRosterRebaseline({
+        guildId: input.guildId,
+        actorDiscordId: ctx.user.discordId,
+        stage: configuration.environment,
+        db: tx,
+      });
       return { alias: updated.alias };
     });
+    return renamed;
   } catch (error) {
     if (isUniqueConstraintError(error)) {
       throw conflict(`A player named "${input.newAlias}" already exists`);
@@ -195,6 +204,12 @@ export async function deletePlayer(ctx: WebCtx, input: DeletePlayerInputData) {
       },
       tx,
     );
+    await queueHallRosterRebaseline({
+      guildId: input.guildId,
+      actorDiscordId: ctx.user.discordId,
+      stage: configuration.environment,
+      db: tx,
+    });
   });
   return { deletedAlias: player.alias };
 }
@@ -261,6 +276,12 @@ export async function mergePlayers(ctx: WebCtx, input: MergePlayersInputData) {
       },
       tx,
     );
+    await queueHallRosterRebaseline({
+      guildId: input.guildId,
+      actorDiscordId: ctx.user.discordId,
+      stage: configuration.environment,
+      db: tx,
+    });
   });
   return { sourceAlias: source.alias, targetAlias: target.alias };
 }

--- a/packages/scout-for-lol/packages/backend/src/metrics/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/index.ts
@@ -8,6 +8,7 @@ import "#src/metrics/season-schedule.ts";
 import "#src/metrics/product-analytics.ts";
 import "#src/metrics/feature-flags.ts";
 import "#src/metrics/discord-gateway-health.ts";
+import "#src/metrics/progression.ts";
 
 const logger = createLogger("metrics");
 

--- a/packages/scout-for-lol/packages/backend/src/metrics/progression.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/progression.ts
@@ -1,0 +1,77 @@
+import { Counter, Gauge, Histogram } from "prom-client";
+import { registry } from "#src/metrics/registry.ts";
+
+export const hallBaselineDuration = new Histogram({
+  name: "scout_hall_baseline_duration_seconds",
+  help: "Hall of Fame baseline duration by outcome",
+  labelNames: ["status"] as const,
+  buckets: [1, 5, 15, 30, 60, 300, 900, 3600],
+  registers: [registry],
+});
+
+export const hallRecordBreakDeliveries = new Counter({
+  name: "scout_hall_record_break_deliveries_total",
+  help: "Hall of Fame record-break delivery outcomes",
+  labelNames: ["status"] as const,
+  registers: [registry],
+});
+
+export const challengeRecomputeDuration = new Histogram({
+  name: "scout_challenge_recompute_duration_seconds",
+  help: "Challenge run recomputation duration by outcome",
+  labelNames: ["status"] as const,
+  buckets: [1, 5, 15, 30, 60, 300, 900, 3600],
+  registers: [registry],
+});
+
+export const challengeMissingTimelineMatches = new Counter({
+  name: "scout_challenge_missing_timeline_matches_total",
+  help: "Matches reported without timeline evidence in completed challenge revisions",
+  registers: [registry],
+});
+
+export const challengeRunCompletions = new Counter({
+  name: "scout_challenge_run_completions_total",
+  help: "Challenge runs completed by deterministic evidence evaluation",
+  registers: [registry],
+});
+
+export const challengeRecomputeLag = new Gauge({
+  name: "scout_challenge_recompute_lag_seconds",
+  help: "Age of the oldest queued or running challenge revision",
+  registers: [registry],
+});
+
+export const duelSeriesState = new Gauge({
+  name: "scout_duel_series_state",
+  help: "Current duel-series rows by lifecycle state",
+  labelNames: ["state"] as const,
+  registers: [registry],
+});
+
+export const duelSeriesTransitions = new Counter({
+  name: "scout_duel_series_transitions_total",
+  help: "Duel-series lifecycle transitions",
+  labelNames: ["from", "to"] as const,
+  registers: [registry],
+});
+
+export const duelSeriesOverdue = new Counter({
+  name: "scout_duel_series_overdue_total",
+  help: "Duel series whose durable deadline expired",
+  registers: [registry],
+});
+
+export const duelResults = new Counter({
+  name: "scout_duel_results_total",
+  help: "Duel result evaluation outcomes",
+  labelNames: ["status"] as const,
+  registers: [registry],
+});
+
+export const duelTournamentProvisioning = new Counter({
+  name: "scout_duel_tournament_provisioning_total",
+  help: "Duel Tournament API provisioning outcomes",
+  labelNames: ["status"] as const,
+  registers: [registry],
+});

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/baseline.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/baseline.ts
@@ -1,0 +1,302 @@
+import {
+  DiscordGuildIdSchema,
+  HallQueueFamilyIdSchema,
+  HallRecordEvidenceSchema,
+  HallRecordHolderSchema,
+  HallRecordIdSchema,
+  classifyHallQueueFamily,
+  compareHallCandidate,
+  hallRecordValue,
+  isHallEligibleMatch,
+  type DiscordGuildId,
+  type HallRecordEvidence,
+  type HallRecordHolder,
+  type HallRecordId,
+} from "@scout-for-lol/data";
+import type { ScoutHallBaselineInput } from "@scout-for-lol/temporal";
+import { prisma, type Db } from "#src/database/index.ts";
+import { hallBaselineDuration } from "#src/metrics/progression.ts";
+import {
+  fetchProgressionMatches,
+  type ProgressionMatchCursor,
+  type ProgressionMatchRow,
+} from "#src/progression/progression-lake-reads.ts";
+
+const PAGE_SIZE = 10_000;
+
+export async function lockHallRecords(
+  tx: Pick<Db, "$executeRaw">,
+  guildId: string,
+): Promise<void> {
+  await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('scout-hall-records'), hashtext(${guildId}))`;
+}
+
+type TrackedAccount = {
+  readonly id: number;
+  readonly alias: string;
+  readonly puuid: string;
+  readonly createdTime: Date;
+  readonly player: { readonly id: number; readonly alias: string };
+};
+
+type BaselineValue = {
+  readonly value: number;
+  readonly holders: HallRecordHolder[];
+  readonly evidence: HallRecordEvidence[];
+};
+
+function cellKey(queueFamilyId: string, recordId: string): string {
+  return `${queueFamilyId}:${recordId}`;
+}
+
+function holderFor(account: TrackedAccount): HallRecordHolder {
+  return HallRecordHolderSchema.parse({
+    playerId: account.player.id,
+    playerAlias: account.player.alias,
+    accountId: account.id,
+    accountAlias: account.alias,
+    puuid: account.puuid,
+  });
+}
+
+function evidenceFor(
+  match: ProgressionMatchRow,
+  value: number,
+  holder: HallRecordHolder,
+): HallRecordEvidence {
+  return HallRecordEvidenceSchema.parse({
+    matchId: match.match_id,
+    gameEndAt: match.game_end_at,
+    value,
+    holder,
+  });
+}
+
+function considerMatch(
+  values: Map<string, BaselineValue>,
+  match: ProgressionMatchRow,
+  account: TrackedAccount,
+  catalog: {
+    readonly targetCellKeys: ReadonlySet<string>;
+    readonly recordIds: readonly HallRecordId[];
+  },
+): void {
+  if (!isHallEligibleMatch(match, account.createdTime)) return;
+  const family = classifyHallQueueFamily(match.queue);
+  if (family === null) return;
+  const holder = holderFor(account);
+  for (const recordId of catalog.recordIds) {
+    const key = cellKey(family, recordId);
+    if (!catalog.targetCellKeys.has(key)) continue;
+    const value = hallRecordValue(match, recordId);
+    const candidateEvidence = evidenceFor(match, value, holder);
+    const current = values.get(key);
+    const comparison = compareHallCandidate(
+      current?.value ?? null,
+      current?.holders ?? [],
+      current?.evidence ?? [],
+      {
+        queueFamilyId: family,
+        recordId,
+        value,
+        holder,
+        evidence: candidateEvidence,
+      },
+    );
+    if (comparison.kind === "below") continue;
+    values.set(key, {
+      value: comparison.kind === "break" ? comparison.value : value,
+      holders: comparison.holders,
+      evidence: comparison.evidence,
+    });
+  }
+}
+
+function nextCursor(
+  rows: readonly ProgressionMatchRow[],
+): ProgressionMatchCursor {
+  const last = rows.at(-1);
+  if (last === undefined) throw new Error("Cannot advance an empty Hall page");
+  return {
+    gameEndMs: last.game_end_ms,
+    matchId: last.match_id,
+    puuid: last.puuid,
+  };
+}
+
+async function calculateBaseline(
+  accounts: readonly TrackedAccount[],
+  targetCellKeys: ReadonlySet<string>,
+  recordIds: readonly HallRecordId[],
+  onProgress: ((rows: number) => void) | undefined,
+): Promise<Map<string, BaselineValue>> {
+  const earliest = accounts.reduce(
+    (minimum, account) =>
+      new Date(Math.min(account.createdTime.getTime(), minimum.getTime())),
+    accounts[0]?.createdTime ?? new Date(),
+  );
+  const byPuuid = new Map(accounts.map((account) => [account.puuid, account]));
+  const values = new Map<string, BaselineValue>();
+  let cursor: ProgressionMatchCursor | undefined;
+  let processed = 0;
+  for (;;) {
+    const rows = await fetchProgressionMatches({
+      puuids: [...byPuuid.keys()],
+      startAt: earliest,
+      ...(cursor === undefined ? {} : { cursor }),
+      limit: PAGE_SIZE,
+    });
+    for (const match of rows) {
+      const account = byPuuid.get(match.puuid);
+      if (account === undefined) {
+        throw new Error(`Hall lake returned unrequested PUUID ${match.puuid}`);
+      }
+      considerMatch(values, match, account, { targetCellKeys, recordIds });
+    }
+    processed += rows.length;
+    onProgress?.(processed);
+    if (rows.length < PAGE_SIZE) return values;
+    cursor = nextCursor(rows);
+  }
+}
+
+async function markBaselineFailed(
+  input: ScoutHallBaselineInput,
+  error: unknown,
+): Promise<void> {
+  const guildId = DiscordGuildIdSchema.parse(input.guildId);
+  const message = error instanceof Error ? error.message : String(error);
+  await prisma.$transaction([
+    prisma.hallRecordCell.updateMany({
+      where: {
+        guildId,
+        baselineRevision: input.revision,
+        baselineStatus: "building",
+      },
+      data: {
+        baselineStatus: "failed",
+        errorMessage: message,
+        baselineCompletedAt: new Date(),
+      },
+    }),
+    prisma.hallBaselineRun.updateMany({
+      where: {
+        guildId,
+        revision: input.revision,
+        baselineState: "building",
+      },
+      data: {
+        baselineState: "failed",
+        errorMessage: message,
+        completedAt: new Date(),
+      },
+    }),
+  ]);
+}
+
+async function calculateAndPersistBaseline(
+  tx: Db,
+  input: ScoutHallBaselineInput,
+  guildId: DiscordGuildId,
+  onProgress: ((rows: number) => void) | undefined,
+): Promise<boolean> {
+  await lockHallRecords(tx, guildId);
+  const run = await tx.hallBaselineRun.findUnique({
+    where: {
+      guildId_revision: { guildId, revision: input.revision },
+    },
+  });
+  if (run === null) throw new Error("Hall baseline run is missing");
+  if (run.baselineState === "ready") return false;
+  await tx.hallBaselineRun.update({
+    where: { id: run.id },
+    data: {
+      baselineState: "building",
+      startedAt: run.startedAt ?? new Date(),
+      errorMessage: null,
+    },
+  });
+  await tx.hallRecordCell.updateMany({
+    where: {
+      guildId,
+      baselineRevision: input.revision,
+      baselineStatus: "failed",
+    },
+    data: { baselineStatus: "building", errorMessage: null },
+  });
+  const cells = await tx.hallRecordCell.findMany({
+    where: {
+      guildId,
+      baselineRevision: input.revision,
+      baselineStatus: "building",
+    },
+  });
+  const accounts = await tx.account.findMany({
+    where: { serverId: guildId },
+    include: { player: true },
+  });
+  const keys = new Set(
+    cells.map((cell) =>
+      cellKey(
+        HallQueueFamilyIdSchema.parse(cell.queueFamilyId),
+        HallRecordIdSchema.parse(cell.recordId),
+      ),
+    ),
+  );
+  const recordIds = [
+    ...new Set(cells.map((cell) => HallRecordIdSchema.parse(cell.recordId))),
+  ];
+  const values = await calculateBaseline(accounts, keys, recordIds, onProgress);
+  const completedAt = new Date();
+  for (const cell of cells) {
+    const value = values.get(cellKey(cell.queueFamilyId, cell.recordId));
+    await tx.hallRecordCell.updateMany({
+      where: {
+        id: cell.id,
+        baselineRevision: input.revision,
+        baselineStatus: "building",
+      },
+      data: {
+        baselineStatus: "ready",
+        baselineValue: value?.value ?? null,
+        currentValue: value?.value ?? null,
+        holdersJson: JSON.stringify(value?.holders ?? []),
+        evidenceJson: JSON.stringify(value?.evidence ?? []),
+        errorMessage: null,
+        baselineCompletedAt: completedAt,
+      },
+    });
+  }
+  await tx.hallBaselineRun.updateMany({
+    where: { id: run.id, baselineState: "building" },
+    data: { baselineState: "ready", completedAt, errorMessage: null },
+  });
+  return true;
+}
+
+export async function runHallBaseline(
+  input: ScoutHallBaselineInput,
+  onProgress?: (rows: number) => void,
+): Promise<void> {
+  const startedAt = Date.now();
+  const guildId = DiscordGuildIdSchema.parse(input.guildId);
+  try {
+    const completed = await prisma.$transaction(
+      async (tx) =>
+        await calculateAndPersistBaseline(tx, input, guildId, onProgress),
+      { maxWait: 60_000, timeout: 60 * 60 * 1000 },
+    );
+    if (!completed) return;
+    hallBaselineDuration.observe(
+      { status: "ready" },
+      (Date.now() - startedAt) / 1000,
+    );
+  } catch (error) {
+    await markBaselineFailed(input, error);
+    hallBaselineDuration.observe(
+      { status: "failed" },
+      (Date.now() - startedAt) / 1000,
+    );
+    throw error;
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/evaluate-match.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/evaluate-match.ts
@@ -185,6 +185,18 @@ export async function evaluateHallMatch(matchData: RawMatch): Promise<void> {
     include: { player: true },
   });
   if (accounts.length === 0) return;
+  const enabledGuildIds = new Set<DiscordGuildId>();
+  for (const account of accounts) {
+    const guildId = DiscordGuildIdSchema.parse(account.serverId);
+    if (
+      await isPolicyEnabled("hall_of_fame_enabled", {
+        server: guildId,
+      })
+    ) {
+      enabledGuildIds.add(guildId);
+    }
+  }
+  if (enabledGuildIds.size === 0) return;
   const earliest = accounts.reduce(
     (minimum, account) =>
       new Date(Math.min(account.createdTime.getTime(), minimum.getTime())),
@@ -196,21 +208,14 @@ export async function evaluateHallMatch(matchData: RawMatch): Promise<void> {
     matchId,
   });
   const byPuuid = new Map(rows.map((row) => [row.puuid, row]));
-  const guildIds = new Set<string>();
+  const guildIds = new Set<DiscordGuildId>();
   for (const account of accounts) {
     const row = byPuuid.get(account.puuid);
     if (row === undefined) continue;
-    guildIds.add(account.serverId);
+    const guildId = DiscordGuildIdSchema.parse(account.serverId);
+    if (enabledGuildIds.has(guildId)) guildIds.add(guildId);
   }
   for (const guildId of guildIds) {
-    const parsedGuildId = DiscordGuildIdSchema.parse(guildId);
-    if (
-      !(await isPolicyEnabled("hall_of_fame_enabled", {
-        server: parsedGuildId,
-      }))
-    ) {
-      continue;
-    }
-    await evaluateGuild(parsedGuildId, matchId, byPuuid);
+    await evaluateGuild(guildId, matchId, byPuuid);
   }
 }

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/evaluate-match.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/evaluate-match.ts
@@ -1,0 +1,216 @@
+import {
+  HallQueueFamilyIdSchema,
+  HallRecordEvidenceSchema,
+  HallRecordHolderSchema,
+  HallRecordIdSchema,
+  DiscordGuildIdSchema,
+  classifyHallQueueFamily,
+  compareHallCandidate,
+  hallRecordValue,
+  isHallEligibleMatch,
+  type DiscordGuildId,
+  type HallRecordHolder,
+  type RawMatch,
+} from "@scout-for-lol/data";
+import { prisma, type Db } from "#src/database/index.ts";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
+import { parseProgressionJson } from "#src/progression/json.ts";
+import { lockHallRecords } from "#src/progression/hall/baseline.ts";
+import { hallSettingsFromRow } from "#src/progression/hall/settings.ts";
+import {
+  fetchProgressionMatches,
+  type ProgressionMatchRow,
+} from "#src/progression/progression-lake-reads.ts";
+
+type TrackedAccount = {
+  readonly id: number;
+  readonly alias: string;
+  readonly puuid: string;
+  readonly createdTime: Date;
+  readonly serverId: string;
+  readonly player: { readonly id: number; readonly alias: string };
+};
+
+const HallBreakPayloadSchema = HallRecordEvidenceSchema.extend({
+  queueFamilyId: HallQueueFamilyIdSchema,
+  recordId: HallRecordIdSchema,
+  holders: HallRecordHolderSchema.array(),
+});
+export const HallBreakOutboxPayloadSchema = HallBreakPayloadSchema.array();
+
+function holderFor(account: TrackedAccount): HallRecordHolder {
+  return HallRecordHolderSchema.parse({
+    playerId: account.player.id,
+    playerAlias: account.player.alias,
+    accountId: account.id,
+    accountAlias: account.alias,
+    puuid: account.puuid,
+  });
+}
+
+async function evaluateCandidate(
+  tx: Db,
+  options: {
+    readonly guildId: string;
+    readonly match: ProgressionMatchRow;
+    readonly account: TrackedAccount;
+    readonly enabledRecords: ReadonlySet<string>;
+    readonly enabledFamilies: ReadonlySet<string>;
+  },
+): Promise<string[]> {
+  if (!isHallEligibleMatch(options.match, options.account.createdTime)) {
+    return [];
+  }
+  const family = classifyHallQueueFamily(options.match.queue);
+  if (family === null || !options.enabledFamilies.has(family)) return [];
+  const holder = holderFor(options.account);
+  const brokenCellIds: string[] = [];
+  for (const rawRecordId of options.enabledRecords) {
+    const recordId = HallRecordIdSchema.parse(rawRecordId);
+    const cell = await tx.hallRecordCell.findUnique({
+      where: {
+        guildId_queueFamilyId_recordId: {
+          guildId: options.guildId,
+          queueFamilyId: family,
+          recordId,
+        },
+      },
+    });
+    if (cell?.baselineStatus !== "ready") continue;
+    const value = hallRecordValue(options.match, recordId);
+    const evidence = HallRecordEvidenceSchema.parse({
+      matchId: options.match.match_id,
+      gameEndAt: options.match.game_end_at,
+      value,
+      holder,
+    });
+    const comparison = compareHallCandidate(
+      cell.currentValue,
+      parseProgressionJson(cell.holdersJson, HallRecordHolderSchema.array()),
+      parseProgressionJson(cell.evidenceJson, HallRecordEvidenceSchema.array()),
+      { queueFamilyId: family, recordId, value, holder, evidence },
+    );
+    if (comparison.kind === "below") continue;
+    await tx.hallRecordCell.update({
+      where: { id: cell.id },
+      data: {
+        currentValue:
+          comparison.kind === "break" ? comparison.value : cell.currentValue,
+        holdersJson: JSON.stringify(comparison.holders),
+        evidenceJson: JSON.stringify(comparison.evidence),
+      },
+    });
+    if (comparison.kind === "break") brokenCellIds.push(cell.id);
+  }
+  return brokenCellIds;
+}
+
+async function evaluateGuild(
+  guildId: DiscordGuildId,
+  matchId: string,
+  matchesByPuuid: ReadonlyMap<string, ProgressionMatchRow>,
+): Promise<void> {
+  await prisma.$transaction(async (tx) => {
+    await lockHallRecords(tx, guildId);
+    const accounts = await tx.account.findMany({
+      where: {
+        serverId: guildId,
+        puuid: { in: [...matchesByPuuid.keys()] },
+      },
+      include: { player: true },
+    });
+    const settingsRow = await tx.hallSettings.findUnique({
+      where: { guildId },
+    });
+    if (settingsRow === null) return;
+    const settings = hallSettingsFromRow(settingsRow);
+    const brokenCellIds = new Set<string>();
+    for (const account of accounts) {
+      const match = matchesByPuuid.get(account.puuid);
+      if (match === undefined) continue;
+      const broken = await evaluateCandidate(tx, {
+        guildId,
+        match,
+        account,
+        enabledRecords: new Set(settings.enabledRecords),
+        enabledFamilies: new Set(settings.enabledQueueFamilies),
+      });
+      for (const cellId of broken) brokenCellIds.add(cellId);
+    }
+    if (brokenCellIds.size === 0 || settings.channelId === null) return;
+    const cells = await tx.hallRecordCell.findMany({
+      where: { id: { in: [...brokenCellIds] } },
+    });
+    const payload = cells.map((cell) => {
+      const evidence = parseProgressionJson(
+        cell.evidenceJson,
+        HallRecordEvidenceSchema.array(),
+      );
+      const primaryEvidence = evidence[0];
+      if (primaryEvidence === undefined) {
+        throw new Error(`Broken Hall cell ${cell.id} has no evidence`);
+      }
+      return HallBreakPayloadSchema.parse({
+        ...primaryEvidence,
+        queueFamilyId: cell.queueFamilyId,
+        recordId: cell.recordId,
+        holders: parseProgressionJson(
+          cell.holdersJson,
+          HallRecordHolderSchema.array(),
+        ),
+      });
+    });
+    await tx.hallRecordBreakOutbox.upsert({
+      where: { guildId_matchId: { guildId, matchId } },
+      create: {
+        guildId,
+        matchId,
+        channelId: settings.channelId,
+        payloadJson: JSON.stringify(payload),
+      },
+      update: {
+        channelId: settings.channelId,
+        payloadJson: JSON.stringify(payload),
+      },
+    });
+  });
+}
+
+/** Evaluate one durably ingested match before account cursors advance. */
+export async function evaluateHallMatch(matchData: RawMatch): Promise<void> {
+  const matchId = matchData.metadata.matchId;
+  const participantPuuids = matchData.metadata.participants;
+  const accounts = await prisma.account.findMany({
+    where: { puuid: { in: participantPuuids } },
+    include: { player: true },
+  });
+  if (accounts.length === 0) return;
+  const earliest = accounts.reduce(
+    (minimum, account) =>
+      new Date(Math.min(account.createdTime.getTime(), minimum.getTime())),
+    accounts[0]?.createdTime ?? new Date(),
+  );
+  const rows = await fetchProgressionMatches({
+    puuids: participantPuuids,
+    startAt: earliest,
+    matchId,
+  });
+  const byPuuid = new Map(rows.map((row) => [row.puuid, row]));
+  const guildIds = new Set<string>();
+  for (const account of accounts) {
+    const row = byPuuid.get(account.puuid);
+    if (row === undefined) continue;
+    guildIds.add(account.serverId);
+  }
+  for (const guildId of guildIds) {
+    const parsedGuildId = DiscordGuildIdSchema.parse(guildId);
+    if (
+      !(await isPolicyEnabled("hall_of_fame_enabled", {
+        server: parsedGuildId,
+      }))
+    ) {
+      continue;
+    }
+    await evaluateGuild(parsedGuildId, matchId, byPuuid);
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/evaluate-match.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/evaluate-match.ts
@@ -197,6 +197,14 @@ export async function evaluateHallMatch(matchData: RawMatch): Promise<void> {
     }
   }
   if (enabledGuildIds.size === 0) return;
+  const configuredGuildIds = new Set<DiscordGuildId>();
+  for (const guildId of enabledGuildIds) {
+    const settingsRow = await prisma.hallSettings.findUnique({
+      where: { guildId },
+    });
+    if (settingsRow !== null) configuredGuildIds.add(guildId);
+  }
+  if (configuredGuildIds.size === 0) return;
   const earliest = accounts.reduce(
     (minimum, account) =>
       new Date(Math.min(account.createdTime.getTime(), minimum.getTime())),
@@ -213,7 +221,7 @@ export async function evaluateHallMatch(matchData: RawMatch): Promise<void> {
     const row = byPuuid.get(account.puuid);
     if (row === undefined) continue;
     const guildId = DiscordGuildIdSchema.parse(account.serverId);
-    if (enabledGuildIds.has(guildId)) guildIds.add(guildId);
+    if (configuredGuildIds.has(guildId)) guildIds.add(guildId);
   }
   for (const guildId of guildIds) {
     await evaluateGuild(guildId, matchId, byPuuid);

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/launch.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/launch.ts
@@ -1,0 +1,20 @@
+import type { HallBaselineRequest } from "#src/progression/hall/settings.ts";
+import { currentScoutTemporalSupervisor } from "#src/temporal/runtime.ts";
+import { startScoutHallBaseline } from "#src/temporal/starts.ts";
+import type { ScoutStage } from "@scout-for-lol/temporal";
+
+export async function launchHallBaseline(
+  stage: ScoutStage,
+  request: HallBaselineRequest | null,
+): Promise<void> {
+  if (request === null) return;
+  const supervisor = currentScoutTemporalSupervisor();
+  if (supervisor === undefined) {
+    throw new Error("Temporal is unavailable for Hall baseline processing");
+  }
+  await startScoutHallBaseline(supervisor.client(), {
+    stage,
+    guildId: request.guildId,
+    revision: request.revision,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/outbox.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/outbox.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import { COMPETITIVE_PROGRESSION_CATALOG } from "@scout-for-lol/data";
+import { hallBreakEmbed } from "#src/progression/hall/outbox.ts";
+
+describe("Hall record-break embeds", () => {
+  test("bounds tied holder names within Discord embed limits", () => {
+    const queueFamily = COMPETITIVE_PROGRESSION_CATALOG.hall.queueFamilies[0];
+    if (queueFamily === undefined) {
+      throw new Error("Hall catalog requires a queue family");
+    }
+    const holder = {
+      playerId: 1,
+      playerAlias: "Long Hall Alias ".repeat(10),
+      accountId: 1,
+      accountAlias: "Main",
+      puuid: "hall-test-puuid",
+    };
+    const payload = COMPETITIVE_PROGRESSION_CATALOG.hall.records.map(
+      (record) => ({
+        matchId: "NA1_HALL_TEST",
+        gameEndAt: "2026-09-04T00:00:00.000Z",
+        value: 12_345,
+        holder,
+        queueFamilyId: queueFamily.id,
+        recordId: record.id,
+        holders: Array.from({ length: 20 }, () => holder),
+      }),
+    );
+
+    const json = hallBreakEmbed(
+      JSON.stringify(payload),
+      "NA1_HALL_TEST",
+    ).toJSON();
+    const fields = json.fields ?? [];
+    const totalLength =
+      (json.title?.length ?? 0) +
+      (json.description?.length ?? 0) +
+      fields.reduce(
+        (total, field) => total + field.name.length + field.value.length,
+        0,
+      );
+
+    expect(fields).toHaveLength(payload.length);
+    expect(fields.every((field) => field.value.length <= 1024)).toBe(true);
+    expect(totalLength).toBeLessThanOrEqual(5800);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/outbox.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/outbox.ts
@@ -1,0 +1,175 @@
+import { EmbedBuilder, escapeMarkdown } from "discord.js";
+import {
+  COMPETITIVE_PROGRESSION_CATALOG,
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/data";
+import { prisma } from "#src/database/index.ts";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
+import { send as sendChannelMessage } from "#src/league/discord/channel.ts";
+import { parseProgressionJson } from "#src/progression/json.ts";
+import { HallBreakOutboxPayloadSchema } from "#src/progression/hall/evaluate-match.ts";
+import { hallRecordBreakDeliveries } from "#src/metrics/progression.ts";
+import {
+  claimScoutEffect,
+  completeScoutEffect,
+  recordScoutEffectFailure,
+} from "#src/temporal/effect-claims.ts";
+
+const HALL_EMBED_TITLE = "🏛️ Guild Hall of Fame record broken!";
+const HALL_EMBED_SAFE_TOTAL_LENGTH = 5800;
+
+function queueLabel(id: string): string {
+  const family = COMPETITIVE_PROGRESSION_CATALOG.hall.queueFamilies.find(
+    (candidate) => candidate.id === id,
+  );
+  if (family === undefined) throw new Error(`Unknown Hall queue family ${id}`);
+  return family.label;
+}
+
+function recordLabel(id: string): string {
+  const record = COMPETITIVE_PROGRESSION_CATALOG.hall.records.find(
+    (candidate) => candidate.id === id,
+  );
+  if (record === undefined) throw new Error(`Unknown Hall record ${id}`);
+  return record.label;
+}
+
+function truncateToLength(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  if (maxLength <= 3) return text.slice(0, Math.max(0, maxLength));
+  return `${text.slice(0, maxLength - 3)}...`;
+}
+
+export function hallBreakEmbed(
+  payloadJson: string,
+  matchId: string,
+): EmbedBuilder {
+  const records = parseProgressionJson(
+    payloadJson,
+    HallBreakOutboxPayloadSchema,
+  );
+  const description = `Match ${escapeMarkdown(matchId)} set new guild records.`;
+  const rawFields = records.map((record) => ({
+    name: `${queueLabel(record.queueFamilyId)} · ${recordLabel(record.recordId)}`,
+    prefix: `${record.value.toLocaleString("en-US")} — `,
+    holders: record.holders
+      .map((holder) => escapeMarkdown(holder.playerAlias))
+      .join(", "),
+  }));
+  const fixedLength = rawFields.reduce(
+    (total, field) => total + field.name.length + field.prefix.length,
+    HALL_EMBED_TITLE.length + description.length,
+  );
+  let remainingHolderLength = Math.max(
+    0,
+    HALL_EMBED_SAFE_TOTAL_LENGTH - fixedLength,
+  );
+  const embed = new EmbedBuilder()
+    .setTitle(HALL_EMBED_TITLE)
+    .setDescription(description)
+    .setColor(0xf5_ba_42);
+  for (const [index, field] of rawFields.entries()) {
+    const remainingFields = rawFields.length - index;
+    const fairShare = Math.floor(remainingHolderLength / remainingFields);
+    const names = truncateToLength(
+      field.holders,
+      Math.min(1024 - field.prefix.length, fairShare),
+    );
+    remainingHolderLength -= names.length;
+    embed.addFields({
+      name: field.name,
+      value: `${field.prefix}${names}`,
+      inline: false,
+    });
+  }
+  return embed;
+}
+
+function discordNonce(outboxId: string): string {
+  return `hf:${Bun.hash(outboxId).toString(36)}`;
+}
+
+export async function deliverHallRecordBreakOutbox(): Promise<void> {
+  const activeRows = await prisma.hallRecordBreakOutbox.findMany({
+    where: { deliveryStatus: { in: ["pending", "sending"] } },
+    orderBy: { createdAt: "asc" },
+    take: 50,
+  });
+  const failedRows = await prisma.hallRecordBreakOutbox.findMany({
+    where: { deliveryStatus: "failed" },
+    orderBy: { updatedAt: "asc" },
+    take: 50 - activeRows.length,
+  });
+  const rows = [...activeRows, ...failedRows];
+  const deliveryErrors: unknown[] = [];
+  for (const row of rows) {
+    const guildId = DiscordGuildIdSchema.parse(row.guildId);
+    if (!(await isPolicyEnabled("hall_of_fame_enabled", { server: guildId }))) {
+      await prisma.hallRecordBreakOutbox.update({
+        where: { id: row.id },
+        data: {
+          deliveryStatus: "suppressed",
+          lastError: "Hall notifications were disabled before delivery",
+        },
+      });
+      continue;
+    }
+    const effectKey = `hall-record-break:${row.id}`;
+    const claim = await claimScoutEffect({
+      key: effectKey,
+      kind: "hall-record-break-discord",
+    });
+    if (claim === "completed") {
+      await prisma.hallRecordBreakOutbox.update({
+        where: { id: row.id },
+        data: { deliveryStatus: "sent", sentAt: row.sentAt ?? new Date() },
+      });
+      hallRecordBreakDeliveries.inc({ status: "deduplicated" });
+      continue;
+    }
+    try {
+      await prisma.hallRecordBreakOutbox.update({
+        where: { id: row.id },
+        data: {
+          deliveryStatus: "sending",
+          attemptCount: { increment: 1 },
+          lastError: null,
+        },
+      });
+      await sendChannelMessage(
+        {
+          embeds: [hallBreakEmbed(row.payloadJson, row.matchId)],
+          allowedMentions: { parse: [] },
+          nonce: discordNonce(row.id),
+          enforceNonce: true,
+        },
+        DiscordChannelIdSchema.parse(row.channelId),
+        guildId,
+      );
+      await completeScoutEffect(effectKey);
+      await prisma.hallRecordBreakOutbox.update({
+        where: { id: row.id },
+        data: { deliveryStatus: "sent", sentAt: new Date(), lastError: null },
+      });
+      hallRecordBreakDeliveries.inc({ status: "sent" });
+    } catch (error) {
+      await recordScoutEffectFailure(effectKey, error);
+      await prisma.hallRecordBreakOutbox.update({
+        where: { id: row.id },
+        data: {
+          deliveryStatus: "failed",
+          lastError: error instanceof Error ? error.message : String(error),
+        },
+      });
+      hallRecordBreakDeliveries.inc({ status: "failed" });
+      deliveryErrors.push(error);
+    }
+  }
+  if (deliveryErrors.length > 0) {
+    throw new AggregateError(
+      deliveryErrors,
+      `${deliveryErrors.length.toString()} Hall record-break delivery attempt(s) failed`,
+    );
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/read.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/read.ts
@@ -1,0 +1,52 @@
+import {
+  COMPETITIVE_PROGRESSION_CATALOG,
+  HallRecordEntrySchema,
+  HallRecordEvidenceSchema,
+  HallRecordHolderSchema,
+  type HallRecordEntry,
+} from "@scout-for-lol/data";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import { parseProgressionJson } from "#src/progression/json.ts";
+import { getHallSettings } from "#src/progression/hall/settings.ts";
+
+export async function getHall(
+  db: ExtendedPrismaClient,
+  guildId: string,
+): Promise<{
+  readonly settings: Awaited<ReturnType<typeof getHallSettings>>;
+  readonly entries: HallRecordEntry[];
+  readonly catalog: typeof COMPETITIVE_PROGRESSION_CATALOG;
+}> {
+  const settings = await getHallSettings(db, guildId);
+  const cells = await db.hallRecordCell.findMany({
+    where: {
+      guildId,
+      queueFamilyId: { in: settings.enabledQueueFamilies },
+      recordId: { in: settings.enabledRecords },
+    },
+    orderBy: [{ queueFamilyId: "asc" }, { recordId: "asc" }],
+  });
+  return {
+    settings,
+    catalog: COMPETITIVE_PROGRESSION_CATALOG,
+    entries: cells.map((cell) =>
+      HallRecordEntrySchema.parse({
+        queueFamilyId: cell.queueFamilyId,
+        recordId: cell.recordId,
+        baselineStatus: cell.baselineStatus,
+        baselineValue: cell.baselineValue,
+        currentValue: cell.currentValue,
+        holders: parseProgressionJson(
+          cell.holdersJson,
+          HallRecordHolderSchema.array(),
+        ),
+        evidence: parseProgressionJson(
+          cell.evidenceJson,
+          HallRecordEvidenceSchema.array(),
+        ),
+        updatedAt: cell.updatedAt.toISOString(),
+        errorMessage: cell.errorMessage,
+      }),
+    ),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/roster-change.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/roster-change.ts
@@ -1,0 +1,23 @@
+import type { ScoutStage } from "@scout-for-lol/temporal";
+import type { Db } from "#src/database/index.ts";
+import { requestConfiguredFullHallBaseline } from "#src/progression/hall/settings.ts";
+
+/**
+ * Persists a silent full re-baseline after tracked roster/account membership
+ * changes in the same transaction as the roster mutation. The progression
+ * reconciler owns the Temporal start, so Worker availability is not part of
+ * the mutation transaction.
+ */
+export async function queueHallRosterRebaseline(options: {
+  readonly guildId: string;
+  readonly actorDiscordId: string;
+  readonly stage: ScoutStage;
+  readonly db: Db;
+}): Promise<void> {
+  await requestConfiguredFullHallBaseline(options.db, {
+    guildId: options.guildId,
+    actorDiscordId: options.actorDiscordId,
+    stage: options.stage,
+    reuseActive: false,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/settings.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/settings.integration.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import {
+  COMPETITIVE_PROGRESSION_CATALOG_VERSION,
+  HallSettingsSchema,
+} from "@scout-for-lol/data";
+import {
+  requestFullHallBaseline,
+  updateHallSettings,
+} from "#src/progression/hall/settings.ts";
+import {
+  createTestDatabase,
+  dropTestDatabase,
+} from "#src/testing/test-database.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+} from "#src/testing/test-ids.ts";
+
+const { prisma: db, dbPath } = createTestDatabase("hall-settings");
+const GUILD_ID = testGuildId("711");
+const ACTOR_ID = testAccountId("711");
+
+beforeEach(async () => {
+  await db.hallRecordBreakOutbox.deleteMany();
+  await db.hallSettings.deleteMany();
+});
+
+afterAll(async () => {
+  await dropTestDatabase(db, dbPath);
+});
+
+describe("Hall settings persistence", () => {
+  test("normalizes catalog order and baselines every newly enabled cell", async () => {
+    const result = await updateHallSettings(db, {
+      settings: HallSettingsSchema.parse({
+        guildId: GUILD_ID,
+        catalogVersion: COMPETITIVE_PROGRESSION_CATALOG_VERSION,
+        channelId: testChannelId("711"),
+        enabledQueueFamilies: ["aram", "ranked_sr"],
+        enabledRecords: ["assists", "kills"],
+      }),
+      actorDiscordId: ACTOR_ID,
+      stage: "beta",
+    });
+
+    expect(result.settings.enabledQueueFamilies).toEqual(["ranked_sr", "aram"]);
+    expect(result.settings.enabledRecords).toEqual(["kills", "assists"]);
+    expect(result.baseline).toMatchObject({ revision: 1, reused: false });
+    expect(await db.hallRecordCell.count()).toBe(4);
+    expect(
+      await db.hallRecordCell.count({
+        where: { baselineStatus: "building", baselineRevision: 1 },
+      }),
+    ).toBe(4);
+  });
+
+  test("serializes concurrent full-baseline requests onto one active run", async () => {
+    await updateHallSettings(db, {
+      settings: HallSettingsSchema.parse({
+        guildId: GUILD_ID,
+        catalogVersion: COMPETITIVE_PROGRESSION_CATALOG_VERSION,
+        channelId: null,
+        enabledQueueFamilies: ["aram"],
+        enabledRecords: ["kills"],
+      }),
+      actorDiscordId: ACTOR_ID,
+      stage: "beta",
+    });
+    await db.hallBaselineRun.updateMany({
+      data: { baselineState: "ready", completedAt: new Date() },
+    });
+
+    const requests = await Promise.all(
+      [1, 2].map(
+        async () =>
+          await requestFullHallBaseline(db, {
+            guildId: GUILD_ID,
+            actorDiscordId: ACTOR_ID,
+            stage: "beta",
+          }),
+      ),
+    );
+
+    expect(new Set(requests.map((request) => request.workflowId)).size).toBe(1);
+    expect(
+      requests
+        .map((request) => request.reused)
+        .toSorted((left, right) => Number(left) - Number(right)),
+    ).toEqual([false, true]);
+    expect(
+      await db.hallBaselineRun.count({
+        where: { guildId: GUILD_ID, baselineState: "building" },
+      }),
+    ).toBe(1);
+  });
+
+  test("re-enabling a Hall cell starts a silent fresh baseline revision", async () => {
+    const base = HallSettingsSchema.parse({
+      guildId: GUILD_ID,
+      catalogVersion: COMPETITIVE_PROGRESSION_CATALOG_VERSION,
+      channelId: null,
+      enabledQueueFamilies: ["ranked_sr", "aram"],
+      enabledRecords: ["kills"],
+    });
+    await updateHallSettings(db, {
+      settings: base,
+      actorDiscordId: ACTOR_ID,
+      stage: "beta",
+    });
+    const disabled = await updateHallSettings(db, {
+      settings: { ...base, enabledQueueFamilies: ["ranked_sr"] },
+      actorDiscordId: ACTOR_ID,
+      stage: "beta",
+    });
+    expect(disabled.baseline).toBeNull();
+
+    const reenabled = await updateHallSettings(db, {
+      settings: base,
+      actorDiscordId: ACTOR_ID,
+      stage: "beta",
+    });
+    expect(reenabled.baseline).toMatchObject({ revision: 2, reused: false });
+    expect(
+      await db.hallRecordCell.findUniqueOrThrow({
+        where: {
+          guildId_queueFamilyId_recordId: {
+            guildId: GUILD_ID,
+            queueFamilyId: "aram",
+            recordId: "kills",
+          },
+        },
+      }),
+    ).toMatchObject({ baselineStatus: "building", baselineRevision: 2 });
+  });
+
+  test("does not mistake an active partial baseline for a full baseline", async () => {
+    const base = {
+      guildId: GUILD_ID,
+      catalogVersion: COMPETITIVE_PROGRESSION_CATALOG_VERSION,
+      channelId: null,
+      enabledQueueFamilies: ["aram"],
+    } as const;
+    await updateHallSettings(db, {
+      settings: HallSettingsSchema.parse({
+        ...base,
+        enabledRecords: ["kills"],
+      }),
+      actorDiscordId: ACTOR_ID,
+      stage: "beta",
+    });
+    await updateHallSettings(db, {
+      settings: HallSettingsSchema.parse({
+        ...base,
+        enabledRecords: ["kills", "assists"],
+      }),
+      actorDiscordId: ACTOR_ID,
+      stage: "beta",
+    });
+
+    const request = await requestFullHallBaseline(db, {
+      guildId: GUILD_ID,
+      actorDiscordId: ACTOR_ID,
+      stage: "beta",
+    });
+
+    expect(request).toMatchObject({ revision: 3, reused: false });
+    expect(
+      await db.hallRecordCell.count({
+        where: { guildId: GUILD_ID, baselineRevision: 3 },
+      }),
+    ).toBe(2);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/settings.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/settings.ts
@@ -1,0 +1,333 @@
+import {
+  COMPETITIVE_PROGRESSION_CATALOG,
+  COMPETITIVE_PROGRESSION_CATALOG_VERSION,
+  DEFAULT_HALL_QUEUE_FAMILIES,
+  DEFAULT_HALL_RECORDS,
+  HallQueueFamilyIdSchema,
+  HallRecordIdSchema,
+  HallSettingsSchema,
+  type HallQueueFamilyId,
+  type HallRecordId,
+  type HallSettings,
+  type DiscordGuildId,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/data";
+import {
+  scoutHallBaselineWorkflowId,
+  type ScoutStage,
+} from "@scout-for-lol/temporal";
+import type { Db, ExtendedPrismaClient } from "#src/database/index.ts";
+import { parseProgressionJson } from "#src/progression/json.ts";
+
+const QueueFamilyArraySchema = HallQueueFamilyIdSchema.array();
+const RecordArraySchema = HallRecordIdSchema.array();
+
+type HallSettingsRow = {
+  readonly guildId: string;
+  readonly catalogVersion: number;
+  readonly channelId: string | null;
+  readonly enabledQueueFamilies: string;
+  readonly enabledRecords: string;
+};
+
+export type HallBaselineRequest = {
+  readonly guildId: string;
+  readonly revision: number;
+  readonly workflowId: string;
+  readonly reused: boolean;
+};
+
+export function defaultHallSettings(guildId: string): HallSettings {
+  return HallSettingsSchema.parse({
+    guildId,
+    catalogVersion: COMPETITIVE_PROGRESSION_CATALOG_VERSION,
+    channelId: null,
+    enabledQueueFamilies: DEFAULT_HALL_QUEUE_FAMILIES,
+    enabledRecords: DEFAULT_HALL_RECORDS,
+  });
+}
+
+export function hallSettingsFromRow(row: HallSettingsRow): HallSettings {
+  return HallSettingsSchema.parse({
+    guildId: row.guildId,
+    catalogVersion: row.catalogVersion,
+    channelId: row.channelId,
+    enabledQueueFamilies: parseProgressionJson(
+      row.enabledQueueFamilies,
+      QueueFamilyArraySchema,
+    ),
+    enabledRecords: parseProgressionJson(row.enabledRecords, RecordArraySchema),
+  });
+}
+
+export async function getHallSettings(
+  db: ExtendedPrismaClient,
+  guildId: string,
+): Promise<HallSettings> {
+  const parsedGuildId = DiscordGuildIdSchema.parse(guildId);
+  const row = await db.hallSettings.findUnique({
+    where: { guildId: parsedGuildId },
+  });
+  return row === null ? defaultHallSettings(guildId) : hallSettingsFromRow(row);
+}
+
+function orderedQueueFamilies(
+  values: readonly HallQueueFamilyId[],
+): HallQueueFamilyId[] {
+  const selected = new Set(values);
+  return COMPETITIVE_PROGRESSION_CATALOG.hall.queueFamilies
+    .filter((family) => selected.has(family.id))
+    .map((family) => family.id);
+}
+
+function orderedRecords(values: readonly HallRecordId[]): HallRecordId[] {
+  const selected = new Set(values);
+  return COMPETITIVE_PROGRESSION_CATALOG.hall.records
+    .filter((record) => selected.has(record.id))
+    .map((record) => record.id);
+}
+
+function assertNoDuplicates(label: string, values: readonly string[]): void {
+  if (new Set(values).size !== values.length) {
+    throw new Error(`Hall settings contain duplicate ${label}`);
+  }
+}
+
+function cellKey(queueFamilyId: string, recordId: string): string {
+  return `${queueFamilyId}:${recordId}`;
+}
+
+function enabledCellKeys(settings: HallSettings): Set<string> {
+  return new Set(
+    settings.enabledQueueFamilies.flatMap((queueFamilyId) =>
+      settings.enabledRecords.map((recordId) =>
+        cellKey(queueFamilyId, recordId),
+      ),
+    ),
+  );
+}
+
+async function createBaselineRun(
+  tx: Db,
+  options: {
+    readonly guildId: DiscordGuildId;
+    readonly actorDiscordId: string;
+    readonly stage: ScoutStage;
+    readonly cellKeys: ReadonlySet<string>;
+    readonly reuseActive: boolean;
+  },
+): Promise<HallBaselineRequest | null> {
+  if (options.cellKeys.size === 0) return null;
+  await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('scout-hall-baseline'), hashtext(${options.guildId}))`;
+  if (options.reuseActive) {
+    const active = await tx.hallBaselineRun.findFirst({
+      where: { guildId: options.guildId, baselineState: "building" },
+      orderBy: { revision: "desc" },
+    });
+    if (active !== null) {
+      const activeCells = await tx.hallRecordCell.findMany({
+        where: {
+          guildId: options.guildId,
+          baselineRevision: active.revision,
+          baselineStatus: "building",
+        },
+        select: { queueFamilyId: true, recordId: true },
+      });
+      const activeCellKeys = new Set(
+        activeCells.map((cell) => cellKey(cell.queueFamilyId, cell.recordId)),
+      );
+      if (
+        activeCellKeys.size === options.cellKeys.size &&
+        [...options.cellKeys].every((key) => activeCellKeys.has(key))
+      ) {
+        return {
+          guildId: options.guildId,
+          revision: active.revision,
+          workflowId: active.workflowId,
+          reused: true,
+        };
+      }
+    }
+  }
+  const settings = await tx.hallSettings.update({
+    where: { guildId: options.guildId },
+    data: { baselineRevision: { increment: 1 } },
+  });
+  const revision = settings.baselineRevision;
+  const enabled = hallSettingsFromRow(settings);
+  for (const queueFamilyId of enabled.enabledQueueFamilies) {
+    for (const recordId of enabled.enabledRecords) {
+      if (!options.cellKeys.has(cellKey(queueFamilyId, recordId))) continue;
+      await tx.hallRecordCell.upsert({
+        where: {
+          guildId_queueFamilyId_recordId: {
+            guildId: options.guildId,
+            queueFamilyId,
+            recordId,
+          },
+        },
+        create: {
+          guildId: options.guildId,
+          queueFamilyId,
+          recordId,
+          baselineRevision: revision,
+          baselineStatus: "building",
+          baselineStartedAt: new Date(),
+        },
+        update: {
+          baselineRevision: revision,
+          baselineStatus: "building",
+          baselineStartedAt: new Date(),
+          baselineCompletedAt: null,
+          errorMessage: null,
+        },
+      });
+    }
+  }
+  const workflowId = scoutHallBaselineWorkflowId(
+    options.stage,
+    options.guildId,
+    revision,
+  );
+  await tx.hallBaselineRun.create({
+    data: {
+      guildId: options.guildId,
+      revision,
+      baselineState: "building",
+      requestedByDiscordId: options.actorDiscordId,
+      workflowId,
+    },
+  });
+  return {
+    guildId: options.guildId,
+    revision,
+    workflowId,
+    reused: false,
+  };
+}
+
+export async function updateHallSettings(
+  db: ExtendedPrismaClient,
+  options: {
+    readonly settings: HallSettings;
+    readonly actorDiscordId: string;
+    readonly stage: ScoutStage;
+  },
+): Promise<{
+  readonly settings: HallSettings;
+  readonly baseline: HallBaselineRequest | null;
+}> {
+  const parsed = HallSettingsSchema.parse(options.settings);
+  assertNoDuplicates("queue families", parsed.enabledQueueFamilies);
+  assertNoDuplicates("records", parsed.enabledRecords);
+  const normalized = HallSettingsSchema.parse({
+    ...parsed,
+    enabledQueueFamilies: orderedQueueFamilies(parsed.enabledQueueFamilies),
+    enabledRecords: orderedRecords(parsed.enabledRecords),
+  });
+  return await db.$transaction(async (tx) => {
+    const previousRow = await tx.hallSettings.findUnique({
+      where: { guildId: normalized.guildId },
+    });
+    const previous =
+      previousRow === null ? null : hallSettingsFromRow(previousRow);
+    await tx.hallSettings.upsert({
+      where: { guildId: normalized.guildId },
+      create: {
+        guildId: normalized.guildId,
+        catalogVersion: normalized.catalogVersion,
+        channelId: normalized.channelId,
+        enabledQueueFamilies: JSON.stringify(normalized.enabledQueueFamilies),
+        enabledRecords: JSON.stringify(normalized.enabledRecords),
+        updatedByDiscordId: options.actorDiscordId,
+      },
+      update: {
+        catalogVersion: normalized.catalogVersion,
+        channelId: normalized.channelId,
+        enabledQueueFamilies: JSON.stringify(normalized.enabledQueueFamilies),
+        enabledRecords: JSON.stringify(normalized.enabledRecords),
+        updatedByDiscordId: options.actorDiscordId,
+      },
+    });
+    const currentKeys = enabledCellKeys(normalized);
+    const previousKeys =
+      previous === null ? new Set<string>() : enabledCellKeys(previous);
+    const newlyEnabled = new Set(
+      [...currentKeys].filter((key) => !previousKeys.has(key)),
+    );
+    const baseline = await createBaselineRun(tx, {
+      guildId: normalized.guildId,
+      actorDiscordId: options.actorDiscordId,
+      stage: options.stage,
+      cellKeys: newlyEnabled,
+      reuseActive: false,
+    });
+    return { settings: normalized, baseline };
+  });
+}
+
+export async function requestFullHallBaseline(
+  db: ExtendedPrismaClient,
+  options: {
+    readonly guildId: string;
+    readonly actorDiscordId: string;
+    readonly stage: ScoutStage;
+    readonly reuseActive?: boolean;
+  },
+): Promise<HallBaselineRequest> {
+  const guildId = DiscordGuildIdSchema.parse(options.guildId);
+  const request = await db.$transaction(async (tx) => {
+    const existing = await tx.hallSettings.findUnique({
+      where: { guildId },
+    });
+    if (existing === null) {
+      const defaults = defaultHallSettings(guildId);
+      await tx.hallSettings.create({
+        data: {
+          guildId,
+          catalogVersion: defaults.catalogVersion,
+          channelId: defaults.channelId,
+          enabledQueueFamilies: JSON.stringify(defaults.enabledQueueFamilies),
+          enabledRecords: JSON.stringify(defaults.enabledRecords),
+          updatedByDiscordId: options.actorDiscordId,
+        },
+      });
+    }
+    const settings = await tx.hallSettings.findUniqueOrThrow({
+      where: { guildId },
+    });
+    const parsed = hallSettingsFromRow(settings);
+    return await createBaselineRun(tx, {
+      guildId,
+      actorDiscordId: options.actorDiscordId,
+      stage: options.stage,
+      cellKeys: enabledCellKeys(parsed),
+      reuseActive: options.reuseActive ?? true,
+    });
+  });
+  if (request === null) {
+    throw new Error("Hall baseline requires at least one enabled cell");
+  }
+  return request;
+}
+
+export async function requestConfiguredFullHallBaseline(
+  tx: Db,
+  options: {
+    readonly guildId: string;
+    readonly actorDiscordId: string;
+    readonly stage: ScoutStage;
+    readonly reuseActive?: boolean;
+  },
+): Promise<HallBaselineRequest | null> {
+  const guildId = DiscordGuildIdSchema.parse(options.guildId);
+  const row = await tx.hallSettings.findUnique({ where: { guildId } });
+  if (row === null) return null;
+  return await createBaselineRun(tx, {
+    guildId,
+    actorDiscordId: options.actorDiscordId,
+    stage: options.stage,
+    cellKeys: enabledCellKeys(hallSettingsFromRow(row)),
+    reuseActive: options.reuseActive ?? true,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/json.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/json.ts
@@ -1,0 +1,9 @@
+import type { z } from "zod";
+
+/** Parse a persisted JSON column and validate its typed contract in one step. */
+export function parseProgressionJson<T>(
+  serialized: string,
+  schema: z.ZodType<T>,
+): T {
+  return schema.parse(JSON.parse(serialized));
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/postmatch.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/postmatch.ts
@@ -1,0 +1,17 @@
+import type {
+  PlayerConfigEntry,
+  RawMatch,
+  RawTimeline,
+} from "@scout-for-lol/data";
+import { evaluateHallMatch } from "#src/progression/hall/evaluate-match.ts";
+
+/**
+ * Last durable progression hook before account match cursors advance.
+ */
+export async function processCompetitiveProgressionMatch(input: {
+  readonly match: RawMatch;
+  readonly timeline: RawTimeline | null | undefined;
+  readonly trackedPlayers: PlayerConfigEntry[];
+}): Promise<void> {
+  await evaluateHallMatch(input.match);
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/progression-lake-reads.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/progression-lake-reads.ts
@@ -1,0 +1,217 @@
+import { z } from "zod";
+import {
+  QueueTypeSchema,
+  type HallEligibleMatch,
+  type HallRecordMatch,
+} from "@scout-for-lol/data";
+import { resolveLakeDir } from "#src/report-lake/paths.ts";
+import { bindParams } from "#src/reports/duckdb/lake-reads.ts";
+import { withDuckDBConnection } from "#src/reports/duckdb/instance.ts";
+import {
+  buildMatchesSource,
+  buildTimelineEventsSource,
+  buildTimelineCoverageSource,
+  listParam,
+  resolveLakeFiles,
+  scalarParam,
+} from "#src/reports/duckdb/lake.ts";
+
+const LakeIntSchema = z.union([z.bigint(), z.number()]).transform(Number);
+
+const ProgressionMatchRowSchema = z.strictObject({
+  match_id: z.string(),
+  game_end_at: z.string(),
+  game_end_ms: LakeIntSchema,
+  game_duration_seconds: LakeIntSchema,
+  queue: QueueTypeSchema,
+  end_of_game_result: z.string().nullable(),
+  early_surrendered: z.boolean(),
+  puuid: z.string(),
+  champion_id: LakeIntSchema,
+  champion_name: z.string(),
+  team_position: z.string(),
+  win: z.boolean(),
+  kills: LakeIntSchema,
+  deaths: LakeIntSchema,
+  assists: LakeIntSchema,
+  creep_score: LakeIntSchema,
+  gold_earned: LakeIntSchema,
+  total_damage_dealt_to_champions: LakeIntSchema,
+  total_damage_taken: LakeIntSchema,
+  damage_self_mitigated: LakeIntSchema,
+  total_heals_on_teammates: LakeIntSchema,
+  vision_score: LakeIntSchema,
+  wards_killed: LakeIntSchema,
+  damage_dealt_to_objectives: LakeIntSchema,
+  damage_dealt_to_turrets: LakeIntSchema,
+  time_ccing_others: LakeIntSchema,
+  longest_time_spent_living: LakeIntSchema,
+  total_time_spent_dead: LakeIntSchema,
+  largest_multi_kill: LakeIntSchema,
+  timeline_complete: z.boolean(),
+});
+
+export type ProgressionMatchRow = z.infer<typeof ProgressionMatchRowSchema> &
+  HallEligibleMatch &
+  HallRecordMatch;
+
+export type ProgressionMatchCursor = {
+  readonly gameEndMs: number;
+  readonly matchId: string;
+  readonly puuid: string;
+};
+
+const MATCH_COLUMNS = [
+  "m.match_id",
+  "strftime(m.game_end_at, '%Y-%m-%dT%H:%M:%S.%fZ') AS game_end_at",
+  "epoch_ms(m.game_end_at)::BIGINT AS game_end_ms",
+  "m.game_duration_seconds",
+  "m.queue",
+  "m.end_of_game_result",
+  "m.early_surrendered",
+  "m.puuid",
+  "m.champion_id",
+  "m.champion_name",
+  "m.team_position",
+  "m.win",
+  "m.kills",
+  "m.deaths",
+  "m.assists",
+  "m.creep_score",
+  "m.gold_earned",
+  "m.total_damage_dealt_to_champions",
+  "m.total_damage_taken",
+  "m.damage_self_mitigated",
+  "m.total_heals_on_teammates",
+  "m.vision_score",
+  "m.wards_killed",
+  "m.damage_dealt_to_objectives",
+  "m.damage_dealt_to_turrets",
+  "m.time_ccing_others",
+  "m.longest_time_spent_living",
+  "m.total_time_spent_dead",
+  "m.largest_multi_kill",
+].join(", ");
+
+function cursorPredicate(cursor: ProgressionMatchCursor | undefined): {
+  readonly sql: string;
+  readonly params: ReturnType<typeof scalarParam>[];
+} {
+  if (cursor === undefined) return { sql: "", params: [] };
+  return {
+    sql:
+      "AND (epoch_ms(game_end_at) > ? OR " +
+      "(epoch_ms(game_end_at) = ? AND match_id > ?) OR " +
+      "(epoch_ms(game_end_at) = ? AND match_id = ? AND puuid > ?))",
+    params: [
+      scalarParam(cursor.gameEndMs),
+      scalarParam(cursor.gameEndMs),
+      scalarParam(cursor.matchId),
+      scalarParam(cursor.gameEndMs),
+      scalarParam(cursor.matchId),
+      scalarParam(cursor.puuid),
+    ],
+  };
+}
+
+const TimelineEventCountRowSchema = z.strictObject({
+  match_id: z.string(),
+  event_type: z.string(),
+  event_count: LakeIntSchema,
+});
+
+export async function fetchTimelineEventCounts(options: {
+  readonly matchIds: string[];
+  readonly lakeDir?: string;
+}): Promise<ReadonlyMap<string, Readonly<Record<string, number>>>> {
+  if (options.matchIds.length === 0) return new Map();
+  const files = await resolveLakeFiles(options.lakeDir ?? resolveLakeDir());
+  const source = buildTimelineEventsSource(files, {
+    sql: "match_id IN (SELECT unnest(?))",
+    params: [listParam(options.matchIds)],
+  });
+  if (source === undefined) return new Map();
+  const rows = await withDuckDBConnection(async (session) => {
+    const values = await session.run(
+      `SELECT match_id, event_type, count(*)::BIGINT AS event_count ` +
+        `FROM (${source.sql}) GROUP BY match_id, event_type`,
+      bindParams(session, source.params),
+    );
+    return values.map((row) => TimelineEventCountRowSchema.parse(row));
+  });
+  const counts = new Map<string, Record<string, number>>();
+  for (const row of rows) {
+    const matchCounts = counts.get(row.match_id) ?? {};
+    matchCounts[row.event_type] = row.event_count;
+    counts.set(row.match_id, matchCounts);
+  }
+  return counts;
+}
+
+/**
+ * Read progression evidence in stable ascending order. The caller-provided
+ * PUUIDs are the complete authorization boundary; no global lake scan is
+ * exposed through this helper.
+ */
+export async function fetchProgressionMatches(options: {
+  readonly puuids: string[];
+  readonly startAt: Date;
+  readonly endAt?: Date;
+  readonly matchId?: string;
+  readonly cursor?: ProgressionMatchCursor;
+  readonly limit?: number;
+  readonly lakeDir?: string;
+}): Promise<ProgressionMatchRow[]> {
+  if (options.puuids.length === 0) return [];
+  const files = await resolveLakeFiles(options.lakeDir ?? resolveLakeDir());
+  const cursor = cursorPredicate(options.cursor);
+  const endClause =
+    options.endAt === undefined ? "" : " AND epoch_ms(game_end_at) <= ?";
+  const matchClause = options.matchId === undefined ? "" : " AND match_id = ?";
+  const source = buildMatchesSource(files, {
+    sql:
+      "puuid IN (SELECT unnest(?)) AND epoch_ms(game_end_at) >= ?" +
+      endClause +
+      matchClause +
+      ` ${cursor.sql}`,
+    params: [
+      listParam(options.puuids),
+      scalarParam(options.startAt.getTime()),
+      ...(options.endAt === undefined
+        ? []
+        : [scalarParam(options.endAt.getTime())]),
+      ...(options.matchId === undefined ? [] : [scalarParam(options.matchId)]),
+      ...cursor.params,
+    ],
+  });
+  if (source === undefined) return [];
+  const coverage = buildTimelineCoverageSource(files, {
+    sql: "match_id IN (SELECT DISTINCT match_id FROM matches_for_progression)",
+    params: [],
+  });
+  const coverageJoin =
+    coverage === undefined
+      ? "false AS timeline_complete"
+      : "c.coverage_state = 'complete' AS timeline_complete";
+  const coverageCte =
+    coverage === undefined ? "" : `, coverage AS (${coverage.sql})`;
+  const coverageJoinSql =
+    coverage === undefined
+      ? ""
+      : " LEFT JOIN coverage c ON c.match_id = m.match_id";
+  const limit = Math.floor(options.limit ?? 100_000);
+  return await withDuckDBConnection(async (session) => {
+    const rows = await session.run(
+      `WITH matches_for_progression AS (${source.sql})${coverageCte} ` +
+        `SELECT ${MATCH_COLUMNS}, ${coverageJoin} ` +
+        `FROM matches_for_progression m${coverageJoinSql} ` +
+        `ORDER BY m.game_end_at ASC, m.match_id ASC, m.puuid ASC LIMIT ?`,
+      bindParams(session, [
+        ...source.params,
+        ...(coverage?.params ?? []),
+        scalarParam(limit),
+      ]),
+    );
+    return rows.map((row) => ProgressionMatchRowSchema.parse(row));
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/progression-lake-reads.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/progression-lake-reads.ts
@@ -170,7 +170,7 @@ export async function fetchProgressionMatches(options: {
   const matchClause = options.matchId === undefined ? "" : " AND match_id = ?";
   const source = buildMatchesSource(files, {
     sql:
-      "puuid IN (SELECT unnest(?)) AND epoch_ms(game_end_at) >= ?" +
+      "puuid IN (SELECT unnest(?)) AND queue IS NOT NULL AND epoch_ms(game_end_at) >= ?" +
       endClause +
       matchClause +
       ` ${cursor.sql}`,

--- a/packages/scout-for-lol/packages/backend/src/progression/reconcile.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/reconcile.ts
@@ -1,0 +1,28 @@
+import type { ScoutStage } from "@scout-for-lol/temporal";
+import { prisma } from "#src/database/index.ts";
+import { launchHallBaseline } from "#src/progression/hall/launch.ts";
+
+const RECONCILIATION_BATCH_SIZE = 100;
+
+/**
+ * Replays durable Hall baseline intents whose initial Temporal start may have
+ * been interrupted after the transaction committed.
+ */
+export async function reconcileCompetitiveProgression(
+  stage: ScoutStage,
+): Promise<void> {
+  const hallRuns = await prisma.hallBaselineRun.findMany({
+    where: { baselineState: "building" },
+    orderBy: { createdAt: "asc" },
+    take: RECONCILIATION_BATCH_SIZE,
+  });
+
+  for (const run of hallRuns) {
+    await launchHallBaseline(stage, {
+      guildId: run.guildId,
+      revision: run.revision,
+      workflowId: run.workflowId,
+      reused: true,
+    });
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/temporal/activities.policy.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/activities.policy.test.ts
@@ -8,6 +8,7 @@ describe("Scout Temporal production policy", () => {
   test.each([
     ["tournament-lobbies", "tournament_lobbies_enabled"],
     ["custom-nights-expiry", "custom_nights_enabled"],
+    ["progression-outbox", null],
     ["bucks-reconciliation", "betting_enabled"],
     ["weekly-bucks-leaderboard", "betting_enabled"],
     ["competition-refresh", null],

--- a/packages/scout-for-lol/packages/backend/src/temporal/activities.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/activities.ts
@@ -324,6 +324,18 @@ function createBackgroundActivities(): ScoutTemporalActivityGroups["background"]
             await expireCustomNights();
             break;
           }
+          case "progression-outbox": {
+            const [
+              { deliverHallRecordBreakOutbox },
+              { reconcileCompetitiveProgression },
+            ] = await Promise.all([
+              import("#src/progression/hall/outbox.ts"),
+              import("#src/progression/reconcile.ts"),
+            ]);
+            await reconcileCompetitiveProgression(input.stage);
+            await deliverHallRecordBreakOutbox();
+            break;
+          }
           case "prediction-ingest":
           case "legacy-backfill":
             unavailable(input.kind);
@@ -427,6 +439,20 @@ function createLakeActivities(): ScoutTemporalActivityGroups["lake"] {
         }
       });
       Context.current().heartbeat({ kind: input.kind, phase: "complete" });
+    },
+    runHallBaseline: async (input) => {
+      await heartbeatWhile(
+        {
+          guildId: input.guildId,
+          revision: input.revision,
+          phase: "building-hall-baseline",
+        },
+        async () => {
+          const { runHallBaseline } =
+            await import("#src/progression/hall/baseline.ts");
+          await runHallBaseline(input);
+        },
+      );
     },
   };
 }

--- a/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.ts
@@ -130,7 +130,7 @@ type BackgroundActivities = Pick<
 };
 type LakeActivities = Pick<
   ScoutTemporalActivities,
-  "runReportLakeJob" | "runDetachedLakeWork" | "probeQueue"
+  "runReportLakeJob" | "runDetachedLakeWork" | "runHallBaseline" | "probeQueue"
 >;
 
 export type ScoutTemporalActivityGroups = {

--- a/packages/scout-for-lol/packages/backend/src/temporal/starts.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/starts.ts
@@ -13,6 +13,9 @@ import {
   scoutMatchWorkflowId,
   scoutReportScheduleReconcilerWorkflowId,
   scoutQueueCanaryWorkflowId,
+  scoutHallBaselineWorkflowId,
+  scoutChallengeRunRecomputeWorkflowId,
+  scoutDuelSeriesWorkflowId,
   scoutTaskQueues,
   type ScoutInitialHistoryInput,
   type ScoutDetachedWorkInput,
@@ -21,7 +24,11 @@ import {
   type ScoutReportRunInput,
   type ScoutQueueCanaryInput,
   type ScoutStage,
+  type ScoutHallBaselineInput,
+  type ScoutChallengeRunRecomputeInput,
+  type ScoutDuelSeriesInput,
 } from "@scout-for-lol/temporal";
+import { duelSeriesChangedSignal } from "@scout-for-lol/temporal/signals";
 import { reconcileReportSchedulesSignal } from "@scout-for-lol/temporal/signals";
 import { requestInitialHistoryRunSignal } from "@scout-for-lol/temporal/signals";
 import {
@@ -216,6 +223,97 @@ export async function signalScoutReportReconciliation(
         "workflow",
         "Reconcile Scout report schedules",
         "Reconciles database-owned Scout report schedules with Temporal.",
+      ),
+    },
+  );
+}
+
+export async function startScoutHallBaseline(
+  client: Client,
+  input: ScoutHallBaselineInput,
+): Promise<WorkflowHandle> {
+  return await client.workflow.start(SCOUT_WORKFLOW_NAMES.hallBaseline, {
+    ...RESTART_FAILED_START_POLICIES,
+    workflowId: scoutHallBaselineWorkflowId(
+      input.stage,
+      input.guildId,
+      input.revision,
+    ),
+    taskQueue: scoutTaskQueues(input.stage).workflow,
+    args: [input],
+    ...startMetadata(
+      input.stage,
+      "api",
+      "Build Scout Hall of Fame baseline",
+      "Builds every requested Hall record from eligible Scout-known match evidence.",
+    ),
+  });
+}
+
+export async function startScoutChallengeRunRecompute(
+  client: Client,
+  input: ScoutChallengeRunRecomputeInput,
+): Promise<WorkflowHandle> {
+  return await client.workflow.start(
+    SCOUT_WORKFLOW_NAMES.challengeRunRecompute,
+    {
+      ...IDEMPOTENT_START_POLICIES,
+      workflowId: scoutChallengeRunRecomputeWorkflowId(
+        input.stage,
+        input.runId,
+        input.revision,
+      ),
+      taskQueue: scoutTaskQueues(input.stage).workflow,
+      args: [input],
+      ...startMetadata(
+        input.stage,
+        "api",
+        "Recompute Scout challenge run",
+        "Pages through Scout evidence and atomically replaces one challenge-run revision.",
+      ),
+    },
+  );
+}
+
+export async function startScoutDuelSeries(
+  client: Client,
+  input: ScoutDuelSeriesInput,
+): Promise<WorkflowHandle> {
+  return await client.workflow.start(SCOUT_WORKFLOW_NAMES.duelSeries, {
+    ...IDEMPOTENT_START_POLICIES,
+    workflowId: scoutDuelSeriesWorkflowId(input.stage, input.seriesId),
+    taskQueue: scoutTaskQueues(input.stage).workflow,
+    args: [input],
+    ...startMetadata(
+      input.stage,
+      "api",
+      "Coordinate Scout duel series",
+      "Owns readiness coordination and the durable series deadline.",
+    ),
+  });
+}
+
+export async function signalScoutDuelSeriesChanged(
+  client: Client,
+  input: ScoutDuelSeriesInput & { readonly requestId: string },
+): Promise<WorkflowHandle> {
+  return await client.workflow.signalWithStart(
+    SCOUT_WORKFLOW_NAMES.duelSeries,
+    {
+      // Organizer replay decisions can arrive after the original deadline or
+      // review workflow has closed. Reuse the stable series ID for an open run,
+      // and begin a new run only when the prior execution is already closed.
+      ...RESTART_CLOSED_START_POLICIES,
+      workflowId: scoutDuelSeriesWorkflowId(input.stage, input.seriesId),
+      taskQueue: scoutTaskQueues(input.stage).workflow,
+      args: [input],
+      signal: duelSeriesChangedSignal,
+      signalArgs: [{ requestId: input.requestId }],
+      ...startMetadata(
+        input.stage,
+        "api",
+        "Update Scout duel series",
+        "Reconciles an accepted or readiness change against the durable series deadline.",
       ),
     },
   );

--- a/packages/scout-for-lol/packages/backend/src/testing/test-user.ts
+++ b/packages/scout-for-lol/packages/backend/src/testing/test-user.ts
@@ -1,0 +1,17 @@
+import type { DiscordAccountId } from "@scout-for-lol/data";
+import type { User } from "#generated/prisma/client/index.js";
+
+export function createTestUser(discordId: DiscordAccountId): User {
+  return {
+    discordId,
+    discordUsername: "Test Admin",
+    discordAvatar: null,
+    discordAccessToken: "access",
+    discordRefreshToken: "refresh",
+    tokenExpiresAt: null,
+    analyticsUserId: `analytics-${discordId}`,
+    lastSeenAt: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/hall.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/hall.router.ts
@@ -1,0 +1,79 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import {
+  DiscordGuildIdSchema,
+  HallSettingsSchema,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import configuration from "#src/configuration.ts";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
+import { prisma } from "#src/database/index.ts";
+import { launchHallBaseline } from "#src/progression/hall/launch.ts";
+import { getHall } from "#src/progression/hall/read.ts";
+import {
+  getHallSettings,
+  requestFullHallBaseline,
+  updateHallSettings,
+} from "#src/progression/hall/settings.ts";
+import {
+  guildMutationProcedure,
+  guildProcedure,
+  resolveGuildPermissions,
+} from "#src/trpc/guild-permission.ts";
+import { assertChannelInGuild } from "#src/trpc/guild-guard.ts";
+import { router, webProcedure } from "#src/trpc/trpc.ts";
+
+const GuildInputSchema = z.strictObject({ guildId: DiscordGuildIdSchema });
+
+async function assertHallEnabled(guildId: DiscordGuildId): Promise<void> {
+  if (!(await isPolicyEnabled("hall_of_fame_enabled", { server: guildId }))) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Hall of Fame is unavailable",
+    });
+  }
+}
+
+export const hallRouter = router({
+  get: webProcedure.input(GuildInputSchema).query(async ({ ctx, input }) => {
+    await assertHallEnabled(input.guildId);
+    await resolveGuildPermissions(ctx.user, input.guildId);
+    return await getHall(prisma, input.guildId);
+  }),
+  getSettings: guildProcedure("reports", "read")
+    .input(GuildInputSchema)
+    .query(async ({ input }) => {
+      await assertHallEnabled(input.guildId);
+      return await getHallSettings(prisma, input.guildId);
+    }),
+  updateSettings: guildMutationProcedure("reports", "update")
+    .input(HallSettingsSchema)
+    .mutation(async ({ ctx, input }) => {
+      await assertHallEnabled(input.guildId);
+      if (input.channelId !== null) {
+        assertChannelInGuild({
+          guildId: input.guildId,
+          channelId: input.channelId,
+        });
+      }
+      const result = await updateHallSettings(prisma, {
+        settings: input,
+        actorDiscordId: ctx.user.discordId,
+        stage: configuration.environment,
+      });
+      await launchHallBaseline(configuration.environment, result.baseline);
+      return result;
+    }),
+  startBaseline: guildMutationProcedure("reports", "update")
+    .input(GuildInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await assertHallEnabled(input.guildId);
+      const request = await requestFullHallBaseline(prisma, {
+        guildId: input.guildId,
+        actorDiscordId: ctx.user.discordId,
+        stage: configuration.environment,
+      });
+      await launchHallBaseline(configuration.environment, request);
+      return request;
+    }),
+});

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/index.ts
@@ -28,6 +28,7 @@ import { consumerMatchRouter } from "#src/trpc/router/consumer-match.router.ts";
 import { bucksRouter } from "#src/trpc/router/bucks.router.ts";
 import { customsRouter } from "#src/trpc/router/customs.router.ts";
 import { customsHistoryRouter } from "#src/trpc/router/customs-history.router.ts";
+import { hallRouter } from "#src/trpc/router/hall.router.ts";
 
 export const appRouter = router({
   auth: authRouter,
@@ -52,6 +53,7 @@ export const appRouter = router({
   bucks: bucksRouter,
   customs: customsRouter,
   customsHistory: customsHistoryRouter,
+  hall: hallRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/packages/scout-for-lol/packages/data/src/model/progression/hall.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/progression/hall.test.ts
@@ -181,6 +181,12 @@ describe("Hall of Fame domain", () => {
     expect(isHallEligibleMatch(match, new Date("2025-12-31T00:00:00Z"))).toBe(
       true,
     );
+    expect(
+      isHallEligibleMatch(
+        { ...match, game_end_at: "2026-01-01T00:30:00.000Z" },
+        new Date("2025-12-31T00:00:00Z"),
+      ),
+    ).toBe(true);
     expect(isHallEligibleMatch(match, new Date("2026-01-02T00:00:00Z"))).toBe(
       false,
     );

--- a/packages/scout-for-lol/packages/data/src/model/progression/hall.ts
+++ b/packages/scout-for-lol/packages/data/src/model/progression/hall.ts
@@ -114,7 +114,12 @@ export function isHallEligibleMatch(
   match: HallEligibleMatch,
   trackingStartedAt: Date,
 ): boolean {
-  const gameEndAt = Date.parse(`${match.game_end_at.replace(" ", "T")}Z`);
+  const normalizedGameEndAt = match.game_end_at.replace(" ", "T");
+  const gameEndAt = Date.parse(
+    /(?:Z|[+-]\d{2}:\d{2})$/u.test(normalizedGameEndAt)
+      ? normalizedGameEndAt
+      : `${normalizedGameEndAt}Z`,
+  );
   return (
     match.end_of_game_result === "GameComplete" &&
     !match.early_surrendered &&

--- a/packages/scout-for-lol/packages/temporal/src/activities.ts
+++ b/packages/scout-for-lol/packages/temporal/src/activities.ts
@@ -18,6 +18,11 @@ import type {
   ScoutReportLakeInput,
   ScoutReportActivityInput,
   ScoutReportScheduleReconcilerInput,
+  ScoutHallBaselineInput,
+  ScoutChallengeRunRecomputeInput,
+  ScoutChallengeRunRecomputePageResult,
+  ScoutDuelSeriesInput,
+  ScoutDuelSeriesRefreshResult,
 } from "./contracts.ts";
 
 export type ScoutTemporalActivities = {
@@ -52,4 +57,12 @@ export type ScoutTemporalActivities = {
   persistInteractiveOutcome: (
     input: ScoutInteractiveRunInput & { outcome: InteractiveOutcome },
   ) => Promise<InteractiveOutcome>;
+  runHallBaseline: (input: ScoutHallBaselineInput) => Promise<void>;
+  recomputeChallengeRunPage: (
+    input: ScoutChallengeRunRecomputeInput,
+  ) => Promise<ScoutChallengeRunRecomputePageResult>;
+  refreshDuelSeries: (
+    input: ScoutDuelSeriesInput,
+  ) => Promise<ScoutDuelSeriesRefreshResult>;
+  markDuelSeriesOverdue: (input: ScoutDuelSeriesInput) => Promise<void>;
 };

--- a/packages/scout-for-lol/packages/temporal/src/contracts.ts
+++ b/packages/scout-for-lol/packages/temporal/src/contracts.ts
@@ -110,6 +110,7 @@ export const ScoutBackgroundJobInputSchema = z.object({
     "custom-nights-expiry",
     "prediction-ingest",
     "legacy-backfill",
+    "progression-outbox",
   ]),
 });
 export type ScoutBackgroundJobInput = z.infer<
@@ -193,6 +194,62 @@ export const ScoutQueueCanaryProbeResultSchema =
 export type ScoutQueueCanaryProbeResult = z.infer<
   typeof ScoutQueueCanaryProbeResultSchema
 >;
+
+export const ScoutHallBaselineInputSchema = z.strictObject({
+  stage: ScoutStageSchema,
+  guildId: OpaqueIdentifierSchema,
+  revision: z.number().int().positive(),
+});
+export type ScoutHallBaselineInput = z.infer<
+  typeof ScoutHallBaselineInputSchema
+>;
+
+export const ScoutChallengeRunRecomputeInputSchema = z.strictObject({
+  stage: ScoutStageSchema,
+  runId: z.uuid(),
+  revision: z.number().int().positive(),
+  cursor: z
+    .strictObject({
+      gameEndMs: z.number().int().nonnegative(),
+      matchId: OpaqueIdentifierSchema,
+      puuid: OpaqueIdentifierSchema,
+    })
+    .optional(),
+  pagesProcessed: z.number().int().nonnegative().default(0),
+});
+export type ScoutChallengeRunRecomputeInput = z.infer<
+  typeof ScoutChallengeRunRecomputeInputSchema
+>;
+
+export const ScoutChallengeRunRecomputePageResultSchema = z.strictObject({
+  complete: z.boolean(),
+  nextCursor: ScoutChallengeRunRecomputeInputSchema.shape.cursor,
+  evaluatedMatches: z.number().int().nonnegative(),
+});
+export type ScoutChallengeRunRecomputePageResult = z.infer<
+  typeof ScoutChallengeRunRecomputePageResultSchema
+>;
+
+export const ScoutDuelSeriesInputSchema = z.strictObject({
+  stage: ScoutStageSchema,
+  seriesId: z.uuid(),
+  deadlineAt: IsoInstantSchema,
+});
+export type ScoutDuelSeriesInput = z.infer<typeof ScoutDuelSeriesInputSchema>;
+
+export const ScoutDuelSeriesRefreshResultSchema = z.strictObject({
+  terminal: z.boolean(),
+  status: z.string().min(1),
+  deadlineAt: IsoInstantSchema,
+});
+export type ScoutDuelSeriesRefreshResult = z.infer<
+  typeof ScoutDuelSeriesRefreshResultSchema
+>;
+
+export const ScoutDuelSeriesChangeSchema = z.strictObject({
+  requestId: OpaqueIdentifierSchema,
+});
+export type ScoutDuelSeriesChange = z.infer<typeof ScoutDuelSeriesChangeSchema>;
 
 export const InitialHistoryPageResultSchema = z.object({
   nextCursor: z.string().min(1).max(512).optional(),

--- a/packages/scout-for-lol/packages/temporal/src/identifiers.test.ts
+++ b/packages/scout-for-lol/packages/temporal/src/identifiers.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
 import {
+  scoutChallengeRunRecomputeWorkflowId,
+  scoutDuelSeriesWorkflowId,
+  scoutHallBaselineWorkflowId,
   scoutInitialHistoryWorkflowId,
   scoutInteractiveWorkflowId,
   scoutMatchWorkflowId,
@@ -34,6 +37,15 @@ describe("Scout Temporal identifiers", () => {
     );
     expect(scoutReportScheduleId("beta", "report_123")).toBe(
       "scout-beta-report-report_123",
+    );
+    expect(scoutHallBaselineWorkflowId("beta", "guild_123", 4)).toBe(
+      "scout-beta-hall-guild_123-4",
+    );
+    expect(scoutChallengeRunRecomputeWorkflowId("prod", "run_123", 7)).toBe(
+      "scout-prod-challenge-run_123-7",
+    );
+    expect(scoutDuelSeriesWorkflowId("dev", "series_123")).toBe(
+      "scout-dev-duel-series-series_123",
     );
   });
 });

--- a/packages/scout-for-lol/packages/temporal/src/identifiers.ts
+++ b/packages/scout-for-lol/packages/temporal/src/identifiers.ts
@@ -13,6 +13,9 @@ export const SCOUT_WORKFLOW_NAMES = {
   reportScheduleReconciler: "scoutReportScheduleReconcilerWorkflow",
   interactiveRun: "scoutInteractiveRunWorkflow",
   queueCanary: "scoutQueueCanaryWorkflow",
+  hallBaseline: "scoutHallBaselineWorkflow",
+  challengeRunRecompute: "scoutChallengeRunRecomputeWorkflow",
+  duelSeries: "scoutDuelSeriesWorkflow",
 } as const;
 
 export function scoutTaskQueues(stage: ScoutStage) {
@@ -78,6 +81,29 @@ export function scoutQueueCanaryWorkflowId(
   canaryId: string,
 ): string {
   return `scout-${stage}-canary-${canaryId}`;
+}
+
+export function scoutHallBaselineWorkflowId(
+  stage: ScoutStage,
+  guildId: string,
+  revision: number,
+): string {
+  return `scout-${stage}-hall-${guildId}-${revision.toString()}`;
+}
+
+export function scoutChallengeRunRecomputeWorkflowId(
+  stage: ScoutStage,
+  runId: string,
+  revision: number,
+): string {
+  return `scout-${stage}-challenge-${runId}-${revision.toString()}`;
+}
+
+export function scoutDuelSeriesWorkflowId(
+  stage: ScoutStage,
+  seriesId: string,
+): string {
+  return `scout-${stage}-duel-series-${seriesId}`;
 }
 
 export function scoutSchedulePrefix(stage: ScoutStage): string {

--- a/packages/scout-for-lol/packages/temporal/src/index.ts
+++ b/packages/scout-for-lol/packages/temporal/src/index.ts
@@ -24,6 +24,12 @@ export {
   ScoutStageSchema,
   TemporalNamespaceSchema,
   ScoutWorkflowStatusSchema,
+  ScoutHallBaselineInputSchema,
+  ScoutChallengeRunRecomputeInputSchema,
+  ScoutChallengeRunRecomputePageResultSchema,
+  ScoutDuelSeriesInputSchema,
+  ScoutDuelSeriesRefreshResultSchema,
+  ScoutDuelSeriesChangeSchema,
 } from "./contracts.ts";
 export type {
   InitialHistoryPageResult,
@@ -50,6 +56,12 @@ export type {
   ScoutStage,
   TemporalNamespace,
   ScoutWorkflowStatus,
+  ScoutHallBaselineInput,
+  ScoutChallengeRunRecomputeInput,
+  ScoutChallengeRunRecomputePageResult,
+  ScoutDuelSeriesInput,
+  ScoutDuelSeriesRefreshResult,
+  ScoutDuelSeriesChange,
 } from "./contracts.ts";
 export {
   SCOUT_WORKFLOW_NAMES,
@@ -63,4 +75,7 @@ export {
   scoutReportScheduleReconcilerWorkflowId,
   scoutSchedulePrefix,
   scoutTaskQueues,
+  scoutHallBaselineWorkflowId,
+  scoutChallengeRunRecomputeWorkflowId,
+  scoutDuelSeriesWorkflowId,
 } from "./identifiers.ts";

--- a/packages/scout-for-lol/packages/temporal/src/signals.ts
+++ b/packages/scout-for-lol/packages/temporal/src/signals.ts
@@ -1,4 +1,5 @@
 import { defineSignal } from "@temporalio/workflow";
+import type { ScoutDuelSeriesChange } from "./contracts.ts";
 
 export const requestStopSignal = defineSignal("requestStop");
 export const reconcileReportSchedulesSignal = defineSignal(
@@ -7,3 +8,5 @@ export const reconcileReportSchedulesSignal = defineSignal(
 export const requestInitialHistoryRunSignal = defineSignal(
   "requestInitialHistoryRun",
 );
+export const duelSeriesChangedSignal =
+  defineSignal<[ScoutDuelSeriesChange]>("duelSeriesChanged");

--- a/packages/scout-for-lol/packages/temporal/src/workflows/index.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflows/index.ts
@@ -14,6 +14,9 @@ import type {
   ScoutReportRunInput,
   ScoutReportScheduleReconcilerInput,
   ScoutWorkflowStatus,
+  ScoutHallBaselineInput,
+  ScoutChallengeRunRecomputeInput,
+  ScoutDuelSeriesInput,
 } from "#src/contracts.ts";
 import { scoutRealtimePollWorkflow as realtimePoll } from "./realtime.ts";
 import { scoutMatchIngestionWorkflow as matchIngestion } from "./realtime.ts";
@@ -27,6 +30,11 @@ import { scoutReportRunWorkflow as reportRun } from "./reports.ts";
 import { scoutReportScheduleReconcilerWorkflow as reportScheduleReconciler } from "./reports.ts";
 import { scoutInteractiveRunWorkflow as interactiveRun } from "./interactive.ts";
 import { scoutQueueCanaryWorkflow as queueCanary } from "./canary.ts";
+import {
+  scoutChallengeRunRecomputeWorkflow as challengeRunRecompute,
+  scoutDuelSeriesWorkflow as duelSeries,
+  scoutHallBaselineWorkflow as hallBaseline,
+} from "./progression.ts";
 
 export async function scoutRealtimePollWorkflow(
   input: ScoutRealtimePollInput,
@@ -98,4 +106,22 @@ export async function scoutQueueCanaryWorkflow(
   input: ScoutQueueCanaryInput,
 ): Promise<ScoutQueueCanaryProbeResult[]> {
   return await queueCanary(input);
+}
+
+export async function scoutHallBaselineWorkflow(
+  input: ScoutHallBaselineInput,
+): Promise<ScoutWorkflowStatus> {
+  return await hallBaseline(input);
+}
+
+export async function scoutChallengeRunRecomputeWorkflow(
+  input: ScoutChallengeRunRecomputeInput,
+): Promise<ScoutWorkflowStatus> {
+  return await challengeRunRecompute(input);
+}
+
+export async function scoutDuelSeriesWorkflow(
+  input: ScoutDuelSeriesInput,
+): Promise<ScoutWorkflowStatus> {
+  return await duelSeries(input);
 }

--- a/packages/scout-for-lol/packages/temporal/src/workflows/progression.test.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflows/progression.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+import { duelSeriesChangedSignal } from "#src/signals.ts";
+import {
+  scoutChallengeRunRecomputeWorkflow,
+  scoutDuelSeriesWorkflow,
+  scoutHallBaselineWorkflow,
+} from "./index.ts";
+
+let environment: TestWorkflowEnvironment;
+const runningWorkers: Worker[] = [];
+const workerRuns: Promise<void>[] = [];
+
+async function startWorker(worker: Worker): Promise<void> {
+  runningWorkers.push(worker);
+  workerRuns.push(worker.run());
+  while (worker.getState() === "INITIALIZED") await new Promise(setImmediate);
+}
+
+async function startWorkflowWorker(): Promise<void> {
+  await startWorker(
+    await Worker.create({
+      connection: environment.nativeConnection,
+      taskQueue: "scout-dev",
+      workflowsPath: new URL("index.ts", import.meta.url).pathname,
+      maxConcurrentWorkflowTaskExecutions: 4,
+    }),
+  );
+}
+
+async function startActivityWorker(
+  taskQueue: "scout-dev-background" | "scout-dev-lake",
+  activities: Record<string, (...args: never[]) => unknown>,
+): Promise<void> {
+  await startWorker(
+    await Worker.create({
+      connection: environment.nativeConnection,
+      taskQueue,
+      activities,
+      maxConcurrentActivityTaskExecutions: 2,
+    }),
+  );
+}
+
+async function createProgressionEnvironment(): Promise<void> {
+  environment = await TestWorkflowEnvironment.createTimeSkipping();
+}
+
+async function destroyProgressionEnvironment(): Promise<void> {
+  for (const worker of runningWorkers.splice(0)) {
+    if (worker.getState() === "RUNNING") worker.shutdown();
+  }
+  await Promise.allSettled(workerRuns.splice(0));
+  await environment.teardown();
+}
+
+beforeEach(createProgressionEnvironment, 60_000);
+afterEach(destroyProgressionEnvironment);
+
+test("retries a Hall baseline activity without duplicating workflow state", async () => {
+  let attempts = 0;
+  await startWorkflowWorker();
+  await startActivityWorker("scout-dev-lake", {
+    runHallBaseline: () => {
+      attempts++;
+      if (attempts === 1) throw new Error("retry the baseline page");
+    },
+  });
+
+  await expect(
+    environment.client.workflow.execute(scoutHallBaselineWorkflow, {
+      taskQueue: "scout-dev",
+      workflowId: "progression-hall-retry",
+      args: [{ stage: "dev", guildId: "guild_1", revision: 1 }],
+    }),
+  ).resolves.toBe("completed");
+  expect(attempts).toBe(2);
+});
+
+test("pages a challenge recomputation with its stable evidence cursor", async () => {
+  const observed: unknown[] = [];
+  await startWorkflowWorker();
+  await startActivityWorker("scout-dev-lake", {
+    recomputeChallengeRunPage: (input: unknown) => {
+      observed.push(input);
+      if (observed.length === 1) {
+        return {
+          complete: false,
+          nextCursor: {
+            gameEndMs: 100,
+            matchId: "NA1_1",
+            puuid: "puuid_1",
+          },
+          evaluatedMatches: 1,
+        };
+      }
+      return { complete: true, evaluatedMatches: 2 };
+    },
+  });
+
+  await expect(
+    environment.client.workflow.execute(scoutChallengeRunRecomputeWorkflow, {
+      taskQueue: "scout-dev",
+      workflowId: "progression-challenge-pages",
+      args: [
+        {
+          stage: "dev",
+          runId: "00000000-0000-4000-8000-000000000001",
+          revision: 2,
+          pagesProcessed: 0,
+        },
+      ],
+    }),
+  ).resolves.toBe("completed");
+  expect(observed).toEqual([
+    {
+      stage: "dev",
+      runId: "00000000-0000-4000-8000-000000000001",
+      revision: 2,
+      pagesProcessed: 0,
+    },
+    {
+      stage: "dev",
+      runId: "00000000-0000-4000-8000-000000000001",
+      revision: 2,
+      pagesProcessed: 1,
+      cursor: { gameEndMs: 100, matchId: "NA1_1", puuid: "puuid_1" },
+    },
+  ]);
+});
+
+test(
+  "deduplicates duel change signals by request id",
+  { timeout: 15_000 },
+  async () => {
+    const firstRefresh = Promise.withResolvers<undefined>();
+    const secondRefresh = Promise.withResolvers<undefined>();
+    let refreshes = 0;
+    const deadlineAt = new Date(Date.now() + 86_400_000).toISOString();
+    await startWorkflowWorker();
+    await startActivityWorker("scout-dev-background", {
+      refreshDuelSeries: () => {
+        refreshes++;
+        if (refreshes === 1) firstRefresh.resolve(undefined);
+        if (refreshes === 2) secondRefresh.resolve(undefined);
+        return {
+          terminal: refreshes >= 3,
+          status: refreshes >= 3 ? "completed" : "awaiting_readiness",
+          deadlineAt,
+        };
+      },
+    });
+
+    const handle = await environment.client.workflow.start(
+      scoutDuelSeriesWorkflow,
+      {
+        taskQueue: "scout-dev",
+        workflowId: "progression-duel-signals",
+        args: [
+          {
+            stage: "dev",
+            seriesId: "00000000-0000-4000-8000-000000000002",
+            deadlineAt,
+          },
+        ],
+      },
+    );
+    await firstRefresh.promise;
+    await handle.signal(duelSeriesChangedSignal, { requestId: "ready_1" });
+    await secondRefresh.promise;
+    await handle.signal(duelSeriesChangedSignal, { requestId: "ready_1" });
+    await environment.sleep("1 minute");
+    expect(refreshes).toBe(2);
+    await handle.signal(duelSeriesChangedSignal, { requestId: "ready_2" });
+    await expect(handle.result()).resolves.toBe("completed");
+    expect(refreshes).toBe(3);
+  },
+);
+
+test("time-skips a duel deadline and marks it overdue without a winner", async () => {
+  const overdueInputs: unknown[] = [];
+  const deadlineAt = new Date(Date.now() + 3_600_000).toISOString();
+  await startWorkflowWorker();
+  await startActivityWorker("scout-dev-background", {
+    refreshDuelSeries: () => ({
+      terminal: false,
+      status: "scheduled",
+      deadlineAt,
+    }),
+    markDuelSeriesOverdue: (input: unknown) => {
+      overdueInputs.push(input);
+    },
+  });
+
+  await expect(
+    environment.client.workflow.execute(scoutDuelSeriesWorkflow, {
+      taskQueue: "scout-dev",
+      workflowId: "progression-duel-overdue",
+      args: [
+        {
+          stage: "dev",
+          seriesId: "00000000-0000-4000-8000-000000000003",
+          deadlineAt,
+        },
+      ],
+    }),
+  ).resolves.toBe("completed");
+  expect(overdueInputs).toEqual([
+    {
+      stage: "dev",
+      seriesId: "00000000-0000-4000-8000-000000000003",
+      deadlineAt,
+    },
+  ]);
+});

--- a/packages/scout-for-lol/packages/temporal/src/workflows/progression.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflows/progression.ts
@@ -1,0 +1,98 @@
+import {
+  condition,
+  continueAsNew,
+  setHandler,
+  workflowInfo,
+} from "@temporalio/workflow";
+import {
+  ScoutChallengeRunRecomputeInputSchema,
+  ScoutDuelSeriesChangeSchema,
+  ScoutDuelSeriesInputSchema,
+  ScoutHallBaselineInputSchema,
+  type ScoutChallengeRunRecomputeInput,
+  type ScoutDuelSeriesInput,
+  type ScoutHallBaselineInput,
+  type ScoutWorkflowStatus,
+} from "#src/contracts.ts";
+import { duelSeriesChangedSignal } from "#src/signals.ts";
+import { setWorkflowPhase } from "#src/workflow-ui-interceptor.ts";
+import { backgroundActivities, lakeActivities } from "./activity-options.ts";
+
+export async function scoutHallBaselineWorkflow(
+  rawInput: ScoutHallBaselineInput,
+): Promise<ScoutWorkflowStatus> {
+  const input = ScoutHallBaselineInputSchema.parse(rawInput);
+  setWorkflowPhase("**Phase:** building Hall of Fame baselines");
+  await lakeActivities(input.stage).runHallBaseline(input);
+  setWorkflowPhase("**Phase:** Hall of Fame baseline complete");
+  return "completed";
+}
+
+export async function scoutChallengeRunRecomputeWorkflow(
+  rawInput: ScoutChallengeRunRecomputeInput,
+): Promise<ScoutWorkflowStatus> {
+  let input = ScoutChallengeRunRecomputeInputSchema.parse(rawInput);
+  const activities = lakeActivities(input.stage);
+  for (;;) {
+    setWorkflowPhase(
+      `**Phase:** evaluating challenge evidence page ${(input.pagesProcessed + 1).toString()}`,
+    );
+    const page = await activities.recomputeChallengeRunPage(input);
+    if (page.complete) {
+      setWorkflowPhase("**Phase:** challenge recomputation complete");
+      return "completed";
+    }
+    if (page.nextCursor === undefined) {
+      throw new Error("An incomplete challenge page must return a cursor");
+    }
+    input = {
+      ...input,
+      cursor: page.nextCursor,
+      pagesProcessed: input.pagesProcessed + 1,
+    };
+    if (input.pagesProcessed >= 100 || workflowInfo().continueAsNewSuggested) {
+      await continueAsNew<typeof scoutChallengeRunRecomputeWorkflow>({
+        ...input,
+        pagesProcessed: 0,
+      });
+    }
+  }
+}
+
+export async function scoutDuelSeriesWorkflow(
+  rawInput: ScoutDuelSeriesInput,
+): Promise<ScoutWorkflowStatus> {
+  const input = ScoutDuelSeriesInputSchema.parse(rawInput);
+  const activities = backgroundActivities(input.stage);
+  const seenRequests = new Set<string>();
+  let changed = false;
+  setHandler(duelSeriesChangedSignal, (rawChange) => {
+    const change = ScoutDuelSeriesChangeSchema.parse(rawChange);
+    if (seenRequests.has(change.requestId)) return;
+    seenRequests.add(change.requestId);
+    changed = true;
+  });
+  const hasChanged = () => changed;
+
+  for (;;) {
+    // Clear before the Activity is scheduled. A Signal received while the
+    // Activity is running then remains visible and forces an immediate second
+    // refresh instead of being overwritten after the await.
+    changed = false;
+    setWorkflowPhase("**Phase:** coordinating duel-series readiness");
+    const refreshed = await activities.refreshDuelSeries(input);
+    if (refreshed.terminal) return "completed";
+    const remainingMs = new Date(refreshed.deadlineAt).getTime() - Date.now();
+    if (remainingMs <= 0) {
+      await activities.markDuelSeriesOverdue(input);
+      return "completed";
+    }
+    if (hasChanged()) continue;
+    const receivedChange = await condition(hasChanged, remainingMs);
+    if (!receivedChange) {
+      setWorkflowPhase("**Phase:** marking overdue duel series");
+      await activities.markDuelSeriesOverdue(input);
+      return "completed";
+    }
+  }
+}

--- a/packages/temporal/src/schedules/scout-schedule-definitions.ts
+++ b/packages/temporal/src/schedules/scout-schedule-definitions.ts
@@ -150,6 +150,13 @@ function schedulesForStage(stage: ScoutStage): ScheduleDefinition[] {
       every: "1 minute",
     }),
     intervalSchedule(stage, {
+      name: "progression-outbox",
+      workflowType: "scoutBackgroundJobWorkflow",
+      args: [{ stage, kind: "progression-outbox" }],
+      every: "1 minute",
+      catchupWindow: CATCHUP_TIGHT,
+    }),
+    intervalSchedule(stage, {
       name: "report-lake-fold",
       workflowType: "scoutReportLakeWorkflow",
       args: [{ stage, kind: "fold" }],


### PR DESCRIPTION
## Why

Guilds need opt-in, queue-comparable records built from Scout-known match evidence without leaking custom-game participation.

## What

- classify supported queue families and evaluate every Hall comparator
- baseline enabled family/record cells from eligible Scout history with building, ready, and failed state
- retain ties, holders, and match evidence while requiring a strictly greater value for breaks
- recompute records after player/account removal without announcements
- deliver one idempotent, combined Hall card per record-breaking match
- expose RBAC-protected Hall settings, baseline, and member-read tRPC procedures with metrics

## Verification

- `bunx turbo run build typecheck test lint --filter=@scout-for-lol/backend`
- backend integration coverage includes settings, baseline idempotency, ties, roster removal, and outbox behavior
- staged-file Lefthook checks passed

Not performed: Buildkite exhaustive verification, beta or production deployment, live persistence acceptance, downstream production Discord delivery, or production Riot Tournament API acceptance.