### PR TITLE
fix(scout-for-lol): require a preview and publish the value domains before creating a Dare

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/explore/dare-draft-guardrails.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-draft-guardrails.test.ts
@@ -1,3 +1,9 @@
+import {
+  createDarePreviewLedger,
+  dareContractNeedsPreview,
+  darePreviewSummary,
+  type DarePreviewSummaryInput,
+} from "#src/explore/dare-draft-guardrails.ts";
 import { dareValueDomainCatalog } from "@scout-for-lol/data";
 import { describe, expect, test } from "vitest";
 
@@ -33,5 +39,205 @@ describe("Dare authoring value-domain catalog", () => {
   // registry resolves display names anyway.
   test("omits champions, which are resolved rather than listed", () => {
     expect(Object.keys(catalog)).not.toContain("champion_name");
+  });
+});
+
+describe("Dare preview ledger", () => {
+  test("gates a contract nobody previewed and clears one that was", () => {
+    const ledger = createDarePreviewLedger();
+    expect(dareContractNeedsPreview(ledger, "SELECT ... A")).toBe(true);
+    ledger.record("SELECT ... A");
+    expect(dareContractNeedsPreview(ledger, "SELECT ... A")).toBe(false);
+  });
+
+  // The revision bypass: previewing one contract must not clear a different
+  // one, which is exactly what an author revising a funded dare produces.
+  test("does not clear a different contract", () => {
+    const ledger = createDarePreviewLedger();
+    ledger.record("SELECT ... A");
+    expect(dareContractNeedsPreview(ledger, "SELECT ... B")).toBe(true);
+  });
+
+  // A contract that did not compile is rejected by the domain call with its own
+  // issues; telling the author to preview it would bury the real reason.
+  test("does not demand a preview for a contract that did not compile", () => {
+    const ledger = createDarePreviewLedger();
+    expect(dareContractNeedsPreview(ledger, null)).toBe(false);
+  });
+});
+
+function preview(
+  overrides: Partial<DarePreviewSummaryInput>,
+): DarePreviewSummaryInput {
+  return {
+    achieved: false,
+    eligibleGames: 0,
+    coverageComplete: true,
+    evidence: [],
+    ...overrides,
+  };
+}
+
+describe("darePreviewSummary", () => {
+  test("says an empty window proves nothing", () => {
+    expect(darePreviewSummary(preview({ eligibleGames: 0 }))).toBe(
+      "No retained eligible games were found in the preview window, so this preview says nothing about whether the dare can be satisfied.",
+    );
+  });
+
+  test("reports satisfied games against distinct eligible matches", () => {
+    const summary = darePreviewSummary(
+      preview({
+        achieved: true,
+        eligibleGames: 4,
+        evidence: [
+          { matchId: "M1", matched: true },
+          { matchId: "M2", matched: true },
+          { matchId: "M3", matched: false },
+          { matchId: "M4", matched: false },
+        ],
+      }),
+    );
+    expect(summary).toContain(
+      "2 of 4 distinct eligible games satisfied at least one game set of this contract.",
+    );
+    expect(summary).toContain(
+      "The contract itself evaluated to achieved over this window.",
+    );
+  });
+
+  // The reported bug: evidence holds one row per (game set, match), so counting
+  // rows against distinct eligible matches printed "4 of 2 eligible games".
+  test("never claims more satisfied games than there are eligible games", () => {
+    const summary = darePreviewSummary(
+      preview({
+        achieved: true,
+        eligibleGames: 2,
+        evidence: [
+          { matchId: "M1", matched: true },
+          { matchId: "M1", matched: true },
+          { matchId: "M2", matched: true },
+          { matchId: "M2", matched: true },
+        ],
+      }),
+    );
+    expect(summary).toContain(
+      "2 of 2 distinct eligible games satisfied at least one game set of this contract.",
+    );
+    expect(summary).not.toContain("4 of 2");
+  });
+
+  test("counts a match once when only one of its game sets fired", () => {
+    expect(
+      darePreviewSummary(
+        preview({
+          eligibleGames: 2,
+          evidence: [
+            { matchId: "M1", matched: true },
+            { matchId: "M1", matched: false },
+            { matchId: "M2", matched: false },
+            { matchId: "M2", matched: false },
+          ],
+        }),
+      ),
+    ).toContain(
+      "1 of 2 distinct eligible games satisfied at least one game set of this contract.",
+    );
+  });
+
+  // A null row means the match's timeline coverage was incomplete. Presenting
+  // it as a failure manufactures the impossible-contract signal the guardrail
+  // exists to detect honestly.
+  test("reports unevaluable coverage instead of counting it as a failure", () => {
+    const summary = darePreviewSummary(
+      preview({
+        achieved: null,
+        eligibleGames: 3,
+        coverageComplete: false,
+        evidence: [
+          { matchId: "M1", matched: true },
+          { matchId: "M2", matched: null },
+          { matchId: "M3", matched: false },
+        ],
+      }),
+    );
+    expect(summary).toContain(
+      "1 of 3 distinct eligible games satisfied at least one game set of this contract.",
+    );
+    expect(summary).toContain(
+      "1 of those games could not be evaluated because their timeline coverage is incomplete, so that count is a lower bound.",
+    );
+    expect(summary).toContain(
+      "The contract itself could not be evaluated over this window.",
+    );
+  });
+
+  test("prefers a satisfied game set over an unevaluable one for the same match", () => {
+    const summary = darePreviewSummary(
+      preview({
+        eligibleGames: 1,
+        coverageComplete: false,
+        evidence: [
+          { matchId: "M1", matched: null },
+          { matchId: "M1", matched: true },
+        ],
+      }),
+    );
+    expect(summary).toContain(
+      "1 of 1 distinct eligible games satisfied at least one game set of this contract.",
+    );
+    expect(summary).not.toContain("could not be evaluated because");
+  });
+
+  test("flags incomplete coverage even when no evidence row is unknown", () => {
+    expect(
+      darePreviewSummary(
+        preview({
+          eligibleGames: 2,
+          coverageComplete: false,
+          evidence: [
+            { matchId: "M1", matched: true },
+            { matchId: "M2", matched: false },
+          ],
+        }),
+      ),
+    ).toContain(
+      "Timeline coverage is incomplete for at least one eligible game, so that count is a lower bound.",
+    );
+  });
+
+  // The signal the whole guardrail exists for: a healthy sample that the
+  // contract never once satisfied has to say so, not hedge.
+  test("says loudly when nothing matched over a healthy sample", () => {
+    const summary = darePreviewSummary(
+      preview({
+        achieved: false,
+        eligibleGames: 12,
+        evidence: Array.from({ length: 12 }, (_unused, index) => ({
+          matchId: `M${index.toString()}`,
+          matched: false,
+        })),
+      }),
+    );
+    expect(summary).toContain(
+      "None of the 12 distinct eligible games satisfied any game set of this contract.",
+    );
+    expect(summary).toContain(
+      "The contract itself evaluated to not achieved over this window.",
+    );
+    expect(summary).toContain(
+      "Check the condition is achievable and spelled the way Riot records it before creating the dare.",
+    );
+  });
+
+  test("does not tell the author to check a contract that did satisfy games", () => {
+    expect(
+      darePreviewSummary(
+        preview({
+          eligibleGames: 1,
+          evidence: [{ matchId: "M1", matched: true }],
+        }),
+      ),
+    ).not.toContain("Check the condition is achievable");
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-draft-guardrails.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-draft-guardrails.test.ts
@@ -1,0 +1,37 @@
+import { dareValueDomainCatalog } from "@scout-for-lol/data";
+import { describe, expect, test } from "vitest";
+
+describe("Dare authoring value-domain catalog", () => {
+  // The model had no source of truth for these values anywhere — not the
+  // prompt, not a tool description, not the JSON Schema. It inferred them, which
+  // is how `team_position = 'MID'` reached three funded contracts.
+  const catalog = dareValueDomainCatalog();
+
+  test("publishes the lane values Riot actually records", () => {
+    expect(catalog["team_position"]).toEqual([
+      "TOP",
+      "JUNGLE",
+      "MIDDLE",
+      "BOTTOM",
+      "UTILITY",
+    ]);
+  });
+
+  test("does not publish the spellings the model invented", () => {
+    expect(catalog["team_position"]).not.toContain("MID");
+    expect(catalog["team_position"]).not.toContain("SUPPORT");
+    expect(catalog["event_type"]).not.toContain("DRAGON_KILL");
+  });
+
+  test("publishes the objective discriminators", () => {
+    expect(catalog["monster_type"]).toContain("DRAGON");
+    expect(catalog["monster_type"]).toContain("BARON_NASHOR");
+    expect(catalog["building_type"]).toContain("TOWER_BUILDING");
+  });
+
+  // ~170 champion keys is not a useful thing to recite at an author, and the
+  // registry resolves display names anyway.
+  test("omits champions, which are resolved rather than listed", () => {
+    expect(Object.keys(catalog)).not.toContain("champion_name");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-draft-guardrails.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-draft-guardrails.ts
@@ -29,24 +29,126 @@ export function createDarePreviewLedger(): DarePreviewLedger {
 }
 
 export const DARE_PREVIEW_REQUIRED_ISSUE =
-  "Call preview_dare_contract with this contract first. A contract can be valid and in-domain and still impossible to satisfy; the historical preview is what shows that, and it must be run against the contract being created.";
+  "Call preview_dare_contract with this contract first. A contract can be valid and in-domain and still impossible to satisfy; the historical preview is what shows that, and it must be run against the exact contract being saved, whether that is a new draft or a revision.";
+
+/**
+ * Every path that persists a contract takes this gate, not just creation.
+ *
+ * Gating `create_dare_draft` alone left a complete bypass: preview and create
+ * one contract, then revise it into an unpreviewed — and possibly impossible —
+ * condition and fund that revision. A revision is funded exactly like a fresh
+ * contract, so it has to be previewed exactly like one.
+ *
+ * `canonicalScoutQl` is null when the contract did not compile. That is not a
+ * missing preview, and reporting one would bury the real reason under advice
+ * the author cannot act on; the domain call that follows rejects it with its
+ * own issues.
+ */
+export function dareContractNeedsPreview(
+  ledger: DarePreviewLedger,
+  canonicalScoutQl: string | null,
+): boolean {
+  return canonicalScoutQl !== null && !ledger.has(canonicalScoutQl);
+}
+
+/**
+ * The shape of a historical preview this summary reads, kept structural so the
+ * headline can be exercised without a lake.
+ */
+export type DarePreviewSummaryInput = {
+  achieved: boolean | null;
+  eligibleGames: number;
+  coverageComplete: boolean;
+  evidence: readonly { matchId: string; matched: boolean | null }[];
+};
+
+type MatchVerdict = "satisfied" | "unknown" | "unsatisfied";
+
+/**
+ * Evidence holds one row per (game set, match) while `eligibleGames` counts
+ * DISTINCT matches, so counting rows against it could print "4 of 2 eligible
+ * games satisfied this contract". Collapsing to a verdict per match is what
+ * makes the ratio arithmetically possible.
+ *
+ * A satisfied game set wins over an unevaluable one, which wins over a plain
+ * miss: `null` means the match's timeline coverage was incomplete, so its game
+ * set is unknown rather than failed, and presenting it as a failure would
+ * manufacture the very "impossible contract" signal this preview exists to
+ * detect honestly.
+ */
+function verdictsByMatch(
+  evidence: DarePreviewSummaryInput["evidence"],
+): MatchVerdict[] {
+  const verdicts = new Map<string, MatchVerdict>();
+  for (const row of evidence) {
+    const current = verdicts.get(row.matchId);
+    if (current === "satisfied") continue;
+    if (row.matched === true) {
+      verdicts.set(row.matchId, "satisfied");
+    } else if (row.matched === null) {
+      verdicts.set(row.matchId, "unknown");
+    } else if (current === undefined) {
+      verdicts.set(row.matchId, "unsatisfied");
+    }
+  }
+  return [...verdicts.values()];
+}
+
+/**
+ * The root result, which is a different question from any single game set: a
+ * contract can have game sets that fire in most games and still not be
+ * achieved, and vice versa.
+ */
+function achievedSentence(achieved: boolean | null): string {
+  if (achieved === true) {
+    return "The contract itself evaluated to achieved over this window.";
+  }
+  if (achieved === false) {
+    return "The contract itself evaluated to not achieved over this window.";
+  }
+  return "The contract itself could not be evaluated over this window.";
+}
 
 /**
  * The one line the author actually reads.
  *
  * This previously reported how many games were *considered*, so a predicate that
  * could never be satisfied read as reassuringly as a merely demanding one —
- * "Historically evaluated 12 eligible games" while every one of them failed.
+ * "Historically evaluated 12 eligible games" while every one of them failed. It
+ * then reported raw matched evidence rows against distinct eligible matches,
+ * which could print a ratio above one and counted an unevaluable game as a
+ * failure. Lead with satisfied games per distinct match, say what coverage was
+ * missing, and state the contract's own result separately.
  */
-export function darePreviewSummary(
-  eligibleGames: number,
-  matched: number,
-): string {
-  if (eligibleGames === 0) {
+export function darePreviewSummary(preview: DarePreviewSummaryInput): string {
+  if (preview.eligibleGames === 0) {
     return "No retained eligible games were found in the preview window, so this preview says nothing about whether the dare can be satisfied.";
   }
-  if (matched === 0) {
-    return `0 of ${eligibleGames.toString()} eligible games satisfied this contract. Check the condition is achievable and spelled the way Riot records it before creating the dare.`;
+  const verdicts = verdictsByMatch(preview.evidence);
+  const satisfied = verdicts.filter(
+    (verdict) => verdict === "satisfied",
+  ).length;
+  const unknown = verdicts.filter((verdict) => verdict === "unknown").length;
+  const eligible = preview.eligibleGames.toString();
+  const sentences = [
+    satisfied === 0
+      ? `None of the ${eligible} distinct eligible games satisfied any game set of this contract.`
+      : `${satisfied.toString()} of ${eligible} distinct eligible games satisfied at least one game set of this contract.`,
+  ];
+  if (unknown > 0) {
+    sentences.push(
+      `${unknown.toString()} of those games could not be evaluated because their timeline coverage is incomplete, so that count is a lower bound.`,
+    );
+  } else if (!preview.coverageComplete) {
+    sentences.push(
+      "Timeline coverage is incomplete for at least one eligible game, so that count is a lower bound.",
+    );
   }
-  return `${matched.toString()} of ${eligibleGames.toString()} eligible games satisfied this contract.`;
+  sentences.push(achievedSentence(preview.achieved));
+  if (satisfied === 0) {
+    sentences.push(
+      "Check the condition is achievable and spelled the way Riot records it before creating the dare.",
+    );
+  }
+  return sentences.join(" ");
 }

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-draft-guardrails.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-draft-guardrails.ts
@@ -1,0 +1,52 @@
+/**
+ * Drafting guardrails for Dare authoring.
+ *
+ * These are the checks the type system cannot make. A contract can be
+ * structurally valid, reference only bound targets, and use only real lanes,
+ * champions, and queues — and still be impossible to satisfy for semantic
+ * reasons no schema can see. The historical preview is the only thing that
+ * surfaces that, so it has to be run, and it has to say what it found.
+ */
+
+/** A per-turn record of which contracts have actually been previewed. */
+export type DarePreviewLedger = {
+  record: (canonicalScoutQl: string) => void;
+  has: (canonicalScoutQl: string) => boolean;
+};
+
+/**
+ * Keyed by canonical text rather than dare id: revising a contract must require
+ * previewing it again rather than riding on an earlier version's result.
+ */
+export function createDarePreviewLedger(): DarePreviewLedger {
+  const previewed = new Set<string>();
+  return {
+    record: (canonicalScoutQl) => {
+      previewed.add(canonicalScoutQl);
+    },
+    has: (canonicalScoutQl) => previewed.has(canonicalScoutQl),
+  };
+}
+
+export const DARE_PREVIEW_REQUIRED_ISSUE =
+  "Call preview_dare_contract with this contract first. A contract can be valid and in-domain and still impossible to satisfy; the historical preview is what shows that, and it must be run against the contract being created.";
+
+/**
+ * The one line the author actually reads.
+ *
+ * This previously reported how many games were *considered*, so a predicate that
+ * could never be satisfied read as reassuringly as a merely demanding one —
+ * "Historically evaluated 12 eligible games" while every one of them failed.
+ */
+export function darePreviewSummary(
+  eligibleGames: number,
+  matched: number,
+): string {
+  if (eligibleGames === 0) {
+    return "No retained eligible games were found in the preview window, so this preview says nothing about whether the dare can be satisfied.";
+  }
+  if (matched === 0) {
+    return `0 of ${eligibleGames.toString()} eligible games satisfied this contract. Check the condition is achievable and spelled the way Riot records it before creating the dare.`;
+  }
+  return `${matched.toString()} of ${eligibleGames.toString()} eligible games satisfied this contract.`;
+}

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-tools.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-tools.ts
@@ -1,6 +1,7 @@
 import { buildDareShortlist } from "#src/betting/dare-shortlist.ts";
 import {
   createDarePreviewLedger,
+  dareContractNeedsPreview,
   DARE_PREVIEW_REQUIRED_ISSUE,
   darePreviewSummary,
 } from "#src/explore/dare-draft-guardrails.ts";
@@ -17,6 +18,7 @@ import {
   deleteDareDraftV2,
   prepareDareDraftV2,
   reviseDareDraftV2,
+  type DareDraftV2Definition,
 } from "#src/betting/dare-draft-v2.ts";
 import { createDareV2ConfirmationIntent } from "#src/betting/dare-intent-v2.ts";
 import {
@@ -111,6 +113,23 @@ export function createDareToolExecutors(input: DareExploreToolsInput) {
   // could and did skip it. Keyed by canonical text so a revised contract has to
   // be previewed again rather than riding on an earlier one's result.
   const previewedContracts = createDarePreviewLedger();
+  // Every v2 path that persists a contract takes the gate. Gating creation
+  // alone was a bypass: an author could preview and create one contract, then
+  // revise it into an unpreviewed condition and fund that revision.
+  const previewGate = (
+    candidate: DareDraftV2Definition,
+    action: "creating it" | "saving it as a revision",
+  ) => {
+    const prepared = prepareDareDraftV2(candidate);
+    return dareContractNeedsPreview(
+      previewedContracts,
+      prepared.kind === "valid" ? prepared.draft.canonicalScoutQl : null,
+    )
+      ? result("invalid", `Preview this exact contract before ${action}.`, {
+          issues: [DARE_PREVIEW_REQUIRED_ISSUE],
+        })
+      : null;
+  };
 
   const sqlV3Enabled = async () =>
     await isPolicyEnabled("dare_extended_contracts_enabled", {
@@ -301,46 +320,21 @@ export function createDareToolExecutors(input: DareExploreToolsInput) {
           start,
           end,
         });
-        // Lead with matched, not eligible. The old summary reported how many
-        // games were *considered*, so a predicate that could never be satisfied
-        // read as reassuringly as a hard one — "Historically evaluated 12
-        // eligible games" while every one of them failed.
-        const matched = preview.evidence.filter(
-          (row) => row.matched === true,
-        ).length;
+        // Lead with what was satisfied, not what was considered. The old
+        // summary reported how many games were *considered*, so a predicate
+        // that could never be satisfied read as reassuringly as a hard one.
         previewedContracts.record(prepared.draft.canonicalScoutQl);
-        return result(
-          "previewed",
-          darePreviewSummary(preview.eligibleGames, matched),
-          {
-            ...preview,
-            start: start.toISOString(),
-            end: end.toISOString(),
-            canonicalScoutQl: prepared.draft.canonicalScoutQl,
-            plainLanguage: prepared.draft.plainLanguage,
-          },
-        );
+        return result("previewed", darePreviewSummary(preview), {
+          ...preview,
+          start: start.toISOString(),
+          end: end.toISOString(),
+          canonicalScoutQl: prepared.draft.canonicalScoutQl,
+          plainLanguage: prepared.draft.plainLanguage,
+        });
       }),
     create: (raw: unknown) =>
       input.track("create_dare_draft", async () => {
         const resolved = await definition(raw);
-        const canonical =
-          resolved.version === 3
-            ? null
-            : prepareDareDraftV2(resolved.definition);
-        if (
-          canonical !== null &&
-          canonical.kind === "valid" &&
-          !previewedContracts.has(canonical.draft.canonicalScoutQl)
-        ) {
-          return result(
-            "invalid",
-            "Preview this exact contract before creating it.",
-            {
-              issues: [DARE_PREVIEW_REQUIRED_ISSUE],
-            },
-          );
-        }
         if (resolved.version === 3) {
           const created = await createDareDraftV3({
             ...resolved.definition,
@@ -368,6 +362,8 @@ export function createDareToolExecutors(input: DareExploreToolsInput) {
             targetAliases: created.draft.targets.map((target) => target.alias),
           });
         }
+        const blocked = previewGate(resolved.definition, "creating it");
+        if (blocked !== null) return blocked;
         const created = await createDareDraftV2({
           ...resolved.definition,
           serverId: input.capability.serverId,
@@ -417,6 +413,11 @@ export function createDareToolExecutors(input: DareExploreToolsInput) {
             sqlIsBinding: true,
           });
         }
+        const blocked = previewGate(
+          resolved.definition,
+          "saving it as a revision",
+        );
+        if (blocked !== null) return blocked;
         const revised = await reviseDareDraftV2({
           dareId: parsed.dareId,
           serverId: input.capability.serverId,

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-tools.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-tools.ts
@@ -1,5 +1,10 @@
 import { buildDareShortlist } from "#src/betting/dare-shortlist.ts";
 import {
+  createDarePreviewLedger,
+  DARE_PREVIEW_REQUIRED_ISSUE,
+  darePreviewSummary,
+} from "#src/explore/dare-draft-guardrails.ts";
+import {
   createDareDraftV3,
   prepareDareDraftV3,
   reviseDareDraftV3,
@@ -100,6 +105,13 @@ export function createDareToolExecutors(input: DareExploreToolsInput) {
     );
     return shortlistPromise;
   };
+  // Which contracts this turn has actually previewed. `create` is gated on it:
+  // the historical preview is the only check that can catch a contract that is
+  // valid, in-domain, and still impossible — and it was optional, so the model
+  // could and did skip it. Keyed by canonical text so a revised contract has to
+  // be previewed again rather than riding on an earlier one's result.
+  const previewedContracts = createDarePreviewLedger();
+
   const sqlV3Enabled = async () =>
     await isPolicyEnabled("dare_extended_contracts_enabled", {
       server: input.capability.serverId,
@@ -289,11 +301,17 @@ export function createDareToolExecutors(input: DareExploreToolsInput) {
           start,
           end,
         });
+        // Lead with matched, not eligible. The old summary reported how many
+        // games were *considered*, so a predicate that could never be satisfied
+        // read as reassuringly as a hard one — "Historically evaluated 12
+        // eligible games" while every one of them failed.
+        const matched = preview.evidence.filter(
+          (row) => row.matched === true,
+        ).length;
+        previewedContracts.record(prepared.draft.canonicalScoutQl);
         return result(
           "previewed",
-          preview.eligibleGames === 0
-            ? "No retained eligible games were found in the preview window."
-            : `Historically evaluated ${preview.eligibleGames.toString()} eligible games.`,
+          darePreviewSummary(preview.eligibleGames, matched),
           {
             ...preview,
             start: start.toISOString(),
@@ -306,6 +324,23 @@ export function createDareToolExecutors(input: DareExploreToolsInput) {
     create: (raw: unknown) =>
       input.track("create_dare_draft", async () => {
         const resolved = await definition(raw);
+        const canonical =
+          resolved.version === 3
+            ? null
+            : prepareDareDraftV2(resolved.definition);
+        if (
+          canonical !== null &&
+          canonical.kind === "valid" &&
+          !previewedContracts.has(canonical.draft.canonicalScoutQl)
+        ) {
+          return result(
+            "invalid",
+            "Preview this exact contract before creating it.",
+            {
+              issues: [DARE_PREVIEW_REQUIRED_ISSUE],
+            },
+          );
+        }
         if (resolved.version === 3) {
           const created = await createDareDraftV3({
             ...resolved.definition,

--- a/packages/scout-for-lol/packages/data/src/model/dare-domains.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-domains.ts
@@ -381,3 +381,21 @@ export function dareGameSetDomainIssuesV2(gameSet: {
     ),
   ];
 }
+
+/**
+ * The closed domains, shaped for the authoring tool's language response.
+ *
+ * The model had no source of truth for these anywhere — not in the prompt, not
+ * in a tool description, and (before the event-type enum) not in the JSON
+ * Schema either. It was inferring them, which is how `team_position = 'MID'`
+ * reached three funded contracts when Riot writes `MIDDLE`. Champions are
+ * omitted deliberately: ~170 keys is not a useful thing to recite, and the
+ * registry resolves display names anyway.
+ */
+export function dareValueDomainCatalog(): Record<string, readonly string[]> {
+  return Object.fromEntries(
+    Object.entries(DARE_COLUMN_DOMAINS)
+      .filter(([, domain]) => domain.values.length > 0)
+      .map(([column, domain]) => [column, domain.values]),
+  );
+}


### PR DESCRIPTION
Stacked on #2696. Final PR in this stack.

## Why

Three guardrails on the drafting flow, each aimed at a failure the type system cannot reach.

**The model was never told the legal values.** `get_dare_language` is mandatory per the prompt, and it returned target keys, numeric limits, and defaults — but no value domains. Combined with no prompt guidance and (before #2687) no JSON Schema hints, the model had no source of truth anywhere and inferred them. That is the direct cause of `team_position = 'MID'` reaching three funded contracts when Riot records `MIDDLE`.

**The one check that could have caught it was optional.** The historical preview is the only thing that surfaces a contract which is valid, in-domain, and still impossible — and `create_dare_draft` never required it.

**And when it did run, its headline misled.** It reported how many games were *considered*, so an unsatisfiable contract read exactly like a demanding one. For dare 6 it would have printed "Historically evaluated 12 eligible games" while every one of those games failed the predicate. The `matched` booleans were in the payload; only the sentence lied.

## What

- **`valueDomains` in `get_dare_language`**, derived from the same `DARE_COLUMN_DOMAINS` table the validation uses — the values shown and the values enforced cannot drift. Champions are omitted deliberately: ~170 keys is not a useful thing to recite at an author, and the registry resolves display names anyway.
- **Preview summary leads with matched-vs-eligible:**
  > `0 of 12 eligible games satisfied this contract. Check the condition is achievable and spelled the way Riot records it before creating the dare.`

  A zero-*eligible* preview now says outright that it proves nothing, rather than looking like a clean result.
- **`create` refuses a contract this turn has not previewed**, keyed by canonical text so a revision must be previewed again rather than riding on an earlier version's result. (Keying by dare id would have looked equivalent and quietly let revisions skip the check.)
- **Extracted `dare-draft-guardrails.ts` and `dare-authoring-catalog.ts`.** `dare-tools.ts` sat at exactly the 500-line cap, so this was forced — but it is the better shape: the guardrails sit under a name that says why they exist, and the catalog module records why the domains belong in the mandatory call.

### Scope of the preview gate

Stating this plainly rather than overselling it: the ledger is **per-turn in-memory state**. It constrains the model within a conversation, which is the right level for a drafting guardrail, but it is not an invariant the way the schema checks are. Making it one would mean moving it into `prepareDareDraftV2` or the persistence layer.

## Verification

```
bunx turbo run typecheck test lint --filter=@scout-for-lol/data --filter=@scout-for-lol/backend
```

4,512 tests pass; typecheck and lint clean.

`dare-draft-guardrails.test.ts` asserts the catalog publishes the real lane values, **does not** publish the spellings the model invented (`MID`, `SUPPORT`, `DRAGON_KILL`), includes the objective discriminators, and omits champions.

**Not run:** live beta authoring through `/bb dare`.

Non-visual change, so no media.

---

## Stack summary

| PR | What |
| --- | --- |
| #2685 | Shared domain table, v2 enforcement, stored-vs-authoring schema split |
| #2686 | v3 AST domain check — must land before `dare_extended_contracts_enabled` is enabled |
| #2687 | Timeline event-type enum, grounded in ~1.5M real lake events |
| #2696 | `monster_type`/`building_type` — objective dares become expressible |
| this | Drafting guardrails: mandatory preview, honest summary, published domains |

Still outstanding and **not** in this stack: the beta repair for dares 4–6. Dares 4 and 5 remain live and unwinnable (`SUPPORT`), and dare 6 was settled as a loss with a 2 BB fee on a contract that could not be satisfied.