### PR TITLE
fix(better-skill-capped): resolve pagination race, blank facets, and filter scrollbar clipping

### DIFF
--- a/packages/better-skill-capped/src/components/search/facet-checklist.tsx
+++ b/packages/better-skill-capped/src/components/search/facet-checklist.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "#components/ui/card";
 import { Checkbox } from "#components/ui/checkbox";
 import { Input } from "#components/ui/input";
 import { Label } from "#components/ui/label";
+import { cn } from "#lib/utils";
 
 export type FacetChecklistProps = {
   title: string;
@@ -32,7 +33,10 @@ export function FacetChecklist({
   const [filter, setFilter] = useState("");
 
   const values = Object.entries(counts)
-    .filter(([value, count]) => count > 0 || selected.includes(value))
+    .filter(
+      ([value, count]) =>
+        value.trim() !== "" && (count > 0 || selected.includes(value)),
+    )
     .sort(([aValue, aCount], [bValue, bCount]) =>
       bCount === aCount ? aValue.localeCompare(bValue) : bCount - aCount,
     );
@@ -78,7 +82,13 @@ export function FacetChecklist({
             }}
           />
         )}
-        <div className="flex max-h-56 flex-col gap-2 overflow-y-auto">
+        <div
+          className={cn(
+            "flex flex-col gap-2",
+            visible.length > visibleLimit &&
+              "max-h-72 overflow-y-auto pr-2.5 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-muted-foreground/30",
+          )}
+        >
           {visible.map(([value, count]) => (
             <div key={value} className="flex items-center gap-2">
               <Checkbox
@@ -92,7 +102,7 @@ export function FacetChecklist({
                 htmlFor={`${title}-${value}`}
                 className="flex w-full justify-between gap-2 font-normal"
               >
-                <span className="truncate">{value}</span>
+                <span className="truncate py-0.5">{value}</span>
                 <span className="text-muted-foreground">{count}</span>
               </Label>
             </div>

--- a/packages/better-skill-capped/src/components/search/search-page.tsx
+++ b/packages/better-skill-capped/src/components/search/search-page.tsx
@@ -52,7 +52,7 @@ export function SearchPage(): React.ReactElement {
   // Defer the query so typing stays responsive; the search itself is an
   // in-memory pass over ~6.3k docs.
   const deferredQ = useDeferredValue(search.q);
-  const { result } = useSearch({ ...search, q: deferredQ });
+  const { result, isPlaceholderData } = useSearch({ ...search, q: deferredQ });
 
   const championAliases = useMemo(
     () =>
@@ -75,15 +75,33 @@ export function SearchPage(): React.ReactElement {
   // truth — otherwise ?page=99 stays shareable while page 3 is on screen.
   // `replace` keeps the bogus page out of history, and the mismatch guard makes
   // the effect a no-op on the next render rather than a navigation loop.
+  //
+  // Only sync when `result` reflects the current search state:
+  // when `isPlaceholderData` is true or `deferredQ` has not caught up with
+  // `search.q`, `result` still holds the PREVIOUS search's clamped page.
+  // Writing that stale page back to the URL immediately reverts page changes
+  // on the first click.
   const clampedPage = result?.page;
   React.useEffect(() => {
-    if (clampedPage !== undefined && clampedPage !== search.page) {
+    if (
+      clampedPage !== undefined &&
+      !isPlaceholderData &&
+      deferredQ === search.q &&
+      clampedPage !== search.page
+    ) {
       void navigate({
         search: (previous) => ({ ...previous, page: clampedPage }),
         replace: true,
       });
     }
-  }, [clampedPage, search.page, navigate]);
+  }, [
+    clampedPage,
+    search.page,
+    navigate,
+    isPlaceholderData,
+    deferredQ,
+    search.q,
+  ]);
 
   const updateSearch = (updated: Partial<SearchParams>) => {
     void navigate({
@@ -163,9 +181,14 @@ export function SearchPage(): React.ReactElement {
             />
           ))}
           <PaginationControls
-            currentPage={result?.page ?? search.page}
+            currentPage={
+              isPlaceholderData ? search.page : (result?.page ?? search.page)
+            }
             lastPage={result?.pageCount ?? 0}
             onPageChange={(newPage) => {
+              if (newPage === search.page) {
+                return;
+              }
               // Scrolling here (the event handler) rather than in an effect —
               // scrollRestoration only manages full-navigation scroll.
               window.scrollTo(0, 0);

--- a/packages/better-skill-capped/src/components/ui/label.tsx
+++ b/packages/better-skill-capped/src/components/ui/label.tsx
@@ -7,7 +7,7 @@ function Label({ className, ...props }: React.ComponentProps<"label">) {
     <label
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex items-center gap-2 text-sm leading-normal font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className,
       )}
       {...props}

--- a/packages/better-skill-capped/src/features/home/recommended-rail.tsx
+++ b/packages/better-skill-capped/src/features/home/recommended-rail.tsx
@@ -34,7 +34,7 @@ export function RecommendedRail({
       <h2 className="mb-2 flex items-center gap-1.5 text-sm font-semibold text-muted-foreground">
         <Star className="size-4" /> Recommended courses
       </h2>
-      <div className="flex gap-3 overflow-x-auto pb-2">
+      <div className="flex gap-3 overflow-x-auto pb-2 [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-muted-foreground/30">
         {recommended.map((course) => (
           <Link
             key={course.uuid}

--- a/packages/better-skill-capped/src/search/run-search.test.ts
+++ b/packages/better-skill-capped/src/search/run-search.test.ts
@@ -123,6 +123,10 @@ describe("runSearch", () => {
     expect(result.facets.staff["Sjorry"]).toBe(2);
     expect(result.facets.staff["Hector"]).toBe(1);
     expect(result.facets.champion["Kai'Sa"]).toBe(1);
+    expect(result.facets.champion[""]).toBeUndefined();
+    expect(result.facets.staff[""]).toBeUndefined();
+    expect(result.facets.carry[""]).toBeUndefined();
+    expect(result.facets.commentaryType[""]).toBeUndefined();
   });
 
   test("watched filter excludes docs and corrects facet counts", async () => {

--- a/packages/better-skill-capped/src/search/run-search.ts
+++ b/packages/better-skill-capped/src/search/run-search.ts
@@ -73,13 +73,13 @@ const BOOSTS = {
 // Orama caps facet values at 10 by default; every real cardinality here is
 // known (173 champions, ~25 coaches, ~100 tags).
 const FACETS_CONFIG = {
-  kind: { limit: 3 },
-  role: { limit: 6 },
-  yourChampion: { limit: 200 },
+  kind: { limit: 5 },
+  role: { limit: 10 },
+  yourChampion: { limit: 250 },
   staff: { limit: 50 },
   tags: { limit: 150 },
-  carry: { limit: 3 },
-  commentaryType: { limit: 5 },
+  carry: { limit: 10 },
+  commentaryType: { limit: 10 },
 };
 
 type EnumInClause = { in: string[] };
@@ -145,7 +145,16 @@ function passesUserState(
 function extractFacets(results: Results<SearchDoc>): SearchRunResult["facets"] {
   const read = (field: keyof typeof FACETS_CONFIG): FacetCounts => {
     const facet = results.facets?.[field];
-    return facet === undefined ? {} : { ...facet.values };
+    if (facet === undefined) {
+      return {};
+    }
+    const values: FacetCounts = {};
+    for (const [key, valueCount] of Object.entries(facet.values)) {
+      if (key !== "") {
+        values[key] = valueCount;
+      }
+    }
+    return values;
   };
   return {
     kind: read("kind"),

--- a/packages/better-skill-capped/src/search/use-search.ts
+++ b/packages/better-skill-capped/src/search/use-search.ts
@@ -28,6 +28,7 @@ function getSearchIndex(stamp: number, content: Content): Promise<SearchIndex> {
 export type UseSearchResult = {
   result: SearchRunResult | undefined;
   isPending: boolean;
+  isPlaceholderData: boolean;
 };
 
 /**
@@ -69,5 +70,9 @@ export function useSearch(params: SearchRunParams): UseSearchResult {
     },
   });
 
-  return { result: query.data, isPending: query.isPending };
+  return {
+    result: query.data,
+    isPending: query.isPending,
+    isPlaceholderData: query.isPlaceholderData,
+  };
 }


### PR DESCRIPTION
### Why
1. **Two-click pagination**: Navigating to another page required two clicks because TanStack Query's placeholder data caused the URL clamping effect in `SearchPage` to fire prematurely with the previous query's page before the new search query settled, immediately reverting the URL back.
2. **Blank filter checkboxes**: The upstream manifest stores empty string (`""`) sentinels for commentary-only fields on courses and videos. These empty values were indexed and surfaced by Orama facets as blank selectable filter options.
3. **Unnecessary scrollbars on filter checklists**: Checklists had a static `max-h-56 overflow-y-auto` style, which caused browsers to render permanent scrollbars even when only 2 or 3 items were visible.
4. **Font descender clipping**: Checkbox labels (such as the "g" in "Light") had descenders visually clipped due to `leading-none` and zero vertical padding.

### What
- **Search & Pagination**:
  - Export `isPlaceholderData` from the `useSearch` hook.
  - Guard the clamped page sync effect in `SearchPage` so it only writes back to the URL when `!isPlaceholderData && deferredQ === search.q`.
  - Pass `isPlaceholderData ? search.page : (result?.page ?? search.page)` to `PaginationControls` to prevent the UI from temporarily jumping or reverting during transitions.
  - Add guard in `onPageChange` to ignore clicks on the already active page.
- **Facet Filtering**:
  - Exclude empty string keys (`""`) in `extractFacets` within `run-search.ts`.
  - Guard `FacetChecklist` against empty/blank strings (`value.trim() !== ""`).
  - Add unit test coverage in `run-search.test.ts` verifying that empty sentinel facet keys are stripped.
- **UI & Layout**:
  - Apply scrolling and custom thin scrollbars in `FacetChecklist` conditionally only when item count exceeds `visibleLimit`.
  - Style the horizontal `RecommendedRail` with a clean, thin scrollbar.
  - Change `Label` default line height from `leading-none` to `leading-normal` and add `py-0.5` vertical padding to truncated label text.

### Verification
- `bun run typecheck`: Passed (0 errors)
- `bun run lint`: Passed (0 errors)
- `bun run test`: Passed (all 73 vitest tests pass)
- `bun run build`: Passed (clean production build)
- Interactive browser verification via PinchTab on `http://localhost:5173/`:
  - Verified single-click pagination navigation to page 2 (`/?page=2`) updates immediately.
  - Verified all filter sections (Roles, Type, Coach, Carry, etc.) render cleanly with zero blank options.
  - Verified scrollbars appear only when lists overflow.
  - Verified descenders on "Light" and other labels render without clipping.