### PR TITLE
feat(scout-for-lol): add direct duels and structured events

### DIFF
--- a/packages/scout-for-lol/packages/app/src/lib/route-params.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/route-params.ts
@@ -57,6 +57,10 @@ export const ChallengeTemplateParamsSchema = z.object({
 });
 export const ChallengeDraftParamsSchema = z.object({ draftId: z.uuid() });
 export const ChallengeRunParamsSchema = z.object({ runId: z.uuid() });
+export const DuelSeriesParamsSchema = z.object({
+  guildId: z.string().min(1),
+  seriesId: z.uuid(),
+});
 
 /**
  * Marks validation failures that came specifically from parsing matched URL
@@ -137,4 +141,8 @@ export function useChallengeRunParams(): z.infer<
   typeof ChallengeRunParamsSchema
 > {
   return parseRouteParams(ChallengeRunParamsSchema, useParams());
+}
+
+export function useDuelSeriesParams(): z.infer<typeof DuelSeriesParamsSchema> {
+  return parseRouteParams(DuelSeriesParamsSchema, useParams());
 }

--- a/packages/scout-for-lol/packages/app/src/router.test.ts
+++ b/packages/scout-for-lol/packages/app/src/router.test.ts
@@ -25,6 +25,7 @@ const KNOWN_URLS = [
   "/challenges/1b4e28ba-2fa1-41d2-883f-0016d3cca427",
   "/challenges/drafts/1b4e28ba-2fa1-41d2-883f-0016d3cca427",
   "/challenge-runs/1b4e28ba-2fa1-41d2-883f-0016d3cca427",
+  "/duels/1/series/1b4e28ba-2fa1-41d2-883f-0016d3cca427",
   "/bucks",
   "/bucks/dares",
   "/bucks/dares/42",

--- a/packages/scout-for-lol/packages/app/src/router.tsx
+++ b/packages/scout-for-lol/packages/app/src/router.tsx
@@ -46,6 +46,7 @@ import { ChallengeCatalog } from "#src/routes/challenge-catalog.tsx";
 import { ChallengeTemplate } from "#src/routes/challenge-template.tsx";
 import { ChallengeDraft } from "#src/routes/challenge-draft.tsx";
 import { ChallengeRun } from "#src/routes/challenge-run.tsx";
+import { DuelSeries } from "#src/routes/duel-series.tsx";
 import { RouteErrorPanel } from "#src/components/route-error-panel.tsx";
 import { GUILD_ACTION_ROUTE_PERMISSIONS } from "#src/lib/guild-route-permissions.ts";
 import {
@@ -251,6 +252,11 @@ export const routes: RouteObject[] = [
               {
                 path: "challenge-runs/:runId",
                 element: <ChallengeRun />,
+                errorElement: <RouteErrorPanel />,
+              },
+              {
+                path: "duels/:guildId/series/:seriesId",
+                element: <DuelSeries />,
                 errorElement: <RouteErrorPanel />,
               },
               {

--- a/packages/scout-for-lol/packages/app/src/routes/duel-series.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/duel-series.tsx
@@ -324,7 +324,7 @@ export function DuelSeries() {
   const reviewRequired =
     series.data.state === "needs_review" || series.data.state === "overdue";
   const canReview =
-    series.data.isOrganizer && perms.can("competitions", "update");
+    series.data.isOrganizer || perms.can("competitions", "update");
   return (
     <div className="mx-auto max-w-4xl space-y-6 px-4 py-8 sm:py-12">
       <Link className="text-sm text-scout-subtle hover:underline" to="/">

--- a/packages/scout-for-lol/packages/app/src/routes/duel-series.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/duel-series.tsx
@@ -1,0 +1,418 @@
+import { useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router";
+import { z } from "zod";
+import { Badge } from "@scout-for-lol/design-system/components/badge";
+import { Button } from "@scout-for-lol/design-system/components/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@scout-for-lol/design-system/components/card";
+import {
+  FormPendingStatus,
+  focusFirstInvalid,
+  handleFormSubmit,
+  submitThenChangeValidation,
+  useScoutForm,
+} from "#src/components/semantic-form.tsx";
+import { usePermissions } from "#src/hooks/use-permissions.ts";
+import { useDuelSeriesParams } from "#src/lib/route-params.ts";
+import { useTRPC } from "#src/lib/trpc.ts";
+
+type Competitor = {
+  id: string;
+  teamName: string | null;
+  accounts: readonly { playerAlias: string }[];
+};
+
+type Participant = {
+  playerId: number;
+  accepted: boolean;
+  ready: boolean;
+};
+
+function competitorName(competitor: Competitor) {
+  return (
+    competitor.teamName ??
+    competitor.accounts.map((account) => account.playerAlias).join(" + ")
+  );
+}
+
+function ParticipantActions(props: {
+  participants: readonly Participant[];
+  state: string;
+  onDisclosure: (playerId: number) => void;
+  onAccept: () => void;
+  onReady: () => void;
+  onRevealCode: () => void;
+}) {
+  if (props.participants.length === 0) return null;
+  const needsAcceptance = props.participants.some(
+    (participant) => !participant.accepted,
+  );
+  const needsReadiness = props.participants.some(
+    (participant) => !participant.ready,
+  );
+  const codeAvailable =
+    props.state === "code_ready" || props.state === "in_progress";
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Your actions</CardTitle>
+        <CardDescription>
+          Consent, challenge acceptance, and readiness are recorded separately
+          for every assigned player.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-wrap gap-2">
+        {props.participants.map((participant) => (
+          <Button
+            key={participant.playerId}
+            type="button"
+            variant="outline"
+            onClick={() => {
+              props.onDisclosure(participant.playerId);
+            }}
+          >
+            Accept disclosure · player {participant.playerId.toString()}
+          </Button>
+        ))}
+        {needsAcceptance ? (
+          <Button type="button" onClick={props.onAccept}>
+            Accept challenge
+          </Button>
+        ) : null}
+        {!needsAcceptance && needsReadiness ? (
+          <Button type="button" onClick={props.onReady}>
+            Mark ready
+          </Button>
+        ) : null}
+        {codeAvailable ? (
+          <Button type="button" onClick={props.onRevealCode}>
+            Reveal tournament code
+          </Button>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function RulesCard(props: {
+  ruleset: {
+    killTarget: number | null;
+    laneCsTarget: number | null;
+    firstTurret: boolean;
+  };
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Rules</CardTitle>
+      </CardHeader>
+      <CardContent className="text-sm">
+        <ul className="space-y-1">
+          <li>Kill target: {props.ruleset.killTarget?.toString() ?? "off"}</li>
+          <li>
+            Lane CS target: {props.ruleset.laneCsTarget?.toString() ?? "off"}
+          </li>
+          <li>First turret: {props.ruleset.firstTurret ? "on" : "off"}</li>
+        </ul>
+        <p className="mt-3 text-scout-subtle">
+          The earliest configured objective wins. Jungle CS is excluded.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function GamesCard(props: {
+  games: readonly {
+    id: string;
+    gameNumber: number;
+    state: string;
+    objective: string | null;
+    reviewReason: string | null;
+  }[];
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Games</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ol className="space-y-2">
+          {props.games.map((game) => (
+            <li className="rounded-md border p-3 text-sm" key={game.id}>
+              <strong>Game {game.gameNumber.toString()}</strong> ·{" "}
+              {game.state.replaceAll("_", " ")}
+              {game.objective === null
+                ? ""
+                : ` · ${game.objective.replaceAll("_", " ")}`}
+              {game.reviewReason === null ? null : (
+                <span className="mt-1 block text-scout-danger">
+                  {game.reviewReason}
+                </span>
+              )}
+            </li>
+          ))}
+        </ol>
+      </CardContent>
+    </Card>
+  );
+}
+
+const ReviewFormSchema = z.strictObject({
+  decision: z.string().min(1),
+  reason: z.string().trim().min(3).max(1000),
+});
+
+function OrganizerReview(props: {
+  first: Competitor;
+  second: Competitor;
+  allowNoContest: boolean;
+  pending: boolean;
+  onSubmit: (value: z.output<typeof ReviewFormSchema>) => void;
+}) {
+  const formElement = useRef<HTMLFormElement>(null);
+  const form = useScoutForm({
+    defaultValues: { decision: "replay", reason: "" },
+    validationLogic: submitThenChangeValidation,
+    validators: { onDynamic: ReviewFormSchema },
+    onSubmit: ({ value }) => {
+      props.onSubmit(ReviewFormSchema.parse(value));
+    },
+    onSubmitInvalid: () => {
+      focusFirstInvalid(formElement.current);
+    },
+  });
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Organizer review</CardTitle>
+        <CardDescription>
+          No result is awarded automatically. Record an audited reason for
+          replay, no-contest, or advancement.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form
+          ref={formElement}
+          className="space-y-3"
+          onSubmit={(event) => {
+            handleFormSubmit(event, () => form.handleSubmit());
+          }}
+        >
+          <fieldset className="space-y-3" disabled={props.pending}>
+            <form.AppField name="decision">
+              {(field) => (
+                <field.NativeSelectField
+                  id="review-decision"
+                  label="Decision"
+                  required
+                  options={[
+                    { value: "replay", label: "Replay" },
+                    ...(props.allowNoContest
+                      ? [{ value: "no_contest", label: "No contest" }]
+                      : []),
+                    {
+                      value: props.first.id,
+                      label: `Advance ${competitorName(props.first)}`,
+                    },
+                    {
+                      value: props.second.id,
+                      label: `Advance ${competitorName(props.second)}`,
+                    },
+                  ]}
+                />
+              )}
+            </form.AppField>
+            <form.AppField name="reason">
+              {(field) => (
+                <field.TextField
+                  id="review-reason"
+                  label="Audited reason"
+                  required
+                  minLength={3}
+                  maxLength={1000}
+                />
+              )}
+            </form.AppField>
+          </fieldset>
+          <FormPendingStatus pending={props.pending}>
+            Recording organizer decision…
+          </FormPendingStatus>
+          <Button type="submit" disabled={props.pending}>
+            Record decision
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function DuelSeries() {
+  const { guildId, seriesId } = useDuelSeriesParams();
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const { perms } = usePermissions(guildId);
+  const [error, setError] = useState<string | null>(null);
+  const [code, setCode] = useState<string | null>(null);
+  const series = useQuery(
+    trpc.duel.series.queryOptions(
+      { guildId, seriesId },
+      { refetchInterval: 3000 },
+    ),
+  );
+  const linked = useQuery(trpc.duel.linkedAccounts.queryOptions({ guildId }));
+  const invalidate = () => {
+    void queryClient.invalidateQueries({
+      queryKey: trpc.duel.series.queryKey({ guildId, seriesId }),
+    });
+  };
+  const mutationOptions = {
+    onSuccess: invalidate,
+    onError: (mutationError: { message: string }) => {
+      setError(mutationError.message);
+    },
+  };
+  const disclosure = useMutation(
+    trpc.duel.acceptDisclosure.mutationOptions(mutationOptions),
+  );
+  const accept = useMutation(
+    trpc.duel.acceptChallenge.mutationOptions(mutationOptions),
+  );
+  const ready = useMutation(trpc.duel.ready.mutationOptions(mutationOptions));
+  const review = useMutation(
+    trpc.duel.reviewResult.mutationOptions(mutationOptions),
+  );
+
+  if (series.isPending || linked.isPending) {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-8 text-sm text-scout-subtle">
+        Loading series…
+      </div>
+    );
+  }
+  if (series.isError || linked.isError) {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-8 text-sm text-scout-danger">
+        {series.error?.message ?? linked.error?.message}
+      </div>
+    );
+  }
+  const ownPlayerIds = new Set<number>(
+    linked.data.map((account) => account.playerId),
+  );
+  const ownParticipants = series.data.participants.filter((participant) =>
+    ownPlayerIds.has(participant.playerId),
+  );
+  const revealCode = async () => {
+    try {
+      const result = await queryClient.query(
+        trpc.duel.code.queryOptions({ guildId, seriesId }),
+      );
+      setCode(result.code);
+    } catch (codeError) {
+      setError(
+        codeError instanceof Error ? codeError.message : String(codeError),
+      );
+    }
+  };
+  const reviewRequired =
+    series.data.state === "needs_review" || series.data.state === "overdue";
+  const canReview =
+    series.data.isOrganizer && perms.can("competitions", "update");
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 px-4 py-8 sm:py-12">
+      <Link className="text-sm text-scout-subtle hover:underline" to="/">
+        ← Back to Scout
+      </Link>
+      <header className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <h1 className="text-3xl font-semibold tracking-tight">
+            {competitorName(series.data.competitorOne)} vs{" "}
+            {competitorName(series.data.competitorTwo)}
+          </h1>
+          <Badge variant="outline">
+            {series.data.state.replaceAll("_", " ")}
+          </Badge>
+        </div>
+        <p className="text-scout-subtle">
+          Best of {series.data.bestOf.toString()} · deadline{" "}
+          {series.data.deadlineAt === null
+            ? "not set"
+            : new Date(series.data.deadlineAt).toLocaleString()}
+        </p>
+      </header>
+      {error === null ? null : (
+        <p role="alert" className="text-sm text-scout-danger">
+          {error}
+        </p>
+      )}
+      <ParticipantActions
+        participants={ownParticipants}
+        state={series.data.state}
+        onDisclosure={(playerId) => {
+          setError(null);
+          disclosure.mutate({ guildId, playerId });
+        }}
+        onAccept={() => {
+          setError(null);
+          accept.mutate({ guildId, seriesId });
+        }}
+        onReady={() => {
+          setError(null);
+          ready.mutate({ guildId, seriesId });
+        }}
+        onRevealCode={() => {
+          void revealCode();
+        }}
+      />
+      {code === null ? null : (
+        <Card>
+          <CardHeader>
+            <CardTitle>Tournament code</CardTitle>
+            <CardDescription>
+              Visible only in this authenticated participant view. Do not post
+              it publicly.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <code className="break-all text-lg">{code}</code>
+          </CardContent>
+        </Card>
+      )}
+      <RulesCard ruleset={series.data.ruleset} />
+      <GamesCard games={series.data.games} />
+      {reviewRequired && canReview ? (
+        <OrganizerReview
+          first={series.data.competitorOne}
+          second={series.data.competitorTwo}
+          allowNoContest={series.data.eventId === null}
+          pending={review.isPending}
+          onSubmit={(value) => {
+            const decision =
+              value.decision === "replay"
+                ? { kind: "replay" as const }
+                : value.decision === "no_contest"
+                  ? { kind: "no_contest" as const }
+                  : {
+                      kind: "advance" as const,
+                      winnerCompetitorId: value.decision,
+                    };
+            review.mutate({
+              guildId,
+              seriesId,
+              reason: value.reason,
+              idempotencyKey: crypto.randomUUID(),
+              decision,
+            });
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/backend/prisma/migrations/20260904071334_competitive_progression/migration.sql
+++ b/packages/scout-for-lol/packages/backend/prisma/migrations/20260904071334_competitive_progression/migration.sql
@@ -323,6 +323,7 @@ CREATE TABLE "DuelSeries" (
     "competitorOneId" TEXT NOT NULL,
     "competitorTwoId" TEXT NOT NULL,
     "bestOf" INTEGER NOT NULL,
+    "matchWindowHours" INTEGER NOT NULL DEFAULT 168,
     "rulesetJson" TEXT NOT NULL,
     "seriesState" TEXT NOT NULL DEFAULT 'awaiting_acceptance',
     "channelId" TEXT NOT NULL,
@@ -438,6 +439,9 @@ ALTER TABLE "DuelEventRoundOverride"
 
 ALTER TABLE "DuelSeries"
     ADD CONSTRAINT "DuelSeries_bestOf_check" CHECK ("bestOf" IN (1, 3, 5));
+
+ALTER TABLE "DuelSeries"
+    ADD CONSTRAINT "DuelSeries_matchWindowHours_check" CHECK ("matchWindowHours" BETWEEN 24 AND 336);
 
 -- CreateIndex
 CREATE INDEX "HallSettings_updatedAt_idx" ON "HallSettings"("updatedAt");

--- a/packages/scout-for-lol/packages/backend/prisma/migrations/20260904071334_competitive_progression/migration.sql
+++ b/packages/scout-for-lol/packages/backend/prisma/migrations/20260904071334_competitive_progression/migration.sql
@@ -323,7 +323,6 @@ CREATE TABLE "DuelSeries" (
     "competitorOneId" TEXT NOT NULL,
     "competitorTwoId" TEXT NOT NULL,
     "bestOf" INTEGER NOT NULL,
-    "matchWindowHours" INTEGER NOT NULL DEFAULT 168,
     "rulesetJson" TEXT NOT NULL,
     "seriesState" TEXT NOT NULL DEFAULT 'awaiting_acceptance',
     "channelId" TEXT NOT NULL,
@@ -439,9 +438,6 @@ ALTER TABLE "DuelEventRoundOverride"
 
 ALTER TABLE "DuelSeries"
     ADD CONSTRAINT "DuelSeries_bestOf_check" CHECK ("bestOf" IN (1, 3, 5));
-
-ALTER TABLE "DuelSeries"
-    ADD CONSTRAINT "DuelSeries_matchWindowHours_check" CHECK ("matchWindowHours" BETWEEN 24 AND 336);
 
 -- CreateIndex
 CREATE INDEX "HallSettings_updatedAt_idx" ON "HallSettings"("updatedAt");

--- a/packages/scout-for-lol/packages/backend/prisma/migrations/20260905000000_duel_series_match_window/migration.sql
+++ b/packages/scout-for-lol/packages/backend/prisma/migrations/20260905000000_duel_series_match_window/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "DuelSeries"
+    ADD COLUMN "matchWindowHours" INTEGER NOT NULL DEFAULT 168;
+
+ALTER TABLE "DuelSeries"
+    ADD CONSTRAINT "DuelSeries_matchWindowHours_check" CHECK ("matchWindowHours" BETWEEN 24 AND 336);

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -2524,6 +2524,7 @@ model DuelSeries {
   competitorOneId    String
   competitorTwoId    String
   bestOf             Int
+  matchWindowHours   Int       @default(168)
   rulesetJson        String
   seriesState        String    @default("awaiting_acceptance")
   channelId          String

--- a/packages/scout-for-lol/packages/backend/src/league/api/riot-call.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/api/riot-call.test.ts
@@ -3,6 +3,7 @@ import { ZodError, z } from "zod";
 import {
   callRiotOrThrow,
   callRiotOrUndefined,
+  callRiotOrUndefinedOn404,
 } from "#src/league/api/riot-call.ts";
 import { RiotHttpError } from "#src/league/api/client/errors.ts";
 
@@ -140,6 +141,50 @@ describe("callRiotOrThrow", () => {
       fails(new Error("ENOTFOUND")),
     );
     await expect(promise).rejects.toThrow(/ENOTFOUND/);
+  });
+});
+
+describe("callRiotOrUndefinedOn404", () => {
+  test("returns parsed data on success", async () => {
+    const result = await callRiotOrUndefinedOn404(
+      { source: "test-404-only-success", schema: Schema, context: {} },
+      ok({ id: 1, name: "ok" }),
+    );
+    expect(result).toEqual({ id: 1, name: "ok" });
+  });
+
+  test("returns undefined on HTTP 404", async () => {
+    const result = await callRiotOrUndefinedOn404(
+      { source: "test-404-only-missing", schema: Schema, context: {} },
+      fails(httpError(404)),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("throws ZodError on validation failure", async () => {
+    const promise = callRiotOrUndefinedOn404(
+      { source: "test-404-only-validation", schema: Schema, context: {} },
+      ok({ id: "not-a-number", name: "ok" }),
+    );
+    await expect(promise).rejects.toBeInstanceOf(ZodError);
+  });
+
+  test("throws the underlying HTTP error when the status is not 404", async () => {
+    const error = httpError(500);
+    const promise = callRiotOrUndefinedOn404(
+      { source: "test-404-only-500", schema: Schema, context: {} },
+      fails(error),
+    );
+    await expect(promise).rejects.toBe(error);
+  });
+
+  test("throws the underlying transport error", async () => {
+    const error = new Error("ENOTFOUND");
+    const promise = callRiotOrUndefinedOn404(
+      { source: "test-404-only-transport", schema: Schema, context: {} },
+      fails(error),
+    );
+    await expect(promise).rejects.toBe(error);
   });
 });
 

--- a/packages/scout-for-lol/packages/backend/src/league/api/riot-call.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/api/riot-call.ts
@@ -78,7 +78,7 @@ function contextAsTags(
 
 /**
  * Internal core: request → metric → parse → audit → policy dispatch.
- * Returns a discriminated result so the two public variants can either
+ * Returns a discriminated result so the public variants can selectively
  * fold failures into `undefined` or rethrow. All shared plumbing
  * (metrics, health updates, breadcrumbs, Sentry capture, S3 save,
  * unknown-key audit log) runs in here exactly once per call.
@@ -179,6 +179,22 @@ async function runRiotCall<T>(
   return { kind: "success", data: parsed.data };
 }
 
+function throwRiotFailure<T>(
+  config: CallRiotConfig<T>,
+  result: Exclude<CallResult<T>, { kind: "success" }>,
+): never {
+  switch (result.kind) {
+    case "validation-failure":
+      throw result.error;
+    case "http-404":
+    case "http-error":
+    case "transport-error":
+      throw result.error instanceof Error
+        ? result.error
+        : new Error(`Riot API call ${config.source} failed (${result.kind})`);
+  }
+}
+
 /**
  * Returns `T` on success; `undefined` on any failure (validation, 404,
  * upstream outage, HTTP error, timeout, transport error). All
@@ -193,6 +209,21 @@ export async function callRiotOrUndefined<T>(
 }
 
 /**
+ * Returns `T` on success and `undefined` only when Riot returns 404. All
+ * validation, upstream, HTTP, timeout, and transport failures throw after
+ * the shared metric/log/Sentry/S3 plumbing runs.
+ */
+export async function callRiotOrUndefinedOn404<T>(
+  config: CallRiotConfig<T>,
+  fn: () => Promise<unknown>,
+): Promise<T | undefined> {
+  const result = await runRiotCall(config, fn);
+  if (result.kind === "success") return result.data;
+  if (result.kind === "http-404") return undefined;
+  throwRiotFailure(config, result);
+}
+
+/**
  * Returns `T` on success; throws on any failure (after full plumbing
  * runs). Validation failures throw the `ZodError`; HTTP/transport
  * failures throw the underlying error.
@@ -202,16 +233,6 @@ export async function callRiotOrThrow<T>(
   fn: () => Promise<unknown>,
 ): Promise<T> {
   const result = await runRiotCall(config, fn);
-  switch (result.kind) {
-    case "success":
-      return result.data;
-    case "validation-failure":
-      throw result.error;
-    case "http-404":
-    case "http-error":
-    case "transport-error":
-      throw result.error instanceof Error
-        ? result.error
-        : new Error(`Riot API call ${config.source} failed (${result.kind})`);
-  }
+  if (result.kind === "success") return result.data;
+  throwRiotFailure(config, result);
 }

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-data-fetcher.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-data-fetcher.ts
@@ -13,6 +13,7 @@ import {
 import {
   callRiotOrThrow,
   callRiotOrUndefined,
+  callRiotOrUndefinedOn404,
   type CallRiotConfig,
 } from "#src/league/api/riot-call.ts";
 import { createLogger } from "#src/logger.ts";
@@ -105,7 +106,10 @@ export async function fetchMatchData(
 export async function fetchMatchTimeline(
   matchId: MatchId,
   playerRegion: Region,
-  failureMode: "return_undefined" | "throw" = "return_undefined",
+  failureMode:
+    | "return_undefined"
+    | "return_undefined_on_404"
+    | "throw" = "return_undefined",
 ): Promise<RawTimeline | undefined> {
   const regionalRoute = platformToRegionalRoute(playerRegion);
   const config: CallRiotConfig<RawTimeline> = {
@@ -121,7 +125,12 @@ export async function fetchMatchTimeline(
     sentry: true,
   };
   const fetch = () => riotClient.match.timeline(matchId, regionalRoute);
-  return failureMode === "throw"
-    ? await callRiotOrThrow(config, fetch)
-    : await callRiotOrUndefined(config, fetch);
+  switch (failureMode) {
+    case "throw":
+      return await callRiotOrThrow(config, fetch);
+    case "return_undefined_on_404":
+      return await callRiotOrUndefinedOn404(config, fetch);
+    case "return_undefined":
+      return await callRiotOrUndefined(config, fetch);
+  }
 }

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-standard.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-standard.test.ts
@@ -5,6 +5,7 @@ import {
   RawMatchSchema,
 } from "@scout-for-lol/data";
 import {
+  fetchTimelineForDuelProgression,
   fetchTimelineForProgression,
   fetchTimelineIfStandardMatch,
 } from "./match-report-standard.ts";
@@ -50,6 +51,9 @@ describe("required progression timelines", () => {
     ).rejects.toThrow("match processing must retry");
     await expect(
       fetchTimelineIfStandardMatch(fixture.match, matchId, fixture.players),
+    ).resolves.toBeUndefined();
+    await expect(
+      fetchTimelineForDuelProgression(fixture.match, matchId, fixture.players),
     ).resolves.toBeUndefined();
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-standard.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-standard.ts
@@ -12,12 +12,14 @@ import { recordTimelineForReportStore } from "#src/report-store/live-ingest.ts";
 
 const logger = createLogger("postmatch-match-report-standard");
 
+type TimelinePersistence = "best_effort" | "required" | "required_if_available";
+
 function requireTimelineStaging(
-  persistence: "best_effort" | "required",
+  persistence: TimelinePersistence,
   staged: boolean,
   matchId: MatchId,
 ): void {
-  if (staged || persistence !== "required") return;
+  if (staged || persistence === "best_effort") return;
   throw new Error(
     `Timeline lake staging failed for ${matchId}; match processing must retry.`,
   );
@@ -70,6 +72,21 @@ export async function fetchTimelineForProgression(
   });
 }
 
+/** Duel evidence is durable when Riot supplies it; missing evidence enters organizer review. */
+export async function fetchTimelineForDuelProgression(
+  matchData: RawMatch,
+  matchId: MatchId,
+  playersInMatch: PlayerConfigEntry[],
+): Promise<RawTimeline | undefined> {
+  return await fetchAndRecordTimeline({
+    matchData,
+    matchId,
+    playersInMatch,
+    persistence: "required_if_available",
+    source: "timeline_progression",
+  });
+}
+
 /** Reassert durable persistence when an earlier best-effort report fetch supplied the timeline. */
 export async function persistTimelineForProgression(
   timeline: RawTimeline,
@@ -84,11 +101,55 @@ export async function persistTimelineForProgression(
   requireTimelineStaging("required", staged, matchId);
 }
 
+function requireAvailableTimeline(options: {
+  readonly persistence: TimelinePersistence;
+  readonly matchId: MatchId;
+}): void {
+  if (options.persistence === "required") {
+    requireTimelineStaging(options.persistence, false, options.matchId);
+  }
+}
+
+async function stageFetchedTimeline(
+  options: {
+    readonly persistence: TimelinePersistence;
+    readonly source?: "timeline_progression";
+    readonly playersInMatch: PlayerConfigEntry[];
+    readonly matchId: MatchId;
+  },
+  timeline: RawTimeline,
+): Promise<void> {
+  logger.info(
+    `[generateMatchReport] ✅ Timeline fetched with ${timeline.info.frames.length.toString()} frames`,
+  );
+  try {
+    const trackedPlayerAliases = options.playersInMatch.map(
+      (player) => player.alias,
+    );
+    const staged = await recordTimelineForReportStore({
+      timeline,
+      source:
+        options.source ??
+        (options.persistence === "required"
+          ? "timeline_dare_v2"
+          : "timeline_live"),
+      trackedPlayerAliases,
+    });
+    requireTimelineStaging(options.persistence, staged, options.matchId);
+  } catch (error) {
+    if (options.persistence !== "best_effort") throw error;
+    logger.error(
+      `[generateMatchReport] Error saving timeline ${options.matchId} to S3:`,
+      error,
+    );
+  }
+}
+
 async function fetchAndRecordTimeline(options: {
   matchData: RawMatch;
   matchId: MatchId;
   playersInMatch: PlayerConfigEntry[];
-  persistence: "best_effort" | "required";
+  persistence: TimelinePersistence;
   source?: "timeline_progression";
 }): Promise<RawTimeline | undefined> {
   // Don't fetch timeline for arena matches
@@ -98,14 +159,14 @@ async function fetchAndRecordTimeline(options: {
       options.matchData.info.gameMode,
     )
   ) {
-    requireTimelineStaging(options.persistence, false, options.matchId);
-    return undefined;
+    requireAvailableTimeline(options);
+    return;
   }
 
   const firstPlayer = options.playersInMatch[0];
   if (!firstPlayer) {
-    requireTimelineStaging(options.persistence, false, options.matchId);
-    return undefined;
+    requireAvailableTimeline(options);
+    return;
   }
 
   const playerRegion = firstPlayer.league.leagueAccount.region;
@@ -116,43 +177,17 @@ async function fetchAndRecordTimeline(options: {
     const timelineData = await fetchMatchTimeline(
       options.matchId,
       playerRegion,
-      options.persistence === "required" ? "throw" : "return_undefined",
+      options.persistence === "required"
+        ? "throw"
+        : options.persistence === "required_if_available"
+          ? "return_undefined_on_404"
+          : "return_undefined",
     );
-    if (timelineData) {
-      logger.info(
-        `[generateMatchReport] ✅ Timeline fetched with ${timelineData.info.frames.length.toString()} frames`,
-      );
-
-      // A funded Dare makes this write authoritative evidence and therefore
-      // retryable. Report-only capture remains best-effort because the match
-      // itself was already durably saved upstream.
-      try {
-        const trackedPlayerAliases = options.playersInMatch.map(
-          (player) => player.alias,
-        );
-        const staged = await recordTimelineForReportStore({
-          timeline: timelineData,
-          source:
-            options.source ??
-            (options.persistence === "required"
-              ? "timeline_dare_v2"
-              : "timeline_live"),
-          trackedPlayerAliases,
-        });
-        requireTimelineStaging(options.persistence, staged, options.matchId);
-      } catch (error) {
-        if (options.persistence === "required") throw error;
-        logger.error(
-          `[generateMatchReport] Error saving timeline ${options.matchId} to S3:`,
-          error,
-        );
-      }
+    if (timelineData === undefined) {
+      requireAvailableTimeline(options);
+      return;
     }
-    requireTimelineStaging(
-      options.persistence,
-      timelineData !== undefined,
-      options.matchId,
-    );
+    await stageFetchedTimeline(options, timelineData);
     return timelineData;
   } catch (error) {
     logger.error(
@@ -162,7 +197,7 @@ async function fetchAndRecordTimeline(options: {
     Sentry.captureException(error, {
       tags: { source: "timeline-fetch-wrapper", matchId: options.matchId },
     });
-    if (options.persistence === "required") throw error;
+    if (options.persistence !== "best_effort") throw error;
     return undefined;
   }
 }

--- a/packages/scout-for-lol/packages/backend/src/league/tournament/lobby-store.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tournament/lobby-store.ts
@@ -161,7 +161,9 @@ export async function findLobbyByCode(
   client: ExtendedPrismaClient,
   code: string,
 ): Promise<TournamentLobbyRecord | undefined> {
-  const row = await client.tournamentLobby.findUnique({ where: { code } });
+  const row = await client.tournamentLobby.findFirst({
+    where: { code, duelGame: { is: null } },
+  });
   return row === null ? undefined : parseLobbyRow(row);
 }
 
@@ -178,7 +180,7 @@ export async function listLobbiesForGuild(
   serverId: DiscordGuildId,
 ): Promise<TournamentLobbyRecord[]> {
   const rows = await client.tournamentLobby.findMany({
-    where: { serverId },
+    where: { serverId, duelGame: { is: null } },
     orderBy: { createdAt: "desc" },
     take: 25,
   });

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/access.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/access.ts
@@ -1,0 +1,38 @@
+import { TRPCError } from "@trpc/server";
+import type { DiscordGuildId } from "@scout-for-lol/data";
+import type { ScoutStage } from "@scout-for-lol/temporal";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+
+const REQUIRED_RIOT_APPROVALS = [
+  "classic_objectives",
+  "sub_twenty_events",
+] as const;
+
+export async function duelRolloutAllowed(
+  db: ExtendedPrismaClient,
+  guildId: DiscordGuildId,
+  stage: ScoutStage,
+): Promise<boolean> {
+  if (!(await isPolicyEnabled("duels_enabled", { server: guildId }))) {
+    return false;
+  }
+  if (stage === "dev") return true;
+  const approvals = await db.duelRiotApproval.count({
+    where: { feature: { in: [...REQUIRED_RIOT_APPROVALS] } },
+  });
+  return approvals === REQUIRED_RIOT_APPROVALS.length;
+}
+
+export async function assertDuelsEnabled(
+  db: ExtendedPrismaClient,
+  guildId: DiscordGuildId,
+  stage: ScoutStage,
+): Promise<void> {
+  if (!(await duelRolloutAllowed(db, guildId, stage))) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Duels are unavailable pending Riot approval",
+    });
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/advancement.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/advancement.ts
@@ -16,6 +16,7 @@ import {
 } from "#src/database/index.ts";
 import { duelSeriesParticipantsCreateData } from "#src/progression/duels/competitors.ts";
 import { launchDuelSeries } from "#src/progression/duels/launch.ts";
+import { latestRoundRobinResults } from "#src/progression/duels/round-robin.ts";
 
 type EventWithSeries = NonNullable<
   Awaited<ReturnType<typeof loadEventForAdvancement>>
@@ -359,32 +360,7 @@ async function advanceRoundRobin(
   ) {
     return [];
   }
-  // A tiebreak rematch is the decisive meeting for that pair. Keep only the
-  // latest series for each unordered matchup so rankRoundRobin cannot select
-  // an earlier result with its first-match lookup.
-  const latestByMatchup = new Map<string, (typeof event.series)[number]>();
-  for (const series of event.series.toSorted(
-    (left, right) =>
-      (left.roundNumber ?? 0) - (right.roundNumber ?? 0) ||
-      left.createdAt.getTime() - right.createdAt.getTime() ||
-      left.id.localeCompare(right.id),
-  )) {
-    const matchup = [series.competitorOneId, series.competitorTwoId]
-      .toSorted()
-      .join(":");
-    latestByMatchup.set(matchup, series);
-  }
-  const results = [...latestByMatchup.values()].map((series) => ({
-    firstCompetitorId: series.competitorOneId,
-    secondCompetitorId: series.competitorTwoId,
-    winnerCompetitorId: series.winnerCompetitorId ?? "",
-    firstGameWins: series.games.filter(
-      (game) => game.winnerCompetitorId === series.competitorOneId,
-    ).length,
-    secondGameWins: series.games.filter(
-      (game) => game.winnerCompetitorId === series.competitorTwoId,
-    ).length,
-  }));
+  const results = latestRoundRobinResults(event.series);
   const ranks = rankRoundRobin(
     event.entrants.map((entrant) => entrant.competitorId),
     results,

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/advancement.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/advancement.ts
@@ -85,6 +85,7 @@ async function createSeries(
         competitorOneId: options.firstId,
         competitorTwoId: options.secondId,
         bestOf: seriesBestOf(event, options.roundNumber),
+        matchWindowHours: event.matchWindowHours,
         rulesetJson: event.rulesetJson,
         seriesState: "awaiting_readiness",
         channelId: DiscordChannelIdSchema.parse(event.channelId),

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/advancement.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/advancement.ts
@@ -1,0 +1,415 @@
+import { z } from "zod";
+import {
+  DiscordChannelIdSchema,
+  DuelBestOfSchema,
+  DuelEventFormatSchema,
+  createEliminationFirstRound,
+  rankRoundRobin,
+} from "@scout-for-lol/data";
+import {
+  scoutDuelSeriesWorkflowId,
+  type ScoutStage,
+} from "@scout-for-lol/temporal";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { duelSeriesParticipantsCreateData } from "#src/progression/duels/competitors.ts";
+import { launchDuelSeries } from "#src/progression/duels/launch.ts";
+
+const UniqueViolationSchema = z.object({ code: z.literal("P2002") });
+
+type EventWithSeries = NonNullable<
+  Awaited<ReturnType<typeof loadEventForAdvancement>>
+>;
+
+async function loadEventForAdvancement(
+  db: ExtendedPrismaClient,
+  eventId: string,
+) {
+  return await db.duelEvent.findUnique({
+    where: { id: eventId },
+    include: {
+      entrants: {
+        where: { registrationState: "accepted" },
+        orderBy: [{ seed: "asc" }, { createdAt: "asc" }],
+        include: {
+          competitor: { include: { members: true } },
+        },
+      },
+      roundOverrides: true,
+      series: { include: { games: true } },
+    },
+  });
+}
+
+function seriesBestOf(event: EventWithSeries, roundNumber: number) {
+  return DuelBestOfSchema.parse(
+    event.roundOverrides.find(
+      (override) => override.roundNumber === roundNumber,
+    )?.bestOf ?? event.bestOf,
+  );
+}
+
+async function createSeries(
+  db: ExtendedPrismaClient,
+  event: EventWithSeries,
+  options: {
+    readonly firstId: string;
+    readonly secondId: string;
+    readonly bracket: string;
+    readonly roundNumber: number;
+    readonly position: number;
+    readonly stage: ScoutStage;
+  },
+) {
+  const first = event.entrants.find(
+    (entrant) => entrant.competitorId === options.firstId,
+  );
+  const second = event.entrants.find(
+    (entrant) => entrant.competitorId === options.secondId,
+  );
+  if (first === undefined || second === undefined) {
+    throw new Error("An advancing competitor is not registered in the event");
+  }
+  const deadlineAt = new Date(
+    Date.now() + event.matchWindowHours * 60 * 60 * 1000,
+  );
+  const seriesId = crypto.randomUUID();
+  try {
+    const series = await db.duelSeries.create({
+      data: {
+        id: seriesId,
+        guildId: event.guildId,
+        eventId: event.id,
+        roundNumber: options.roundNumber,
+        bracket: options.bracket,
+        position: options.position,
+        competitorOneId: options.firstId,
+        competitorTwoId: options.secondId,
+        bestOf: seriesBestOf(event, options.roundNumber),
+        rulesetJson: event.rulesetJson,
+        seriesState: "awaiting_readiness",
+        channelId: DiscordChannelIdSchema.parse(event.channelId),
+        organizerDiscordId: event.organizerDiscordId,
+        windowStartsAt: new Date(),
+        deadlineAt,
+        workflowId: scoutDuelSeriesWorkflowId(options.stage, seriesId),
+        participants: {
+          create: duelSeriesParticipantsCreateData([first, second]),
+        },
+      },
+    });
+    return { seriesId: series.id, deadlineAt };
+  } catch (error) {
+    if (!UniqueViolationSchema.safeParse(error).success) throw error;
+    const existing = await db.duelSeries.findUniqueOrThrow({
+      where: {
+        eventId_bracket_roundNumber_position: {
+          eventId: event.id,
+          bracket: options.bracket,
+          roundNumber: options.roundNumber,
+          position: options.position,
+        },
+      },
+    });
+    if (
+      existing.competitorOneId !== options.firstId ||
+      existing.competitorTwoId !== options.secondId
+    ) {
+      throw new Error(
+        "An event bracket slot was reused with different competitors",
+        { cause: error },
+      );
+    }
+    return {
+      seriesId: existing.id,
+      deadlineAt: existing.deadlineAt ?? deadlineAt,
+    };
+  }
+}
+
+function completedRound(event: EventWithSeries, roundNumber: number): boolean {
+  const series = event.series.filter(
+    (candidate) => candidate.roundNumber === roundNumber,
+  );
+  return (
+    series.length > 0 &&
+    series.every(
+      (candidate) =>
+        candidate.seriesState === "completed" &&
+        candidate.winnerCompetitorId !== null,
+    )
+  );
+}
+
+function lossCounts(event: EventWithSeries): Map<string, number> {
+  const losses = new Map(
+    event.entrants.map((entrant) => [entrant.competitorId, 0]),
+  );
+  for (const series of event.series) {
+    if (
+      series.seriesState !== "completed" ||
+      series.winnerCompetitorId === null
+    ) {
+      continue;
+    }
+    const loser =
+      series.winnerCompetitorId === series.competitorOneId
+        ? series.competitorTwoId
+        : series.competitorOneId;
+    losses.set(loser, (losses.get(loser) ?? 0) + 1);
+  }
+  return losses;
+}
+
+function pairAdjacent(ids: readonly string[]): [string, string][] {
+  const pairs: [string, string][] = [];
+  for (let index = 0; index + 1 < ids.length; index += 2) {
+    const first = ids[index];
+    const second = ids[index + 1];
+    if (first !== undefined && second !== undefined)
+      pairs.push([first, second]);
+  }
+  return pairs;
+}
+
+function everyPair(ids: readonly string[]): [string, string][] {
+  const pairs: [string, string][] = [];
+  for (let firstIndex = 0; firstIndex < ids.length; firstIndex += 1) {
+    for (
+      let secondIndex = firstIndex + 1;
+      secondIndex < ids.length;
+      secondIndex += 1
+    ) {
+      const first = ids[firstIndex];
+      const second = ids[secondIndex];
+      if (first !== undefined && second !== undefined) {
+        pairs.push([first, second]);
+      }
+    }
+  }
+  return pairs;
+}
+
+async function advanceDoubleElimination(
+  db: ExtendedPrismaClient,
+  event: EventWithSeries,
+  stage: ScoutStage,
+) {
+  const latestRound = Math.max(
+    1,
+    ...event.series.map((series) => series.roundNumber ?? 1),
+  );
+  if (!completedRound(event, latestRound)) return [];
+  const losses = lossCounts(event);
+  const active = event.entrants
+    .map((entrant) => entrant.competitorId)
+    .filter((competitorId) => (losses.get(competitorId) ?? 0) < 2);
+  if (active.length === 1) {
+    await db.duelEvent.update({
+      where: { id: event.id },
+      data: { eventState: "completed", completedAt: new Date() },
+    });
+    return [];
+  }
+  const nextRound = latestRound + 1;
+  const zeroLoss = active.filter((id) => (losses.get(id) ?? 0) === 0);
+  const oneLoss = active.filter((id) => (losses.get(id) ?? 0) === 1);
+  let pairs: [string, string][];
+  let bracket: string;
+  if (active.length === 2 && zeroLoss.length === 1 && oneLoss.length === 1) {
+    const winnersFinalist = zeroLoss[0];
+    const losersFinalist = oneLoss[0];
+    if (winnersFinalist === undefined || losersFinalist === undefined) {
+      throw new Error("A double-elimination final requires two finalists");
+    }
+    pairs = [[winnersFinalist, losersFinalist]];
+    bracket = "grand_final";
+  } else if (
+    active.length === 2 &&
+    zeroLoss.length === 0 &&
+    oneLoss.length === 2
+  ) {
+    const firstFinalist = oneLoss[0];
+    const secondFinalist = oneLoss[1];
+    if (firstFinalist === undefined || secondFinalist === undefined) {
+      throw new Error("A grand-final reset requires two finalists");
+    }
+    pairs = [[firstFinalist, secondFinalist]];
+    bracket = "grand_final_reset";
+  } else {
+    pairs = [...pairAdjacent(zeroLoss), ...pairAdjacent(oneLoss)];
+    bracket = "double_elimination";
+  }
+  return await Promise.all(
+    pairs.map(([firstId, secondId], position) =>
+      createSeries(db, event, {
+        firstId,
+        secondId,
+        bracket,
+        roundNumber: nextRound,
+        position,
+        stage,
+      }),
+    ),
+  );
+}
+
+function singleEliminationRoundWinners(
+  event: EventWithSeries,
+  roundNumber: number,
+): (string | null)[] {
+  if (roundNumber === 1) {
+    const initial = createEliminationFirstRound(
+      event.entrants.map((entrant) => entrant.competitorId),
+    );
+    return initial.map((pairing) => {
+      if (pairing.byeWinnerEntrantId !== null) {
+        return pairing.byeWinnerEntrantId;
+      }
+      return (
+        event.series.find(
+          (series) =>
+            series.bracket === "winners" &&
+            series.roundNumber === 1 &&
+            series.position === pairing.position &&
+            series.seriesState === "completed",
+        )?.winnerCompetitorId ?? null
+      );
+    });
+  }
+  return event.series
+    .filter(
+      (series) =>
+        series.bracket === "winners" && series.roundNumber === roundNumber,
+    )
+    .toSorted((left, right) => (left.position ?? 0) - (right.position ?? 0))
+    .map((series) =>
+      series.seriesState === "completed" ? series.winnerCompetitorId : null,
+    );
+}
+
+async function advanceSingleElimination(
+  db: ExtendedPrismaClient,
+  event: EventWithSeries,
+  stage: ScoutStage,
+) {
+  const currentRound = Math.max(
+    1,
+    ...event.series
+      .filter((series) => series.bracket === "winners")
+      .map((series) => series.roundNumber ?? 1),
+  );
+  const winners = singleEliminationRoundWinners(event, currentRound);
+  if (winners.length === 0 || winners.includes(null)) {
+    return [];
+  }
+  const resolvedWinners = winners.flatMap((winner) =>
+    winner === null ? [] : [winner],
+  );
+  if (resolvedWinners.length === 1) {
+    await db.duelEvent.update({
+      where: { id: event.id },
+      data: { eventState: "completed", completedAt: new Date() },
+    });
+    return [];
+  }
+  const nextRound = currentRound + 1;
+  const alreadyCreated = event.series.some(
+    (series) =>
+      series.bracket === "winners" && series.roundNumber === nextRound,
+  );
+  if (alreadyCreated) return [];
+  return await Promise.all(
+    pairAdjacent(resolvedWinners).map(([firstId, secondId], position) =>
+      createSeries(db, event, {
+        firstId,
+        secondId,
+        bracket: "winners",
+        roundNumber: nextRound,
+        position,
+        stage,
+      }),
+    ),
+  );
+}
+
+async function advanceRoundRobin(
+  db: ExtendedPrismaClient,
+  event: EventWithSeries,
+  stage: ScoutStage,
+) {
+  if (
+    event.series.some(
+      (series) =>
+        series.seriesState !== "completed" ||
+        series.winnerCompetitorId === null,
+    )
+  ) {
+    return [];
+  }
+  const results = event.series.map((series) => ({
+    firstCompetitorId: series.competitorOneId,
+    secondCompetitorId: series.competitorTwoId,
+    winnerCompetitorId: series.winnerCompetitorId ?? "",
+    firstGameWins: series.games.filter(
+      (game) => game.winnerCompetitorId === series.competitorOneId,
+    ).length,
+    secondGameWins: series.games.filter(
+      (game) => game.winnerCompetitorId === series.competitorTwoId,
+    ).length,
+  }));
+  const ranks = rankRoundRobin(
+    event.entrants.map((entrant) => entrant.competitorId),
+    results,
+  );
+  const tied = ranks.filter((rank) => rank.needsTiebreak);
+  if (tied.length === 0) {
+    await db.duelEvent.update({
+      where: { id: event.id },
+      data: { eventState: "completed", completedAt: new Date() },
+    });
+    return [];
+  }
+  const nextRound =
+    Math.max(1, ...event.series.map((series) => series.roundNumber ?? 1)) + 1;
+  const tiedGroups = Map.groupBy(
+    tied,
+    (rank) =>
+      `${rank.seriesWins.toString()}:${rank.gameDifferential.toString()}`,
+  );
+  const pairs = [...tiedGroups.values()].flatMap((group) =>
+    everyPair(group.map((rank) => rank.competitorId)),
+  );
+  return await Promise.all(
+    pairs.map(([firstId, secondId], position) =>
+      createSeries(db, event, {
+        firstId,
+        secondId,
+        bracket: "tiebreak",
+        roundNumber: nextRound,
+        position,
+        stage,
+      }),
+    ),
+  );
+}
+
+export async function advanceDuelEvent(
+  eventId: string,
+  stage: ScoutStage,
+  db: ExtendedPrismaClient = prisma,
+): Promise<void> {
+  const event = await loadEventForAdvancement(db, eventId);
+  if (event?.eventState !== "in_progress") return;
+  const format = DuelEventFormatSchema.parse(event.format);
+  const requests =
+    format === "single_elimination"
+      ? await advanceSingleElimination(db, event, stage)
+      : format === "double_elimination"
+        ? await advanceDoubleElimination(db, event, stage)
+        : format === "round_robin"
+          ? await advanceRoundRobin(db, event, stage)
+          : [];
+  await Promise.all(
+    requests.map((request) => launchDuelSeries({ stage, ...request })),
+  );
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/advancement.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/advancement.ts
@@ -359,7 +359,22 @@ async function advanceRoundRobin(
   ) {
     return [];
   }
-  const results = event.series.map((series) => ({
+  // A tiebreak rematch is the decisive meeting for that pair. Keep only the
+  // latest series for each unordered matchup so rankRoundRobin cannot select
+  // an earlier result with its first-match lookup.
+  const latestByMatchup = new Map<string, (typeof event.series)[number]>();
+  for (const series of event.series.toSorted(
+    (left, right) =>
+      (left.roundNumber ?? 0) - (right.roundNumber ?? 0) ||
+      left.createdAt.getTime() - right.createdAt.getTime() ||
+      left.id.localeCompare(right.id),
+  )) {
+    const matchup = [series.competitorOneId, series.competitorTwoId]
+      .toSorted()
+      .join(":");
+    latestByMatchup.set(matchup, series);
+  }
+  const results = [...latestByMatchup.values()].map((series) => ({
     firstCompetitorId: series.competitorOneId,
     secondCompetitorId: series.competitorTwoId,
     winnerCompetitorId: series.winnerCompetitorId ?? "",

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/advancement.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/advancement.ts
@@ -1,4 +1,3 @@
-import { z } from "zod";
 import {
   DiscordChannelIdSchema,
   DuelBestOfSchema,
@@ -10,11 +9,13 @@ import {
   scoutDuelSeriesWorkflowId,
   type ScoutStage,
 } from "@scout-for-lol/temporal";
-import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import {
+  prisma,
+  type Db,
+  type ExtendedPrismaClient,
+} from "#src/database/index.ts";
 import { duelSeriesParticipantsCreateData } from "#src/progression/duels/competitors.ts";
 import { launchDuelSeries } from "#src/progression/duels/launch.ts";
-
-const UniqueViolationSchema = z.object({ code: z.literal("P2002") });
 
 type EventWithSeries = NonNullable<
   Awaited<ReturnType<typeof loadEventForAdvancement>>
@@ -49,7 +50,7 @@ function seriesBestOf(event: EventWithSeries, roundNumber: number) {
 }
 
 async function createSeries(
-  db: ExtendedPrismaClient,
+  db: Db,
   event: EventWithSeries,
   options: {
     readonly firstId: string;
@@ -72,52 +73,23 @@ async function createSeries(
   const deadlineAt = new Date(
     Date.now() + event.matchWindowHours * 60 * 60 * 1000,
   );
-  const seriesId = crypto.randomUUID();
-  try {
-    const series = await db.duelSeries.create({
-      data: {
-        id: seriesId,
-        guildId: event.guildId,
+  const existing = await db.duelSeries.findUnique({
+    where: {
+      eventId_bracket_roundNumber_position: {
         eventId: event.id,
-        roundNumber: options.roundNumber,
         bracket: options.bracket,
+        roundNumber: options.roundNumber,
         position: options.position,
-        competitorOneId: options.firstId,
-        competitorTwoId: options.secondId,
-        bestOf: seriesBestOf(event, options.roundNumber),
-        matchWindowHours: event.matchWindowHours,
-        rulesetJson: event.rulesetJson,
-        seriesState: "awaiting_readiness",
-        channelId: DiscordChannelIdSchema.parse(event.channelId),
-        organizerDiscordId: event.organizerDiscordId,
-        windowStartsAt: new Date(),
-        deadlineAt,
-        workflowId: scoutDuelSeriesWorkflowId(options.stage, seriesId),
-        participants: {
-          create: duelSeriesParticipantsCreateData([first, second]),
-        },
       },
-    });
-    return { seriesId: series.id, deadlineAt };
-  } catch (error) {
-    if (!UniqueViolationSchema.safeParse(error).success) throw error;
-    const existing = await db.duelSeries.findUniqueOrThrow({
-      where: {
-        eventId_bracket_roundNumber_position: {
-          eventId: event.id,
-          bracket: options.bracket,
-          roundNumber: options.roundNumber,
-          position: options.position,
-        },
-      },
-    });
+    },
+  });
+  if (existing !== null) {
     if (
       existing.competitorOneId !== options.firstId ||
       existing.competitorTwoId !== options.secondId
     ) {
       throw new Error(
         "An event bracket slot was reused with different competitors",
-        { cause: error },
       );
     }
     return {
@@ -125,6 +97,63 @@ async function createSeries(
       deadlineAt: existing.deadlineAt ?? deadlineAt,
     };
   }
+  const seriesId = crypto.randomUUID();
+  const series = await db.duelSeries.create({
+    data: {
+      id: seriesId,
+      guildId: event.guildId,
+      eventId: event.id,
+      roundNumber: options.roundNumber,
+      bracket: options.bracket,
+      position: options.position,
+      competitorOneId: options.firstId,
+      competitorTwoId: options.secondId,
+      bestOf: seriesBestOf(event, options.roundNumber),
+      matchWindowHours: event.matchWindowHours,
+      rulesetJson: event.rulesetJson,
+      seriesState: "awaiting_readiness",
+      channelId: DiscordChannelIdSchema.parse(event.channelId),
+      organizerDiscordId: event.organizerDiscordId,
+      windowStartsAt: new Date(),
+      deadlineAt,
+      workflowId: scoutDuelSeriesWorkflowId(options.stage, seriesId),
+      participants: {
+        create: duelSeriesParticipantsCreateData([first, second]),
+      },
+    },
+  });
+  return { seriesId: series.id, deadlineAt };
+}
+
+async function createSeriesRound(
+  db: ExtendedPrismaClient,
+  event: EventWithSeries,
+  options: {
+    readonly pairs: readonly [string, string][];
+    readonly bracket: string;
+    readonly roundNumber: number;
+    readonly stage: ScoutStage;
+  },
+) {
+  return await db.$transaction(async (tx) => {
+    // A whole round is one durable unit. This lock also makes the read-then-
+    // create idempotency check safe when reconciliation runs concurrently.
+    await tx.$executeRaw`SELECT 1 FROM "DuelEvent" WHERE "id" = ${event.id} FOR UPDATE`;
+    const requests: Awaited<ReturnType<typeof createSeries>>[] = [];
+    for (const [firstId, secondId] of options.pairs) {
+      requests.push(
+        await createSeries(tx, event, {
+          firstId,
+          secondId,
+          bracket: options.bracket,
+          roundNumber: options.roundNumber,
+          position: requests.length,
+          stage: options.stage,
+        }),
+      );
+    }
+    return requests;
+  });
 }
 
 function completedRound(event: EventWithSeries, roundNumber: number): boolean {
@@ -240,18 +269,12 @@ async function advanceDoubleElimination(
     pairs = [...pairAdjacent(zeroLoss), ...pairAdjacent(oneLoss)];
     bracket = "double_elimination";
   }
-  return await Promise.all(
-    pairs.map(([firstId, secondId], position) =>
-      createSeries(db, event, {
-        firstId,
-        secondId,
-        bracket,
-        roundNumber: nextRound,
-        position,
-        stage,
-      }),
-    ),
-  );
+  return await createSeriesRound(db, event, {
+    pairs,
+    bracket,
+    roundNumber: nextRound,
+    stage,
+  });
 }
 
 function singleEliminationRoundWinners(
@@ -314,23 +337,12 @@ async function advanceSingleElimination(
     return [];
   }
   const nextRound = currentRound + 1;
-  const alreadyCreated = event.series.some(
-    (series) =>
-      series.bracket === "winners" && series.roundNumber === nextRound,
-  );
-  if (alreadyCreated) return [];
-  return await Promise.all(
-    pairAdjacent(resolvedWinners).map(([firstId, secondId], position) =>
-      createSeries(db, event, {
-        firstId,
-        secondId,
-        bracket: "winners",
-        roundNumber: nextRound,
-        position,
-        stage,
-      }),
-    ),
-  );
+  return await createSeriesRound(db, event, {
+    pairs: pairAdjacent(resolvedWinners),
+    bracket: "winners",
+    roundNumber: nextRound,
+    stage,
+  });
 }
 
 async function advanceRoundRobin(
@@ -380,18 +392,12 @@ async function advanceRoundRobin(
   const pairs = [...tiedGroups.values()].flatMap((group) =>
     everyPair(group.map((rank) => rank.competitorId)),
   );
-  return await Promise.all(
-    pairs.map(([firstId, secondId], position) =>
-      createSeries(db, event, {
-        firstId,
-        secondId,
-        bracket: "tiebreak",
-        roundNumber: nextRound,
-        position,
-        stage,
-      }),
-    ),
-  );
+  return await createSeriesRound(db, event, {
+    pairs,
+    bracket: "tiebreak",
+    roundNumber: nextRound,
+    stage,
+  });
 }
 
 export async function advanceDuelEvent(

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/code.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/code.ts
@@ -1,0 +1,83 @@
+import type { DiscordAccountId, DiscordGuildId } from "@scout-for-lol/data";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import {
+  currentDisclosureKeys,
+  currentParticipantDiscordIds,
+  effectiveParticipantDiscordId,
+} from "#src/progression/duels/series.ts";
+
+export async function getDuelCode(
+  db: ExtendedPrismaClient,
+  seriesId: string,
+  viewerDiscordId: DiscordAccountId,
+  guildId: DiscordGuildId,
+) {
+  const series = await db.duelSeries.findFirstOrThrow({
+    where: { id: seriesId, guildId },
+    include: {
+      participants: true,
+      games: {
+        orderBy: { gameNumber: "desc" },
+        take: 1,
+        include: { tournamentLobby: true },
+      },
+    },
+  });
+  const currentDiscordIdByPlayer = await currentParticipantDiscordIds(
+    db,
+    guildId,
+    series.participants,
+  );
+  const disclosureKeys = await currentDisclosureKeys(
+    db,
+    guildId,
+    series.participants,
+  );
+  const allParticipantsCurrent = series.participants.every((participant) => {
+    const currentDiscordId = effectiveParticipantDiscordId(
+      currentDiscordIdByPlayer,
+      participant,
+    );
+    return (
+      currentDiscordId === participant.discordId &&
+      participant.acceptedAt !== null &&
+      participant.readyAt !== null &&
+      disclosureKeys.has(
+        `${participant.playerId.toString()}:${participant.discordId}`,
+      )
+    );
+  });
+  const viewerIsAssigned = series.participants.some((participant) => {
+    const currentDiscordId = effectiveParticipantDiscordId(
+      currentDiscordIdByPlayer,
+      participant,
+    );
+    return (
+      currentDiscordId === viewerDiscordId &&
+      participant.discordId === viewerDiscordId
+    );
+  });
+  if (!viewerIsAssigned) {
+    throw new Error(
+      "Tournament codes are visible only to assigned participants",
+    );
+  }
+  if (!allParticipantsCurrent) {
+    throw new Error(
+      "The tournament code is unavailable until every participant re-accepts",
+    );
+  }
+  const game = series.games[0];
+  if (game?.gameState !== "code_ready" || series.seriesState !== "code_ready") {
+    throw new Error("The tournament code is not ready yet");
+  }
+  if (game.tournamentLobby === null) {
+    throw new Error("The tournament code is not ready yet");
+  }
+  return {
+    gameId: game.id,
+    gameNumber: game.gameNumber,
+    code: game.tournamentLobby.code,
+    stub: game.tournamentLobby.apiMode === "stub",
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/competitors.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/competitors.ts
@@ -1,0 +1,181 @@
+import type { AccountIdSchema } from "@scout-for-lol/data";
+import {
+  DUEL_DISCLOSURE_VERSION,
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+  DuelCompetitorSchema,
+  PlayerIdSchema,
+  type DiscordAccountId,
+  type DiscordGuildId,
+  type DuelCompetitor,
+} from "@scout-for-lol/data";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+
+type DuelAccountReader = Pick<ExtendedPrismaClient, "account">;
+
+export type DuelCompetitorSelection = {
+  readonly accountIds: ReturnType<typeof AccountIdSchema.parse>[];
+  readonly teamName?: string;
+};
+
+export async function resolveDuelCompetitorSelection(
+  db: DuelAccountReader,
+  guildId: DiscordGuildId,
+  kind: "player" | "pair",
+  selection: DuelCompetitorSelection,
+) {
+  const expected = kind === "player" ? 1 : 2;
+  if (selection.accountIds.length !== expected) {
+    throw new Error(
+      `${kind} competitors require ${expected.toString()} account(s)`,
+    );
+  }
+  if (new Set(selection.accountIds).size !== selection.accountIds.length) {
+    throw new Error("A duel competitor cannot select an account twice");
+  }
+  const accounts = await db.account.findMany({
+    where: { id: { in: selection.accountIds }, serverId: guildId },
+    include: { player: true },
+    orderBy: { id: "asc" },
+  });
+  if (accounts.length !== expected) {
+    throw new Error(
+      "Every selected Riot account must be tracked in this guild",
+    );
+  }
+  if (new Set(accounts.map((account) => account.playerId)).size !== expected) {
+    throw new Error("A 2v2 pair requires two different guild players");
+  }
+  if (accounts.some((account) => account.player.discordId === null)) {
+    throw new Error("Every duel participant must link a Discord identity");
+  }
+  return {
+    kind,
+    teamName: selection.teamName ?? null,
+    accounts: accounts.map((account, position) => ({
+      playerId: account.playerId,
+      playerAlias: account.player.alias,
+      accountId: account.id,
+      accountAlias: account.alias,
+      puuid: account.puuid,
+      region: account.region,
+      discordId: DiscordAccountIdSchema.parse(account.player.discordId),
+      position,
+    })),
+  };
+}
+
+export function duelCompetitorCreateData(
+  guildId: DiscordGuildId,
+  resolved: Awaited<ReturnType<typeof resolveDuelCompetitorSelection>>,
+) {
+  return {
+    guildId,
+    kind: resolved.kind,
+    teamName: resolved.teamName,
+    members: {
+      create: resolved.accounts.map((account) => ({
+        playerId: account.playerId,
+        accountId: account.accountId,
+        puuid: account.puuid,
+        region: account.region,
+        discordId: account.discordId,
+        playerAlias: account.playerAlias,
+        accountAlias: account.accountAlias,
+        position: account.position,
+      })),
+    },
+  };
+}
+
+export function duelSeriesParticipantsCreateData(
+  entrants: readonly {
+    readonly competitorId: string;
+    readonly competitor: {
+      readonly members: readonly {
+        readonly playerId: number;
+        readonly discordId: string;
+      }[];
+    };
+  }[],
+) {
+  return entrants.flatMap((entrant) =>
+    entrant.competitor.members.map((member) => ({
+      playerId: PlayerIdSchema.parse(member.playerId),
+      competitorId: entrant.competitorId,
+      discordId: DiscordAccountIdSchema.parse(member.discordId),
+      disclosureVersion: DUEL_DISCLOSURE_VERSION,
+      acceptedAt: new Date(),
+    })),
+  );
+}
+
+export function parseDuelCompetitor(row: {
+  readonly id: string;
+  readonly guildId: string;
+  readonly kind: string;
+  readonly teamName: string | null;
+  readonly members: readonly {
+    readonly playerId: number;
+    readonly playerAlias: string;
+    readonly accountId: number;
+    readonly accountAlias: string;
+    readonly puuid: string;
+    readonly position: number;
+  }[];
+}): DuelCompetitor {
+  DiscordGuildIdSchema.parse(row.guildId);
+  return DuelCompetitorSchema.parse({
+    id: row.id,
+    kind: row.kind,
+    teamName: row.teamName,
+    accounts: row.members
+      .toSorted((left, right) => left.position - right.position)
+      .map((member) => ({
+        playerId: member.playerId,
+        playerAlias: member.playerAlias,
+        accountId: member.accountId,
+        accountAlias: member.accountAlias,
+        puuid: member.puuid,
+      })),
+  });
+}
+
+export async function linkedDuelAccounts(
+  db: ExtendedPrismaClient,
+  guildId: DiscordGuildId,
+  discordId: DiscordAccountId,
+) {
+  return await listDuelAccounts(db, guildId, discordId);
+}
+
+export async function eligibleDuelAccounts(
+  db: ExtendedPrismaClient,
+  guildId: DiscordGuildId,
+) {
+  return await listDuelAccounts(db, guildId);
+}
+
+async function listDuelAccounts(
+  db: ExtendedPrismaClient,
+  guildId: DiscordGuildId,
+  discordId?: DiscordAccountId,
+) {
+  const players = await db.player.findMany({
+    where: {
+      serverId: guildId,
+      discordId: discordId ?? { not: null },
+    },
+    orderBy: { alias: "asc" },
+    include: { accounts: { orderBy: { alias: "asc" } } },
+  });
+  return players.flatMap((player) =>
+    player.accounts.map((account) => ({
+      accountId: account.id,
+      accountAlias: account.alias,
+      playerId: player.id,
+      playerAlias: player.alias,
+      region: account.region,
+    })),
+  );
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/events.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/events.ts
@@ -1,0 +1,404 @@
+import {
+  DUEL_DISCLOSURE_VERSION,
+  DiscordChannelIdSchema,
+  DuelBestOfSchema,
+  DuelEventFormatSchema,
+  DuelRulesetV1Schema,
+  createEliminationFirstRound,
+  seedDuelEntrants,
+  type DiscordAccountId,
+  type DiscordChannelId,
+  type DiscordGuildId,
+  type DuelBestOf,
+  type DuelEventFormat,
+  type DuelRulesetV1,
+  type DuelSeedMethod,
+} from "@scout-for-lol/data";
+import {
+  scoutDuelSeriesWorkflowId,
+  type ScoutStage,
+} from "@scout-for-lol/temporal";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import { duelSeriesParticipantsCreateData } from "#src/progression/duels/competitors.ts";
+
+export type DuelEventCreate = {
+  readonly guildId: DiscordGuildId;
+  readonly name: string;
+  readonly format: Exclude<DuelEventFormat, "direct">;
+  readonly competitorKind: "player" | "pair";
+  readonly bestOf: DuelBestOf;
+  readonly ruleset: DuelRulesetV1;
+  readonly registrationMode: "open" | "invitations";
+  readonly seedMethod: DuelSeedMethod;
+  readonly matchWindowHours: number;
+  readonly channelId: DiscordChannelId;
+  readonly organizerDiscordId: DiscordAccountId;
+  readonly registrationClosesAt?: Date;
+  readonly roundOverrides: readonly {
+    readonly roundNumber: number;
+    readonly bestOf: DuelBestOf;
+  }[];
+};
+
+function assertEventLimits(
+  format: Exclude<DuelEventFormat, "direct">,
+  count: number,
+) {
+  const maximum = format === "round_robin" ? 16 : 64;
+  if (count < 2 || count > maximum) {
+    throw new Error(
+      `${format === "round_robin" ? "Round-robin" : "Elimination"} events require between 2 and ${maximum.toString()} entrants`,
+    );
+  }
+}
+
+function validateMatchWindow(hours: number): number {
+  if (!Number.isInteger(hours) || hours < 24 || hours > 336) {
+    throw new Error("A match window must be between 24 hours and 14 days");
+  }
+  return hours;
+}
+
+export async function createDuelEvent(
+  db: ExtendedPrismaClient,
+  options: DuelEventCreate,
+) {
+  const format = DuelEventFormatSchema.exclude(["direct"]).parse(
+    options.format,
+  );
+  const bestOf = DuelBestOfSchema.parse(options.bestOf);
+  const ruleset = DuelRulesetV1Schema.parse(options.ruleset);
+  const matchWindowHours = validateMatchWindow(options.matchWindowHours);
+  if (
+    options.registrationClosesAt !== undefined &&
+    options.registrationClosesAt <= new Date()
+  ) {
+    throw new Error("Registration must close in the future");
+  }
+  return await db.duelEvent.create({
+    data: {
+      guildId: options.guildId,
+      name: options.name,
+      format,
+      competitorKind: options.competitorKind,
+      bestOf,
+      rulesetJson: JSON.stringify(ruleset),
+      registrationMode: options.registrationMode,
+      seedMethod: options.seedMethod,
+      randomSeed: crypto.randomUUID(),
+      matchWindowHours,
+      channelId: options.channelId,
+      organizerDiscordId: options.organizerDiscordId,
+      eventState: "registration_open",
+      registrationClosesAt: options.registrationClosesAt ?? null,
+      roundOverrides: {
+        create: options.roundOverrides.map((override) => ({
+          roundNumber: override.roundNumber,
+          bestOf: DuelBestOfSchema.parse(override.bestOf),
+        })),
+      },
+    },
+  });
+}
+
+type StartedSeries = {
+  readonly seriesId: string;
+  readonly deadlineAt: Date;
+};
+
+function seriesCreateData(options: {
+  readonly event: {
+    readonly id: string;
+    readonly guildId: string;
+    readonly bestOf: number;
+    readonly rulesetJson: string;
+    readonly channelId: string;
+    readonly organizerDiscordId: string;
+    readonly matchWindowHours: number;
+  };
+  readonly first: {
+    readonly competitorId: string;
+    readonly competitor: {
+      readonly members: readonly {
+        readonly playerId: number;
+        readonly discordId: string;
+      }[];
+    };
+  };
+  readonly second: {
+    readonly competitorId: string;
+    readonly competitor: {
+      readonly members: readonly {
+        readonly playerId: number;
+        readonly discordId: string;
+      }[];
+    };
+  };
+  readonly roundNumber: number;
+  readonly position: number;
+  readonly bracket: string;
+  readonly bestOf: DuelBestOf;
+  readonly stage: ScoutStage;
+  readonly deadlineAt: Date;
+}) {
+  const seriesId = crypto.randomUUID();
+  return {
+    id: seriesId,
+    guildId: options.event.guildId,
+    eventId: options.event.id,
+    roundNumber: options.roundNumber,
+    bracket: options.bracket,
+    position: options.position,
+    competitorOneId: options.first.competitorId,
+    competitorTwoId: options.second.competitorId,
+    bestOf: options.bestOf,
+    rulesetJson: options.event.rulesetJson,
+    seriesState: "awaiting_readiness",
+    channelId: DiscordChannelIdSchema.parse(options.event.channelId),
+    organizerDiscordId: options.event.organizerDiscordId,
+    windowStartsAt: new Date(),
+    deadlineAt: options.deadlineAt,
+    workflowId: scoutDuelSeriesWorkflowId(options.stage, seriesId),
+    participants: {
+      create: duelSeriesParticipantsCreateData([options.first, options.second]),
+    },
+  };
+}
+
+function roundRobinPairs<T>(entrants: readonly T[]): [T, T][] {
+  const pairs: [T, T][] = [];
+  for (let first = 0; first < entrants.length; first++) {
+    for (let second = first + 1; second < entrants.length; second++) {
+      const left = entrants[first];
+      const right = entrants[second];
+      if (left !== undefined && right !== undefined) pairs.push([left, right]);
+    }
+  }
+  return pairs;
+}
+
+function parseDuelSeedMethod(seedMethod: string): DuelSeedMethod {
+  switch (seedMethod) {
+    case "manual":
+    case "random":
+    case "rolling_record":
+      return seedMethod;
+    default:
+      throw new Error(`Unknown duel seed method ${seedMethod}`);
+  }
+}
+
+function duelSeedSourceIds(options: {
+  readonly seedMethod: DuelSeedMethod;
+  readonly manualOrder: readonly string[] | undefined;
+  readonly entrantIds: readonly string[];
+}): string[] {
+  if (options.seedMethod !== "manual") return [...options.entrantIds];
+  const sourceIds = [...(options.manualOrder ?? [])];
+  const entrantIdSet = new Set(options.entrantIds);
+  if (
+    sourceIds.length !== options.entrantIds.length ||
+    sourceIds.some((id) => !entrantIdSet.has(id)) ||
+    new Set(sourceIds).size !== sourceIds.length
+  ) {
+    throw new Error(
+      "Manual seeding must list every accepted entrant exactly once",
+    );
+  }
+  return sourceIds;
+}
+
+type OpeningPairing = {
+  readonly first: string;
+  readonly second: string;
+  readonly position: number;
+  readonly bracket: "round_robin" | "winners";
+};
+
+function openingPairings(
+  format: Exclude<DuelEventFormat, "direct">,
+  seededIds: readonly string[],
+): OpeningPairing[] {
+  if (format === "round_robin") {
+    return roundRobinPairs(seededIds).map(([first, second], position) => ({
+      first,
+      second,
+      position,
+      bracket: "round_robin",
+    }));
+  }
+  return createEliminationFirstRound(seededIds).flatMap((pairing) =>
+    pairing.firstEntrantId === null || pairing.secondEntrantId === null
+      ? []
+      : [
+          {
+            first: pairing.firstEntrantId,
+            second: pairing.secondEntrantId,
+            position: pairing.position,
+            bracket: "winners" as const,
+          },
+        ],
+  );
+}
+
+export async function startDuelEvent(
+  db: ExtendedPrismaClient,
+  options: {
+    readonly guildId: DiscordGuildId;
+    readonly eventId: string;
+    readonly actorDiscordId: DiscordAccountId;
+    readonly stage: ScoutStage;
+    readonly manualOrder?: readonly string[];
+  },
+): Promise<StartedSeries[]> {
+  return await db.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('scout-duel-event-registration'), hashtext(${options.eventId}))`;
+    const event = await tx.duelEvent.findFirstOrThrow({
+      where: { id: options.eventId, guildId: options.guildId },
+      include: {
+        entrants: {
+          where: { registrationState: "accepted" },
+          include: {
+            competitor: { include: { members: true } },
+          },
+        },
+        roundOverrides: true,
+      },
+    });
+    if (event.organizerDiscordId !== options.actorDiscordId) {
+      throw new Error("Only the organizer may start this event");
+    }
+    if (event.eventState !== "registration_open") {
+      throw new Error("This event has already started");
+    }
+    const format = DuelEventFormatSchema.parse(event.format);
+    if (format === "direct") throw new Error("Direct duels are not events");
+    assertEventLimits(format, event.entrants.length);
+    const members = event.entrants.flatMap(
+      (entrant) => entrant.competitor.members,
+    );
+    const currentPlayers = await tx.player.findMany({
+      where: {
+        id: { in: members.map((member) => member.playerId) },
+        serverId: options.guildId,
+      },
+      select: { id: true, discordId: true },
+    });
+    const disclosures = await tx.duelDisclosureAcceptance.findMany({
+      where: {
+        guildId: event.guildId,
+        playerId: { in: currentPlayers.map((player) => player.id) },
+        disclosureVersion: DUEL_DISCLOSURE_VERSION,
+      },
+    });
+    if (
+      !currentPlayers.every(
+        (player) =>
+          player.discordId !== null &&
+          members.some(
+            (member) =>
+              member.playerId === player.id &&
+              member.discordId === player.discordId,
+          ) &&
+          disclosures.some(
+            (disclosure) =>
+              disclosure.playerId === player.id &&
+              disclosure.discordId === player.discordId,
+          ),
+      ) ||
+      currentPlayers.length !== members.length
+    ) {
+      throw new Error(
+        "Every entrant must retain disclosure consent under their current Discord identity",
+      );
+    }
+    const entrantsById = new Map(
+      event.entrants.map((entrant) => [entrant.competitorId, entrant]),
+    );
+    const entrantIds = event.entrants.map((entrant) => entrant.competitorId);
+    const subjectByEntrant = new Map(
+      event.entrants.map((entrant) => {
+        const playerIds = entrant.competitor.members
+          .map((member) => member.playerId)
+          .toSorted((left, right) => left - right);
+        return [
+          entrant.competitorId,
+          playerIds.length === 1
+            ? `player:${playerIds[0]?.toString() ?? ""}`
+            : `pair:${playerIds.map(String).join("+")}`,
+        ];
+      }),
+    );
+    const records = await tx.duelRecord.findMany({
+      where: {
+        guildId: event.guildId,
+        scope: event.competitorKind === "pair" ? "pair" : "individual",
+        subjectKey: { in: [...subjectByEntrant.values()] },
+        opponentKey: "",
+      },
+    });
+    const winsBySubject = new Map(
+      records.map((record) => [record.subjectKey, record.wins]),
+    );
+    const rollingWins = Object.fromEntries(
+      entrantIds.map((entrantId) => [
+        entrantId,
+        winsBySubject.get(subjectByEntrant.get(entrantId) ?? "") ?? 0,
+      ]),
+    );
+    const seedMethod = parseDuelSeedMethod(event.seedMethod);
+    const sourceIds = duelSeedSourceIds({
+      seedMethod,
+      manualOrder: options.manualOrder,
+      entrantIds,
+    });
+    const seededIds = seedDuelEntrants(
+      sourceIds,
+      seedMethod,
+      rollingWins,
+      event.randomSeed,
+    );
+    const deadlineAt = new Date(
+      Date.now() + event.matchWindowHours * 60 * 60 * 1000,
+    );
+    const firstRoundBestOf = DuelBestOfSchema.parse(
+      event.roundOverrides.find((override) => override.roundNumber === 1)
+        ?.bestOf ?? event.bestOf,
+    );
+    const pairings = openingPairings(format, seededIds);
+    for (const [index, competitorId] of seededIds.entries()) {
+      await tx.duelEventEntrant.update({
+        where: {
+          eventId_competitorId: { eventId: event.id, competitorId },
+        },
+        data: { seed: index + 1 },
+      });
+    }
+    const started: StartedSeries[] = [];
+    for (const pairing of pairings) {
+      const first = entrantsById.get(pairing.first);
+      const second = entrantsById.get(pairing.second);
+      if (first === undefined || second === undefined) {
+        throw new Error("A seeded duel entrant disappeared during event start");
+      }
+      const data = seriesCreateData({
+        event,
+        first,
+        second,
+        roundNumber: 1,
+        position: pairing.position,
+        bracket: pairing.bracket,
+        bestOf: firstRoundBestOf,
+        stage: options.stage,
+        deadlineAt,
+      });
+      const series = await tx.duelSeries.create({ data });
+      started.push({ seriesId: series.id, deadlineAt });
+    }
+    await tx.duelEvent.update({
+      where: { id: event.id },
+      data: { eventState: "in_progress", startedAt: new Date() },
+    });
+    return started;
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/events.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/events.ts
@@ -152,6 +152,7 @@ function seriesCreateData(options: {
     competitorOneId: options.first.competitorId,
     competitorTwoId: options.second.competitorId,
     bestOf: options.bestOf,
+    matchWindowHours: options.event.matchWindowHours,
     rulesetJson: options.event.rulesetJson,
     seriesState: "awaiting_readiness",
     channelId: DiscordChannelIdSchema.parse(options.event.channelId),

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/launch.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/launch.ts
@@ -1,0 +1,40 @@
+import type { ScoutStage } from "@scout-for-lol/temporal";
+import { currentScoutTemporalSupervisor } from "#src/temporal/runtime.ts";
+import {
+  signalScoutDuelSeriesChanged,
+  startScoutDuelSeries,
+} from "#src/temporal/starts.ts";
+
+export async function launchDuelSeries(options: {
+  readonly stage: ScoutStage;
+  readonly seriesId: string;
+  readonly deadlineAt: Date;
+}): Promise<void> {
+  const supervisor = currentScoutTemporalSupervisor();
+  if (supervisor === undefined) {
+    throw new Error("Temporal is unavailable for duel coordination");
+  }
+  await startScoutDuelSeries(supervisor.client(), {
+    stage: options.stage,
+    seriesId: options.seriesId,
+    deadlineAt: options.deadlineAt.toISOString(),
+  });
+}
+
+export async function signalDuelSeries(options: {
+  readonly stage: ScoutStage;
+  readonly seriesId: string;
+  readonly deadlineAt: Date;
+  readonly requestId: string;
+}): Promise<void> {
+  const supervisor = currentScoutTemporalSupervisor();
+  if (supervisor === undefined) {
+    throw new Error("Temporal is unavailable for duel coordination");
+  }
+  await signalScoutDuelSeriesChanged(supervisor.client(), {
+    stage: options.stage,
+    seriesId: options.seriesId,
+    deadlineAt: options.deadlineAt.toISOString(),
+    requestId: options.requestId,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/outbox.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/outbox.ts
@@ -1,0 +1,165 @@
+import { EmbedBuilder, escapeMarkdown } from "discord.js";
+import { z } from "zod";
+import {
+  DiscordAccountIdSchema,
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/data";
+import configuration from "#src/configuration.ts";
+import { getDashboardUrl } from "#src/discord/commands/links.ts";
+import { prisma } from "#src/database/index.ts";
+import { send as sendChannelMessage } from "#src/league/discord/channel.ts";
+import { duelRolloutAllowed } from "#src/progression/duels/access.ts";
+import { loadProgressionOutboxRows } from "#src/progression/outbox.ts";
+import {
+  claimScoutEffect,
+  completeScoutEffect,
+  recordScoutEffectFailure,
+} from "#src/temporal/effect-claims.ts";
+
+const DuelStatusPayloadSchema = z.discriminatedUnion("kind", [
+  z.strictObject({
+    kind: z.literal("invited"),
+    seriesId: z.uuid(),
+    mentionDiscordIds: DiscordAccountIdSchema.array(),
+  }),
+  z.strictObject({
+    kind: z.literal("overdue"),
+    seriesId: z.uuid(),
+    mentionDiscordIds: DiscordAccountIdSchema.array(),
+  }),
+  z.strictObject({
+    kind: z.literal("code_ready"),
+    seriesId: z.uuid(),
+    gameNumber: z.number().int().positive(),
+  }),
+]);
+
+function renderStatus(
+  payload: z.infer<typeof DuelStatusPayloadSchema>,
+  guildId: string,
+) {
+  const path = new URL(
+    `duels/${guildId}/series/${payload.seriesId}`,
+    getDashboardUrl(),
+  ).toString();
+  if (payload.kind === "code_ready") {
+    return {
+      content: "",
+      embed: new EmbedBuilder()
+        .setTitle("Duel lobby ready")
+        .setDescription(
+          `Game ${payload.gameNumber.toString()} is ready. Assigned players can reveal the code in the [Scout web app](${path}).`,
+        )
+        .setColor(0x57_f2_87),
+      users: [],
+    };
+  }
+  const mentions = payload.mentionDiscordIds.map((id) => `<@${id}>`).join(" ");
+  return {
+    content: mentions,
+    embed: new EmbedBuilder()
+      .setTitle(
+        payload.kind === "overdue" ? "Duel series overdue" : "Duel challenge",
+      )
+      .setDescription(
+        payload.kind === "overdue"
+          ? `The match window expired without an automatic result. An organizer must choose replay, no-contest, or advancement with a reason in the [Scout web app](${path}).`
+          : `A new duel needs participant acceptance in the [Scout web app](${path}).`,
+      )
+      .setFooter({ text: escapeMarkdown(payload.seriesId) })
+      .setColor(payload.kind === "overdue" ? 0xed_42_45 : 0x58_65_f2),
+    users: payload.mentionDiscordIds,
+  };
+}
+
+export async function deliverDuelStatusOutbox(): Promise<void> {
+  const rows = await loadProgressionOutboxRows(
+    async (take) =>
+      await prisma.duelStatusOutbox.findMany({
+        where: { deliveryStatus: { in: ["pending", "sending"] } },
+        orderBy: { createdAt: "asc" },
+        take,
+      }),
+    async (take) =>
+      await prisma.duelStatusOutbox.findMany({
+        where: { deliveryStatus: "failed" },
+        orderBy: { updatedAt: "asc" },
+        take,
+      }),
+  );
+  const deliveryErrors: unknown[] = [];
+  for (const row of rows) {
+    const guildId = DiscordGuildIdSchema.parse(row.guildId);
+    if (
+      !(await duelRolloutAllowed(prisma, guildId, configuration.environment))
+    ) {
+      await prisma.duelStatusOutbox.update({
+        where: { id: row.id },
+        data: {
+          deliveryStatus: "suppressed",
+          lastError: "Duel notifications were disabled before delivery",
+        },
+      });
+      continue;
+    }
+    const effectKey = `duel-status:${row.dedupeKey}`;
+    const claim = await claimScoutEffect({
+      key: effectKey,
+      kind: "duel-status-discord",
+    });
+    if (claim === "completed") {
+      await prisma.duelStatusOutbox.update({
+        where: { id: row.id },
+        data: { deliveryStatus: "sent", sentAt: row.sentAt ?? new Date() },
+      });
+      continue;
+    }
+    try {
+      await prisma.duelStatusOutbox.update({
+        where: { id: row.id },
+        data: {
+          deliveryStatus: "sending",
+          attemptCount: { increment: 1 },
+          lastError: null,
+        },
+      });
+      const rendered = renderStatus(
+        DuelStatusPayloadSchema.parse(JSON.parse(row.payloadJson)),
+        guildId,
+      );
+      await sendChannelMessage(
+        {
+          content: rendered.content,
+          embeds: [rendered.embed],
+          allowedMentions: { parse: [], users: rendered.users },
+          nonce: `duel:${Bun.hash(row.dedupeKey).toString(36)}`,
+          enforceNonce: true,
+        },
+        DiscordChannelIdSchema.parse(row.channelId),
+        guildId,
+      );
+      await completeScoutEffect(effectKey);
+      await prisma.duelStatusOutbox.update({
+        where: { id: row.id },
+        data: { deliveryStatus: "sent", sentAt: new Date(), lastError: null },
+      });
+    } catch (error) {
+      await recordScoutEffectFailure(effectKey, error);
+      await prisma.duelStatusOutbox.update({
+        where: { id: row.id },
+        data: {
+          deliveryStatus: "failed",
+          lastError: error instanceof Error ? error.message : String(error),
+        },
+      });
+      deliveryErrors.push(error);
+    }
+  }
+  if (deliveryErrors.length > 0) {
+    throw new AggregateError(
+      deliveryErrors,
+      `${deliveryErrors.length.toString()} duel status delivery attempt(s) failed`,
+    );
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/persistence.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/persistence.integration.test.ts
@@ -21,6 +21,7 @@ import {
   acceptDuelChallenge,
   acceptDuelDisclosure,
   createDirectDuel,
+  getDuelCode,
   getDuelSeries,
   markDuelReady,
 } from "#src/progression/duels/series.ts";
@@ -327,6 +328,72 @@ async function verifyRoundRobinAcceptanceCap(): Promise<void> {
   ).toBe(1);
 }
 
+async function verifyCodeVisibilityAfterIdentityChange(): Promise<void> {
+  const first = await createPlayer(1);
+  const second = await createPlayer(2);
+  const duel = await createTestDirectDuel(first, second);
+  for (const player of [first, second]) {
+    await acceptDuelDisclosure(db, {
+      guildId: GUILD_ID,
+      playerId: player.playerId,
+      discordId: player.discordId,
+    });
+    await acceptDuelChallenge(db, duel.seriesId, player.discordId, GUILD_ID);
+    await markDuelReady(db, duel.seriesId, player.discordId, GUILD_ID);
+  }
+  const lobby = await db.tournamentLobby.create({
+    data: {
+      code: `DUEL-CODE-${crypto.randomUUID()}`,
+      apiMode: "stub",
+      providerId: 1,
+      tournamentId: 2,
+      region: "AMERICA_NORTH",
+      platformId: "NA1",
+      serverId: GUILD_ID,
+      channelId: CHANNEL_ID,
+      creatorDiscordId: ORGANIZER_ID,
+      bluePuuids: "[]",
+      redPuuids: "[]",
+      blueAliases: "[]",
+      redAliases: "[]",
+      teamSize: 2,
+      pickType: "TOURNAMENT_DRAFT",
+      mapType: "SUMMONERS_RIFT",
+      spectatorType: "ALL",
+      state: "created",
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    },
+  });
+  await db.duelSeries.update({
+    where: { id: duel.seriesId },
+    data: { seriesState: "code_ready" },
+  });
+  await db.duelGame.create({
+    data: {
+      seriesId: duel.seriesId,
+      gameNumber: 1,
+      gameState: "code_ready",
+      tournamentLobbyId: lobby.id,
+    },
+  });
+
+  const replacementDiscordId = testAccountId("73188");
+  await db.player.update({
+    where: { id: first.playerId },
+    data: { discordId: replacementDiscordId },
+  });
+  await expect(
+    getDuelCode(db, duel.seriesId, replacementDiscordId, GUILD_ID),
+  ).rejects.toThrow(
+    "Tournament codes are visible only to assigned participants",
+  );
+  await expect(
+    getDuelCode(db, duel.seriesId, first.discordId, GUILD_ID),
+  ).rejects.toThrow(
+    "Tournament codes are visible only to assigned participants",
+  );
+}
+
 beforeEach(async () => {
   vi.mocked(launchDuelSeries).mockClear();
   await db.duelStatusOutbox.deleteMany();
@@ -455,6 +522,10 @@ describe("duel persistence", () => {
     await expect(
       markDuelReady(db, duel.seriesId, replacementDiscordId, GUILD_ID),
     ).resolves.toMatchObject({ deadlineAt: expect.any(Date) });
+  });
+
+  test("does not reveal a code to an identity that has not re-consented", async () => {
+    await verifyCodeVisibilityAfterIdentityChange();
   });
 
   test("revokes member-wide list visibility after an identity change", async () => {

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/persistence.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/persistence.integration.test.ts
@@ -22,7 +22,9 @@ import {
   acceptDuelDisclosure,
   createDirectDuel,
   getDuelSeries,
+  markDuelReady,
 } from "#src/progression/duels/series.ts";
+import { listGuildDuels } from "#src/progression/duels/read.ts";
 import {
   createTestDatabase,
   dropTestDatabase,
@@ -89,6 +91,7 @@ async function createTestDirectDuel(
   first: Awaited<ReturnType<typeof createPlayer>>,
   second: Awaited<ReturnType<typeof createPlayer>>,
   requestId = crypto.randomUUID(),
+  matchWindowHours = 168,
 ) {
   return await createDirectDuel(db, {
     requestId,
@@ -100,7 +103,7 @@ async function createTestDirectDuel(
     second: { accountIds: [second.accountId] },
     bestOf: 1,
     ruleset: RULESET,
-    matchWindowHours: 168,
+    matchWindowHours,
     stage: "dev",
   });
 }
@@ -231,6 +234,99 @@ async function verifyCommitteeSeriesRecord(): Promise<void> {
   ).toEqual([0, 1]);
 }
 
+async function verifyRoundRobinAcceptanceCap(): Promise<void> {
+  const players = await Promise.all(
+    Array.from(
+      { length: 17 },
+      async (_, index) => await createPlayer(index + 1),
+    ),
+  );
+  const event = await createDuelEvent(db, {
+    guildId: GUILD_ID,
+    name: "Capped round robin",
+    format: "round_robin",
+    competitorKind: "player",
+    bestOf: 1,
+    ruleset: RULESET,
+    registrationMode: "invitations",
+    seedMethod: "manual",
+    matchWindowHours: 168,
+    channelId: CHANNEL_ID,
+    organizerDiscordId: ORGANIZER_ID,
+    roundOverrides: [],
+  });
+  const registrations: { readonly competitorId: string }[] = [];
+  for (const player of players) {
+    registrations.push(
+      await registerDuelEventEntrant(db, {
+        guildId: GUILD_ID,
+        eventId: event.id,
+        actorDiscordId: ORGANIZER_ID,
+        selection: { accountIds: [player.accountId] },
+        source: "invitation",
+      }),
+    );
+  }
+  for (const [index, player] of players.slice(0, 15).entries()) {
+    const registration = registrations[index];
+    if (registration === undefined) {
+      throw new Error("Accepted entrant fixture is incomplete");
+    }
+    await acceptDuelDisclosure(db, {
+      guildId: GUILD_ID,
+      playerId: player.playerId,
+      discordId: player.discordId,
+    });
+    await acceptDuelEventRegistration(db, {
+      guildId: GUILD_ID,
+      eventId: event.id,
+      competitorId: registration.competitorId,
+      actorDiscordId: player.discordId,
+    });
+  }
+  const finalPlayers = players.slice(15);
+  await Promise.all(
+    finalPlayers.map(async (player) => {
+      await acceptDuelDisclosure(db, {
+        guildId: GUILD_ID,
+        playerId: player.playerId,
+        discordId: player.discordId,
+      });
+    }),
+  );
+  const finalAcceptances = await Promise.allSettled(
+    finalPlayers.map(async (player, index) => {
+      const registration = registrations[index + 15];
+      if (registration === undefined) {
+        throw new Error("Final entrant fixture is incomplete");
+      }
+      await acceptDuelEventRegistration(db, {
+        guildId: GUILD_ID,
+        eventId: event.id,
+        competitorId: registration.competitorId,
+        actorDiscordId: player.discordId,
+      });
+    }),
+  );
+
+  expect(
+    finalAcceptances.filter((result) => result.status === "fulfilled"),
+  ).toHaveLength(1);
+  expect(
+    finalAcceptances.filter((result) => result.status === "rejected"),
+  ).toHaveLength(1);
+  expect(
+    await db.duelEventEntrant.count({
+      where: { eventId: event.id, registrationState: "accepted" },
+    }),
+  ).toBe(16);
+  expect(
+    await db.duelEventEntrant.count({
+      where: { eventId: event.id, registrationState: "pending" },
+    }),
+  ).toBe(1);
+}
+
 beforeEach(async () => {
   vi.mocked(launchDuelSeries).mockClear();
   await db.duelStatusOutbox.deleteMany();
@@ -325,6 +421,73 @@ describe("duel persistence", () => {
     await verifyCurrentDiscordIdentity();
   });
 
+  test("requires renewed acceptance before readiness after an identity change", async () => {
+    const first = await createPlayer(1);
+    const second = await createPlayer(2);
+    const duel = await createTestDirectDuel(first, second);
+    await acceptDuelDisclosure(db, {
+      guildId: GUILD_ID,
+      playerId: first.playerId,
+      discordId: first.discordId,
+    });
+    await acceptDuelChallenge(db, duel.seriesId, first.discordId, GUILD_ID);
+    const replacementDiscordId = testAccountId("73188");
+    await db.player.update({
+      where: { id: first.playerId },
+      data: { discordId: replacementDiscordId },
+    });
+    await acceptDuelDisclosure(db, {
+      guildId: GUILD_ID,
+      playerId: first.playerId,
+      discordId: replacementDiscordId,
+    });
+
+    await expect(
+      markDuelReady(db, duel.seriesId, replacementDiscordId, GUILD_ID),
+    ).rejects.toThrow("Accept the duel again");
+
+    await acceptDuelChallenge(
+      db,
+      duel.seriesId,
+      replacementDiscordId,
+      GUILD_ID,
+    );
+    await expect(
+      markDuelReady(db, duel.seriesId, replacementDiscordId, GUILD_ID),
+    ).resolves.toMatchObject({ deadlineAt: expect.any(Date) });
+  });
+
+  test("revokes member-wide list visibility after an identity change", async () => {
+    const first = await createPlayer(1);
+    const second = await createPlayer(2);
+    const outsider = testAccountId("73199");
+    const duel = await createTestDirectDuel(first, second);
+    for (const player of [first, second]) {
+      await acceptDuelDisclosure(db, {
+        guildId: GUILD_ID,
+        playerId: player.playerId,
+        discordId: player.discordId,
+      });
+      await acceptDuelChallenge(db, duel.seriesId, player.discordId, GUILD_ID);
+    }
+    await expect(listGuildDuels(db, GUILD_ID, outsider)).resolves.toMatchObject(
+      { direct: [{ id: duel.seriesId }] },
+    );
+
+    const replacementDiscordId = testAccountId("73188");
+    await db.player.update({
+      where: { id: first.playerId },
+      data: { discordId: replacementDiscordId },
+    });
+
+    await expect(listGuildDuels(db, GUILD_ID, outsider)).resolves.toMatchObject(
+      { direct: [] },
+    );
+    await expect(
+      listGuildDuels(db, GUILD_ID, replacementDiscordId),
+    ).resolves.toMatchObject({ direct: [{ id: duel.seriesId }] });
+  });
+
   test("records a committee series result only after a verified game", async () => {
     await verifyCommitteeSeriesRecord();
   });
@@ -366,6 +529,37 @@ describe("duel persistence", () => {
     await expect(
       db.duelSeries.findUniqueOrThrow({ where: { id: duel.seriesId } }),
     ).resolves.toMatchObject({ seriesState: "needs_review" });
+  });
+
+  test("preserves the configured match window when committeeing a replay", async () => {
+    const first = await createPlayer(1);
+    const second = await createPlayer(2);
+    const duel = await createTestDirectDuel(
+      first,
+      second,
+      crypto.randomUUID(),
+      24,
+    );
+    await db.duelSeries.update({
+      where: { id: duel.seriesId },
+      data: { seriesState: "needs_review" },
+    });
+    const beforeDecision = Date.now();
+
+    const decision = await decideDuelSeries(db, {
+      seriesId: duel.seriesId,
+      guildId: GUILD_ID,
+      actorDiscordId: ORGANIZER_ID,
+      idempotencyKey: "configured-replay-window",
+      reason: "Timeline evidence was incomplete",
+      decision: { kind: "replay" },
+    });
+
+    const expectedDeadline = beforeDecision + 24 * 60 * 60 * 1000;
+    expect(decision.deadlineAt.getTime()).toBeGreaterThanOrEqual(
+      expectedDeadline,
+    );
+    expect(decision.deadlineAt.getTime()).toBeLessThan(expectedDeadline + 1000);
   });
 });
 
@@ -510,59 +704,8 @@ describe("duel event registration", () => {
     ).rejects.toThrow("retain disclosure consent");
   });
 
-  test("serializes registration at the round-robin entrant cap", async () => {
-    const players = await Promise.all(
-      Array.from(
-        { length: 17 },
-        async (_, index) => await createPlayer(index + 1),
-      ),
-    );
-    const event = await createDuelEvent(db, {
-      guildId: GUILD_ID,
-      name: "Capped round robin",
-      format: "round_robin",
-      competitorKind: "player",
-      bestOf: 1,
-      ruleset: RULESET,
-      registrationMode: "invitations",
-      seedMethod: "manual",
-      matchWindowHours: 168,
-      channelId: CHANNEL_ID,
-      organizerDiscordId: ORGANIZER_ID,
-      roundOverrides: [],
-    });
-    for (const player of players.slice(0, 15)) {
-      await registerDuelEventEntrant(db, {
-        guildId: GUILD_ID,
-        eventId: event.id,
-        actorDiscordId: ORGANIZER_ID,
-        selection: { accountIds: [player.accountId] },
-        source: "invitation",
-      });
-    }
-    const finalPlayers = players.slice(15);
-    const registrations = await Promise.allSettled(
-      finalPlayers.map(
-        async (player) =>
-          await registerDuelEventEntrant(db, {
-            guildId: GUILD_ID,
-            eventId: event.id,
-            actorDiscordId: ORGANIZER_ID,
-            selection: { accountIds: [player.accountId] },
-            source: "invitation",
-          }),
-      ),
-    );
-
-    expect(
-      registrations.filter((result) => result.status === "fulfilled"),
-    ).toHaveLength(1);
-    expect(
-      registrations.filter((result) => result.status === "rejected"),
-    ).toHaveLength(1);
-    expect(
-      await db.duelEventEntrant.count({ where: { eventId: event.id } }),
-    ).toBe(16);
+  test("serializes acceptance at the round-robin entrant cap", async () => {
+    await verifyRoundRobinAcceptanceCap();
   });
 });
 

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/persistence.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/persistence.integration.test.ts
@@ -475,6 +475,9 @@ describe("duel persistence", () => {
     });
     await expect(
       getDuelSeries(db, duel.seriesId, outsider, GUILD_ID),
+    ).rejects.toThrow("private until every participant accepts");
+    await expect(
+      getDuelSeries(db, duel.seriesId, ORGANIZER_ID, GUILD_ID),
     ).resolves.toMatchObject({
       competitorOne: {
         accounts: [{ playerAlias: "Duel Player 1" }],
@@ -657,7 +660,7 @@ describe("duel event registration", () => {
       organizerDiscordId: ORGANIZER_ID,
       roundOverrides: [],
     });
-    await registerDuelEventEntrant(db, {
+    const firstEntrant = await registerDuelEventEntrant(db, {
       guildId: GUILD_ID,
       eventId: event.id,
       actorDiscordId: ORGANIZER_ID,
@@ -665,18 +668,40 @@ describe("duel event registration", () => {
       source: "invitation",
     });
 
+    const secondEntrant = await registerDuelEventEntrant(db, {
+      guildId: GUILD_ID,
+      eventId: event.id,
+      actorDiscordId: ORGANIZER_ID,
+      selection: { accountIds: [second.accountId] },
+      source: "invitation",
+    });
+    await acceptDuelDisclosure(db, {
+      guildId: GUILD_ID,
+      playerId: first.playerId,
+      discordId: first.discordId,
+    });
+    await acceptDuelEventRegistration(db, {
+      guildId: GUILD_ID,
+      eventId: event.id,
+      competitorId: firstEntrant.competitorId,
+      actorDiscordId: first.discordId,
+    });
+    await acceptDuelDisclosure(db, {
+      guildId: GUILD_ID,
+      playerId: second.playerId,
+      discordId: second.discordId,
+    });
     await expect(
-      registerDuelEventEntrant(db, {
+      acceptDuelEventRegistration(db, {
         guildId: GUILD_ID,
         eventId: event.id,
-        actorDiscordId: ORGANIZER_ID,
-        selection: { accountIds: [second.accountId] },
-        source: "invitation",
+        competitorId: secondEntrant.competitorId,
+        actorDiscordId: second.discordId,
       }),
     ).rejects.toThrow("one Riot region");
     expect(
       await db.duelEventEntrant.count({ where: { eventId: event.id } }),
-    ).toBe(1);
+    ).toBe(2);
   });
 
   test("requires disclosure from the player's current Discord identity", async () => {

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/persistence.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/persistence.integration.test.ts
@@ -204,6 +204,7 @@ async function verifyCommitteeSeriesRecord(): Promise<void> {
     seriesId: series.id,
     guildId: GUILD_ID,
     actorDiscordId: ORGANIZER_ID,
+    allowPrivilegedReviewer: false,
     idempotencyKey: "committee-after-played-game",
     reason: "Remaining games could not be completed",
     decision: {
@@ -483,7 +484,9 @@ describe("duel persistence", () => {
       },
     });
   });
+});
 
+describe("duel persistence after identity changes", () => {
   test("moves direct acceptance to the player's current Discord identity", async () => {
     await verifyCurrentDiscordIdentity();
   });
@@ -591,6 +594,7 @@ describe("duel persistence", () => {
         seriesId: duel.seriesId,
         guildId: GUILD_ID,
         actorDiscordId: ORGANIZER_ID,
+        allowPrivilegedReviewer: false,
         idempotencyKey: "structured-no-contest",
         reason: "Both players were unavailable",
         decision: { kind: "no_contest" },
@@ -621,6 +625,7 @@ describe("duel persistence", () => {
       seriesId: duel.seriesId,
       guildId: GUILD_ID,
       actorDiscordId: ORGANIZER_ID,
+      allowPrivilegedReviewer: false,
       idempotencyKey: "configured-replay-window",
       reason: "Timeline evidence was incomplete",
       decision: { kind: "replay" },

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/persistence.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/persistence.integration.test.ts
@@ -16,12 +16,12 @@ import {
 } from "#src/progression/duels/registration.ts";
 import { advanceDuelEvent } from "#src/progression/duels/advancement.ts";
 import { launchDuelSeries } from "#src/progression/duels/launch.ts";
+import { getDuelCode } from "#src/progression/duels/code.ts";
 import { decideDuelSeries } from "#src/progression/duels/review.ts";
 import {
   acceptDuelChallenge,
   acceptDuelDisclosure,
   createDirectDuel,
-  getDuelCode,
   getDuelSeries,
   markDuelReady,
 } from "#src/progression/duels/series.ts";

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/persistence.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/persistence.integration.test.ts
@@ -1,0 +1,685 @@
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  DuelRulesetV1Schema,
+  type AccountId,
+  type DiscordAccountId,
+  type PlayerId,
+  type Region,
+} from "@scout-for-lol/data";
+import {
+  createDuelEvent,
+  startDuelEvent,
+} from "#src/progression/duels/events.ts";
+import {
+  acceptDuelEventRegistration,
+  registerDuelEventEntrant,
+} from "#src/progression/duels/registration.ts";
+import { advanceDuelEvent } from "#src/progression/duels/advancement.ts";
+import { launchDuelSeries } from "#src/progression/duels/launch.ts";
+import { decideDuelSeries } from "#src/progression/duels/review.ts";
+import {
+  acceptDuelChallenge,
+  acceptDuelDisclosure,
+  createDirectDuel,
+  getDuelSeries,
+} from "#src/progression/duels/series.ts";
+import {
+  createTestDatabase,
+  dropTestDatabase,
+} from "#src/testing/test-database.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+  testPuuid,
+} from "#src/testing/test-ids.ts";
+
+vi.mock("#src/progression/duels/launch.ts", () => ({
+  launchDuelSeries: vi.fn(() => Promise.resolve()),
+}));
+
+const { prisma: db, dbPath } = createTestDatabase("duel-persistence");
+const GUILD_ID = testGuildId("731");
+const ORGANIZER_ID = testAccountId("731");
+const CHANNEL_ID = testChannelId("731");
+const RULESET = DuelRulesetV1Schema.parse({
+  version: 1,
+  killTarget: 1,
+  laneCsTarget: null,
+  firstTurret: false,
+});
+
+async function createPlayer(
+  index: number,
+  region: Region = "AMERICA_NORTH",
+): Promise<{
+  playerId: PlayerId;
+  accountId: AccountId;
+  discordId: DiscordAccountId;
+}> {
+  const discordId = testAccountId(`731${index.toString()}`);
+  const player = await db.player.create({
+    data: {
+      alias: `Duel Player ${index.toString()}`,
+      discordId,
+      serverId: GUILD_ID,
+      creatorDiscordId: ORGANIZER_ID,
+      createdTime: new Date(),
+      updatedTime: new Date(),
+      accounts: {
+        create: {
+          alias: `Duel Account ${index.toString()}`,
+          puuid: testPuuid(`duel-${index.toString()}`),
+          region,
+          serverId: GUILD_ID,
+          creatorDiscordId: ORGANIZER_ID,
+          createdTime: new Date(),
+          updatedTime: new Date(),
+        },
+      },
+    },
+    include: { accounts: true },
+  });
+  const account = player.accounts[0];
+  if (account === undefined) throw new Error("Duel fixture needs an account");
+  return { playerId: player.id, accountId: account.id, discordId };
+}
+
+async function createTestDirectDuel(
+  first: Awaited<ReturnType<typeof createPlayer>>,
+  second: Awaited<ReturnType<typeof createPlayer>>,
+  requestId = crypto.randomUUID(),
+) {
+  return await createDirectDuel(db, {
+    requestId,
+    guildId: GUILD_ID,
+    organizerDiscordId: ORGANIZER_ID,
+    channelId: CHANNEL_ID,
+    competitorKind: "player",
+    first: { accountIds: [first.accountId] },
+    second: { accountIds: [second.accountId] },
+    bestOf: 1,
+    ruleset: RULESET,
+    matchWindowHours: 168,
+    stage: "dev",
+  });
+}
+
+async function verifyConcurrentDirectDuelRetries(): Promise<void> {
+  const first = await createPlayer(1);
+  const second = await createPlayer(2);
+  const requestId = crypto.randomUUID();
+
+  const retries = await Promise.all([
+    createTestDirectDuel(first, second, requestId),
+    createTestDirectDuel(first, second, requestId),
+  ]);
+
+  expect(retries[0]).toEqual(retries[1]);
+  expect(await db.duelSeries.count()).toBe(1);
+  expect(await db.duelCompetitor.count()).toBe(2);
+  expect(await db.duelStatusOutbox.count()).toBe(1);
+}
+
+async function verifyCurrentDiscordIdentity(): Promise<void> {
+  const first = await createPlayer(1);
+  const second = await createPlayer(2);
+  const duel = await createTestDirectDuel(first, second);
+  await acceptDuelDisclosure(db, {
+    guildId: GUILD_ID,
+    playerId: first.playerId,
+    discordId: first.discordId,
+  });
+  const replacementDiscordId = testAccountId("73188");
+  await db.player.update({
+    where: { id: first.playerId },
+    data: { discordId: replacementDiscordId },
+  });
+
+  await expect(
+    acceptDuelChallenge(db, duel.seriesId, first.discordId, GUILD_ID),
+  ).rejects.toThrow("Only an assigned participant");
+  await expect(
+    acceptDuelChallenge(db, duel.seriesId, replacementDiscordId, GUILD_ID),
+  ).rejects.toThrow("Accept the custom-match disclosure");
+  await acceptDuelDisclosure(db, {
+    guildId: GUILD_ID,
+    playerId: first.playerId,
+    discordId: replacementDiscordId,
+  });
+  await acceptDuelChallenge(db, duel.seriesId, replacementDiscordId, GUILD_ID);
+
+  await expect(
+    db.duelSeriesParticipant.findUniqueOrThrow({
+      where: {
+        seriesId_playerId: {
+          seriesId: duel.seriesId,
+          playerId: first.playerId,
+        },
+      },
+    }),
+  ).resolves.toMatchObject({
+    discordId: replacementDiscordId,
+    acceptedAt: expect.any(Date),
+  });
+}
+
+async function verifyCommitteeSeriesRecord(): Promise<void> {
+  const first = await createPlayer(1);
+  const second = await createPlayer(2);
+  const event = await createDuelEvent(db, {
+    guildId: GUILD_ID,
+    name: "Committee event",
+    format: "single_elimination",
+    competitorKind: "player",
+    bestOf: 3,
+    ruleset: RULESET,
+    registrationMode: "invitations",
+    seedMethod: "manual",
+    matchWindowHours: 168,
+    channelId: CHANNEL_ID,
+    organizerDiscordId: ORGANIZER_ID,
+    roundOverrides: [],
+  });
+  const duel = await createTestDirectDuel(first, second);
+  const series = await db.duelSeries.update({
+    where: { id: duel.seriesId },
+    data: { eventId: event.id, seriesState: "needs_review", bestOf: 3 },
+  });
+  await db.duelGame.create({
+    data: {
+      seriesId: series.id,
+      gameNumber: 1,
+      gameState: "completed",
+      resultState: "verified",
+      winnerCompetitorId: series.competitorOneId,
+    },
+  });
+
+  await decideDuelSeries(db, {
+    seriesId: series.id,
+    guildId: GUILD_ID,
+    actorDiscordId: ORGANIZER_ID,
+    idempotencyKey: "committee-after-played-game",
+    reason: "Remaining games could not be completed",
+    decision: {
+      kind: "advance",
+      winnerCompetitorId: series.competitorOneId,
+    },
+  });
+
+  const records = await db.duelRecord.findMany({
+    where: {
+      guildId: GUILD_ID,
+      scope: "individual",
+      subjectKey: {
+        in: [
+          `player:${first.playerId.toString()}`,
+          `player:${second.playerId.toString()}`,
+        ],
+      },
+    },
+    orderBy: { subjectKey: "asc" },
+  });
+  expect(records).toHaveLength(2);
+  expect(records.map((record) => record.games)).toEqual([0, 0]);
+  expect(records.map((record) => record.series)).toEqual([1, 1]);
+  expect(
+    records
+      .map((record) => record.seriesWins)
+      .toSorted((left, right) => left - right),
+  ).toEqual([0, 1]);
+}
+
+beforeEach(async () => {
+  vi.mocked(launchDuelSeries).mockClear();
+  await db.duelStatusOutbox.deleteMany();
+  await db.duelSeries.deleteMany();
+  await db.duelEvent.deleteMany();
+  await db.duelDisclosureAcceptance.deleteMany();
+  await db.duelRecord.deleteMany();
+  await db.duelCompetitorMember.deleteMany();
+  await db.duelCompetitor.deleteMany();
+  await db.account.deleteMany();
+  await db.player.deleteMany();
+  await db.bucksLedgerEntry.deleteMany();
+  await db.bucksAccount.deleteMany();
+});
+
+afterAll(async () => {
+  await dropTestDatabase(db, dbPath);
+});
+
+describe("duel persistence", () => {
+  test("deduplicates concurrent direct-challenge retries", async () => {
+    await verifyConcurrentDirectDuelRetries();
+  });
+
+  test("rejects a direct duel whose frozen accounts span Riot regions", async () => {
+    const first = await createPlayer(1);
+    const second = await createPlayer(2, "EU_WEST");
+
+    await expect(createTestDirectDuel(first, second)).rejects.toThrow(
+      "one Riot region",
+    );
+    expect(await db.duelSeries.count()).toBe(0);
+  });
+
+  test("keeps a direct duel private until every player accepts disclosure", async () => {
+    const first = await createPlayer(1);
+    const second = await createPlayer(2);
+    const outsider = testAccountId("73199");
+    const duel = await createTestDirectDuel(first, second);
+
+    await expect(
+      acceptDuelChallenge(db, duel.seriesId, first.discordId, GUILD_ID),
+    ).rejects.toThrow("Accept the custom-match disclosure");
+    await acceptDuelDisclosure(db, {
+      guildId: GUILD_ID,
+      playerId: first.playerId,
+      discordId: first.discordId,
+    });
+    await acceptDuelChallenge(db, duel.seriesId, first.discordId, GUILD_ID);
+    await expect(
+      getDuelSeries(db, duel.seriesId, outsider, GUILD_ID),
+    ).rejects.toThrow("private until every participant accepts");
+
+    await acceptDuelDisclosure(db, {
+      guildId: GUILD_ID,
+      playerId: second.playerId,
+      discordId: second.discordId,
+    });
+    await acceptDuelChallenge(db, duel.seriesId, second.discordId, GUILD_ID);
+    await expect(
+      getDuelSeries(db, duel.seriesId, outsider, GUILD_ID),
+    ).resolves.toMatchObject({
+      id: duel.seriesId,
+      participants: [
+        { accepted: true, ready: false },
+        { accepted: true, ready: false },
+      ],
+    });
+
+    expect(await db.bucksAccount.count()).toBe(0);
+    expect(await db.bucksLedgerEntry.count()).toBe(0);
+
+    await db.account.deleteMany({
+      where: { playerId: { in: [first.playerId, second.playerId] } },
+    });
+    await db.player.deleteMany({
+      where: { id: { in: [first.playerId, second.playerId] } },
+    });
+    await expect(
+      getDuelSeries(db, duel.seriesId, outsider, GUILD_ID),
+    ).resolves.toMatchObject({
+      competitorOne: {
+        accounts: [{ playerAlias: "Duel Player 1" }],
+      },
+      competitorTwo: {
+        accounts: [{ playerAlias: "Duel Player 2" }],
+      },
+    });
+  });
+
+  test("moves direct acceptance to the player's current Discord identity", async () => {
+    await verifyCurrentDiscordIdentity();
+  });
+
+  test("records a committee series result only after a verified game", async () => {
+    await verifyCommitteeSeriesRecord();
+  });
+
+  test("rejects no-contest decisions that would deadlock an event", async () => {
+    const first = await createPlayer(1);
+    const second = await createPlayer(2);
+    const event = await createDuelEvent(db, {
+      guildId: GUILD_ID,
+      name: "Reviewable event",
+      format: "single_elimination",
+      competitorKind: "player",
+      bestOf: 1,
+      ruleset: RULESET,
+      registrationMode: "invitations",
+      seedMethod: "manual",
+      matchWindowHours: 168,
+      channelId: CHANNEL_ID,
+      organizerDiscordId: ORGANIZER_ID,
+      roundOverrides: [],
+    });
+    const duel = await createTestDirectDuel(first, second);
+    await db.duelSeries.update({
+      where: { id: duel.seriesId },
+      data: { eventId: event.id, seriesState: "needs_review" },
+    });
+
+    await expect(
+      decideDuelSeries(db, {
+        seriesId: duel.seriesId,
+        guildId: GUILD_ID,
+        actorDiscordId: ORGANIZER_ID,
+        idempotencyKey: "structured-no-contest",
+        reason: "Both players were unavailable",
+        decision: { kind: "no_contest" },
+      }),
+    ).rejects.toThrow("cannot be closed as no-contest");
+    expect(await db.duelAuditDecision.count()).toBe(0);
+    await expect(
+      db.duelSeries.findUniqueOrThrow({ where: { id: duel.seriesId } }),
+    ).resolves.toMatchObject({ seriesState: "needs_review" });
+  });
+});
+
+describe("duel event registration", () => {
+  test("rejects an entrant from another Riot region", async () => {
+    const first = await createPlayer(1);
+    const second = await createPlayer(2, "EU_WEST");
+    const event = await createDuelEvent(db, {
+      guildId: GUILD_ID,
+      name: "One-region event",
+      format: "single_elimination",
+      competitorKind: "player",
+      bestOf: 1,
+      ruleset: RULESET,
+      registrationMode: "invitations",
+      seedMethod: "manual",
+      matchWindowHours: 168,
+      channelId: CHANNEL_ID,
+      organizerDiscordId: ORGANIZER_ID,
+      roundOverrides: [],
+    });
+    await registerDuelEventEntrant(db, {
+      guildId: GUILD_ID,
+      eventId: event.id,
+      actorDiscordId: ORGANIZER_ID,
+      selection: { accountIds: [first.accountId] },
+      source: "invitation",
+    });
+
+    await expect(
+      registerDuelEventEntrant(db, {
+        guildId: GUILD_ID,
+        eventId: event.id,
+        actorDiscordId: ORGANIZER_ID,
+        selection: { accountIds: [second.accountId] },
+        source: "invitation",
+      }),
+    ).rejects.toThrow("one Riot region");
+    expect(
+      await db.duelEventEntrant.count({ where: { eventId: event.id } }),
+    ).toBe(1);
+  });
+
+  test("requires disclosure from the player's current Discord identity", async () => {
+    const player = await createPlayer(1);
+    const event = await createDuelEvent(db, {
+      guildId: GUILD_ID,
+      name: "Identity-bound disclosure",
+      format: "single_elimination",
+      competitorKind: "player",
+      bestOf: 1,
+      ruleset: RULESET,
+      registrationMode: "invitations",
+      seedMethod: "manual",
+      matchWindowHours: 168,
+      channelId: CHANNEL_ID,
+      organizerDiscordId: ORGANIZER_ID,
+      roundOverrides: [],
+    });
+    const entrant = await registerDuelEventEntrant(db, {
+      guildId: GUILD_ID,
+      eventId: event.id,
+      actorDiscordId: ORGANIZER_ID,
+      selection: { accountIds: [player.accountId] },
+      source: "invitation",
+    });
+    await expect(
+      registerDuelEventEntrant(db, {
+        guildId: GUILD_ID,
+        eventId: event.id,
+        actorDiscordId: ORGANIZER_ID,
+        selection: { accountIds: [player.accountId] },
+        source: "invitation",
+      }),
+    ).rejects.toThrow("may enter an event only once");
+    await acceptDuelDisclosure(db, {
+      guildId: GUILD_ID,
+      playerId: player.playerId,
+      discordId: player.discordId,
+    });
+    const replacementDiscordId = testAccountId("73188");
+    await db.player.update({
+      where: { id: player.playerId },
+      data: { discordId: replacementDiscordId },
+    });
+
+    await expect(
+      acceptDuelEventRegistration(db, {
+        guildId: GUILD_ID,
+        eventId: event.id,
+        competitorId: entrant.competitorId,
+        actorDiscordId: replacementDiscordId,
+      }),
+    ).rejects.toThrow("Every teammate must accept");
+
+    await acceptDuelDisclosure(db, {
+      guildId: GUILD_ID,
+      playerId: player.playerId,
+      discordId: replacementDiscordId,
+    });
+    await expect(
+      acceptDuelEventRegistration(db, {
+        guildId: GUILD_ID,
+        eventId: event.id,
+        competitorId: entrant.competitorId,
+        actorDiscordId: replacementDiscordId,
+      }),
+    ).resolves.toBeUndefined();
+
+    const second = await createPlayer(2);
+    const secondEntrant = await registerDuelEventEntrant(db, {
+      guildId: GUILD_ID,
+      eventId: event.id,
+      actorDiscordId: ORGANIZER_ID,
+      selection: { accountIds: [second.accountId] },
+      source: "invitation",
+    });
+    await acceptDuelDisclosure(db, {
+      guildId: GUILD_ID,
+      playerId: second.playerId,
+      discordId: second.discordId,
+    });
+    await acceptDuelEventRegistration(db, {
+      guildId: GUILD_ID,
+      eventId: event.id,
+      competitorId: secondEntrant.competitorId,
+      actorDiscordId: second.discordId,
+    });
+    await db.player.update({
+      where: { id: player.playerId },
+      data: { discordId: testAccountId("73189") },
+    });
+
+    await expect(
+      startDuelEvent(db, {
+        guildId: GUILD_ID,
+        eventId: event.id,
+        actorDiscordId: ORGANIZER_ID,
+        stage: "dev",
+        manualOrder: [entrant.competitorId, secondEntrant.competitorId],
+      }),
+    ).rejects.toThrow("retain disclosure consent");
+  });
+
+  test("serializes registration at the round-robin entrant cap", async () => {
+    const players = await Promise.all(
+      Array.from(
+        { length: 17 },
+        async (_, index) => await createPlayer(index + 1),
+      ),
+    );
+    const event = await createDuelEvent(db, {
+      guildId: GUILD_ID,
+      name: "Capped round robin",
+      format: "round_robin",
+      competitorKind: "player",
+      bestOf: 1,
+      ruleset: RULESET,
+      registrationMode: "invitations",
+      seedMethod: "manual",
+      matchWindowHours: 168,
+      channelId: CHANNEL_ID,
+      organizerDiscordId: ORGANIZER_ID,
+      roundOverrides: [],
+    });
+    for (const player of players.slice(0, 15)) {
+      await registerDuelEventEntrant(db, {
+        guildId: GUILD_ID,
+        eventId: event.id,
+        actorDiscordId: ORGANIZER_ID,
+        selection: { accountIds: [player.accountId] },
+        source: "invitation",
+      });
+    }
+    const finalPlayers = players.slice(15);
+    const registrations = await Promise.allSettled(
+      finalPlayers.map(
+        async (player) =>
+          await registerDuelEventEntrant(db, {
+            guildId: GUILD_ID,
+            eventId: event.id,
+            actorDiscordId: ORGANIZER_ID,
+            selection: { accountIds: [player.accountId] },
+            source: "invitation",
+          }),
+      ),
+    );
+
+    expect(
+      registrations.filter((result) => result.status === "fulfilled"),
+    ).toHaveLength(1);
+    expect(
+      registrations.filter((result) => result.status === "rejected"),
+    ).toHaveLength(1);
+    expect(
+      await db.duelEventEntrant.count({ where: { eventId: event.id } }),
+    ).toBe(16);
+  });
+});
+
+describe("duel event advancement", () => {
+  test("preserves standard five-entrant byes and advances idempotently", async () => {
+    const players = await Promise.all(
+      [1, 2, 3, 4, 5].map(async (index) => await createPlayer(index)),
+    );
+    const event = await createDuelEvent(db, {
+      guildId: GUILD_ID,
+      name: "Five player bracket",
+      format: "single_elimination",
+      competitorKind: "player",
+      bestOf: 1,
+      ruleset: RULESET,
+      registrationMode: "invitations",
+      seedMethod: "manual",
+      matchWindowHours: 168,
+      channelId: CHANNEL_ID,
+      organizerDiscordId: ORGANIZER_ID,
+      roundOverrides: [],
+    });
+    const competitorIds: string[] = [];
+    for (const player of players) {
+      const entrant = await registerDuelEventEntrant(db, {
+        guildId: GUILD_ID,
+        eventId: event.id,
+        actorDiscordId: ORGANIZER_ID,
+        selection: { accountIds: [player.accountId] },
+        source: "invitation",
+      });
+      competitorIds.push(entrant.competitorId);
+      await acceptDuelDisclosure(db, {
+        guildId: GUILD_ID,
+        playerId: player.playerId,
+        discordId: player.discordId,
+      });
+      await acceptDuelEventRegistration(db, {
+        guildId: GUILD_ID,
+        eventId: event.id,
+        competitorId: entrant.competitorId,
+        actorDiscordId: player.discordId,
+      });
+    }
+    const [seedOne, seedTwo, seedThree, seedFour, seedFive] = competitorIds;
+    if (
+      seedOne === undefined ||
+      seedTwo === undefined ||
+      seedThree === undefined ||
+      seedFour === undefined ||
+      seedFive === undefined
+    ) {
+      throw new Error("Five-player bracket fixture is incomplete");
+    }
+
+    const firstRound = await startDuelEvent(db, {
+      guildId: GUILD_ID,
+      eventId: event.id,
+      actorDiscordId: ORGANIZER_ID,
+      stage: "dev",
+      manualOrder: competitorIds,
+    });
+    const firstPlayer = players[0];
+    if (firstPlayer === undefined) {
+      throw new Error("Five-player bracket requires a first player");
+    }
+    await expect(
+      acceptDuelEventRegistration(db, {
+        guildId: GUILD_ID,
+        eventId: event.id,
+        competitorId: seedOne,
+        actorDiscordId: firstPlayer.discordId,
+      }),
+    ).rejects.toThrow("not accepting registrations");
+    expect(firstRound).toHaveLength(1);
+    const openingRequest = firstRound[0];
+    if (openingRequest === undefined) {
+      throw new Error("Five-player bracket requires an opening series");
+    }
+    const opening = await db.duelSeries.findUniqueOrThrow({
+      where: { id: openingRequest.seriesId },
+    });
+    expect([opening.competitorOneId, opening.competitorTwoId]).toEqual([
+      seedFour,
+      seedFive,
+    ]);
+    await db.duelSeries.update({
+      where: { id: opening.id },
+      data: {
+        seriesState: "completed",
+        winnerCompetitorId: seedFour,
+        advancementKind: "played",
+        completedAt: new Date(),
+      },
+    });
+
+    await advanceDuelEvent(event.id, "dev", db);
+    const secondRound = await db.duelSeries.findMany({
+      where: { eventId: event.id, bracket: "winners", roundNumber: 2 },
+      orderBy: { position: "asc" },
+    });
+    expect(
+      secondRound.map((series) => [
+        series.competitorOneId,
+        series.competitorTwoId,
+      ]),
+    ).toEqual([
+      [seedOne, seedFour],
+      [seedTwo, seedThree],
+    ]);
+    expect(vi.mocked(launchDuelSeries)).toHaveBeenCalledTimes(2);
+
+    await advanceDuelEvent(event.id, "dev", db);
+    expect(
+      await db.duelSeries.count({
+        where: { eventId: event.id, bracket: "winners", roundNumber: 2 },
+      }),
+    ).toBe(2);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/read.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/read.ts
@@ -13,6 +13,7 @@ import {
   duelSeriesVisibleTo,
   effectiveParticipantDiscordId,
 } from "#src/progression/duels/series.ts";
+import { latestRoundRobinResults } from "#src/progression/duels/round-robin.ts";
 
 export async function listGuildDuels(
   db: ExtendedPrismaClient,
@@ -223,22 +224,7 @@ export async function getDuelEventStandings(
     });
   });
   if (event.format !== "round_robin") return { standings, ranks: null };
-  const results = event.series.flatMap((series) => {
-    if (series.winnerCompetitorId === null) return [];
-    return [
-      {
-        firstCompetitorId: series.competitorOneId,
-        secondCompetitorId: series.competitorTwoId,
-        winnerCompetitorId: series.winnerCompetitorId,
-        firstGameWins: series.games.filter(
-          (game) => game.winnerCompetitorId === series.competitorOneId,
-        ).length,
-        secondGameWins: series.games.filter(
-          (game) => game.winnerCompetitorId === series.competitorTwoId,
-        ).length,
-      },
-    ];
-  });
+  const results = latestRoundRobinResults(event.series);
   return {
     standings,
     ranks: rankRoundRobin(

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/read.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/read.ts
@@ -1,0 +1,319 @@
+import {
+  DuelEventFormatSchema,
+  DuelSeriesStatusSchema,
+  buildDuelStanding,
+  rankRoundRobin,
+  type DiscordAccountId,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import { parseDuelCompetitor } from "#src/progression/duels/competitors.ts";
+
+export async function listGuildDuels(
+  db: ExtendedPrismaClient,
+  guildId: DiscordGuildId,
+  viewerDiscordId: DiscordAccountId,
+) {
+  const [events, direct] = await Promise.all([
+    db.duelEvent.findMany({
+      where: { guildId },
+      orderBy: { createdAt: "desc" },
+      include: { _count: { select: { entrants: true, series: true } } },
+    }),
+    db.duelSeries.findMany({
+      where: {
+        guildId,
+        eventId: null,
+        OR: [
+          { participants: { every: { acceptedAt: { not: null } } } },
+          { participants: { some: { discordId: viewerDiscordId } } },
+          { organizerDiscordId: viewerDiscordId },
+        ],
+      },
+      orderBy: { createdAt: "desc" },
+      take: 100,
+      include: {
+        competitorOne: { include: { members: true } },
+        competitorTwo: { include: { members: true } },
+      },
+    }),
+  ]);
+  return {
+    events: events.map((event) => ({
+      id: event.id,
+      name: event.name,
+      format: DuelEventFormatSchema.parse(event.format),
+      competitorKind: event.competitorKind,
+      state: event.eventState,
+      entrants: event._count.entrants,
+      series: event._count.series,
+      createdAt: event.createdAt.toISOString(),
+    })),
+    direct: direct.map((series) => ({
+      id: series.id,
+      state: DuelSeriesStatusSchema.parse(series.seriesState),
+      bestOf: series.bestOf,
+      competitorOne: parseDuelCompetitor(series.competitorOne),
+      competitorTwo: parseDuelCompetitor(series.competitorTwo),
+      winnerCompetitorId: series.winnerCompetitorId,
+      deadlineAt: series.deadlineAt?.toISOString() ?? null,
+    })),
+  };
+}
+
+export async function getDuelEvent(
+  db: ExtendedPrismaClient,
+  guildId: DiscordGuildId,
+  eventId: string,
+  viewerDiscordId: DiscordAccountId,
+) {
+  const event = await db.duelEvent.findFirstOrThrow({
+    where: { id: eventId, guildId },
+    include: {
+      entrants: {
+        orderBy: [{ seed: "asc" }, { createdAt: "asc" }],
+        include: {
+          competitor: { include: { members: true } },
+        },
+      },
+      roundOverrides: { orderBy: { roundNumber: "asc" } },
+      series: {
+        orderBy: [{ roundNumber: "asc" }, { position: "asc" }],
+        include: {
+          competitorOne: { include: { members: true } },
+          competitorTwo: { include: { members: true } },
+          games: true,
+          participants: true,
+        },
+      },
+    },
+  });
+  const isOrganizer = event.organizerDiscordId === viewerDiscordId;
+  const viewerPlayers = await db.player.findMany({
+    where: {
+      serverId: guildId,
+      discordId: viewerDiscordId,
+      id: {
+        in: event.entrants.flatMap((entrant) =>
+          entrant.competitor.members.map((member) => member.playerId),
+        ),
+      },
+    },
+    select: { id: true },
+  });
+  const viewerPlayerIds = new Set(viewerPlayers.map((player) => player.id));
+  const visibleEntrants = event.entrants.filter(
+    (entrant) =>
+      entrant.registrationState === "accepted" ||
+      isOrganizer ||
+      entrant.competitor.members.some((member) =>
+        viewerPlayerIds.has(member.playerId),
+      ),
+  );
+  const visibleSeries = event.series.filter(
+    (series) =>
+      series.participants.every(
+        (participant) => participant.acceptedAt !== null,
+      ) ||
+      isOrganizer ||
+      series.participants.some(
+        (participant) => participant.discordId === viewerDiscordId,
+      ),
+  );
+  return {
+    id: event.id,
+    guildId: event.guildId,
+    name: event.name,
+    format: DuelEventFormatSchema.parse(event.format),
+    competitorKind: event.competitorKind,
+    bestOf: event.bestOf,
+    registrationMode: event.registrationMode,
+    seedMethod: event.seedMethod,
+    matchWindowHours: event.matchWindowHours,
+    state: event.eventState,
+    registrationClosesAt: event.registrationClosesAt?.toISOString() ?? null,
+    entrants: visibleEntrants.map((entrant) => ({
+      competitor: parseDuelCompetitor(entrant.competitor),
+      state: entrant.registrationState,
+      seed: entrant.seed,
+    })),
+    roundOverrides: event.roundOverrides,
+    series: visibleSeries.map((series) => ({
+      id: series.id,
+      roundNumber: series.roundNumber,
+      bracket: series.bracket,
+      position: series.position,
+      state: DuelSeriesStatusSchema.parse(series.seriesState),
+      competitorOne: parseDuelCompetitor(series.competitorOne),
+      competitorTwo: parseDuelCompetitor(series.competitorTwo),
+      winnerCompetitorId: series.winnerCompetitorId,
+      gameWins: {
+        first: series.games.filter(
+          (game) => game.winnerCompetitorId === series.competitorOneId,
+        ).length,
+        second: series.games.filter(
+          (game) => game.winnerCompetitorId === series.competitorTwoId,
+        ).length,
+      },
+    })),
+  };
+}
+
+export async function getDuelEventStandings(
+  db: ExtendedPrismaClient,
+  guildId: DiscordGuildId,
+  eventId: string,
+) {
+  const event = await db.duelEvent.findFirstOrThrow({
+    where: { id: eventId, guildId },
+    include: {
+      entrants: { where: { registrationState: "accepted" } },
+      series: { include: { games: true } },
+    },
+  });
+  const standings = event.entrants.map((entrant) => {
+    const relevant = event.series.filter(
+      (series) =>
+        series.competitorOneId === entrant.competitorId ||
+        series.competitorTwoId === entrant.competitorId,
+    );
+    const games = relevant.flatMap((series) => series.games);
+    return buildDuelStanding({
+      competitorId: entrant.competitorId,
+      gameWins: games.filter(
+        (game) => game.winnerCompetitorId === entrant.competitorId,
+      ).length,
+      gameLosses: games.filter(
+        (game) =>
+          game.resultState === "verified" &&
+          game.winnerCompetitorId !== entrant.competitorId,
+      ).length,
+      seriesWins: relevant.filter(
+        (series) => series.winnerCompetitorId === entrant.competitorId,
+      ).length,
+      seriesLosses: relevant.filter(
+        (series) =>
+          series.seriesState === "completed" &&
+          series.winnerCompetitorId !== entrant.competitorId,
+      ).length,
+      streak: 0,
+    });
+  });
+  if (event.format !== "round_robin") return { standings, ranks: null };
+  const results = event.series.flatMap((series) => {
+    if (series.winnerCompetitorId === null) return [];
+    return [
+      {
+        firstCompetitorId: series.competitorOneId,
+        secondCompetitorId: series.competitorTwoId,
+        winnerCompetitorId: series.winnerCompetitorId,
+        firstGameWins: series.games.filter(
+          (game) => game.winnerCompetitorId === series.competitorOneId,
+        ).length,
+        secondGameWins: series.games.filter(
+          (game) => game.winnerCompetitorId === series.competitorTwoId,
+        ).length,
+      },
+    ];
+  });
+  return {
+    standings,
+    ranks: rankRoundRobin(
+      event.entrants.map((entrant) => entrant.competitorId),
+      results,
+    ),
+  };
+}
+
+export async function getRollingDuelRecords(
+  db: ExtendedPrismaClient,
+  guildId: DiscordGuildId,
+  scope: "individual" | "pair",
+) {
+  const [records, competitors] = await Promise.all([
+    db.duelRecord.findMany({
+      where: { guildId, scope, opponentKey: "" },
+      orderBy: [{ wins: "desc" }, { games: "desc" }, { subjectKey: "asc" }],
+    }),
+    db.duelCompetitor.findMany({
+      where: { guildId },
+      orderBy: { createdAt: "desc" },
+      include: { members: true },
+    }),
+  ]);
+  const labels = new Map<string, string>();
+  for (const competitor of competitors) {
+    const members = competitor.members.toSorted(
+      (left, right) => left.position - right.position,
+    );
+    for (const member of members) {
+      const key = `player:${member.playerId.toString()}`;
+      if (!labels.has(key)) labels.set(key, member.playerAlias);
+    }
+    if (members.length === 2) {
+      const pairKey = `pair:${members
+        .map((member) => member.playerId)
+        .toSorted((left, right) => left - right)
+        .map(String)
+        .join("+")}`;
+      if (!labels.has(pairKey)) {
+        labels.set(
+          pairKey,
+          competitor.teamName ??
+            members.map((member) => member.playerAlias).join(" + "),
+        );
+      }
+    }
+  }
+  return records.map((record) => ({
+    subjectKey: record.subjectKey,
+    label: labels.get(record.subjectKey) ?? record.subjectKey,
+    games: record.games,
+    series: record.series,
+    wins: record.wins,
+    losses: record.losses,
+    seriesWins: record.seriesWins,
+    seriesLosses: record.seriesLosses,
+    winRate: record.games === 0 ? null : record.wins / record.games,
+    placed: record.games >= 5,
+    streak: record.streak,
+  }));
+}
+
+export async function getDuelHeadToHead(
+  db: ExtendedPrismaClient,
+  options: {
+    readonly guildId: DiscordGuildId;
+    readonly scope: "individual" | "pair";
+    readonly firstSubjectKey: string;
+    readonly secondSubjectKey: string;
+  },
+) {
+  const recordScope =
+    options.scope === "individual"
+      ? "head_to_head_individual"
+      : "head_to_head_pair";
+  const [first, second] = await Promise.all([
+    db.duelRecord.findUnique({
+      where: {
+        guildId_scope_subjectKey_opponentKey: {
+          guildId: options.guildId,
+          scope: recordScope,
+          subjectKey: options.firstSubjectKey,
+          opponentKey: options.secondSubjectKey,
+        },
+      },
+    }),
+    db.duelRecord.findUnique({
+      where: {
+        guildId_scope_subjectKey_opponentKey: {
+          guildId: options.guildId,
+          scope: recordScope,
+          subjectKey: options.secondSubjectKey,
+          opponentKey: options.firstSubjectKey,
+        },
+      },
+    }),
+  ]);
+  return { first, second };
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/read.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/read.ts
@@ -8,12 +8,22 @@ import {
 } from "@scout-for-lol/data";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
 import { parseDuelCompetitor } from "#src/progression/duels/competitors.ts";
+import {
+  currentParticipantDiscordIds,
+  duelSeriesVisibleTo,
+  effectiveParticipantDiscordId,
+} from "#src/progression/duels/series.ts";
 
 export async function listGuildDuels(
   db: ExtendedPrismaClient,
   guildId: DiscordGuildId,
   viewerDiscordId: DiscordAccountId,
 ) {
+  const viewerPlayers = await db.player.findMany({
+    where: { serverId: guildId, discordId: viewerDiscordId },
+    select: { id: true },
+  });
+  const viewerPlayerIds = viewerPlayers.map((player) => player.id);
   const [events, direct] = await Promise.all([
     db.duelEvent.findMany({
       where: { guildId },
@@ -26,7 +36,7 @@ export async function listGuildDuels(
         eventId: null,
         OR: [
           { participants: { every: { acceptedAt: { not: null } } } },
-          { participants: { some: { discordId: viewerDiscordId } } },
+          { participants: { some: { playerId: { in: viewerPlayerIds } } } },
           { organizerDiscordId: viewerDiscordId },
         ],
       },
@@ -35,9 +45,18 @@ export async function listGuildDuels(
       include: {
         competitorOne: { include: { members: true } },
         competitorTwo: { include: { members: true } },
+        participants: true,
       },
     }),
   ]);
+  const currentDiscordIdByPlayer = await currentParticipantDiscordIds(
+    db,
+    guildId,
+    direct.flatMap((series) => series.participants),
+  );
+  const visibleDirect = direct.filter((series) =>
+    duelSeriesVisibleTo(currentDiscordIdByPlayer, series, viewerDiscordId),
+  );
   return {
     events: events.map((event) => ({
       id: event.id,
@@ -49,7 +68,7 @@ export async function listGuildDuels(
       series: event._count.series,
       createdAt: event.createdAt.toISOString(),
     })),
-    direct: direct.map((series) => ({
+    direct: visibleDirect.map((series) => ({
       id: series.id,
       state: DuelSeriesStatusSchema.parse(series.seriesState),
       bestOf: series.bestOf,
@@ -89,36 +108,40 @@ export async function getDuelEvent(
     },
   });
   const isOrganizer = event.organizerDiscordId === viewerDiscordId;
-  const viewerPlayers = await db.player.findMany({
+  const currentPlayers = await db.player.findMany({
     where: {
       serverId: guildId,
-      discordId: viewerDiscordId,
       id: {
         in: event.entrants.flatMap((entrant) =>
           entrant.competitor.members.map((member) => member.playerId),
         ),
       },
     },
-    select: { id: true },
+    select: { id: true, discordId: true },
   });
-  const viewerPlayerIds = new Set(viewerPlayers.map((player) => player.id));
+  const currentDiscordIdByPlayer = new Map(
+    currentPlayers.map((player) => [player.id, player.discordId]),
+  );
+  const viewerPlayerIds = new Set(
+    currentPlayers
+      .filter((player) => player.discordId === viewerDiscordId)
+      .map((player) => player.id),
+  );
   const visibleEntrants = event.entrants.filter(
     (entrant) =>
-      entrant.registrationState === "accepted" ||
+      (entrant.registrationState === "accepted" &&
+        entrant.competitor.members.every(
+          (member) =>
+            effectiveParticipantDiscordId(currentDiscordIdByPlayer, member) ===
+            member.discordId,
+        )) ||
       isOrganizer ||
       entrant.competitor.members.some((member) =>
         viewerPlayerIds.has(member.playerId),
       ),
   );
-  const visibleSeries = event.series.filter(
-    (series) =>
-      series.participants.every(
-        (participant) => participant.acceptedAt !== null,
-      ) ||
-      isOrganizer ||
-      series.participants.some(
-        (participant) => participant.discordId === viewerDiscordId,
-      ),
+  const visibleSeries = event.series.filter((series) =>
+    duelSeriesVisibleTo(currentDiscordIdByPlayer, series, viewerDiscordId),
   );
   return {
     id: event.id,

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/records.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/records.ts
@@ -1,0 +1,203 @@
+import type { Db } from "#src/database/index.ts";
+
+export function duelRecordSubjectKeys(competitor: {
+  readonly members: readonly { readonly playerId: number }[];
+}) {
+  const players = competitor.members
+    .map((member) => member.playerId)
+    .toSorted((left, right) => left - right);
+  return {
+    individuals: players.map((playerId) => `player:${playerId.toString()}`),
+    pair: players.length === 2 ? `pair:${players.map(String).join("+")}` : null,
+  };
+}
+
+function nextStreak(previous: number | null, won: boolean): number {
+  if (previous === null) return won ? 1 : -1;
+  if (won) return previous >= 0 ? previous + 1 : 1;
+  return previous <= 0 ? previous - 1 : -1;
+}
+
+async function updateRecord(
+  tx: Db,
+  options: {
+    readonly guildId: string;
+    readonly scope: string;
+    readonly subjectKey: string;
+    readonly opponentKey: string;
+    readonly gameResult: "won" | "lost" | null;
+    readonly seriesResult: "won" | "lost" | null;
+  },
+): Promise<void> {
+  const key = {
+    guildId_scope_subjectKey_opponentKey: {
+      guildId: options.guildId,
+      scope: options.scope,
+      subjectKey: options.subjectKey,
+      opponentKey: options.opponentKey,
+    },
+  };
+  const existing = await tx.duelRecord.findUnique({ where: key });
+  const streak =
+    options.gameResult === null
+      ? (existing?.streak ?? 0)
+      : nextStreak(existing?.streak ?? null, options.gameResult === "won");
+  await tx.duelRecord.upsert({
+    where: key,
+    create: {
+      guildId: options.guildId,
+      scope: options.scope,
+      subjectKey: options.subjectKey,
+      opponentKey: options.opponentKey,
+      games: options.gameResult === null ? 0 : 1,
+      wins: options.gameResult === "won" ? 1 : 0,
+      losses: options.gameResult === "lost" ? 1 : 0,
+      series: options.seriesResult === null ? 0 : 1,
+      seriesWins: options.seriesResult === "won" ? 1 : 0,
+      seriesLosses: options.seriesResult === "lost" ? 1 : 0,
+      streak,
+    },
+    update: {
+      ...(options.gameResult === null
+        ? {}
+        : {
+            games: { increment: 1 },
+            wins: { increment: options.gameResult === "won" ? 1 : 0 },
+            losses: { increment: options.gameResult === "lost" ? 1 : 0 },
+            streak,
+          }),
+      series: { increment: options.seriesResult === null ? 0 : 1 },
+      seriesWins: { increment: options.seriesResult === "won" ? 1 : 0 },
+      seriesLosses: { increment: options.seriesResult === "lost" ? 1 : 0 },
+    },
+  });
+}
+
+async function updateStructuredSeries(
+  tx: Db,
+  options: {
+    readonly guildId: string;
+    readonly scope: string;
+    readonly subjectKey: string;
+    readonly won: boolean;
+  },
+): Promise<void> {
+  await tx.duelRecord.upsert({
+    where: {
+      guildId_scope_subjectKey_opponentKey: {
+        guildId: options.guildId,
+        scope: options.scope,
+        subjectKey: options.subjectKey,
+        opponentKey: "",
+      },
+    },
+    create: {
+      guildId: options.guildId,
+      scope: options.scope,
+      subjectKey: options.subjectKey,
+      series: 1,
+      seriesWins: options.won ? 1 : 0,
+      seriesLosses: options.won ? 0 : 1,
+    },
+    update: {
+      series: { increment: 1 },
+      seriesWins: { increment: options.won ? 1 : 0 },
+      seriesLosses: { increment: options.won ? 0 : 1 },
+    },
+  });
+}
+
+export async function recordDuelSide(
+  tx: Db,
+  options: {
+    readonly guildId: string;
+    readonly own: ReturnType<typeof duelRecordSubjectKeys>;
+    readonly opponent: ReturnType<typeof duelRecordSubjectKeys>;
+    readonly gameResult: "won" | "lost" | null;
+    readonly seriesResult: "won" | "lost" | null;
+    readonly structured: boolean;
+  },
+): Promise<void> {
+  for (const subjectKey of options.own.individuals) {
+    await updateRecord(tx, {
+      guildId: options.guildId,
+      scope: "individual",
+      subjectKey,
+      opponentKey: "",
+      gameResult: options.gameResult,
+      seriesResult: options.seriesResult,
+    });
+    for (const opponentKey of options.opponent.individuals) {
+      await updateRecord(tx, {
+        guildId: options.guildId,
+        scope: "head_to_head_individual",
+        subjectKey,
+        opponentKey,
+        gameResult: options.gameResult,
+        seriesResult: options.seriesResult,
+      });
+    }
+    if (options.structured && options.seriesResult !== null) {
+      await updateStructuredSeries(tx, {
+        guildId: options.guildId,
+        scope: "structured_individual",
+        subjectKey,
+        won: options.seriesResult === "won",
+      });
+    }
+  }
+  if (options.own.pair === null) return;
+  await updateRecord(tx, {
+    guildId: options.guildId,
+    scope: "pair",
+    subjectKey: options.own.pair,
+    opponentKey: "",
+    gameResult: options.gameResult,
+    seriesResult: options.seriesResult,
+  });
+  if (options.opponent.pair !== null) {
+    await updateRecord(tx, {
+      guildId: options.guildId,
+      scope: "head_to_head_pair",
+      subjectKey: options.own.pair,
+      opponentKey: options.opponent.pair,
+      gameResult: options.gameResult,
+      seriesResult: options.seriesResult,
+    });
+  }
+  if (options.structured && options.seriesResult !== null) {
+    await updateStructuredSeries(tx, {
+      guildId: options.guildId,
+      scope: "structured_pair",
+      subjectKey: options.own.pair,
+      won: options.seriesResult === "won",
+    });
+  }
+}
+
+export async function recordCommitteeSeriesOutcome(
+  tx: Db,
+  options: {
+    readonly guildId: string;
+    readonly winner: Parameters<typeof duelRecordSubjectKeys>[0];
+    readonly loser: Parameters<typeof duelRecordSubjectKeys>[0];
+    readonly structured: boolean;
+  },
+): Promise<void> {
+  await recordDuelSide(tx, {
+    guildId: options.guildId,
+    own: duelRecordSubjectKeys(options.winner),
+    opponent: duelRecordSubjectKeys(options.loser),
+    gameResult: null,
+    seriesResult: "won",
+    structured: options.structured,
+  });
+  await recordDuelSide(tx, {
+    guildId: options.guildId,
+    own: duelRecordSubjectKeys(options.loser),
+    opponent: duelRecordSubjectKeys(options.winner),
+    gameResult: null,
+    seriesResult: "lost",
+    structured: options.structured,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/registration.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/registration.ts
@@ -31,7 +31,6 @@ export async function registerDuelEventEntrant(
     await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('scout-duel-event-registration'), hashtext(${options.eventId}))`;
     const event = await tx.duelEvent.findFirstOrThrow({
       where: { id: options.eventId, guildId: options.guildId },
-      include: { _count: { select: { entrants: true } } },
     });
     if (event.eventState !== "registration_open") {
       throw new Error("This event is not accepting registrations");
@@ -50,10 +49,6 @@ export async function registerDuelEventEntrant(
       event.organizerDiscordId !== options.actorDiscordId
     ) {
       throw new Error("Only the organizer may invite an entrant");
-    }
-    const maximum = event.format === "round_robin" ? 16 : 64;
-    if (event._count.entrants >= maximum) {
-      throw new Error(`This event is capped at ${maximum.toString()} entrants`);
     }
     const kind = event.competitorKind === "player" ? "player" : "pair";
     const guildId = DiscordGuildIdSchema.parse(event.guildId);
@@ -144,6 +139,17 @@ export async function acceptDuelEventRegistration(
       entrant.event.registrationClosesAt <= new Date()
     ) {
       throw new Error("Registration has closed");
+    }
+    const maximum = entrant.event.format === "round_robin" ? 16 : 64;
+    const acceptedCompetitors = await tx.duelEventEntrant.count({
+      where: {
+        eventId: entrant.eventId,
+        registrationState: "accepted",
+        competitorId: { not: entrant.competitorId },
+      },
+    });
+    if (acceptedCompetitors >= maximum) {
+      throw new Error(`This event is capped at ${maximum.toString()} entrants`);
     }
     const players = await tx.player.findMany({
       where: {

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/registration.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/registration.ts
@@ -64,9 +64,11 @@ export async function registerDuelEventEntrant(
     });
     assertSingleRiotRegion([
       ...competitor.accounts.map((account) => account.region),
-      ...existingEntrants.flatMap((entrant) =>
-        entrant.competitor.members.map((member) => member.region),
-      ),
+      ...existingEntrants
+        .filter((entrant) => entrant.registrationState === "accepted")
+        .flatMap((entrant) =>
+          entrant.competitor.members.map((member) => member.region),
+        ),
     ]);
     const registeredPlayerIds = new Set(
       existingEntrants.flatMap((entrant) =>
@@ -140,6 +142,20 @@ export async function acceptDuelEventRegistration(
     ) {
       throw new Error("Registration has closed");
     }
+    const acceptedEntrants = await tx.duelEventEntrant.findMany({
+      where: {
+        eventId: entrant.eventId,
+        registrationState: "accepted",
+        competitorId: { not: entrant.competitorId },
+      },
+      include: { competitor: { include: { members: true } } },
+    });
+    assertSingleRiotRegion([
+      ...entrant.competitor.members.map((member) => member.region),
+      ...acceptedEntrants.flatMap((acceptedEntrant) =>
+        acceptedEntrant.competitor.members.map((member) => member.region),
+      ),
+    ]);
     const maximum = entrant.event.format === "round_robin" ? 16 : 64;
     const acceptedCompetitors = await tx.duelEventEntrant.count({
       where: {

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/registration.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/registration.ts
@@ -1,0 +1,211 @@
+import {
+  DUEL_DISCLOSURE_VERSION,
+  DiscordGuildIdSchema,
+  type DiscordAccountId,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import {
+  duelCompetitorCreateData,
+  resolveDuelCompetitorSelection,
+  type DuelCompetitorSelection,
+} from "#src/progression/duels/competitors.ts";
+
+function assertSingleRiotRegion(regions: readonly string[]): void {
+  if (new Set(regions).size !== 1) {
+    throw new Error("Duel competitors must use accounts in one Riot region");
+  }
+}
+
+export async function registerDuelEventEntrant(
+  db: ExtendedPrismaClient,
+  options: {
+    readonly guildId: DiscordGuildId;
+    readonly eventId: string;
+    readonly actorDiscordId: DiscordAccountId;
+    readonly selection: DuelCompetitorSelection;
+    readonly source: "open" | "invitation";
+  },
+) {
+  return await db.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('scout-duel-event-registration'), hashtext(${options.eventId}))`;
+    const event = await tx.duelEvent.findFirstOrThrow({
+      where: { id: options.eventId, guildId: options.guildId },
+      include: { _count: { select: { entrants: true } } },
+    });
+    if (event.eventState !== "registration_open") {
+      throw new Error("This event is not accepting registrations");
+    }
+    if (
+      event.registrationClosesAt !== null &&
+      event.registrationClosesAt <= new Date()
+    ) {
+      throw new Error("Registration has closed");
+    }
+    if (options.source === "open" && event.registrationMode !== "open") {
+      throw new Error("This event accepts invitations only");
+    }
+    if (
+      options.source === "invitation" &&
+      event.organizerDiscordId !== options.actorDiscordId
+    ) {
+      throw new Error("Only the organizer may invite an entrant");
+    }
+    const maximum = event.format === "round_robin" ? 16 : 64;
+    if (event._count.entrants >= maximum) {
+      throw new Error(`This event is capped at ${maximum.toString()} entrants`);
+    }
+    const kind = event.competitorKind === "player" ? "player" : "pair";
+    const guildId = DiscordGuildIdSchema.parse(event.guildId);
+    const competitor = await resolveDuelCompetitorSelection(
+      tx,
+      guildId,
+      kind,
+      options.selection,
+    );
+    const existingEntrants = await tx.duelEventEntrant.findMany({
+      where: { eventId: event.id },
+      include: { competitor: { include: { members: true } } },
+    });
+    assertSingleRiotRegion([
+      ...competitor.accounts.map((account) => account.region),
+      ...existingEntrants.flatMap((entrant) =>
+        entrant.competitor.members.map((member) => member.region),
+      ),
+    ]);
+    const registeredPlayerIds = new Set(
+      existingEntrants.flatMap((entrant) =>
+        entrant.competitor.members.map((member) => member.playerId),
+      ),
+    );
+    if (
+      competitor.accounts.some((account) =>
+        registeredPlayerIds.has(account.playerId),
+      )
+    ) {
+      throw new Error("A guild player may enter an event only once");
+    }
+    if (
+      options.source === "open" &&
+      !competitor.accounts.some(
+        (account) => account.discordId === options.actorDiscordId,
+      )
+    ) {
+      throw new Error("Open registration must include the signed-in player");
+    }
+    const row = await tx.duelCompetitor.create({
+      data: duelCompetitorCreateData(guildId, competitor),
+    });
+    await tx.duelEventEntrant.create({
+      data: {
+        eventId: event.id,
+        competitorId: row.id,
+        registrationSource: options.source,
+        registrationState: "pending",
+        invitedAt: options.source === "invitation" ? new Date() : null,
+        registeredAt: options.source === "open" ? new Date() : null,
+      },
+    });
+    return { competitorId: row.id };
+  });
+}
+
+export async function acceptDuelEventRegistration(
+  db: ExtendedPrismaClient,
+  options: {
+    readonly guildId: DiscordGuildId;
+    readonly eventId: string;
+    readonly competitorId: string;
+    readonly actorDiscordId: DiscordAccountId;
+  },
+) {
+  await db.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('scout-duel-event-registration'), hashtext(${options.eventId}))`;
+    const entrant = await tx.duelEventEntrant.findUniqueOrThrow({
+      where: {
+        eventId_competitorId: {
+          eventId: options.eventId,
+          competitorId: options.competitorId,
+        },
+      },
+      include: {
+        event: true,
+        competitor: { include: { members: true } },
+      },
+    });
+    if (entrant.event.guildId !== options.guildId) {
+      throw new Error("Event does not belong to this guild");
+    }
+    if (entrant.event.eventState !== "registration_open") {
+      throw new Error("This event is not accepting registrations");
+    }
+    if (
+      entrant.event.registrationClosesAt !== null &&
+      entrant.event.registrationClosesAt <= new Date()
+    ) {
+      throw new Error("Registration has closed");
+    }
+    const players = await tx.player.findMany({
+      where: {
+        id: {
+          in: entrant.competitor.members.map((member) => member.playerId),
+        },
+        serverId: options.guildId,
+      },
+      select: { id: true, discordId: true },
+    });
+    if (
+      !players.some((player) => player.discordId === options.actorDiscordId)
+    ) {
+      throw new Error("Only an invited competitor may accept registration");
+    }
+    if (players.length !== entrant.competitor.members.length) {
+      throw new Error("Every invited guild player must still be tracked");
+    }
+    const disclosures = await tx.duelDisclosureAcceptance.findMany({
+      where: {
+        guildId: entrant.event.guildId,
+        playerId: { in: players.map((player) => player.id) },
+        disclosureVersion: DUEL_DISCLOSURE_VERSION,
+      },
+    });
+    if (
+      !players.every(
+        (player) =>
+          player.discordId !== null &&
+          disclosures.some(
+            (disclosure) =>
+              disclosure.playerId === player.id &&
+              disclosure.discordId === player.discordId,
+          ),
+      )
+    ) {
+      throw new Error(
+        "Every teammate must accept the custom-match disclosure first",
+      );
+    }
+    for (const player of players) {
+      if (player.discordId === null) {
+        throw new Error("Every teammate must retain a Discord identity");
+      }
+      await tx.duelCompetitorMember.update({
+        where: {
+          competitorId_playerId: {
+            competitorId: entrant.competitorId,
+            playerId: player.id,
+          },
+        },
+        data: { discordId: player.discordId },
+      });
+    }
+    await tx.duelEventEntrant.update({
+      where: {
+        eventId_competitorId: {
+          eventId: entrant.eventId,
+          competitorId: entrant.competitorId,
+        },
+      },
+      data: { registrationState: "accepted", acceptedAt: new Date() },
+    });
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/results.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/results.ts
@@ -71,7 +71,19 @@ function timelineInput(match: RawMatch, timeline: RawTimeline) {
         ) {
           return [];
         }
-        return [{ timestampMs: event.timestamp, scoringTeamId: event.teamId }];
+        // Riot's BUILDING_KILL teamId is the team whose structure was
+        // destroyed, not the team credited with the takedown. A duel's first
+        // turret belongs to the opposing team in the match roster.
+        const teamIds = new Set(
+          match.info.participants.map((participant) => participant.teamId),
+        );
+        if (teamIds.size !== 2 || !teamIds.has(event.teamId)) return [];
+        const scoringTeamId = [...teamIds].find(
+          (teamId) => teamId !== event.teamId,
+        );
+        return scoringTeamId === undefined
+          ? []
+          : [{ timestampMs: event.timestamp, scoringTeamId }];
       }),
     ),
     frames: timeline.info.frames.map((frame) => ({

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/results.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/results.ts
@@ -1,0 +1,341 @@
+import {
+  DuelRulesetV1Schema,
+  DuelTimelineInputSchema,
+  MatchIdSchema,
+  evaluateDuelGame,
+  type DuelResultEvidence,
+  type RawMatch,
+  type RawTimeline,
+} from "@scout-for-lol/data";
+import type { ScoutStage } from "@scout-for-lol/temporal";
+import { prisma } from "#src/database/index.ts";
+import { advanceDuelEvent } from "#src/progression/duels/advancement.ts";
+import { parseDuelCompetitor } from "#src/progression/duels/competitors.ts";
+import { signalDuelSeries } from "#src/progression/duels/launch.ts";
+import {
+  duelRecordSubjectKeys,
+  recordDuelSide,
+} from "#src/progression/duels/records.ts";
+import {
+  duelResults,
+  duelSeriesTransitions,
+} from "#src/metrics/progression.ts";
+export async function duelMatchNeedsTimeline(
+  match: RawMatch,
+): Promise<boolean> {
+  const tournamentCode = match.info.tournamentCode;
+  if (tournamentCode === undefined) return false;
+  return (
+    (await prisma.duelGame.count({
+      where: {
+        gameState: { in: ["code_ready", "in_progress"] },
+        tournamentLobby: { code: tournamentCode },
+        series: { seriesState: { in: ["code_ready", "in_progress"] } },
+      },
+    })) > 0
+  );
+}
+
+function timelineInput(match: RawMatch, timeline: RawTimeline) {
+  const puuidByParticipant = new Map(
+    timeline.info.participants.map((participant) => [
+      participant.participantId,
+      participant.puuid,
+    ]),
+  );
+  return DuelTimelineInputSchema.parse({
+    matchId: match.metadata.matchId,
+    completed: true,
+    timelineComplete: true,
+    participants: match.info.participants.map((participant) => ({
+      puuid: participant.puuid,
+      teamId: participant.teamId,
+    })),
+    kills: timeline.info.frames.flatMap((frame) =>
+      frame.events.flatMap((event) => {
+        if (event.type !== "CHAMPION_KILL" || event.killerId === undefined) {
+          return [];
+        }
+        const killerPuuid = puuidByParticipant.get(event.killerId);
+        return killerPuuid === undefined
+          ? []
+          : [{ timestampMs: event.timestamp, killerPuuid }];
+      }),
+    ),
+    turretKills: timeline.info.frames.flatMap((frame) =>
+      frame.events.flatMap((event) => {
+        if (
+          event.type !== "BUILDING_KILL" ||
+          event.buildingType !== "TOWER_BUILDING" ||
+          event.teamId === undefined
+        ) {
+          return [];
+        }
+        return [
+          { timestampMs: event.timestamp, destroyedTeamId: event.teamId },
+        ];
+      }),
+    ),
+    frames: timeline.info.frames.map((frame) => ({
+      timestampMs: frame.timestamp,
+      participants: Object.values(frame.participantFrames ?? {}).flatMap(
+        (participant) => {
+          const puuid = puuidByParticipant.get(participant.participantId);
+          return puuid === undefined
+            ? []
+            : [
+                {
+                  puuid,
+                  minionsKilled: participant.minionsKilled,
+                  jungleMinionsKilled: participant.jungleMinionsKilled,
+                },
+              ];
+        },
+      ),
+    })),
+  });
+}
+
+function seriesAcceptsGame(
+  seriesState: string,
+  gameNumber: number,
+  games: readonly { readonly gameNumber: number }[],
+): boolean {
+  return (
+    ["code_ready", "in_progress"].includes(seriesState) &&
+    !games.some((candidate) => candidate.gameNumber > gameNumber)
+  );
+}
+
+async function recordVerifiedResult(
+  gameId: string,
+  evidence: DuelResultEvidence,
+  stage: ScoutStage,
+): Promise<void> {
+  const change = await prisma.$transaction(async (tx) => {
+    // Serialize every rolling-record mutation in a guild. Besides preserving
+    // streak order, taking the lock before reading the game makes duplicate
+    // post-match deliveries observe the committed verified result and return
+    // without incrementing any record twice.
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('scout-duel-records'), hashtext((SELECT "guildId" FROM "DuelSeries" WHERE id = (SELECT "seriesId" FROM "DuelGame" WHERE id = ${gameId}))))`;
+    await tx.$executeRaw`SELECT 1 FROM "DuelSeries" WHERE "id" = (SELECT "seriesId" FROM "DuelGame" WHERE "id" = ${gameId}) FOR UPDATE`;
+    const game = await tx.duelGame.findUniqueOrThrow({
+      where: { id: gameId },
+      include: {
+        series: {
+          include: {
+            competitorOne: { include: { members: true } },
+            competitorTwo: { include: { members: true } },
+            games: true,
+          },
+        },
+      },
+    });
+    if (game.resultState === "verified") return null;
+    const series = game.series;
+    if (!seriesAcceptsGame(series.seriesState, game.gameNumber, series.games))
+      return null;
+    const winnerIsFirst =
+      evidence.winnerCompetitorId === series.competitorOneId;
+    if (
+      !winnerIsFirst &&
+      evidence.winnerCompetitorId !== series.competitorTwoId
+    ) {
+      throw new Error("Verified duel evidence names an unassigned winner");
+    }
+    const winner = winnerIsFirst ? series.competitorOne : series.competitorTwo;
+    const loser = winnerIsFirst ? series.competitorTwo : series.competitorOne;
+    const priorWinnerGames = series.games.filter(
+      (candidate) =>
+        candidate.resultState === "verified" &&
+        candidate.winnerCompetitorId === evidence.winnerCompetitorId,
+    ).length;
+    const requiredWins = Math.floor(series.bestOf / 2) + 1;
+    const seriesComplete = priorWinnerGames + 1 >= requiredWins;
+    const winnerKeys = duelRecordSubjectKeys(winner);
+    const loserKeys = duelRecordSubjectKeys(loser);
+    await tx.duelGame.update({
+      where: { id: game.id },
+      data: {
+        matchId: MatchIdSchema.parse(evidence.matchId),
+        gameState: "completed",
+        resultState: "verified",
+        winnerCompetitorId: evidence.winnerCompetitorId,
+        objective: evidence.objective,
+        objectiveTimestampMs: evidence.objectiveTimestampMs,
+        evidenceJson: JSON.stringify(evidence),
+        reviewReason: null,
+        verifiedAt: new Date(),
+      },
+    });
+    await recordDuelSide(tx, {
+      guildId: series.guildId,
+      own: winnerKeys,
+      opponent: loserKeys,
+      gameResult: "won",
+      seriesResult: seriesComplete ? "won" : null,
+      structured: series.eventId !== null,
+    });
+    await recordDuelSide(tx, {
+      guildId: series.guildId,
+      own: loserKeys,
+      opponent: winnerKeys,
+      gameResult: "lost",
+      seriesResult: seriesComplete ? "lost" : null,
+      structured: series.eventId !== null,
+    });
+    if (seriesComplete) {
+      await tx.duelSeries.update({
+        where: { id: series.id },
+        data: {
+          seriesState: "completed",
+          winnerCompetitorId: evidence.winnerCompetitorId,
+          advancementKind: "played",
+          completedAt: new Date(),
+        },
+      });
+    } else {
+      await tx.duelSeries.update({
+        where: { id: series.id },
+        data: { seriesState: "awaiting_readiness" },
+      });
+      await tx.duelSeriesParticipant.updateMany({
+        where: { seriesId: series.id },
+        data: { readyAt: null },
+      });
+      await tx.duelGame.create({
+        data: {
+          seriesId: series.id,
+          gameNumber:
+            Math.max(...series.games.map((row) => row.gameNumber)) + 1,
+        },
+      });
+    }
+    return {
+      seriesId: series.id,
+      eventId: series.eventId,
+      seriesComplete,
+      deadlineAt: series.deadlineAt ?? new Date(),
+      requestId: `duel-result:${game.id}`,
+    };
+  });
+  if (change === null) return;
+  duelResults.inc({ status: "verified" });
+  duelSeriesTransitions.inc({
+    from: "in_progress",
+    to: change.seriesComplete ? "completed" : "awaiting_readiness",
+  });
+  await signalDuelSeries({
+    stage,
+    seriesId: change.seriesId,
+    deadlineAt: change.deadlineAt,
+    requestId: change.requestId,
+  });
+  if (change.seriesComplete && change.eventId !== null) {
+    await advanceDuelEvent(change.eventId, stage);
+  }
+}
+
+export async function processDuelResult(
+  match: RawMatch,
+  timeline: RawTimeline | null | undefined,
+  stage: ScoutStage,
+): Promise<void> {
+  const tournamentCode = match.info.tournamentCode;
+  const game = await prisma.duelGame.findFirst({
+    where: {
+      OR: [
+        { matchId: MatchIdSchema.parse(match.metadata.matchId) },
+        ...(tournamentCode === undefined
+          ? []
+          : [{ tournamentLobby: { code: tournamentCode } }]),
+      ],
+    },
+    include: {
+      series: {
+        include: {
+          participants: true,
+          competitorOne: { include: { members: true } },
+          competitorTwo: { include: { members: true } },
+          games: true,
+        },
+      },
+    },
+  });
+  if (game === null) return;
+  if (game.resultState === "verified") return;
+  const series = game.series;
+  if (!seriesAcceptsGame(series.seriesState, game.gameNumber, series.games))
+    return;
+  const competitors = [
+    parseDuelCompetitor(series.competitorOne),
+    parseDuelCompetitor(series.competitorTwo),
+  ];
+  const evidence =
+    timeline === null || timeline === undefined
+      ? {
+          matchId: match.metadata.matchId,
+          state: "needs_review" as const,
+          winnerCompetitorId: null,
+          objective: null,
+          objectiveTimestampMs: null,
+          reason: "Complete timeline evidence is unavailable",
+          participantPuuids: match.metadata.participants,
+          timelineComplete: false,
+        }
+      : evaluateDuelGame(
+          DuelRulesetV1Schema.parse(JSON.parse(series.rulesetJson)),
+          competitors,
+          timelineInput(match, timeline),
+        );
+  if (
+    evidence.state === "needs_review" ||
+    evidence.winnerCompetitorId === null
+  ) {
+    const applied = await prisma.$transaction(async (tx) => {
+      await tx.$executeRaw`SELECT 1 FROM "DuelSeries" WHERE "id" = ${series.id} FOR UPDATE`;
+      const current = await tx.duelGame.findUniqueOrThrow({
+        where: { id: game.id },
+        include: { series: { include: { games: true } } },
+      });
+      if (
+        !seriesAcceptsGame(
+          current.series.seriesState,
+          current.gameNumber,
+          current.series.games,
+        )
+      ) {
+        return false;
+      }
+      await tx.duelGame.update({
+        where: { id: game.id },
+        data: {
+          matchId: MatchIdSchema.parse(match.metadata.matchId),
+          gameState: "needs_review",
+          resultState: "needs_review",
+          evidenceJson: JSON.stringify(evidence),
+          reviewReason: evidence.reason,
+        },
+      });
+      await tx.duelSeries.update({
+        where: { id: series.id },
+        data: { seriesState: "needs_review" },
+      });
+      return true;
+    });
+    if (!applied) return;
+    duelResults.inc({ status: "needs_review" });
+    duelSeriesTransitions.inc({
+      from: series.seriesState,
+      to: "needs_review",
+    });
+    await signalDuelSeries({
+      stage,
+      seriesId: series.id,
+      deadlineAt: series.deadlineAt ?? new Date(),
+      requestId: `duel-result-review:${game.id}`,
+    });
+    return;
+  }
+  await recordVerifiedResult(game.id, evidence, stage);
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/results.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/results.ts
@@ -71,9 +71,7 @@ function timelineInput(match: RawMatch, timeline: RawTimeline) {
         ) {
           return [];
         }
-        return [
-          { timestampMs: event.timestamp, destroyedTeamId: event.teamId },
-        ];
+        return [{ timestampMs: event.timestamp, scoringTeamId: event.teamId }];
       }),
     ),
     frames: timeline.info.frames.map((frame) => ({

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/review.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/review.ts
@@ -1,0 +1,225 @@
+import type { DiscordAccountId, DiscordGuildId } from "@scout-for-lol/data";
+import type { Db, ExtendedPrismaClient } from "#src/database/index.ts";
+import { recordCommitteeSeriesOutcome } from "#src/progression/duels/records.ts";
+
+type DuelSeriesDecision =
+  | { readonly kind: "replay" }
+  | { readonly kind: "no_contest" }
+  | { readonly kind: "advance"; readonly winnerCompetitorId: string };
+
+type DecisionSeries = {
+  readonly id: string;
+  readonly guildId: string;
+  readonly organizerDiscordId: string;
+  readonly seriesState: string;
+  readonly eventId: string | null;
+  readonly competitorOneId: string;
+  readonly competitorTwoId: string;
+  readonly competitorOne: {
+    readonly members: readonly { readonly playerId: number }[];
+  };
+  readonly competitorTwo: {
+    readonly members: readonly { readonly playerId: number }[];
+  };
+  readonly games: readonly {
+    readonly gameNumber: number;
+    readonly resultState: string | null;
+  }[];
+};
+
+function validateDecision(
+  series: DecisionSeries,
+  actorDiscordId: string,
+  decision: DuelSeriesDecision,
+): void {
+  if (series.organizerDiscordId !== actorDiscordId) {
+    throw new Error("Only the series organizer may committee a result");
+  }
+  if (!["overdue", "needs_review"].includes(series.seriesState)) {
+    throw new Error("This series does not require an organizer decision");
+  }
+  if (
+    decision.kind === "advance" &&
+    decision.winnerCompetitorId !== series.competitorOneId &&
+    decision.winnerCompetitorId !== series.competitorTwoId
+  ) {
+    throw new Error("The advancement winner is not assigned to this series");
+  }
+  if (decision.kind === "no_contest" && series.eventId !== null) {
+    throw new Error(
+      "Structured event series cannot be closed as no-contest; choose replay or advancement",
+    );
+  }
+}
+
+async function applyReplay(
+  tx: Db,
+  series: DecisionSeries,
+  deadlineAt: Date,
+): Promise<void> {
+  await tx.duelGame.create({
+    data: {
+      seriesId: series.id,
+      gameNumber:
+        Math.max(0, ...series.games.map((game) => game.gameNumber)) + 1,
+    },
+  });
+  await tx.duelSeriesParticipant.updateMany({
+    where: { seriesId: series.id },
+    data: { readyAt: null },
+  });
+  await tx.duelSeries.update({
+    where: { id: series.id },
+    data: {
+      seriesState: "awaiting_readiness",
+      deadlineAt,
+      advancementKind: null,
+      advancementReason: null,
+    },
+  });
+}
+
+async function applyNoContest(
+  tx: Db,
+  seriesId: string,
+  reason: string,
+  now: Date,
+): Promise<void> {
+  await tx.duelSeries.update({
+    where: { id: seriesId },
+    data: {
+      seriesState: "no_contest",
+      advancementKind: "no_contest",
+      advancementReason: reason,
+      completedAt: now,
+    },
+  });
+}
+
+async function applyAdvancement(
+  tx: Db,
+  series: DecisionSeries,
+  options: {
+    readonly winnerCompetitorId: string;
+    readonly reason: string;
+    readonly now: Date;
+  },
+): Promise<void> {
+  if (series.games.some((game) => game.resultState === "verified")) {
+    const winnerIsFirst = options.winnerCompetitorId === series.competitorOneId;
+    await recordCommitteeSeriesOutcome(tx, {
+      guildId: series.guildId,
+      winner: winnerIsFirst ? series.competitorOne : series.competitorTwo,
+      loser: winnerIsFirst ? series.competitorTwo : series.competitorOne,
+      structured: series.eventId !== null,
+    });
+  }
+  await tx.duelSeries.update({
+    where: { id: series.id },
+    data: {
+      seriesState: "completed",
+      winnerCompetitorId: options.winnerCompetitorId,
+      advancementKind: "committee",
+      advancementReason: options.reason,
+      completedAt: options.now,
+    },
+  });
+}
+
+async function applyDecision(
+  tx: Db,
+  series: DecisionSeries,
+  options: {
+    readonly decision: DuelSeriesDecision;
+    readonly reason: string;
+    readonly now: Date;
+    readonly deadlineAt: Date;
+  },
+): Promise<void> {
+  if (options.decision.kind === "replay") {
+    await applyReplay(tx, series, options.deadlineAt);
+    return;
+  }
+  if (options.decision.kind === "no_contest") {
+    await applyNoContest(tx, series.id, options.reason, options.now);
+    return;
+  }
+  await applyAdvancement(tx, series, {
+    winnerCompetitorId: options.decision.winnerCompetitorId,
+    reason: options.reason,
+    now: options.now,
+  });
+}
+
+export async function decideDuelSeries(
+  db: ExtendedPrismaClient,
+  options: {
+    readonly seriesId: string;
+    readonly guildId: DiscordGuildId;
+    readonly actorDiscordId: DiscordAccountId;
+    readonly idempotencyKey: string;
+    readonly reason: string;
+    readonly decision: DuelSeriesDecision;
+  },
+) {
+  if (options.reason.trim().length < 3) {
+    throw new Error("An organizer decision requires an audited reason");
+  }
+  return await db.$transaction(async (tx) => {
+    const prior = await tx.duelAuditDecision.findUnique({
+      where: { idempotencyKey: options.idempotencyKey },
+    });
+    if (prior !== null) {
+      if (prior.seriesId !== options.seriesId) {
+        throw new Error(
+          "The organizer decision key was reused for another series",
+        );
+      }
+      const series = await tx.duelSeries.findFirstOrThrow({
+        where: { id: options.seriesId, guildId: options.guildId },
+      });
+      return {
+        seriesId: series.id,
+        eventId: series.eventId,
+        seriesComplete:
+          series.seriesState === "completed" &&
+          series.winnerCompetitorId !== null,
+        deadlineAt: series.deadlineAt ?? new Date(),
+      };
+    }
+    await tx.$executeRaw`SELECT 1 FROM "DuelSeries" WHERE "id" = ${options.seriesId} FOR UPDATE`;
+    const series = await tx.duelSeries.findFirstOrThrow({
+      where: { id: options.seriesId, guildId: options.guildId },
+      include: {
+        games: true,
+        competitorOne: { include: { members: true } },
+        competitorTwo: { include: { members: true } },
+      },
+    });
+    validateDecision(series, options.actorDiscordId, options.decision);
+    const now = new Date();
+    const deadlineAt = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+    await tx.duelAuditDecision.create({
+      data: {
+        seriesId: series.id,
+        actorDiscordId: options.actorDiscordId,
+        action: options.decision.kind,
+        reason: options.reason.trim(),
+        payloadJson: JSON.stringify(options.decision),
+        idempotencyKey: options.idempotencyKey,
+      },
+    });
+    await applyDecision(tx, series, {
+      decision: options.decision,
+      reason: options.reason.trim(),
+      now,
+      deadlineAt,
+    });
+    return {
+      seriesId: series.id,
+      eventId: series.eventId,
+      seriesComplete: options.decision.kind === "advance",
+      deadlineAt,
+    };
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/review.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/review.ts
@@ -31,9 +31,13 @@ type DecisionSeries = {
 function validateDecision(
   series: DecisionSeries,
   actorDiscordId: string,
+  allowPrivilegedReviewer: boolean,
   decision: DuelSeriesDecision,
 ): void {
-  if (series.organizerDiscordId !== actorDiscordId) {
+  if (
+    !allowPrivilegedReviewer &&
+    series.organizerDiscordId !== actorDiscordId
+  ) {
     throw new Error("Only the series organizer may committee a result");
   }
   if (!["overdue", "needs_review"].includes(series.seriesState)) {
@@ -158,6 +162,7 @@ export async function decideDuelSeries(
     readonly seriesId: string;
     readonly guildId: DiscordGuildId;
     readonly actorDiscordId: DiscordAccountId;
+    readonly allowPrivilegedReviewer: boolean;
     readonly idempotencyKey: string;
     readonly reason: string;
     readonly decision: DuelSeriesDecision;
@@ -197,7 +202,12 @@ export async function decideDuelSeries(
         competitorTwo: { include: { members: true } },
       },
     });
-    validateDecision(series, options.actorDiscordId, options.decision);
+    validateDecision(
+      series,
+      options.actorDiscordId,
+      options.allowPrivilegedReviewer,
+      options.decision,
+    );
     const now = new Date();
     const deadlineAt = new Date(
       now.getTime() + series.matchWindowHours * 60 * 60 * 1000,

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/review.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/review.ts
@@ -15,6 +15,7 @@ type DecisionSeries = {
   readonly eventId: string | null;
   readonly competitorOneId: string;
   readonly competitorTwoId: string;
+  readonly matchWindowHours: number;
   readonly competitorOne: {
     readonly members: readonly { readonly playerId: number }[];
   };
@@ -198,7 +199,9 @@ export async function decideDuelSeries(
     });
     validateDecision(series, options.actorDiscordId, options.decision);
     const now = new Date();
-    const deadlineAt = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+    const deadlineAt = new Date(
+      now.getTime() + series.matchWindowHours * 60 * 60 * 1000,
+    );
     await tx.duelAuditDecision.create({
       data: {
         seriesId: series.id,

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/round-robin.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/round-robin.ts
@@ -1,0 +1,48 @@
+import type { RoundRobinSeriesResult } from "@scout-for-lol/data";
+
+export type RoundRobinSeries = {
+  readonly id: string;
+  readonly roundNumber: number | null;
+  readonly createdAt: Date;
+  readonly competitorOneId: string;
+  readonly competitorTwoId: string;
+  readonly winnerCompetitorId: string | null;
+  readonly games: readonly { readonly winnerCompetitorId: string | null }[];
+};
+
+/**
+ * Tiebreak rematches replace the original meeting for their competitor pair.
+ * Keep only the latest series so every caller uses the same decisive result.
+ */
+export function latestRoundRobinResults(
+  series: readonly RoundRobinSeries[],
+): RoundRobinSeriesResult[] {
+  const latestByMatchup = new Map<string, RoundRobinSeries>();
+  for (const candidate of series.toSorted(
+    (left, right) =>
+      (left.roundNumber ?? 0) - (right.roundNumber ?? 0) ||
+      left.createdAt.getTime() - right.createdAt.getTime() ||
+      left.id.localeCompare(right.id),
+  )) {
+    const matchup = [candidate.competitorOneId, candidate.competitorTwoId]
+      .toSorted()
+      .join(":");
+    latestByMatchup.set(matchup, candidate);
+  }
+  return [...latestByMatchup.values()].flatMap((candidate) => {
+    if (candidate.winnerCompetitorId === null) return [];
+    return [
+      {
+        firstCompetitorId: candidate.competitorOneId,
+        secondCompetitorId: candidate.competitorTwoId,
+        winnerCompetitorId: candidate.winnerCompetitorId,
+        firstGameWins: candidate.games.filter(
+          (game) => game.winnerCompetitorId === candidate.competitorOneId,
+        ).length,
+        secondGameWins: candidate.games.filter(
+          (game) => game.winnerCompetitorId === candidate.competitorTwoId,
+        ).length,
+      },
+    ];
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/series-workflow-state.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/series-workflow-state.ts
@@ -1,0 +1,366 @@
+import {
+  DiscordAccountIdSchema,
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+  DuelSeriesStatusSchema,
+  RegionSchema,
+  type DiscordChannelId,
+} from "@scout-for-lol/data";
+import type {
+  ScoutDuelSeriesInput,
+  ScoutDuelSeriesRefreshResult,
+} from "@scout-for-lol/temporal";
+import { tournamentApiMode } from "#src/config/dynamic.ts";
+import { prisma } from "#src/database/index.ts";
+import { provisionTournamentLobby } from "#src/league/tournament/provision-lobby.ts";
+import { duelRolloutAllowed } from "#src/progression/duels/access.ts";
+import {
+  duelResults,
+  duelSeriesOverdue,
+  duelSeriesTransitions,
+  duelTournamentProvisioning,
+} from "#src/metrics/progression.ts";
+
+const TERMINAL_STATES = new Set([
+  "overdue",
+  "needs_review",
+  "completed",
+  "no_contest",
+  "cancelled",
+]);
+
+function recordTransition(from: string, to: string): void {
+  if (from !== to) duelSeriesTransitions.inc({ from, to });
+}
+
+function refreshResult(
+  state: string,
+  deadlineAt: Date,
+): ScoutDuelSeriesRefreshResult {
+  const seriesState = DuelSeriesStatusSchema.parse(state);
+  return {
+    terminal: TERMINAL_STATES.has(seriesState),
+    status: seriesState,
+    deadlineAt: deadlineAt.toISOString(),
+  };
+}
+
+function closedSeriesResult(
+  state: string,
+  deadlineAt: Date,
+): ScoutDuelSeriesRefreshResult | null {
+  if (TERMINAL_STATES.has(state)) return refreshResult(state, deadlineAt);
+  if (deadlineAt <= new Date()) return refreshResult(state, deadlineAt);
+  return null;
+}
+
+async function currentRefreshResult(
+  seriesId: string,
+  fallbackDeadlineAt: Date,
+): Promise<ScoutDuelSeriesRefreshResult> {
+  const current = await prisma.duelSeries.findUniqueOrThrow({
+    where: { id: seriesId },
+    select: { seriesState: true, deadlineAt: true },
+  });
+  return refreshResult(
+    current.seriesState,
+    current.deadlineAt ?? fallbackDeadlineAt,
+  );
+}
+
+async function transitionSeries(options: {
+  readonly seriesId: string;
+  readonly currentState: string;
+  readonly nextState:
+    "awaiting_acceptance" | "awaiting_readiness" | "code_ready";
+  readonly deadlineAt: Date;
+  readonly windowStartsAt?: Date | null;
+}): Promise<ScoutDuelSeriesRefreshResult> {
+  if (options.currentState === options.nextState) {
+    return refreshResult(options.nextState, options.deadlineAt);
+  }
+  const updated = await prisma.duelSeries.updateMany({
+    where: { id: options.seriesId, seriesState: options.currentState },
+    data: {
+      seriesState: options.nextState,
+      ...(options.nextState === "awaiting_readiness"
+        ? {
+            windowStartsAt: options.windowStartsAt ?? new Date(),
+            deadlineAt: options.deadlineAt,
+          }
+        : {}),
+    },
+  });
+  if (updated.count === 0) {
+    return await currentRefreshResult(options.seriesId, options.deadlineAt);
+  }
+  recordTransition(options.currentState, options.nextState);
+  return refreshResult(options.nextState, options.deadlineAt);
+}
+
+async function claimGameProvisioning(options: {
+  readonly seriesId: string;
+  readonly currentState: string;
+  readonly gameNumber: number;
+}) {
+  return await prisma.$transaction(async (tx) => {
+    const transitioned = await tx.duelSeries.updateMany({
+      where: { id: options.seriesId, seriesState: options.currentState },
+      data: { seriesState: "provisioning_code" },
+    });
+    if (transitioned.count === 0) return null;
+    return await tx.duelGame.upsert({
+      where: {
+        seriesId_gameNumber: {
+          seriesId: options.seriesId,
+          gameNumber: options.gameNumber,
+        },
+      },
+      create: {
+        seriesId: options.seriesId,
+        gameNumber: options.gameNumber,
+        gameState: "provisioning_code",
+      },
+      update: { gameState: "provisioning_code" },
+    });
+  });
+}
+
+async function markRegionReview(options: {
+  readonly seriesId: string;
+  readonly gameId: string;
+  readonly deadlineAt: Date;
+}): Promise<ScoutDuelSeriesRefreshResult> {
+  const transitioned = await prisma.$transaction(async (tx) => {
+    const updatedSeries = await tx.duelSeries.updateMany({
+      where: { id: options.seriesId, seriesState: "provisioning_code" },
+      data: { seriesState: "needs_review" },
+    });
+    if (updatedSeries.count === 0) return false;
+    const updatedGame = await tx.duelGame.updateMany({
+      where: { id: options.gameId, gameState: "provisioning_code" },
+      data: {
+        gameState: "needs_review",
+        resultState: "needs_review",
+        reviewReason: "Duel competitors must use accounts in one Riot region",
+      },
+    });
+    if (updatedGame.count !== 1) {
+      throw new Error("A provisioning duel game changed state unexpectedly");
+    }
+    return true;
+  });
+  if (!transitioned) {
+    return await currentRefreshResult(options.seriesId, options.deadlineAt);
+  }
+  duelResults.inc({ status: "needs_review" });
+  recordTransition("provisioning_code", "needs_review");
+  return refreshResult("needs_review", options.deadlineAt);
+}
+
+async function finishCodeProvisioning(options: {
+  readonly seriesId: string;
+  readonly gameId: string;
+  readonly guildId: string;
+  readonly channelId: DiscordChannelId;
+  readonly gameNumber: number;
+  readonly lobbyId: number;
+}): Promise<boolean> {
+  return await prisma.$transaction(async (tx) => {
+    const transitioned = await tx.duelSeries.updateMany({
+      where: { id: options.seriesId, seriesState: "provisioning_code" },
+      data: { seriesState: "code_ready" },
+    });
+    if (transitioned.count === 0) return false;
+    const updatedGame = await tx.duelGame.updateMany({
+      where: { id: options.gameId, gameState: "provisioning_code" },
+      data: { tournamentLobbyId: options.lobbyId, gameState: "code_ready" },
+    });
+    if (updatedGame.count !== 1) {
+      throw new Error("A provisioned duel game changed state unexpectedly");
+    }
+    await tx.duelStatusOutbox.upsert({
+      where: { dedupeKey: `duel-code-ready:${options.gameId}` },
+      create: {
+        guildId: options.guildId,
+        channelId: options.channelId,
+        dedupeKey: `duel-code-ready:${options.gameId}`,
+        payloadJson: JSON.stringify({
+          kind: "code_ready",
+          seriesId: options.seriesId,
+          gameNumber: options.gameNumber,
+        }),
+      },
+      update: {},
+    });
+    return true;
+  });
+}
+
+export async function refreshDuelSeriesWorkflowState(
+  input: ScoutDuelSeriesInput,
+): Promise<ScoutDuelSeriesRefreshResult> {
+  const series = await prisma.duelSeries.findUniqueOrThrow({
+    where: { id: input.seriesId },
+    include: {
+      participants: true,
+      games: { orderBy: { gameNumber: "desc" }, take: 1 },
+      competitorOne: { include: { members: true } },
+      competitorTwo: { include: { members: true } },
+    },
+  });
+  const deadlineAt = series.deadlineAt ?? new Date(input.deadlineAt);
+  const currentState = DuelSeriesStatusSchema.parse(series.seriesState);
+  const closed = closedSeriesResult(currentState, deadlineAt);
+  if (closed !== null) return closed;
+  if (
+    series.participants.some((participant) => participant.acceptedAt === null)
+  ) {
+    return await transitionSeries({
+      seriesId: series.id,
+      currentState,
+      nextState: "awaiting_acceptance",
+      deadlineAt,
+    });
+  }
+  if (series.participants.some((participant) => participant.readyAt === null)) {
+    return await transitionSeries({
+      seriesId: series.id,
+      currentState,
+      nextState: "awaiting_readiness",
+      deadlineAt,
+      windowStartsAt: series.windowStartsAt,
+    });
+  }
+
+  const existingGame = series.games[0];
+  if (existingGame !== undefined && existingGame.tournamentLobbyId !== null) {
+    return await transitionSeries({
+      seriesId: series.id,
+      currentState,
+      nextState: "code_ready",
+      deadlineAt,
+    });
+  }
+
+  const guildId = DiscordGuildIdSchema.parse(series.guildId);
+  if (!(await duelRolloutAllowed(prisma, guildId, input.stage))) {
+    return refreshResult("awaiting_readiness", deadlineAt);
+  }
+  const gameNumber = existingGame?.gameNumber ?? 1;
+  const game = await claimGameProvisioning({
+    seriesId: series.id,
+    currentState,
+    gameNumber,
+  });
+  if (game === null) {
+    return await currentRefreshResult(series.id, deadlineAt);
+  }
+  recordTransition(currentState, "provisioning_code");
+  const firstMembers = series.competitorOne.members.toSorted(
+    (left, right) => left.position - right.position,
+  );
+  const secondMembers = series.competitorTwo.members.toSorted(
+    (left, right) => left.position - right.position,
+  );
+  const regions = new Set(
+    [...firstMembers, ...secondMembers].map((member) => member.region),
+  );
+  if (regions.size !== 1) {
+    return await markRegionReview({
+      seriesId: series.id,
+      gameId: game.id,
+      deadlineAt,
+    });
+  }
+  const regionValue = [...regions][0];
+  if (regionValue === undefined) {
+    throw new Error("A ready duel series has no frozen Riot accounts");
+  }
+  let lobby;
+  try {
+    lobby = await provisionTournamentLobby(prisma, {
+      kind: "declared",
+      requestId: `duel:${series.id}:game:${gameNumber.toString()}`,
+      mode: tournamentApiMode(),
+      serverId: guildId,
+      channelId: DiscordChannelIdSchema.parse(series.channelId),
+      creatorDiscordId: DiscordAccountIdSchema.parse(series.organizerDiscordId),
+      blue: {
+        aliases: firstMembers.map((member) => member.playerAlias),
+        puuids: firstMembers.map((member) => member.puuid),
+        region: RegionSchema.parse(regionValue),
+      },
+      red: {
+        aliases: secondMembers.map((member) => member.playerAlias),
+        puuids: secondMembers.map((member) => member.puuid),
+        region: RegionSchema.parse(regionValue),
+      },
+      pickType: "TOURNAMENT_DRAFT",
+      mapType: "SUMMONERS_RIFT",
+      spectatorType: "ALL",
+      lobbyName: `Scout duel ${series.id.slice(0, 8)}`,
+    });
+    duelTournamentProvisioning.inc({ status: "ready" });
+  } catch (error) {
+    duelTournamentProvisioning.inc({ status: "failed" });
+    throw error;
+  }
+  const codeReady = await finishCodeProvisioning({
+    seriesId: series.id,
+    gameId: game.id,
+    guildId: series.guildId,
+    channelId: series.channelId,
+    gameNumber,
+    lobbyId: lobby.id,
+  });
+  if (!codeReady) return await currentRefreshResult(series.id, deadlineAt);
+  recordTransition("provisioning_code", "code_ready");
+  return refreshResult("code_ready", deadlineAt);
+}
+
+export async function markDuelSeriesOverdue(
+  input: ScoutDuelSeriesInput,
+): Promise<void> {
+  const now = new Date();
+  const transitioned = await prisma.$transaction(async (tx) => {
+    const series = await tx.duelSeries.findUniqueOrThrow({
+      where: { id: input.seriesId },
+      include: { participants: true },
+    });
+    const currentState = DuelSeriesStatusSchema.parse(series.seriesState);
+    if (TERMINAL_STATES.has(currentState)) return null;
+    const deadlineAt = series.deadlineAt ?? new Date(input.deadlineAt);
+    if (deadlineAt > now) return null;
+    const updated = await tx.duelSeries.updateMany({
+      where: {
+        id: series.id,
+        seriesState: { notIn: [...TERMINAL_STATES] },
+        OR: [{ deadlineAt: null }, { deadlineAt: { lte: now } }],
+      },
+      data: { seriesState: "overdue" },
+    });
+    if (updated.count === 0) return null;
+    await tx.duelStatusOutbox.upsert({
+      where: { dedupeKey: `duel-overdue:${series.id}` },
+      create: {
+        guildId: series.guildId,
+        channelId: series.channelId,
+        dedupeKey: `duel-overdue:${series.id}`,
+        payloadJson: JSON.stringify({
+          kind: "overdue",
+          seriesId: series.id,
+          mentionDiscordIds: series.participants.map(
+            (participant) => participant.discordId,
+          ),
+        }),
+      },
+      update: {},
+    });
+    return currentState;
+  });
+  if (transitioned !== null) {
+    recordTransition(transitioned, "overdue");
+    duelSeriesOverdue.inc();
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/series-workflow-state.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/series-workflow-state.ts
@@ -1,10 +1,13 @@
 import {
+  DUEL_DISCLOSURE_VERSION,
   DiscordAccountIdSchema,
   DiscordChannelIdSchema,
   DiscordGuildIdSchema,
   DuelSeriesStatusSchema,
+  PlayerIdSchema,
   RegionSchema,
   type DiscordChannelId,
+  type DiscordGuildId,
 } from "@scout-for-lol/data";
 import type {
   ScoutDuelSeriesInput,
@@ -96,6 +99,74 @@ async function transitionSeries(options: {
   }
   recordTransition(options.currentState, options.nextState);
   return refreshResult(options.nextState, options.deadlineAt);
+}
+
+async function participantsHaveCurrentConsent(
+  guildId: DiscordGuildId,
+  participants: readonly {
+    readonly playerId: number;
+    readonly discordId: string;
+  }[],
+): Promise<boolean> {
+  const playerIds = participants.map((participant) =>
+    PlayerIdSchema.parse(participant.playerId),
+  );
+  const [players, disclosures] = await Promise.all([
+    prisma.player.findMany({
+      where: { id: { in: playerIds }, serverId: guildId },
+      select: { id: true, discordId: true },
+    }),
+    prisma.duelDisclosureAcceptance.findMany({
+      where: {
+        guildId,
+        playerId: { in: playerIds },
+        disclosureVersion: DUEL_DISCLOSURE_VERSION,
+      },
+      select: { playerId: true, discordId: true },
+    }),
+  ]);
+  const currentDiscordIdByPlayer = new Map(
+    players.map((player) => [player.id, player.discordId]),
+  );
+  const disclosureKeys = new Set(
+    disclosures.map(
+      (disclosure) =>
+        `${disclosure.playerId.toString()}:${disclosure.discordId}`,
+    ),
+  );
+  return participants.every(
+    (participant) =>
+      currentDiscordIdByPlayer.get(
+        PlayerIdSchema.parse(participant.playerId),
+      ) === participant.discordId &&
+      disclosureKeys.has(
+        `${participant.playerId.toString()}:${participant.discordId}`,
+      ),
+  );
+}
+
+async function resetStaleParticipantConsent(options: {
+  readonly seriesId: string;
+  readonly currentState: string;
+  readonly deadlineAt: Date;
+}): Promise<ScoutDuelSeriesRefreshResult> {
+  const reset = await prisma.$transaction(async (tx) => {
+    const updated = await tx.duelSeries.updateMany({
+      where: { id: options.seriesId, seriesState: options.currentState },
+      data: { seriesState: "awaiting_acceptance" },
+    });
+    if (updated.count === 0) return false;
+    await tx.duelSeriesParticipant.updateMany({
+      where: { seriesId: options.seriesId },
+      data: { acceptedAt: null, readyAt: null },
+    });
+    return true;
+  });
+  if (!reset) {
+    return await currentRefreshResult(options.seriesId, options.deadlineAt);
+  }
+  recordTransition(options.currentState, "awaiting_acceptance");
+  return refreshResult("awaiting_acceptance", options.deadlineAt);
 }
 
 async function claimGameProvisioning(options: {
@@ -246,6 +317,13 @@ export async function refreshDuelSeriesWorkflowState(
   const guildId = DiscordGuildIdSchema.parse(series.guildId);
   if (!(await duelRolloutAllowed(prisma, guildId, input.stage))) {
     return refreshResult("awaiting_readiness", deadlineAt);
+  }
+  if (!(await participantsHaveCurrentConsent(guildId, series.participants))) {
+    return await resetStaleParticipantConsent({
+      seriesId: series.id,
+      currentState,
+      deadlineAt,
+    });
   }
   const gameNumber = existingGame?.gameNumber ?? 1;
   const game = await claimGameProvisioning({

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/series.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/series.ts
@@ -132,6 +132,7 @@ export async function createDirectDuel(
         existing.organizerDiscordId !== options.organizerDiscordId ||
         existing.channelId !== options.channelId ||
         existing.bestOf !== bestOf ||
+        existing.matchWindowHours !== matchWindowHours ||
         existing.rulesetJson !== JSON.stringify(ruleset) ||
         !competitorMatches(existing.competitorOne, first) ||
         !competitorMatches(existing.competitorTwo, second)
@@ -153,6 +154,7 @@ export async function createDirectDuel(
         competitorOneId: firstRow.id,
         competitorTwoId: secondRow.id,
         bestOf,
+        matchWindowHours,
         rulesetJson: JSON.stringify(ruleset),
         channelId: options.channelId,
         organizerDiscordId: options.organizerDiscordId,
@@ -232,7 +234,7 @@ export async function acceptDuelDisclosure(
   });
 }
 
-async function currentParticipantDiscordIds(
+export async function currentParticipantDiscordIds(
   db: ExtendedPrismaClient,
   guildId: DiscordGuildId,
   participants: readonly {
@@ -250,13 +252,42 @@ async function currentParticipantDiscordIds(
   return new Map(players.map((player) => [player.id, player.discordId]));
 }
 
-function effectiveParticipantDiscordId(
+export function effectiveParticipantDiscordId(
   current: ReadonlyMap<number, string | null>,
   participant: { readonly playerId: number; readonly discordId: string },
 ): string | null | undefined {
   return current.has(participant.playerId)
     ? current.get(participant.playerId)
     : participant.discordId;
+}
+
+export function duelSeriesVisibleTo(
+  currentDiscordIdByPlayer: ReadonlyMap<number, string | null>,
+  series: {
+    readonly organizerDiscordId: string;
+    readonly participants: readonly {
+      readonly playerId: number;
+      readonly discordId: string;
+      readonly acceptedAt: Date | null;
+    }[];
+  },
+  viewerDiscordId: DiscordAccountId,
+): boolean {
+  const allAccepted = series.participants.every(
+    (participant) =>
+      participant.acceptedAt !== null &&
+      effectiveParticipantDiscordId(currentDiscordIdByPlayer, participant) ===
+        participant.discordId,
+  );
+  return (
+    allAccepted ||
+    series.organizerDiscordId === viewerDiscordId ||
+    series.participants.some(
+      (participant) =>
+        effectiveParticipantDiscordId(currentDiscordIdByPlayer, participant) ===
+        viewerDiscordId,
+    )
+  );
 }
 
 async function participantSeries(
@@ -333,6 +364,11 @@ export async function markDuelReady(
   if (participants.some((participant) => participant.acceptedAt === null)) {
     throw new Error("Accept the duel before marking ready");
   }
+  if (participants.some((participant) => participant.discordId !== discordId)) {
+    throw new Error(
+      "Accept the duel again under your current Discord identity before marking ready",
+    );
+  }
   await db.duelSeriesParticipant.updateMany({
     where: {
       seriesId,
@@ -365,21 +401,7 @@ export async function getDuelSeries(
     guildId,
     series.participants,
   );
-  const allAccepted = series.participants.every(
-    (participant) =>
-      participant.acceptedAt !== null &&
-      effectiveParticipantDiscordId(currentDiscordIdByPlayer, participant) ===
-        participant.discordId,
-  );
-  const authorized =
-    allAccepted ||
-    series.organizerDiscordId === viewerDiscordId ||
-    series.participants.some(
-      (participant) =>
-        effectiveParticipantDiscordId(currentDiscordIdByPlayer, participant) ===
-        viewerDiscordId,
-    );
-  if (!authorized) {
+  if (!duelSeriesVisibleTo(currentDiscordIdByPlayer, series, viewerDiscordId)) {
     throw new Error("This duel is private until every participant accepts");
   }
   return {

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/series.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/series.ts
@@ -1,0 +1,475 @@
+import type { PlayerIdSchema } from "@scout-for-lol/data";
+import {
+  DUEL_DISCLOSURE_VERSION,
+  DiscordAccountIdSchema,
+  DuelBestOfSchema,
+  DuelRulesetV1Schema,
+  DuelSeriesStatusSchema,
+  type DiscordAccountId,
+  type DiscordChannelId,
+  type DiscordGuildId,
+  type DuelBestOf,
+  type DuelRulesetV1,
+} from "@scout-for-lol/data";
+import {
+  scoutDuelSeriesWorkflowId,
+  type ScoutStage,
+} from "@scout-for-lol/temporal";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import {
+  duelCompetitorCreateData,
+  parseDuelCompetitor,
+  resolveDuelCompetitorSelection,
+  type DuelCompetitorSelection,
+} from "#src/progression/duels/competitors.ts";
+
+const MIN_WINDOW_HOURS = 24;
+const MAX_WINDOW_HOURS = 14 * 24;
+
+type ResolvedCompetitor = Awaited<
+  ReturnType<typeof resolveDuelCompetitorSelection>
+>;
+
+function validateWindowHours(value: number): number {
+  if (
+    !Number.isInteger(value) ||
+    value < MIN_WINDOW_HOURS ||
+    value > MAX_WINDOW_HOURS
+  ) {
+    throw new Error("A duel match window must be between 24 hours and 14 days");
+  }
+  return value;
+}
+
+function competitorMatches(
+  stored: {
+    readonly kind: string;
+    readonly teamName: string | null;
+    readonly members: readonly { readonly accountId: number }[];
+  },
+  requested: ResolvedCompetitor,
+): boolean {
+  const storedAccounts = stored.members
+    .map((member) => member.accountId)
+    .toSorted((left, right) => left - right);
+  const requestedAccounts = requested.accounts
+    .map((account) => account.accountId)
+    .toSorted((left, right) => left - right);
+  return (
+    stored.kind === requested.kind &&
+    stored.teamName === requested.teamName &&
+    storedAccounts.length === requestedAccounts.length &&
+    storedAccounts.every(
+      (accountId, index) => accountId === requestedAccounts[index],
+    )
+  );
+}
+
+export async function createDirectDuel(
+  db: ExtendedPrismaClient,
+  options: {
+    readonly requestId: string;
+    readonly guildId: DiscordGuildId;
+    readonly organizerDiscordId: DiscordAccountId;
+    readonly channelId: DiscordChannelId;
+    readonly competitorKind: "player" | "pair";
+    readonly first: DuelCompetitorSelection;
+    readonly second: DuelCompetitorSelection;
+    readonly bestOf: DuelBestOf;
+    readonly ruleset: DuelRulesetV1;
+    readonly matchWindowHours: number;
+    readonly stage: ScoutStage;
+  },
+) {
+  const [first, second] = await Promise.all([
+    resolveDuelCompetitorSelection(
+      db,
+      options.guildId,
+      options.competitorKind,
+      options.first,
+    ),
+    resolveDuelCompetitorSelection(
+      db,
+      options.guildId,
+      options.competitorKind,
+      options.second,
+    ),
+  ]);
+  const allPlayers = [...first.accounts, ...second.accounts].map(
+    (account) => account.playerId,
+  );
+  if (new Set(allPlayers).size !== allPlayers.length) {
+    throw new Error("A player cannot appear on both sides of a duel");
+  }
+  if (
+    new Set(
+      [...first.accounts, ...second.accounts].map((account) => account.region),
+    ).size !== 1
+  ) {
+    throw new Error("Duel competitors must use accounts in one Riot region");
+  }
+  const ruleset = DuelRulesetV1Schema.parse(options.ruleset);
+  const bestOf = DuelBestOfSchema.parse(options.bestOf);
+  const matchWindowHours = validateWindowHours(options.matchWindowHours);
+  const now = new Date();
+  const deadlineAt = new Date(
+    now.getTime() + matchWindowHours * 60 * 60 * 1000,
+  );
+  const seriesId = options.requestId;
+  const workflowId = scoutDuelSeriesWorkflowId(options.stage, seriesId);
+  const series = await db.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('scout-direct-duel'), hashtext(${seriesId}))`;
+    const existing = await tx.duelSeries.findUnique({
+      where: { id: seriesId },
+      include: {
+        competitorOne: { include: { members: true } },
+        competitorTwo: { include: { members: true } },
+      },
+    });
+    if (existing !== null) {
+      if (
+        existing.guildId !== options.guildId ||
+        existing.organizerDiscordId !== options.organizerDiscordId ||
+        existing.channelId !== options.channelId ||
+        existing.bestOf !== bestOf ||
+        existing.rulesetJson !== JSON.stringify(ruleset) ||
+        !competitorMatches(existing.competitorOne, first) ||
+        !competitorMatches(existing.competitorTwo, second)
+      ) {
+        throw new Error("The duel request key was reused with different input");
+      }
+      return existing;
+    }
+    const firstRow = await tx.duelCompetitor.create({
+      data: duelCompetitorCreateData(options.guildId, first),
+    });
+    const secondRow = await tx.duelCompetitor.create({
+      data: duelCompetitorCreateData(options.guildId, second),
+    });
+    const row = await tx.duelSeries.create({
+      data: {
+        id: seriesId,
+        guildId: options.guildId,
+        competitorOneId: firstRow.id,
+        competitorTwoId: secondRow.id,
+        bestOf,
+        rulesetJson: JSON.stringify(ruleset),
+        channelId: options.channelId,
+        organizerDiscordId: options.organizerDiscordId,
+        deadlineAt,
+        workflowId,
+        participants: {
+          create: [...first.accounts, ...second.accounts].map((account) => ({
+            playerId: account.playerId,
+            competitorId: first.accounts.some(
+              (candidate) => candidate.playerId === account.playerId,
+            )
+              ? firstRow.id
+              : secondRow.id,
+            discordId: DiscordAccountIdSchema.parse(account.discordId),
+            disclosureVersion: DUEL_DISCLOSURE_VERSION,
+          })),
+        },
+      },
+    });
+    await tx.duelStatusOutbox.create({
+      data: {
+        guildId: options.guildId,
+        channelId: options.channelId,
+        dedupeKey: `duel-invited:${row.id}`,
+        payloadJson: JSON.stringify({
+          kind: "invited",
+          seriesId: row.id,
+          mentionDiscordIds: [...first.accounts, ...second.accounts].map(
+            (account) => account.discordId,
+          ),
+        }),
+      },
+    });
+    return row;
+  });
+  return {
+    seriesId: series.id,
+    deadlineAt: series.deadlineAt ?? deadlineAt,
+    workflowId: series.workflowId,
+  };
+}
+
+export async function acceptDuelDisclosure(
+  db: ExtendedPrismaClient,
+  options: {
+    readonly guildId: DiscordGuildId;
+    readonly playerId: ReturnType<typeof PlayerIdSchema.parse>;
+    readonly discordId: DiscordAccountId;
+  },
+) {
+  const player = await db.player.findFirstOrThrow({
+    where: {
+      id: options.playerId,
+      serverId: options.guildId,
+      discordId: options.discordId,
+    },
+  });
+  return await db.duelDisclosureAcceptance.upsert({
+    where: {
+      guildId_playerId_disclosureVersion: {
+        guildId: options.guildId,
+        playerId: player.id,
+        disclosureVersion: DUEL_DISCLOSURE_VERSION,
+      },
+    },
+    create: {
+      guildId: options.guildId,
+      playerId: player.id,
+      discordId: options.discordId,
+      disclosureVersion: DUEL_DISCLOSURE_VERSION,
+      acceptedAt: new Date(),
+    },
+    update: {
+      discordId: options.discordId,
+      acceptedAt: new Date(),
+    },
+  });
+}
+
+async function currentParticipantDiscordIds(
+  db: ExtendedPrismaClient,
+  guildId: DiscordGuildId,
+  participants: readonly {
+    readonly playerId: number;
+    readonly discordId: string;
+  }[],
+): Promise<ReadonlyMap<number, string | null>> {
+  const players = await db.player.findMany({
+    where: {
+      id: { in: participants.map((participant) => participant.playerId) },
+      serverId: guildId,
+    },
+    select: { id: true, discordId: true },
+  });
+  return new Map(players.map((player) => [player.id, player.discordId]));
+}
+
+function effectiveParticipantDiscordId(
+  current: ReadonlyMap<number, string | null>,
+  participant: { readonly playerId: number; readonly discordId: string },
+): string | null | undefined {
+  return current.has(participant.playerId)
+    ? current.get(participant.playerId)
+    : participant.discordId;
+}
+
+async function participantSeries(
+  db: ExtendedPrismaClient,
+  seriesId: string,
+  discordId: DiscordAccountId,
+  guildId: DiscordGuildId,
+) {
+  const series = await db.duelSeries.findFirstOrThrow({
+    where: { id: seriesId, guildId },
+    include: { participants: true },
+  });
+  const currentDiscordIdByPlayer = await currentParticipantDiscordIds(
+    db,
+    guildId,
+    series.participants,
+  );
+  const participants = series.participants.filter(
+    (participant) =>
+      effectiveParticipantDiscordId(currentDiscordIdByPlayer, participant) ===
+      discordId,
+  );
+  if (participants.length === 0) {
+    throw new Error("Only an assigned participant may change this series");
+  }
+  return { series, participants };
+}
+
+export async function acceptDuelChallenge(
+  db: ExtendedPrismaClient,
+  seriesId: string,
+  discordId: DiscordAccountId,
+  guildId: DiscordGuildId,
+) {
+  const { series, participants } = await participantSeries(
+    db,
+    seriesId,
+    discordId,
+    guildId,
+  );
+  const acceptedDisclosures = await db.duelDisclosureAcceptance.count({
+    where: {
+      guildId: series.guildId,
+      disclosureVersion: DUEL_DISCLOSURE_VERSION,
+      playerId: { in: participants.map((participant) => participant.playerId) },
+      discordId,
+    },
+  });
+  if (acceptedDisclosures !== participants.length) {
+    throw new Error("Accept the custom-match disclosure before joining a duel");
+  }
+  await db.duelSeriesParticipant.updateMany({
+    where: {
+      seriesId,
+      playerId: { in: participants.map((participant) => participant.playerId) },
+    },
+    data: { discordId, acceptedAt: new Date() },
+  });
+  return { deadlineAt: series.deadlineAt ?? new Date() };
+}
+
+export async function markDuelReady(
+  db: ExtendedPrismaClient,
+  seriesId: string,
+  discordId: DiscordAccountId,
+  guildId: DiscordGuildId,
+) {
+  const { series, participants } = await participantSeries(
+    db,
+    seriesId,
+    discordId,
+    guildId,
+  );
+  if (participants.some((participant) => participant.acceptedAt === null)) {
+    throw new Error("Accept the duel before marking ready");
+  }
+  await db.duelSeriesParticipant.updateMany({
+    where: {
+      seriesId,
+      playerId: { in: participants.map((participant) => participant.playerId) },
+      acceptedAt: { not: null },
+    },
+    data: { discordId, readyAt: new Date() },
+  });
+  return { deadlineAt: series.deadlineAt ?? new Date() };
+}
+
+export async function getDuelSeries(
+  db: ExtendedPrismaClient,
+  seriesId: string,
+  viewerDiscordId: DiscordAccountId,
+  guildId: DiscordGuildId,
+) {
+  const series = await db.duelSeries.findFirstOrThrow({
+    where: { id: seriesId, guildId },
+    include: {
+      competitorOne: { include: { members: true } },
+      competitorTwo: { include: { members: true } },
+      participants: true,
+      games: { orderBy: { gameNumber: "asc" } },
+      auditDecisions: { orderBy: { createdAt: "asc" } },
+    },
+  });
+  const currentDiscordIdByPlayer = await currentParticipantDiscordIds(
+    db,
+    guildId,
+    series.participants,
+  );
+  const allAccepted = series.participants.every(
+    (participant) =>
+      participant.acceptedAt !== null &&
+      effectiveParticipantDiscordId(currentDiscordIdByPlayer, participant) ===
+        participant.discordId,
+  );
+  const authorized =
+    allAccepted ||
+    series.organizerDiscordId === viewerDiscordId ||
+    series.participants.some(
+      (participant) =>
+        effectiveParticipantDiscordId(currentDiscordIdByPlayer, participant) ===
+        viewerDiscordId,
+    );
+  if (!authorized) {
+    throw new Error("This duel is private until every participant accepts");
+  }
+  return {
+    id: series.id,
+    guildId: series.guildId,
+    eventId: series.eventId,
+    isOrganizer: series.organizerDiscordId === viewerDiscordId,
+    state: DuelSeriesStatusSchema.parse(series.seriesState),
+    bestOf: DuelBestOfSchema.parse(series.bestOf),
+    ruleset: DuelRulesetV1Schema.parse(JSON.parse(series.rulesetJson)),
+    deadlineAt: series.deadlineAt?.toISOString() ?? null,
+    winnerCompetitorId: series.winnerCompetitorId,
+    competitorOne: parseDuelCompetitor(series.competitorOne),
+    competitorTwo: parseDuelCompetitor(series.competitorTwo),
+    participants: series.participants.map((participant) => ({
+      playerId: participant.playerId,
+      competitorId: participant.competitorId,
+      accepted: participant.acceptedAt !== null,
+      ready: participant.readyAt !== null,
+    })),
+    games: series.games.map((game) => ({
+      id: game.id,
+      gameNumber: game.gameNumber,
+      state: game.gameState,
+      resultState: game.resultState,
+      matchId: game.matchId,
+      winnerCompetitorId: game.winnerCompetitorId,
+      objective: game.objective,
+      objectiveTimestampMs: game.objectiveTimestampMs,
+      reviewReason: game.reviewReason,
+    })),
+    auditDecisions: series.auditDecisions.map((decision) => ({
+      action: decision.action,
+      reason: decision.reason,
+      createdAt: decision.createdAt.toISOString(),
+    })),
+  };
+}
+
+export async function getDuelCode(
+  db: ExtendedPrismaClient,
+  seriesId: string,
+  viewerDiscordId: DiscordAccountId,
+  guildId: DiscordGuildId,
+) {
+  const series = await db.duelSeries.findFirstOrThrow({
+    where: { id: seriesId, guildId },
+    include: {
+      participants: true,
+      games: {
+        orderBy: { gameNumber: "desc" },
+        take: 1,
+        include: { tournamentLobby: true },
+      },
+    },
+  });
+  const currentDiscordIdByPlayer = await currentParticipantDiscordIds(
+    db,
+    guildId,
+    series.participants,
+  );
+  if (
+    !series.participants.some(
+      (participant) =>
+        effectiveParticipantDiscordId(currentDiscordIdByPlayer, participant) ===
+        viewerDiscordId,
+    )
+  ) {
+    throw new Error(
+      "Tournament codes are visible only to assigned participants",
+    );
+  }
+  if (
+    !series.participants.every((participant) => participant.readyAt !== null)
+  ) {
+    throw new Error(
+      "The tournament code is unavailable until everyone is ready",
+    );
+  }
+  const game = series.games[0];
+  if (game?.gameState !== "code_ready" || series.seriesState !== "code_ready") {
+    throw new Error("The tournament code is not ready yet");
+  }
+  if (game.tournamentLobby === null) {
+    throw new Error("The tournament code is not ready yet");
+  }
+  return {
+    gameId: game.id,
+    gameNumber: game.gameNumber,
+    code: game.tournamentLobby.code,
+    stub: game.tournamentLobby.apiMode === "stub",
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/series.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/series.ts
@@ -467,7 +467,9 @@ export async function getDuelCode(
     !series.participants.some(
       (participant) =>
         effectiveParticipantDiscordId(currentDiscordIdByPlayer, participant) ===
-        viewerDiscordId,
+          viewerDiscordId &&
+        participant.discordId === viewerDiscordId &&
+        participant.acceptedAt !== null,
     )
   ) {
     throw new Error(

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/series.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/series.ts
@@ -258,7 +258,7 @@ export function effectiveParticipantDiscordId(
 ): string | null | undefined {
   return current.has(participant.playerId)
     ? current.get(participant.playerId)
-    : participant.discordId;
+    : null;
 }
 
 export function duelSeriesVisibleTo(
@@ -344,7 +344,7 @@ export async function acceptDuelChallenge(
       seriesId,
       playerId: { in: participants.map((participant) => participant.playerId) },
     },
-    data: { discordId, acceptedAt: new Date() },
+    data: { discordId, acceptedAt: new Date(), readyAt: null },
   });
   return { deadlineAt: series.deadlineAt ?? new Date() };
 }

--- a/packages/scout-for-lol/packages/backend/src/progression/duels/series.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/duels/series.ts
@@ -252,6 +252,27 @@ export async function currentParticipantDiscordIds(
   return new Map(players.map((player) => [player.id, player.discordId]));
 }
 
+export async function currentDisclosureKeys(
+  db: ExtendedPrismaClient,
+  guildId: DiscordGuildId,
+  participants: readonly { readonly playerId: number }[],
+): Promise<ReadonlySet<string>> {
+  const disclosures = await db.duelDisclosureAcceptance.findMany({
+    where: {
+      guildId,
+      playerId: { in: participants.map((participant) => participant.playerId) },
+      disclosureVersion: DUEL_DISCLOSURE_VERSION,
+    },
+    select: { playerId: true, discordId: true },
+  });
+  return new Set(
+    disclosures.map(
+      (disclosure) =>
+        `${disclosure.playerId.toString()}:${disclosure.discordId}`,
+    ),
+  );
+}
+
 export function effectiveParticipantDiscordId(
   current: ReadonlyMap<number, string | null>,
   participant: { readonly playerId: number; readonly discordId: string },
@@ -401,6 +422,11 @@ export async function getDuelSeries(
     guildId,
     series.participants,
   );
+  const disclosureKeys = await currentDisclosureKeys(
+    db,
+    guildId,
+    series.participants,
+  );
   if (!duelSeriesVisibleTo(currentDiscordIdByPlayer, series, viewerDiscordId)) {
     throw new Error("This duel is private until every participant accepts");
   }
@@ -416,12 +442,23 @@ export async function getDuelSeries(
     winnerCompetitorId: series.winnerCompetitorId,
     competitorOne: parseDuelCompetitor(series.competitorOne),
     competitorTwo: parseDuelCompetitor(series.competitorTwo),
-    participants: series.participants.map((participant) => ({
-      playerId: participant.playerId,
-      competitorId: participant.competitorId,
-      accepted: participant.acceptedAt !== null,
-      ready: participant.readyAt !== null,
-    })),
+    participants: series.participants.map((participant) => {
+      const currentDiscordId = effectiveParticipantDiscordId(
+        currentDiscordIdByPlayer,
+        participant,
+      );
+      const consentCurrent =
+        currentDiscordId === participant.discordId &&
+        disclosureKeys.has(
+          `${participant.playerId.toString()}:${participant.discordId}`,
+        );
+      return {
+        playerId: participant.playerId,
+        competitorId: participant.competitorId,
+        accepted: participant.acceptedAt !== null && consentCurrent,
+        ready: participant.readyAt !== null && consentCurrent,
+      };
+    }),
     games: series.games.map((game) => ({
       id: game.id,
       gameNumber: game.gameNumber,
@@ -438,62 +475,5 @@ export async function getDuelSeries(
       reason: decision.reason,
       createdAt: decision.createdAt.toISOString(),
     })),
-  };
-}
-
-export async function getDuelCode(
-  db: ExtendedPrismaClient,
-  seriesId: string,
-  viewerDiscordId: DiscordAccountId,
-  guildId: DiscordGuildId,
-) {
-  const series = await db.duelSeries.findFirstOrThrow({
-    where: { id: seriesId, guildId },
-    include: {
-      participants: true,
-      games: {
-        orderBy: { gameNumber: "desc" },
-        take: 1,
-        include: { tournamentLobby: true },
-      },
-    },
-  });
-  const currentDiscordIdByPlayer = await currentParticipantDiscordIds(
-    db,
-    guildId,
-    series.participants,
-  );
-  if (
-    !series.participants.some(
-      (participant) =>
-        effectiveParticipantDiscordId(currentDiscordIdByPlayer, participant) ===
-          viewerDiscordId &&
-        participant.discordId === viewerDiscordId &&
-        participant.acceptedAt !== null,
-    )
-  ) {
-    throw new Error(
-      "Tournament codes are visible only to assigned participants",
-    );
-  }
-  if (
-    !series.participants.every((participant) => participant.readyAt !== null)
-  ) {
-    throw new Error(
-      "The tournament code is unavailable until everyone is ready",
-    );
-  }
-  const game = series.games[0];
-  if (game?.gameState !== "code_ready" || series.seriesState !== "code_ready") {
-    throw new Error("The tournament code is not ready yet");
-  }
-  if (game.tournamentLobby === null) {
-    throw new Error("The tournament code is not ready yet");
-  }
-  return {
-    gameId: game.id,
-    gameNumber: game.gameNumber,
-    code: game.tournamentLobby.code,
-    stub: game.tournamentLobby.apiMode === "stub",
   };
 }

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/outbox.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/outbox.ts
@@ -10,6 +10,7 @@ import { send as sendChannelMessage } from "#src/league/discord/channel.ts";
 import { parseProgressionJson } from "#src/progression/json.ts";
 import { HallBreakOutboxPayloadSchema } from "#src/progression/hall/evaluate-match.ts";
 import { hallRecordBreakDeliveries } from "#src/metrics/progression.ts";
+import { loadProgressionOutboxRows } from "#src/progression/outbox.ts";
 import {
   claimScoutEffect,
   completeScoutEffect,
@@ -91,17 +92,20 @@ function discordNonce(outboxId: string): string {
 }
 
 export async function deliverHallRecordBreakOutbox(): Promise<void> {
-  const activeRows = await prisma.hallRecordBreakOutbox.findMany({
-    where: { deliveryStatus: { in: ["pending", "sending"] } },
-    orderBy: { createdAt: "asc" },
-    take: 50,
-  });
-  const failedRows = await prisma.hallRecordBreakOutbox.findMany({
-    where: { deliveryStatus: "failed" },
-    orderBy: { updatedAt: "asc" },
-    take: 50 - activeRows.length,
-  });
-  const rows = [...activeRows, ...failedRows];
+  const rows = await loadProgressionOutboxRows(
+    async (take) =>
+      await prisma.hallRecordBreakOutbox.findMany({
+        where: { deliveryStatus: { in: ["pending", "sending"] } },
+        orderBy: { createdAt: "asc" },
+        take,
+      }),
+    async (take) =>
+      await prisma.hallRecordBreakOutbox.findMany({
+        where: { deliveryStatus: "failed" },
+        orderBy: { updatedAt: "asc" },
+        take,
+      }),
+  );
   const deliveryErrors: unknown[] = [];
   for (const row of rows) {
     const guildId = DiscordGuildIdSchema.parse(row.guildId);

--- a/packages/scout-for-lol/packages/backend/src/progression/outbox.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/outbox.ts
@@ -1,0 +1,8 @@
+export async function loadProgressionOutboxRows<Row>(
+  loadActive: (take: number) => Promise<Row[]>,
+  loadFailed: (take: number) => Promise<Row[]>,
+): Promise<Row[]> {
+  const activeRows = await loadActive(50);
+  const failedRows = await loadFailed(50 - activeRows.length);
+  return [...activeRows, ...failedRows];
+}

--- a/packages/scout-for-lol/packages/backend/src/progression/postmatch.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/postmatch.test.ts
@@ -22,6 +22,10 @@ const mocks = vi.hoisted(() => {
     queuePreparedChallengeRuns: vi.fn(async () => {
       calls.push("queue");
     }),
+    duelMatchNeedsTimeline: vi.fn(async () => false),
+    processDuelResult: vi.fn(async () => {
+      calls.push("duel");
+    }),
   };
 });
 
@@ -39,6 +43,10 @@ vi.mock("#src/progression/challenges/postmatch.ts", () => ({
 vi.mock("#src/league/tasks/postmatch/match-report-standard.ts", () => ({
   fetchTimelineForProgression: mocks.fetchTimelineForProgression,
   persistTimelineForProgression: vi.fn(),
+}));
+vi.mock("#src/progression/duels/results.ts", () => ({
+  duelMatchNeedsTimeline: mocks.duelMatchNeedsTimeline,
+  processDuelResult: mocks.processDuelResult,
 }));
 
 const { processCompetitiveProgressionMatch } =
@@ -86,6 +94,7 @@ describe("competitive progression post-match ordering", () => {
     });
 
     expect(mocks.calls).toEqual([
+      "duel",
       "hall",
       "prepare",
       "fetch-timeline",

--- a/packages/scout-for-lol/packages/backend/src/progression/postmatch.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/postmatch.test.ts
@@ -14,7 +14,10 @@ const mocks = vi.hoisted(() => {
       return [{ runId: "run-id", revision: 2, timelineRequired: true }];
     }),
     fetchTimelineForProgression: vi.fn(async () => {
-      calls.push("fetch-timeline");
+      calls.push("fetch-required-timeline");
+    }),
+    fetchTimelineForDuelProgression: vi.fn(async () => {
+      calls.push("fetch-duel-timeline");
     }),
     launchPreparedChallengeRuns: vi.fn(async () => {
       calls.push("launch");
@@ -41,6 +44,7 @@ vi.mock("#src/progression/challenges/postmatch.ts", () => ({
   queuePreparedChallengeRuns: mocks.queuePreparedChallengeRuns,
 }));
 vi.mock("#src/league/tasks/postmatch/match-report-standard.ts", () => ({
+  fetchTimelineForDuelProgression: mocks.fetchTimelineForDuelProgression,
   fetchTimelineForProgression: mocks.fetchTimelineForProgression,
   persistTimelineForProgression: vi.fn(),
 }));
@@ -94,13 +98,45 @@ describe("competitive progression post-match ordering", () => {
     });
 
     expect(mocks.calls).toEqual([
+      "prepare",
+      "fetch-required-timeline",
+      "prepare",
       "duel",
       "hall",
-      "prepare",
-      "fetch-timeline",
       "prepare",
       "queue",
       "launch",
     ]);
+  });
+
+  test("lets unavailable duel-only evidence enter organizer review", async () => {
+    mocks.prepareChallengeRunsForMatch.mockImplementation(async () => {
+      mocks.calls.push("prepare");
+      return [];
+    });
+    mocks.duelMatchNeedsTimeline.mockResolvedValue(true);
+
+    await processCompetitiveProgressionMatch({
+      match: matchFixture(),
+      timeline: null,
+      trackedPlayers: [],
+    });
+
+    expect(mocks.calls).toEqual([
+      "prepare",
+      "fetch-duel-timeline",
+      "prepare",
+      "duel",
+      "hall",
+      "prepare",
+      "queue",
+      "launch",
+    ]);
+    expect(mocks.fetchTimelineForProgression).not.toHaveBeenCalled();
+    expect(mocks.processDuelResult).toHaveBeenCalledWith(
+      expect.any(Object),
+      undefined,
+      "beta",
+    );
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/progression/postmatch.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/postmatch.ts
@@ -13,6 +13,7 @@ import {
   type PreparedChallengeRun,
 } from "#src/progression/challenges/postmatch.ts";
 import {
+  fetchTimelineForDuelProgression,
   fetchTimelineForProgression,
   persistTimelineForProgression,
 } from "#src/league/tasks/postmatch/match-report-standard.ts";
@@ -46,14 +47,20 @@ export async function processCompetitiveProgressionMatch(input: {
   let timelinePersisted = false;
   const matchId = MatchIdSchema.parse(input.match.metadata.matchId);
   let timeline = input.timeline;
-  async function ensureProgressionTimeline(): Promise<void> {
+  async function ensureProgressionTimeline(required: boolean): Promise<void> {
     if (timelinePersisted) return;
     if (timeline === null || timeline === undefined) {
-      timeline = await fetchTimelineForProgression(
-        input.match,
-        matchId,
-        input.trackedPlayers,
-      );
+      timeline = required
+        ? await fetchTimelineForProgression(
+            input.match,
+            matchId,
+            input.trackedPlayers,
+          )
+        : await fetchTimelineForDuelProgression(
+            input.match,
+            matchId,
+            input.trackedPlayers,
+          );
     } else {
       await persistTimelineForProgression(
         timeline,
@@ -61,26 +68,31 @@ export async function processCompetitiveProgressionMatch(input: {
         matchId,
       );
     }
-    timelinePersisted = true;
+    timelinePersisted = required || timeline !== undefined;
   }
 
-  if (await duelMatchNeedsTimeline(input.match)) {
-    await ensureProgressionTimeline();
+  const initiallyPrepared = await prepareCurrentRuns();
+  const initiallyRequiresTimeline = initiallyPrepared.some(
+    (revision) => revision.timelineRequired,
+  );
+  const duelNeedsTimeline = await duelMatchNeedsTimeline(input.match);
+  if (initiallyRequiresTimeline || duelNeedsTimeline) {
+    await ensureProgressionTimeline(initiallyRequiresTimeline);
+  }
+  const stagedRediscovery = await prepareCurrentRuns();
+  if (stagedRediscovery.some((revision) => revision.timelineRequired)) {
+    await ensureProgressionTimeline(true);
   }
   await processDuelResult(input.match, timeline, configuration.environment);
 
   await evaluateHallMatch(input.match);
-  const initiallyPrepared = await prepareCurrentRuns();
-  if (initiallyPrepared.some((revision) => revision.timelineRequired)) {
-    await ensureProgressionTimeline();
-  }
   // Catch a run start or account edit that committed while evidence was being
-  // staged. Preparing a match revision supersedes its independently launched
-  // recompute, and waiting revisions are invisible to reconciliation until the
-  // required timeline is durable.
+  // staged or duel and Hall processing ran. Preparing a match revision
+  // supersedes its independently launched recompute, and waiting revisions are
+  // invisible to reconciliation until the required timeline is durable.
   const rediscovered = await prepareCurrentRuns();
   if (rediscovered.some((revision) => revision.timelineRequired)) {
-    await ensureProgressionTimeline();
+    await ensureProgressionTimeline(true);
   }
   const challengeRevisions = [...preparedByRun.values()];
   await queuePreparedChallengeRuns(challengeRevisions);

--- a/packages/scout-for-lol/packages/backend/src/progression/postmatch.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/postmatch.ts
@@ -16,6 +16,10 @@ import {
   fetchTimelineForProgression,
   persistTimelineForProgression,
 } from "#src/league/tasks/postmatch/match-report-standard.ts";
+import {
+  duelMatchNeedsTimeline,
+  processDuelResult,
+} from "#src/progression/duels/results.ts";
 
 /**
  * Last durable progression hook before account match cursors advance. Callers
@@ -40,18 +44,19 @@ export async function processCompetitiveProgressionMatch(input: {
     return prepared;
   }
   let timelinePersisted = false;
-  async function ensureChallengeTimeline(): Promise<void> {
+  const matchId = MatchIdSchema.parse(input.match.metadata.matchId);
+  let timeline = input.timeline;
+  async function ensureProgressionTimeline(): Promise<void> {
     if (timelinePersisted) return;
-    const matchId = MatchIdSchema.parse(input.match.metadata.matchId);
-    if (input.timeline === null || input.timeline === undefined) {
-      await fetchTimelineForProgression(
+    if (timeline === null || timeline === undefined) {
+      timeline = await fetchTimelineForProgression(
         input.match,
         matchId,
         input.trackedPlayers,
       );
     } else {
       await persistTimelineForProgression(
-        input.timeline,
+        timeline,
         input.trackedPlayers,
         matchId,
       );
@@ -59,10 +64,15 @@ export async function processCompetitiveProgressionMatch(input: {
     timelinePersisted = true;
   }
 
+  if (await duelMatchNeedsTimeline(input.match)) {
+    await ensureProgressionTimeline();
+  }
+  await processDuelResult(input.match, timeline, configuration.environment);
+
   await evaluateHallMatch(input.match);
   const initiallyPrepared = await prepareCurrentRuns();
   if (initiallyPrepared.some((revision) => revision.timelineRequired)) {
-    await ensureChallengeTimeline();
+    await ensureProgressionTimeline();
   }
   // Catch a run start or account edit that committed while evidence was being
   // staged. Preparing a match revision supersedes its independently launched
@@ -70,7 +80,7 @@ export async function processCompetitiveProgressionMatch(input: {
   // required timeline is durable.
   const rediscovered = await prepareCurrentRuns();
   if (rediscovered.some((revision) => revision.timelineRequired)) {
-    await ensureChallengeTimeline();
+    await ensureProgressionTimeline();
   }
   const challengeRevisions = [...preparedByRun.values()];
   await queuePreparedChallengeRuns(challengeRevisions);

--- a/packages/scout-for-lol/packages/backend/src/progression/reconcile.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/reconcile.ts
@@ -1,8 +1,13 @@
 import type { ScoutStage } from "@scout-for-lol/temporal";
 import { prisma } from "#src/database/index.ts";
 import { launchChallengeRunRecompute } from "#src/progression/challenges/launch.ts";
+import { advanceDuelEvent } from "#src/progression/duels/advancement.ts";
+import { launchDuelSeries } from "#src/progression/duels/launch.ts";
 import { launchHallBaseline } from "#src/progression/hall/launch.ts";
-import { challengeRecomputeLag } from "#src/metrics/progression.ts";
+import {
+  challengeRecomputeLag,
+  duelSeriesState,
+} from "#src/metrics/progression.ts";
 
 const RECONCILIATION_BATCH_SIZE = 100;
 
@@ -33,11 +38,84 @@ async function reconcileChallengeRevisions(stage: ScoutStage): Promise<void> {
   }
 }
 
+async function reconcileDuelSeries(stage: ScoutStage): Promise<void> {
+  let cursor: string | undefined;
+  for (;;) {
+    const seriesPage = await prisma.duelSeries.findMany({
+      where: {
+        deadlineAt: { not: null },
+        seriesState: {
+          in: [
+            "awaiting_acceptance",
+            "scheduled",
+            "awaiting_readiness",
+            "provisioning_code",
+            "code_ready",
+            "in_progress",
+          ],
+        },
+      },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      take: RECONCILIATION_BATCH_SIZE,
+      ...(cursor === undefined ? {} : { cursor: { id: cursor }, skip: 1 }),
+    });
+    for (const series of seriesPage) {
+      if (series.deadlineAt === null) {
+        throw new Error("A reconcilable duel series has no deadline");
+      }
+      await launchDuelSeries({
+        stage,
+        seriesId: series.id,
+        deadlineAt: series.deadlineAt,
+      });
+    }
+    if (seriesPage.length < RECONCILIATION_BATCH_SIZE) return;
+    const last = seriesPage.at(-1);
+    if (last === undefined) {
+      throw new Error("A full duel reconciliation page must have a cursor");
+    }
+    cursor = last.id;
+  }
+}
+
+async function reconcileDuelEvents(stage: ScoutStage): Promise<void> {
+  let cursor: string | undefined;
+  for (;;) {
+    const events = await prisma.duelEvent.findMany({
+      where: { eventState: "in_progress" },
+      include: {
+        series: {
+          where: {
+            seriesState: "completed",
+            winnerCompetitorId: { not: null },
+          },
+          orderBy: { completedAt: "desc" },
+          take: 1,
+        },
+      },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      take: RECONCILIATION_BATCH_SIZE,
+      ...(cursor === undefined ? {} : { cursor: { id: cursor }, skip: 1 }),
+    });
+    for (const event of events) {
+      if (event.series[0] !== undefined) {
+        await advanceDuelEvent(event.id, stage);
+      }
+    }
+    if (events.length < RECONCILIATION_BATCH_SIZE) return;
+    const last = events.at(-1);
+    if (last === undefined) {
+      throw new Error("A full duel-event reconciliation page needs a cursor");
+    }
+    cursor = last.id;
+  }
+}
+
 /**
  * Replays durable database intents whose initial Temporal start may have been
- * interrupted after the transaction committed. Every workflow ID uses a
- * stable business key, so retries adopt existing work rather than duplicating
- * it.
+ * interrupted after the transaction committed. Every workflow ID and bracket
+ * slot uses a stable business key, so retries adopt existing work rather than
+ * duplicating it.
  */
 export async function reconcileCompetitiveProgression(
   stage: ScoutStage,
@@ -57,12 +135,24 @@ export async function reconcileCompetitiveProgression(
     });
   }
   await reconcileChallengeRevisions(stage);
+  await reconcileDuelSeries(stage);
+  await reconcileDuelEvents(stage);
 
-  const oldestRecompute = await prisma.challengeRunRevision.findFirst({
-    where: { revisionState: { in: ["queued", "running"] } },
-    orderBy: { createdAt: "asc" },
-    select: { createdAt: true },
-  });
+  const [seriesCounts, oldestRecompute] = await Promise.all([
+    prisma.duelSeries.groupBy({
+      by: ["seriesState"],
+      _count: { _all: true },
+    }),
+    prisma.challengeRunRevision.findFirst({
+      where: { revisionState: { in: ["queued", "running"] } },
+      orderBy: { createdAt: "asc" },
+      select: { createdAt: true },
+    }),
+  ]);
+  duelSeriesState.reset();
+  for (const count of seriesCounts) {
+    duelSeriesState.set({ state: count.seriesState }, count._count._all);
+  }
   challengeRecomputeLag.set(
     oldestRecompute === null
       ? 0

--- a/packages/scout-for-lol/packages/backend/src/progression/reconcile.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/reconcile.ts
@@ -39,6 +39,7 @@ async function reconcileChallengeRevisions(stage: ScoutStage): Promise<void> {
 }
 
 async function reconcileDuelSeries(stage: ScoutStage): Promise<void> {
+  const reconciliationRequestId = crypto.randomUUID();
   let cursor: string | undefined;
   for (;;) {
     const seriesPage = await prisma.duelSeries.findMany({
@@ -67,7 +68,7 @@ async function reconcileDuelSeries(stage: ScoutStage): Promise<void> {
         stage,
         seriesId: series.id,
         deadlineAt: series.deadlineAt,
-        requestId: `reconcile-duel:${series.id}`,
+        requestId: `reconcile-duel:${reconciliationRequestId}:${series.id}`,
       });
     }
     if (seriesPage.length < RECONCILIATION_BATCH_SIZE) return;

--- a/packages/scout-for-lol/packages/backend/src/progression/reconcile.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/reconcile.ts
@@ -2,7 +2,7 @@ import type { ScoutStage } from "@scout-for-lol/temporal";
 import { prisma } from "#src/database/index.ts";
 import { launchChallengeRunRecompute } from "#src/progression/challenges/launch.ts";
 import { advanceDuelEvent } from "#src/progression/duels/advancement.ts";
-import { launchDuelSeries } from "#src/progression/duels/launch.ts";
+import { signalDuelSeries } from "#src/progression/duels/launch.ts";
 import { launchHallBaseline } from "#src/progression/hall/launch.ts";
 import {
   challengeRecomputeLag,
@@ -63,10 +63,11 @@ async function reconcileDuelSeries(stage: ScoutStage): Promise<void> {
       if (series.deadlineAt === null) {
         throw new Error("A reconcilable duel series has no deadline");
       }
-      await launchDuelSeries({
+      await signalDuelSeries({
         stage,
         seriesId: series.id,
         deadlineAt: series.deadlineAt,
+        requestId: `reconcile-duel:${series.id}`,
       });
     }
     if (seriesPage.length < RECONCILIATION_BATCH_SIZE) return;

--- a/packages/scout-for-lol/packages/backend/src/temporal/activities.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/activities.ts
@@ -327,13 +327,18 @@ function createBackgroundActivities(): ScoutTemporalActivityGroups["background"]
           case "progression-outbox": {
             const [
               { deliverHallRecordBreakOutbox },
+              { deliverDuelStatusOutbox },
               { reconcileCompetitiveProgression },
             ] = await Promise.all([
               import("#src/progression/hall/outbox.ts"),
+              import("#src/progression/duels/outbox.ts"),
               import("#src/progression/reconcile.ts"),
             ]);
             await reconcileCompetitiveProgression(input.stage);
-            await deliverHallRecordBreakOutbox();
+            await Promise.all([
+              deliverHallRecordBreakOutbox(),
+              deliverDuelStatusOutbox(),
+            ]);
             break;
           }
           case "prediction-ingest":
@@ -410,6 +415,16 @@ function createBackgroundActivities(): ScoutTemporalActivityGroups["background"]
         reportId: input.reportId,
         phase: "complete",
       });
+    },
+    refreshDuelSeries: async (input) => {
+      const { refreshDuelSeriesWorkflowState } =
+        await import("#src/progression/duels/series-workflow-state.ts");
+      return await refreshDuelSeriesWorkflowState(input);
+    },
+    markDuelSeriesOverdue: async (input) => {
+      const { markDuelSeriesOverdue } =
+        await import("#src/progression/duels/series-workflow-state.ts");
+      await markDuelSeriesOverdue(input);
     },
   };
 }

--- a/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.ts
@@ -118,6 +118,8 @@ type BackgroundActivities = Pick<
   | "runDetachedBackgroundWork"
   | "drainReportScheduleOutbox"
   | "runReport"
+  | "refreshDuelSeries"
+  | "markDuelSeriesOverdue"
   | "probeQueue"
 > & {
   invokeScoutWeeklyParlayAction: (

--- a/packages/scout-for-lol/packages/backend/src/temporal/starts.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/starts.ts
@@ -280,7 +280,7 @@ export async function startScoutDuelSeries(
   input: ScoutDuelSeriesInput,
 ): Promise<WorkflowHandle> {
   return await client.workflow.start(SCOUT_WORKFLOW_NAMES.duelSeries, {
-    ...IDEMPOTENT_START_POLICIES,
+    ...RESTART_CLOSED_START_POLICIES,
     workflowId: scoutDuelSeriesWorkflowId(input.stage, input.seriesId),
     taskQueue: scoutTaskQueues(input.stage).workflow,
     args: [input],

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/duel-router-contracts.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/duel-router-contracts.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import {
+  AccountIdSchema,
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+  DuelBestOfSchema,
+  DuelEventFormatSchema,
+  DuelRulesetV1Schema,
+} from "@scout-for-lol/data";
+
+export const DuelGuildInputSchema = z.strictObject({
+  guildId: DiscordGuildIdSchema,
+});
+
+export const DuelCompetitorSelectionInputSchema = z.strictObject({
+  accountIds: AccountIdSchema.array().min(1).max(2),
+  teamName: z.string().trim().min(1).max(80).optional(),
+});
+
+export const DirectDuelChallengeInputSchema = z.strictObject({
+  requestId: z.uuid(),
+  guildId: DiscordGuildIdSchema,
+  channelId: DiscordChannelIdSchema,
+  competitorKind: z.enum(["player", "pair"]),
+  first: DuelCompetitorSelectionInputSchema,
+  second: DuelCompetitorSelectionInputSchema,
+  bestOf: DuelBestOfSchema,
+  ruleset: DuelRulesetV1Schema,
+  matchWindowHours: z.number().int().min(24).max(336).default(168),
+});
+
+export const DuelEventInputSchema = z.strictObject({
+  guildId: DiscordGuildIdSchema,
+  channelId: DiscordChannelIdSchema,
+  name: z.string().trim().min(1).max(120),
+  format: DuelEventFormatSchema.exclude(["direct"]),
+  competitorKind: z.enum(["player", "pair"]),
+  bestOf: DuelBestOfSchema,
+  ruleset: DuelRulesetV1Schema,
+  registrationMode: z.enum(["open", "invitations"]),
+  seedMethod: z.enum(["manual", "random", "rolling_record"]),
+  matchWindowHours: z.number().int().min(24).max(336).default(168),
+  registrationClosesAt: z.date().optional(),
+  roundOverrides: z
+    .array(
+      z.strictObject({
+        roundNumber: z.number().int().positive(),
+        bestOf: DuelBestOfSchema,
+      }),
+    )
+    .default([]),
+});
+
+export function duelCompetitorSelection(
+  input: z.infer<typeof DuelCompetitorSelectionInputSchema>,
+) {
+  return {
+    accountIds: input.accountIds,
+    ...(input.teamName === undefined ? {} : { teamName: input.teamName }),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/duel.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/duel.router.ts
@@ -348,7 +348,7 @@ export const duelRouter = router({
         configuration.environment,
       );
       try {
-        const requests = await startDuelEvent(prisma, {
+        return await startDuelEvent(prisma, {
           guildId: input.guildId,
           eventId: input.eventId,
           actorDiscordId: viewerId(ctx.user.discordId),
@@ -357,15 +357,6 @@ export const duelRouter = router({
             ? {}
             : { manualOrder: input.manualOrder }),
         });
-        await Promise.all(
-          requests.map((request) =>
-            launchDuelSeries({
-              stage: configuration.environment,
-              ...request,
-            }),
-          ),
-        );
-        return requests;
       } catch (error) {
         return domainError(error);
       }

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/duel.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/duel.router.ts
@@ -1,0 +1,472 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+  PlayerIdSchema,
+} from "@scout-for-lol/data";
+import configuration from "#src/configuration.ts";
+import { prisma } from "#src/database/index.ts";
+import { assertDuelsEnabled } from "#src/progression/duels/access.ts";
+import { advanceDuelEvent } from "#src/progression/duels/advancement.ts";
+import {
+  eligibleDuelAccounts,
+  linkedDuelAccounts,
+} from "#src/progression/duels/competitors.ts";
+import {
+  createDuelEvent,
+  startDuelEvent,
+} from "#src/progression/duels/events.ts";
+import {
+  acceptDuelEventRegistration,
+  registerDuelEventEntrant,
+} from "#src/progression/duels/registration.ts";
+import {
+  launchDuelSeries,
+  signalDuelSeries,
+} from "#src/progression/duels/launch.ts";
+import {
+  getDuelEvent,
+  getDuelEventStandings,
+  getDuelHeadToHead,
+  getRollingDuelRecords,
+  listGuildDuels,
+} from "#src/progression/duels/read.ts";
+import { decideDuelSeries } from "#src/progression/duels/review.ts";
+import {
+  acceptDuelChallenge,
+  acceptDuelDisclosure,
+  createDirectDuel,
+  getDuelCode,
+  getDuelSeries,
+  markDuelReady,
+} from "#src/progression/duels/series.ts";
+import {
+  guildMutationProcedure,
+  guildProcedure,
+  resolveGuildPermissions,
+} from "#src/trpc/guild-permission.ts";
+import { assertChannelInGuild } from "#src/trpc/guild-guard.ts";
+import { router, webMutationProcedure, webProcedure } from "#src/trpc/trpc.ts";
+import {
+  DirectDuelChallengeInputSchema,
+  DuelCompetitorSelectionInputSchema,
+  DuelEventInputSchema,
+  DuelGuildInputSchema,
+  duelCompetitorSelection,
+} from "#src/trpc/router/duel-router-contracts.ts";
+
+function viewerId(value: string) {
+  return DiscordAccountIdSchema.parse(value);
+}
+
+function domainError(error: unknown): never {
+  if (error instanceof TRPCError) throw error;
+  throw new TRPCError({
+    code: "BAD_REQUEST",
+    message: error instanceof Error ? error.message : "Duel request failed",
+    cause: error,
+  });
+}
+
+async function assertMemberAndFeature(
+  user: Parameters<typeof resolveGuildPermissions>[0],
+  guildId: ReturnType<typeof DiscordGuildIdSchema.parse>,
+) {
+  await resolveGuildPermissions(user, guildId);
+  await assertDuelsEnabled(prisma, guildId, configuration.environment);
+}
+
+export const duelRouter = router({
+  list: webProcedure
+    .input(DuelGuildInputSchema)
+    .query(async ({ ctx, input }) => {
+      await assertMemberAndFeature(ctx.user, input.guildId);
+      return await listGuildDuels(
+        prisma,
+        input.guildId,
+        viewerId(ctx.user.discordId),
+      );
+    }),
+  linkedAccounts: webProcedure
+    .input(DuelGuildInputSchema)
+    .query(async ({ ctx, input }) => {
+      await assertMemberAndFeature(ctx.user, input.guildId);
+      return await linkedDuelAccounts(
+        prisma,
+        input.guildId,
+        viewerId(ctx.user.discordId),
+      );
+    }),
+  eligibleAccounts: webProcedure
+    .input(DuelGuildInputSchema)
+    .query(async ({ ctx, input }) => {
+      await assertMemberAndFeature(ctx.user, input.guildId);
+      return await eligibleDuelAccounts(prisma, input.guildId);
+    }),
+  challenge: webMutationProcedure
+    .input(DirectDuelChallengeInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await assertMemberAndFeature(ctx.user, input.guildId);
+      assertChannelInGuild({
+        guildId: input.guildId,
+        channelId: input.channelId,
+      });
+      try {
+        const request = await createDirectDuel(prisma, {
+          ...input,
+          first: duelCompetitorSelection(input.first),
+          second: duelCompetitorSelection(input.second),
+          organizerDiscordId: viewerId(ctx.user.discordId),
+          stage: configuration.environment,
+        });
+        await launchDuelSeries({
+          stage: configuration.environment,
+          ...request,
+        });
+        return request;
+      } catch (error) {
+        return domainError(error);
+      }
+    }),
+  acceptDisclosure: webMutationProcedure
+    .input(
+      z.strictObject({
+        guildId: DiscordGuildIdSchema,
+        playerId: PlayerIdSchema,
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertMemberAndFeature(ctx.user, input.guildId);
+      try {
+        return await acceptDuelDisclosure(prisma, {
+          ...input,
+          discordId: viewerId(ctx.user.discordId),
+        });
+      } catch (error) {
+        return domainError(error);
+      }
+    }),
+  acceptChallenge: webMutationProcedure
+    .input(
+      z.strictObject({ guildId: DiscordGuildIdSchema, seriesId: z.uuid() }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertMemberAndFeature(ctx.user, input.guildId);
+      try {
+        const result = await acceptDuelChallenge(
+          prisma,
+          input.seriesId,
+          viewerId(ctx.user.discordId),
+          input.guildId,
+        );
+        await signalDuelSeries({
+          stage: configuration.environment,
+          seriesId: input.seriesId,
+          deadlineAt: result.deadlineAt,
+          requestId: `accept:${crypto.randomUUID()}`,
+        });
+        return { accepted: true };
+      } catch (error) {
+        return domainError(error);
+      }
+    }),
+  ready: webMutationProcedure
+    .input(
+      z.strictObject({ guildId: DiscordGuildIdSchema, seriesId: z.uuid() }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertMemberAndFeature(ctx.user, input.guildId);
+      try {
+        const result = await markDuelReady(
+          prisma,
+          input.seriesId,
+          viewerId(ctx.user.discordId),
+          input.guildId,
+        );
+        await signalDuelSeries({
+          stage: configuration.environment,
+          seriesId: input.seriesId,
+          deadlineAt: result.deadlineAt,
+          requestId: `ready:${crypto.randomUUID()}`,
+        });
+        return { ready: true };
+      } catch (error) {
+        return domainError(error);
+      }
+    }),
+  series: webProcedure
+    .input(
+      z.strictObject({ guildId: DiscordGuildIdSchema, seriesId: z.uuid() }),
+    )
+    .query(async ({ ctx, input }) => {
+      await assertMemberAndFeature(ctx.user, input.guildId);
+      try {
+        return await getDuelSeries(
+          prisma,
+          input.seriesId,
+          viewerId(ctx.user.discordId),
+          input.guildId,
+        );
+      } catch (error) {
+        return domainError(error);
+      }
+    }),
+  code: webProcedure
+    .input(
+      z.strictObject({ guildId: DiscordGuildIdSchema, seriesId: z.uuid() }),
+    )
+    .query(async ({ ctx, input }) => {
+      await assertMemberAndFeature(ctx.user, input.guildId);
+      try {
+        return await getDuelCode(
+          prisma,
+          input.seriesId,
+          viewerId(ctx.user.discordId),
+          input.guildId,
+        );
+      } catch (error) {
+        return domainError(error);
+      }
+    }),
+  createEvent: guildMutationProcedure("competitions", "create")
+    .input(DuelEventInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await assertDuelsEnabled(
+        prisma,
+        input.guildId,
+        configuration.environment,
+      );
+      assertChannelInGuild({
+        guildId: input.guildId,
+        channelId: input.channelId,
+      });
+      try {
+        return await createDuelEvent(prisma, {
+          guildId: input.guildId,
+          channelId: input.channelId,
+          name: input.name,
+          format: input.format,
+          competitorKind: input.competitorKind,
+          bestOf: input.bestOf,
+          ruleset: input.ruleset,
+          registrationMode: input.registrationMode,
+          seedMethod: input.seedMethod,
+          matchWindowHours: input.matchWindowHours,
+          roundOverrides: input.roundOverrides,
+          organizerDiscordId: viewerId(ctx.user.discordId),
+          ...(input.registrationClosesAt === undefined
+            ? {}
+            : { registrationClosesAt: input.registrationClosesAt }),
+        });
+      } catch (error) {
+        return domainError(error);
+      }
+    }),
+  register: webMutationProcedure
+    .input(
+      z.strictObject({
+        guildId: DiscordGuildIdSchema,
+        eventId: z.uuid(),
+        selection: DuelCompetitorSelectionInputSchema,
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertMemberAndFeature(ctx.user, input.guildId);
+      try {
+        return await registerDuelEventEntrant(prisma, {
+          guildId: input.guildId,
+          eventId: input.eventId,
+          actorDiscordId: viewerId(ctx.user.discordId),
+          selection: duelCompetitorSelection(input.selection),
+          source: "open",
+        });
+      } catch (error) {
+        return domainError(error);
+      }
+    }),
+  invite: guildMutationProcedure("competitions", "invite")
+    .input(
+      z.strictObject({
+        guildId: DiscordGuildIdSchema,
+        eventId: z.uuid(),
+        selection: DuelCompetitorSelectionInputSchema,
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertDuelsEnabled(
+        prisma,
+        input.guildId,
+        configuration.environment,
+      );
+      try {
+        return await registerDuelEventEntrant(prisma, {
+          guildId: input.guildId,
+          eventId: input.eventId,
+          actorDiscordId: viewerId(ctx.user.discordId),
+          selection: duelCompetitorSelection(input.selection),
+          source: "invitation",
+        });
+      } catch (error) {
+        return domainError(error);
+      }
+    }),
+  acceptRegistration: webMutationProcedure
+    .input(
+      z.strictObject({
+        guildId: DiscordGuildIdSchema,
+        eventId: z.uuid(),
+        competitorId: z.uuid(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertMemberAndFeature(ctx.user, input.guildId);
+      try {
+        await acceptDuelEventRegistration(prisma, {
+          guildId: input.guildId,
+          eventId: input.eventId,
+          competitorId: input.competitorId,
+          actorDiscordId: viewerId(ctx.user.discordId),
+        });
+        return { accepted: true };
+      } catch (error) {
+        return domainError(error);
+      }
+    }),
+  startEvent: guildMutationProcedure("competitions", "update")
+    .input(
+      z.strictObject({
+        guildId: DiscordGuildIdSchema,
+        eventId: z.uuid(),
+        manualOrder: z.uuid().array().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertDuelsEnabled(
+        prisma,
+        input.guildId,
+        configuration.environment,
+      );
+      try {
+        const requests = await startDuelEvent(prisma, {
+          guildId: input.guildId,
+          eventId: input.eventId,
+          actorDiscordId: viewerId(ctx.user.discordId),
+          stage: configuration.environment,
+          ...(input.manualOrder === undefined
+            ? {}
+            : { manualOrder: input.manualOrder }),
+        });
+        await Promise.all(
+          requests.map((request) =>
+            launchDuelSeries({
+              stage: configuration.environment,
+              ...request,
+            }),
+          ),
+        );
+        return requests;
+      } catch (error) {
+        return domainError(error);
+      }
+    }),
+  event: webProcedure
+    .input(z.strictObject({ guildId: DiscordGuildIdSchema, eventId: z.uuid() }))
+    .query(async ({ ctx, input }) => {
+      await assertMemberAndFeature(ctx.user, input.guildId);
+      return await getDuelEvent(
+        prisma,
+        input.guildId,
+        input.eventId,
+        viewerId(ctx.user.discordId),
+      );
+    }),
+  standings: guildProcedure("competitions", "read")
+    .input(z.strictObject({ guildId: DiscordGuildIdSchema, eventId: z.uuid() }))
+    .query(async ({ input }) => {
+      await assertDuelsEnabled(
+        prisma,
+        input.guildId,
+        configuration.environment,
+      );
+      return await getDuelEventStandings(prisma, input.guildId, input.eventId);
+    }),
+  rollingRecords: guildProcedure("competitions", "read")
+    .input(
+      z.strictObject({
+        guildId: DiscordGuildIdSchema,
+        scope: z.enum(["individual", "pair"]),
+      }),
+    )
+    .query(async ({ input }) => {
+      await assertDuelsEnabled(
+        prisma,
+        input.guildId,
+        configuration.environment,
+      );
+      return await getRollingDuelRecords(prisma, input.guildId, input.scope);
+    }),
+  headToHead: guildProcedure("competitions", "read")
+    .input(
+      z.strictObject({
+        guildId: DiscordGuildIdSchema,
+        scope: z.enum(["individual", "pair"]),
+        firstSubjectKey: z.string().min(1).max(100),
+        secondSubjectKey: z.string().min(1).max(100),
+      }),
+    )
+    .query(async ({ input }) => {
+      await assertDuelsEnabled(
+        prisma,
+        input.guildId,
+        configuration.environment,
+      );
+      return await getDuelHeadToHead(prisma, input);
+    }),
+  reviewResult: guildMutationProcedure("competitions", "update")
+    .input(
+      z.strictObject({
+        guildId: DiscordGuildIdSchema,
+        seriesId: z.uuid(),
+        idempotencyKey: z.string().min(8).max(200),
+        reason: z.string().trim().min(3).max(1000),
+        decision: z.discriminatedUnion("kind", [
+          z.strictObject({ kind: z.literal("replay") }),
+          z.strictObject({ kind: z.literal("no_contest") }),
+          z.strictObject({
+            kind: z.literal("advance"),
+            winnerCompetitorId: z.uuid(),
+          }),
+        ]),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertDuelsEnabled(
+        prisma,
+        input.guildId,
+        configuration.environment,
+      );
+      try {
+        const result = await decideDuelSeries(prisma, {
+          guildId: input.guildId,
+          seriesId: input.seriesId,
+          actorDiscordId: viewerId(ctx.user.discordId),
+          idempotencyKey: input.idempotencyKey,
+          reason: input.reason,
+          decision: input.decision,
+        });
+        await signalDuelSeries({
+          stage: configuration.environment,
+          requestId: input.idempotencyKey,
+          seriesId: result.seriesId,
+          deadlineAt: result.deadlineAt,
+        });
+        if (result.seriesComplete && result.eventId !== null) {
+          await advanceDuelEvent(result.eventId, configuration.environment);
+        }
+        return { decided: true };
+      } catch (error) {
+        return domainError(error);
+      }
+    }),
+});

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/duel.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/duel.router.ts
@@ -32,12 +32,12 @@ import {
   getRollingDuelRecords,
   listGuildDuels,
 } from "#src/progression/duels/read.ts";
+import { getDuelCode } from "#src/progression/duels/code.ts";
 import { decideDuelSeries } from "#src/progression/duels/review.ts";
 import {
   acceptDuelChallenge,
   acceptDuelDisclosure,
   createDirectDuel,
-  getDuelCode,
   getDuelSeries,
   markDuelReady,
 } from "#src/progression/duels/series.ts";

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/duel.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/duel.router.ts
@@ -73,8 +73,9 @@ async function assertMemberAndFeature(
   user: Parameters<typeof resolveGuildPermissions>[0],
   guildId: ReturnType<typeof DiscordGuildIdSchema.parse>,
 ) {
-  await resolveGuildPermissions(user, guildId);
+  const permissions = await resolveGuildPermissions(user, guildId);
   await assertDuelsEnabled(prisma, guildId, configuration.environment);
+  return permissions;
 }
 
 export const duelRouter = router({
@@ -414,7 +415,7 @@ export const duelRouter = router({
       );
       return await getDuelHeadToHead(prisma, input);
     }),
-  reviewResult: guildMutationProcedure("competitions", "update")
+  reviewResult: webMutationProcedure
     .input(
       z.strictObject({
         guildId: DiscordGuildIdSchema,
@@ -432,16 +433,13 @@ export const duelRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      await assertDuelsEnabled(
-        prisma,
-        input.guildId,
-        configuration.environment,
-      );
+      const permissions = await assertMemberAndFeature(ctx.user, input.guildId);
       try {
         const result = await decideDuelSeries(prisma, {
           guildId: input.guildId,
           seriesId: input.seriesId,
           actorDiscordId: viewerId(ctx.user.discordId),
+          allowPrivilegedReviewer: permissions.can("competitions", "update"),
           idempotencyKey: input.idempotencyKey,
           reason: input.reason,
           decision: input.decision,

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/index.ts
@@ -30,6 +30,7 @@ import { customsRouter } from "#src/trpc/router/customs.router.ts";
 import { customsHistoryRouter } from "#src/trpc/router/customs-history.router.ts";
 import { hallRouter } from "#src/trpc/router/hall.router.ts";
 import { challengeRouter } from "#src/trpc/router/challenge.router.ts";
+import { duelRouter } from "#src/trpc/router/duel.router.ts";
 
 export const appRouter = router({
   auth: authRouter,
@@ -56,6 +57,7 @@ export const appRouter = router({
   customsHistory: customsHistoryRouter,
   hall: hallRouter,
   challenge: challengeRouter,
+  duel: duelRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/packages/scout-for-lol/packages/data/src/model/progression/duel-evidence.ts
+++ b/packages/scout-for-lol/packages/data/src/model/progression/duel-evidence.ts
@@ -132,24 +132,20 @@ function turretCrossings(
   return sorted
     .filter((turret) => turret.timestampMs === first.timestampMs)
     .flatMap((turret) => {
-      const defendingCompetitor = competitors.find((competitor) =>
+      const scoringCompetitor = competitors.find((competitor) =>
         competitor.accounts.some((account) =>
           input.participants.some(
             (participant) =>
               participant.puuid === account.puuid &&
-              participant.teamId === turret.destroyedTeamId,
+              participant.teamId === turret.scoringTeamId,
           ),
         ),
       );
-      const winningCompetitor = competitors.find(
-        (competitor) => competitor.id !== defendingCompetitor?.id,
-      );
-      return defendingCompetitor === undefined ||
-        winningCompetitor === undefined
+      return scoringCompetitor === undefined
         ? []
         : [
             {
-              competitorId: winningCompetitor.id,
+              competitorId: scoringCompetitor.id,
               objective: "first_turret" as const,
               timestampMs: turret.timestampMs,
             },

--- a/packages/scout-for-lol/packages/data/src/model/progression/duel-evidence.ts
+++ b/packages/scout-for-lol/packages/data/src/model/progression/duel-evidence.ts
@@ -9,7 +9,8 @@ import type {
 type ObjectiveCrossing = {
   competitorId: string;
   objective: DuelObjective;
-  timestampMs: number;
+  earliestTimestampMs: number;
+  latestTimestampMs: number;
 };
 
 function competitorForPuuid(
@@ -78,7 +79,8 @@ function killCrossings(
       crossings.push({
         competitorId: competitor.id,
         objective: "kills",
-        timestampMs: kill.timestampMs,
+        earliestTimestampMs: kill.timestampMs,
+        latestTimestampMs: kill.timestampMs,
       });
     }
   }
@@ -93,11 +95,12 @@ function laneCsCrossings(
   if (ruleset.laneCsTarget === null) return [];
   const crossed = new Set<string>();
   const crossings: ObjectiveCrossing[] = [];
+  const previousTimestampByCompetitor = new Map<string, number>();
+  const previousCsByCompetitor = new Map<string, number>();
   for (const frame of input.frames.toSorted(
     (left, right) => left.timestampMs - right.timestampMs,
   )) {
     for (const competitor of competitors) {
-      if (crossed.has(competitor.id)) continue;
       const laneCs = frame.participants
         .filter((participant) =>
           competitor.accounts.some(
@@ -105,12 +108,22 @@ function laneCsCrossings(
           ),
         )
         .reduce((total, participant) => total + participant.minionsKilled, 0);
-      if (laneCs >= ruleset.laneCsTarget) {
+      const previousTimestamp =
+        previousTimestampByCompetitor.get(competitor.id) ?? 0;
+      const previousCs = previousCsByCompetitor.get(competitor.id) ?? 0;
+      previousTimestampByCompetitor.set(competitor.id, frame.timestampMs);
+      previousCsByCompetitor.set(competitor.id, laneCs);
+      if (
+        !crossed.has(competitor.id) &&
+        previousCs < ruleset.laneCsTarget &&
+        laneCs >= ruleset.laneCsTarget
+      ) {
         crossed.add(competitor.id);
         crossings.push({
           competitorId: competitor.id,
           objective: "lane_cs",
-          timestampMs: frame.timestampMs,
+          earliestTimestampMs: previousTimestamp,
+          latestTimestampMs: frame.timestampMs,
         });
       }
     }
@@ -147,7 +160,8 @@ function turretCrossings(
             {
               competitorId: scoringCompetitor.id,
               objective: "first_turret" as const,
-              timestampMs: turret.timestampMs,
+              earliestTimestampMs: turret.timestampMs,
+              latestTimestampMs: turret.timestampMs,
             },
           ];
     });
@@ -185,7 +199,9 @@ export function evaluateDuelGame(
     ...killCrossings(ruleset, competitors, input),
     ...laneCsCrossings(ruleset, competitors, input),
     ...turretCrossings(ruleset, competitors, input),
-  ].toSorted((left, right) => left.timestampMs - right.timestampMs);
+  ].toSorted(
+    (left, right) => left.earliestTimestampMs - right.earliestTimestampMs,
+  );
   const first = crossings[0];
   if (first === undefined) {
     return reviewEvidence(
@@ -195,9 +211,28 @@ export function evaluateDuelGame(
         : "No configured objective has been reached",
     );
   }
+  if (
+    crossings.some(
+      (crossing, index) =>
+        index > 0 &&
+        (first.earliestTimestampMs !== first.latestTimestampMs ||
+          crossing.earliestTimestampMs !== crossing.latestTimestampMs) &&
+        crossing.earliestTimestampMs <= first.latestTimestampMs &&
+        first.earliestTimestampMs <= crossing.latestTimestampMs,
+    )
+  ) {
+    return reviewEvidence(
+      input,
+      "A participant-frame CS crossing overlaps another objective, so the winner order is indeterminate",
+    );
+  }
   const simultaneousCompetitors = new Set(
     crossings
-      .filter((crossing) => crossing.timestampMs === first.timestampMs)
+      .filter(
+        (crossing) =>
+          crossing.earliestTimestampMs === first.earliestTimestampMs &&
+          crossing.latestTimestampMs === first.latestTimestampMs,
+      )
       .map((crossing) => crossing.competitorId),
   );
   if (simultaneousCompetitors.size > 1) {
@@ -211,7 +246,7 @@ export function evaluateDuelGame(
     state: "verified",
     winnerCompetitorId: first.competitorId,
     objective: first.objective,
-    objectiveTimestampMs: first.timestampMs,
+    objectiveTimestampMs: first.latestTimestampMs,
     reason: null,
     participantPuuids: input.participants.map(
       (participant) => participant.puuid,

--- a/packages/scout-for-lol/packages/data/src/model/progression/duel.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/progression/duel.test.ts
@@ -140,6 +140,45 @@ describe("duel rules and evidence", () => {
     });
   });
 
+  test("sends CS crossings that overlap exact objectives to review", () => {
+    const competitors = [
+      competitor(FIRST_ID, ["first"]),
+      competitor(SECOND_ID, ["second"]),
+    ];
+    const input = timeline(["first"], ["second"]);
+    input.kills = [{ timestampMs: 30_000, killerPuuid: "second" }];
+    input.frames = [
+      {
+        timestampMs: 20_000,
+        participants: input.participants.map((participant) => ({
+          puuid: participant.puuid,
+          minionsKilled: 9,
+          jungleMinionsKilled: 0,
+        })),
+      },
+      {
+        timestampMs: 60_000,
+        participants: input.participants.map((participant) => ({
+          puuid: participant.puuid,
+          minionsKilled: participant.puuid === "first" ? 10 : 9,
+          jungleMinionsKilled: 0,
+        })),
+      },
+    ];
+
+    expect(
+      evaluateDuelGame(
+        { version: 1, killTarget: 1, laneCsTarget: 10, firstTurret: false },
+        competitors,
+        input,
+      ),
+    ).toMatchObject({
+      state: "needs_review",
+      reason:
+        "A participant-frame CS crossing overlaps another objective, so the winner order is indeterminate",
+    });
+  });
+
   test("sends simultaneous CS crossings and split pairs to review", () => {
     const competitors = [
       competitor(FIRST_ID, ["first-a", "first-b"]),

--- a/packages/scout-for-lol/packages/data/src/model/progression/duel.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/progression/duel.test.ts
@@ -80,7 +80,7 @@ describe("duel rules and evidence", () => {
       { timestampMs: 20_000, killerPuuid: "second" },
       { timestampMs: 30_000, killerPuuid: "first" },
     ];
-    input.turretKills = [{ timestampMs: 40_000, destroyedTeamId: 200 }];
+    input.turretKills = [{ timestampMs: 40_000, scoringTeamId: 100 }];
     const result = evaluateDuelGame(
       { version: 1, killTarget: 1, laneCsTarget: null, firstTurret: true },
       competitors,
@@ -94,13 +94,13 @@ describe("duel rules and evidence", () => {
     });
   });
 
-  test("attributes a minion-destroyed turret to the opposing team", () => {
+  test("attributes a turret kill to Riot's scoring team", () => {
     const competitors = [
       competitor(FIRST_ID, ["first"]),
       competitor(SECOND_ID, ["second"]),
     ];
     const input = timeline(["first"], ["second"]);
-    input.turretKills = [{ timestampMs: 40_000, destroyedTeamId: 200 }];
+    input.turretKills = [{ timestampMs: 40_000, scoringTeamId: 100 }];
 
     expect(
       evaluateDuelGame(
@@ -123,8 +123,8 @@ describe("duel rules and evidence", () => {
     ];
     const input = timeline(["first"], ["second"]);
     input.turretKills = [
-      { timestampMs: 40_000, destroyedTeamId: 100 },
-      { timestampMs: 40_000, destroyedTeamId: 200 },
+      { timestampMs: 40_000, scoringTeamId: 100 },
+      { timestampMs: 40_000, scoringTeamId: 200 },
     ];
 
     expect(

--- a/packages/scout-for-lol/packages/data/src/model/progression/duel.ts
+++ b/packages/scout-for-lol/packages/data/src/model/progression/duel.ts
@@ -132,7 +132,7 @@ export const DuelTimelineInputSchema = z.strictObject({
   turretKills: z.array(
     z.strictObject({
       timestampMs: z.number().int().nonnegative(),
-      destroyedTeamId: z.number().int(),
+      scoringTeamId: z.number().int(),
     }),
   ),
   frames: z.array(


### PR DESCRIPTION
## Why

Guild members need consent-gated friendly 1v1 and 2v2 competition with transparent rolling records and durable asynchronous events.

## What

- add versioned disclosure acceptance, invitations, open registration, readiness, and participant-only Tournament code access
- evaluate first-kill, lane-CS, and first-turret objectives from exact persisted evidence
- add individual, pair, series, and head-to-head records without Elo
- support single elimination, double elimination with grand-final reset, and round robin with deterministic seeding, byes, and tiebreaks
- add durable deadlines, code-free Discord status delivery, and audited organizer review without automatic no-show results
- expose duel/event tRPC procedures and progression metrics

## Approval boundary

Beta and production remain hard-disabled pending written Riot approval for classic objective rules and sub-20 events. This change does not add or alter Bryan Bucks, entry fees, prizes, wagering, bets, or bracket markets.

## Verification

- `bunx turbo run build typecheck test lint --filter=@scout-for-lol/backend --filter=@scout-for-lol/temporal --filter=@shepherdjerred/temporal`
- focused coverage includes objective timing, simultaneous crossings, roster validation, disclosures, seeding, byes, advancement, grand-final reset, round-robin ties, and organizer review
- real-worker workflow tests cover deadlines, retries, duplicate signals, replay, and bundle smoke behavior
- staged-file Lefthook checks passed

Not performed: Buildkite exhaustive verification, beta or production deployment, live persistence acceptance, downstream production Discord delivery, or production Riot Tournament API acceptance.