### PR TITLE
refactor(scout-for-lol): extract the report and competition create pipelines

### DIFF
--- a/packages/scout-for-lol/packages/backend/eslint-suppressions.json
+++ b/packages/scout-for-lol/packages/backend/eslint-suppressions.json
@@ -365,10 +365,5 @@
     "sonarjs/cognitive-complexity": {
       "count": 1
     }
-  },
-  "src/trpc/router/competition.router.ts": {
-    "sonarjs/cognitive-complexity": {
-      "count": 1
-    }
   }
 }

--- a/packages/scout-for-lol/packages/backend/src/database/competition/validation.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/competition/validation.ts
@@ -1,4 +1,4 @@
-import { type ExtendedPrismaClient } from "#src/database/index.ts";
+import { type Db } from "#src/database/index.ts";
 import {
   CompetitionCriteriaSchema,
   CompetitionGameVariantSchema,
@@ -127,11 +127,18 @@ export type CompetitionCreationInput = z.infer<
 // ============================================================================
 
 /**
+ * Only the `competition` delegate is needed, so the root client and a
+ * `$transaction` client both satisfy this — a limit check can run inside the
+ * same transaction as the insert it guards.
+ */
+type CompetitionCountClient = Pick<Db, "competition">;
+
+/**
  * Validate owner doesn't have too many active competitions
  * This is async so it can't be part of Zod schema refinement easily
  */
 export async function validateOwnerLimit(
-  prisma: ExtendedPrismaClient,
+  prisma: CompetitionCountClient,
   serverId: DiscordGuildId,
   ownerId: DiscordAccountId,
 ): Promise<void> {
@@ -165,7 +172,7 @@ export async function validateOwnerLimit(
  * Validate server doesn't have too many active competitions
  */
 export async function validateServerLimit(
-  prisma: ExtendedPrismaClient,
+  prisma: CompetitionCountClient,
   serverId: DiscordGuildId,
   requesterId?: DiscordAccountId,
 ): Promise<void> {

--- a/packages/scout-for-lol/packages/backend/src/lib/audit/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/audit/index.ts
@@ -28,6 +28,8 @@ export const AuditActionSchema = z.enum([
   "ACCOUNT_UPDATE",
   "ROLE_GRANT",
   "ROLE_REVOKE",
+  "REPORT_CREATE",
+  "COMPETITION_CREATE",
 ]);
 export type AuditAction = z.infer<typeof AuditActionSchema>;
 

--- a/packages/scout-for-lol/packages/backend/src/lib/competitions/create.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/competitions/create.ts
@@ -1,0 +1,255 @@
+/**
+ * The competition create pipeline, extracted from `competition.router.ts` so
+ * that every surface that may create a competition runs the same policy.
+ *
+ * The function takes the caller's {@link PermissionSet} rather than a boolean
+ * or a pre-computed decision. Creating a competition is gated on three
+ * separate authorization facts beyond `competitions:create` — the
+ * `competitions:invite` requirement for server-wide or pre-seeded rosters, the
+ * `competitions:schedule` requirement for a customised leaderboard cadence,
+ * and root's bypass of the per-hour rate limit — and they belong in one
+ * reviewed place that every caller shares rather than being restated per
+ * surface.
+ *
+ * Nothing here throws `TRPCError`: policy rejections come back as a
+ * discriminated result so a non-tRPC caller (the confirm path for a prepared
+ * create intent) can map them onto its own transport. The router maps the same
+ * results back onto the errors it has always thrown.
+ *
+ * Two failures deliberately stay exceptions rather than results, because the
+ * caller's transaction must roll back rather than commit a partial
+ * competition:
+ *
+ *   - a malformed `dates` payload throws the `CompetitionDatesSchema` ZodError
+ *     before anything is written, exactly as the router did inline;
+ *   - `InitialEntrantsValidationError` is raised by `enrollInitialPlayers`
+ *     *after* the competition row is inserted, so swallowing it into a result
+ *     would leave that row behind.
+ */
+
+import type {
+  CompetitionWithCriteria,
+  CompetitionWrite,
+  DiscordAccountId,
+  DiscordGuildId,
+  PermissionSet,
+} from "@scout-for-lol/data";
+import {
+  DEFAULT_COMPETITION_CRON,
+  DEFAULT_SCHEDULE_TIMEZONE,
+} from "@scout-for-lol/data/model/competition-cron.ts";
+import type { Db } from "#src/database/index.ts";
+import { CompetitionDatesSchema } from "#src/database/competition/competition-dates.ts";
+import { validateCompetitionConfiguration } from "#src/database/competition/configuration-validation.ts";
+import {
+  bulkEnrollTrackedPlayers,
+  enrollInitialPlayers,
+} from "#src/database/competition/participants.ts";
+import { createCompetition } from "#src/database/competition/queries.ts";
+import {
+  checkRateLimit,
+  getTimeRemaining,
+  recordCreation,
+} from "#src/database/competition/rate-limit.ts";
+import {
+  validateOwnerLimit,
+  validateServerLimit,
+} from "#src/database/competition/validation.ts";
+
+export type CreateCompetitionFailure =
+  /** The criteria/game-variant combination is not a valid competition. */
+  | { kind: "invalid_configuration"; message: string }
+  /** The in-memory per-(guild, owner) creation rate limit rejected this. */
+  | { kind: "rate_limited"; message: string }
+  /** The server or owner already holds its maximum of active competitions. */
+  | { kind: "limit_reached"; message: string }
+  /** `competitions:invite` or `competitions:schedule` is missing. */
+  | { kind: "missing_permission"; message: string };
+
+export type CreateCompetitionResult =
+  /** The competition and its participants are staged in the caller's `db`. */
+  | { kind: "created"; competition: CompetitionWithCriteria }
+  | CreateCompetitionFailure;
+
+export type CreateCompetitionParams = {
+  /** Transaction client; creation and enrollment must commit together. */
+  db: Db;
+  /** The acting caller's effective permissions in `guildId`. */
+  permissions: PermissionSet;
+  guildId: DiscordGuildId;
+  ownerId: DiscordAccountId;
+  input: CompetitionWrite;
+};
+
+function failureMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Persistent active-competition limits (per server + per owner). The in-memory
+ * rate limiter matches the Discord delegated-grant flow; Discord roots bypass
+ * it in both surfaces.
+ */
+async function checkActiveCompetitionLimits(params: {
+  db: Db;
+  guildId: DiscordGuildId;
+  ownerId: DiscordAccountId;
+}): Promise<CreateCompetitionFailure | null> {
+  try {
+    await validateServerLimit(params.db, params.guildId, params.ownerId);
+    await validateOwnerLimit(params.db, params.guildId, params.ownerId);
+  } catch (error) {
+    return { kind: "limit_reached", message: failureMessage(error) };
+  }
+  return null;
+}
+
+function checkCreationRateLimit(params: {
+  permissions: PermissionSet;
+  guildId: DiscordGuildId;
+  ownerId: DiscordAccountId;
+}): CreateCompetitionFailure | null {
+  const { permissions, guildId, ownerId } = params;
+  if (permissions.isRoot || checkRateLimit(guildId, ownerId)) {
+    return null;
+  }
+  const remainingMinutes = Math.ceil(
+    getTimeRemaining(guildId, ownerId) / (60 * 1000),
+  );
+  return {
+    kind: "rate_limited",
+    message: `Rate limited: You can create 1 competition per hour. Try again in ${remainingMinutes.toString()} minute${remainingMinutes === 1 ? "" : "s"}.`,
+  };
+}
+
+/**
+ * SERVER_WIDE bulk-enrolls every tracked player, which is participant
+ * management — gate it on competitions:invite (the permission the invite /
+ * add-all-members procedures already require) rather than letting the create
+ * permission alone bypass it. Checked before insertion so a denied request
+ * never leaves a competition behind.
+ */
+function checkEntrantPermission(params: {
+  permissions: PermissionSet;
+  input: CompetitionWrite;
+}): CreateCompetitionFailure | null {
+  const { permissions, input } = params;
+  const enrollsSomeone =
+    input.visibility === "SERVER_WIDE" || input.initialPlayerIds.length > 0;
+  if (!enrollsSomeone || permissions.can("competitions", "invite")) {
+    return null;
+  }
+  return {
+    kind: "missing_permission",
+    message:
+      input.visibility === "SERVER_WIDE"
+        ? "Server-wide competitions require the invite permission."
+        : "Choosing initial entrants requires the invite permission.",
+  };
+}
+
+function checkSchedulePermission(params: {
+  permissions: PermissionSet;
+  input: CompetitionWrite;
+}): CreateCompetitionFailure | null {
+  const { permissions, input } = params;
+  const customizesSchedule =
+    input.scheduledUpdates.enabled ||
+    input.scheduledUpdates.cronExpression !== DEFAULT_COMPETITION_CRON ||
+    input.scheduledUpdates.timezone !== DEFAULT_SCHEDULE_TIMEZONE;
+  if (!customizesSchedule || permissions.can("competitions", "schedule")) {
+    return null;
+  }
+  return {
+    kind: "missing_permission",
+    message:
+      "Configuring leaderboard updates requires the schedule permission.",
+  };
+}
+
+/**
+ * Authorize and stage a new competition inside `params.db`.
+ *
+ * @throws ZodError when `input.dates` fails `CompetitionDatesSchema`.
+ * @throws InitialEntrantsValidationError when the requested initial roster is
+ * invalid — raised after the competition row exists, so the caller's
+ * transaction must abort.
+ */
+export async function createCompetitionForActor(
+  params: CreateCompetitionParams,
+): Promise<CreateCompetitionResult> {
+  const { db, permissions, guildId, ownerId, input } = params;
+
+  const dates = CompetitionDatesSchema.parse(input.dates);
+  try {
+    validateCompetitionConfiguration(input.criteria, input.gameVariant);
+  } catch (error) {
+    return { kind: "invalid_configuration", message: failureMessage(error) };
+  }
+
+  const rateLimited = checkCreationRateLimit({
+    permissions,
+    guildId,
+    ownerId,
+  });
+  if (rateLimited !== null) return rateLimited;
+
+  const limitReached = await checkActiveCompetitionLimits({
+    db,
+    guildId,
+    ownerId,
+  });
+  if (limitReached !== null) return limitReached;
+
+  const entrantDenial = checkEntrantPermission({ permissions, input });
+  if (entrantDenial !== null) return entrantDenial;
+
+  const scheduleDenial = checkSchedulePermission({ permissions, input });
+  if (scheduleDenial !== null) return scheduleDenial;
+
+  const competition = await createCompetition(db, {
+    serverId: guildId,
+    ownerId,
+    channelId: input.channelId,
+    title: input.title,
+    description: input.description,
+    gameVariant: input.gameVariant,
+    visibility: input.visibility,
+    maxParticipants: input.maxParticipants,
+    dates,
+    criteria: input.criteria,
+    analysisTimezone: input.analysisTimezone,
+    scheduledUpdates: input.scheduledUpdates,
+  });
+  if (input.visibility === "SERVER_WIDE") {
+    await bulkEnrollTrackedPlayers({
+      prisma: db,
+      competitionId: competition.id,
+      guildId,
+    });
+  } else {
+    await enrollInitialPlayers({
+      prisma: db,
+      competitionId: competition.id,
+      guildId,
+      playerIds: input.initialPlayerIds,
+      maxParticipants: input.maxParticipants,
+    });
+  }
+  return { kind: "created", competition };
+}
+
+/**
+ * Post-commit half of the in-memory creation rate limit. Kept out of
+ * {@link createCompetitionForActor} because a rolled-back transaction must not
+ * consume the caller's hourly allowance; root bypasses the limiter entirely,
+ * so it records nothing.
+ */
+export function recordCompetitionCreation(params: {
+  permissions: PermissionSet;
+  guildId: DiscordGuildId;
+  ownerId: DiscordAccountId;
+}): void {
+  if (params.permissions.isRoot) return;
+  recordCreation(params.guildId, params.ownerId);
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/postable-channels.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/postable-channels.ts
@@ -1,0 +1,61 @@
+/**
+ * The bot-postable text channels of a guild, read from the gateway cache.
+ *
+ * Extracted from `guild.router.ts` because more than one surface has to offer
+ * the same channel list — the dashboard picker and, separately, the Explore
+ * agent when it prepares a create intent. Two copies of the filter would drift
+ * into offering channels the bot cannot actually post in.
+ */
+
+import {
+  ChannelType,
+  PermissionFlagsBits,
+  type GuildBasedChannel,
+} from "discord.js";
+import type { DiscordGuildId } from "@scout-for-lol/data";
+import { client as discordClient } from "#src/discord/client.ts";
+
+export type PostableChannel = {
+  id: string;
+  name: string;
+  parentId: string | null;
+};
+
+/** Text channels in `guildId` that the bot can post to, sorted by name. */
+export function listPostableChannels(
+  guildId: DiscordGuildId,
+): PostableChannel[] {
+  const guild = discordClient.guilds.cache.get(guildId);
+  if (guild === undefined) {
+    // Callers have already proved Scout is installed, but the cache lookup is
+    // still narrowed here for type-safety.
+    return [];
+  }
+
+  const me = guild.members.me;
+  const channels = guild.channels.cache
+    .filter((c: GuildBasedChannel) => {
+      const isText =
+        c.type === ChannelType.GuildText ||
+        c.type === ChannelType.GuildAnnouncement;
+      if (!isText) return false;
+      // Only offer channels the bot can actually post in. Without
+      // this we'd show channels Scout could read but never message.
+      const perms = me?.permissionsIn(c);
+      return (
+        perms !== undefined &&
+        perms.has(PermissionFlagsBits.ViewChannel) &&
+        perms.has(PermissionFlagsBits.SendMessages)
+      );
+    })
+    .map((c: GuildBasedChannel) => ({
+      id: c.id,
+      name: c.name,
+      parentId: c.parentId,
+    }));
+
+  // Keep the response deterministic.
+  channels.sort((a, b) => a.name.localeCompare(b.name));
+
+  return channels;
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/reports/authorization.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/reports/authorization.ts
@@ -1,9 +1,16 @@
 import type { DiscordAccountId, DiscordGuildId } from "@scout-for-lol/data";
 import { getLimit } from "#src/configuration/flags.ts";
-import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import type { Db } from "#src/database/index.ts";
+
+/**
+ * Only the `report` delegate is needed, so both the root client and a
+ * `$transaction` client satisfy this — the limit check runs inside the same
+ * transaction as the insert it guards.
+ */
+type ReportCountClient = Pick<Db, "report">;
 
 export async function canCreateAnotherUserReport(params: {
-  prisma: ExtendedPrismaClient;
+  prisma: ReportCountClient;
   serverId: DiscordGuildId;
   ownerId: DiscordAccountId;
 }): Promise<{ allowed: true } | { allowed: false; reason: string }> {

--- a/packages/scout-for-lol/packages/backend/src/lib/reports/create.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/reports/create.ts
@@ -1,0 +1,101 @@
+/**
+ * The report create pipeline, extracted from `report.router.ts` so that every
+ * surface that may create a report runs the same policy.
+ *
+ * This module deliberately knows nothing about tRPC: it returns a
+ * discriminated result instead of throwing `TRPCError`, because the confirm
+ * path for a prepared create intent is not a `guildMutationProcedure` and has
+ * to map failures onto its own transport. The router maps the same results
+ * back onto the errors it has always thrown.
+ *
+ * Everything here is transaction-scoped, and the caller owns the transaction:
+ * the limit check has to see the same snapshot as the insert it guards, and
+ * the schedule outbox row has to commit with the report. The two steps that
+ * are *not* transaction work stay at the call site — `assertChannelInGuild`
+ * (a Discord cache read) before, and `notifyReportScheduleReconciler()`
+ * (a post-commit nudge) after.
+ */
+
+import type {
+  DiscordAccountId,
+  DiscordGuildId,
+  ReportCreateInput,
+} from "@scout-for-lol/data";
+import { computeNextScheduledUpdateAt } from "@scout-for-lol/data/model/competition-cron.ts";
+import { compileScoutQl } from "@scout-for-lol/data/model/scoutql/compile.ts";
+import type { Report } from "#generated/prisma/client/index.js";
+import type { Db } from "#src/database/index.ts";
+import { canCreateAnotherUserReport } from "#src/lib/reports/authorization.ts";
+import { enqueueReportScheduleUpsert } from "#src/reports/temporal-schedules.ts";
+
+export type CreateReportResult =
+  /** The report row and its schedule-outbox entry are staged in `tx`. */
+  | { kind: "created"; report: Report }
+  /** The server or owner is at its active-report limit. */
+  | { kind: "limit_reached"; reason: string }
+  /** `queryText` is not compilable ScoutQL. */
+  | { kind: "invalid_query"; message: string };
+
+export type CreateReportParams = {
+  serverId: DiscordGuildId;
+  ownerId: DiscordAccountId;
+  input: ReportCreateInput;
+  /** Creation timestamp; also the base for the first scheduled run. */
+  now?: Date;
+};
+
+/**
+ * Stage a new report inside `tx`. Returns a failure result without writing
+ * anything when a policy check rejects the request, so the caller decides
+ * whether to abort or simply commit an empty transaction.
+ */
+export async function createReportInTransaction(
+  tx: Db,
+  params: CreateReportParams,
+): Promise<CreateReportResult> {
+  const { serverId, ownerId, input } = params;
+
+  const limitCheck = await canCreateAnotherUserReport({
+    prisma: tx,
+    serverId,
+    ownerId,
+  });
+  if (!limitCheck.allowed) {
+    return { kind: "limit_reached", reason: limitCheck.reason };
+  }
+
+  try {
+    compileScoutQl(input.queryText);
+  } catch (error) {
+    return {
+      kind: "invalid_query",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const now = params.now ?? new Date();
+  const report = await tx.report.create({
+    data: {
+      serverId,
+      ownerId,
+      // Already validated by ReportCreateInputSchema's DiscordChannelIdSchema.
+      channelId: input.channelId,
+      title: input.title,
+      description: input.description,
+      queryText: input.queryText,
+      isEnabled: input.isEnabled,
+      isSystemManaged: false,
+      cronExpression: input.cronExpression,
+      scheduleTimezone: input.scheduleTimezone,
+      nextScheduledRunAt: computeNextScheduledUpdateAt(
+        input.cronExpression,
+        now,
+        input.scheduleTimezone,
+      ),
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+  await enqueueReportScheduleUpsert(tx, report.id, report.revision);
+  return { kind: "created", report };
+}

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competition-create.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competition-create.router.test.ts
@@ -79,6 +79,7 @@ function createInput(
 }
 
 beforeEach(async () => {
+  await testPrisma.auditLog.deleteMany();
   await testPrisma.competitionParticipant.deleteMany();
   await testPrisma.competition.deleteMany();
   await testPrisma.player.deleteMany();
@@ -292,6 +293,47 @@ describe("competition.create auto-enrollment", () => {
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     expect(
       await testPrisma.competition.count({ where: { serverId: guildId } }),
+    ).toBe(0);
+  });
+});
+
+describe("competition.create auditing", () => {
+  test("writes a COMPETITION_CREATE audit row", async () => {
+    const guildId = nextGuildId();
+    const competition = await trpc
+      .authedCaller(actorDiscordId)
+      .competition.create(createInput(guildId, "OPEN"));
+
+    const audits = await testPrisma.auditLog.findMany({
+      where: { serverId: guildId },
+    });
+    expect(audits).toHaveLength(1);
+    const [audit] = audits;
+    expect(audit).toBeDefined();
+    if (audit === undefined) return;
+    expect(audit.action).toBe("COMPETITION_CREATE");
+    expect(audit.actorDiscordId).toBe(actorDiscordId);
+    expect(audit.targetChannelId).toBe(channelId);
+    expect(JSON.parse(audit.payload)).toMatchObject({
+      competitionId: competition.id,
+      title: competition.title,
+      visibility: "OPEN",
+    });
+  });
+
+  test("a rolled-back creation writes no audit row", async () => {
+    const guildId = nextGuildId();
+    const [playerId] = await seedPlayers(guildId, 1);
+    expect(playerId).toBeDefined();
+    if (playerId === undefined) return;
+    await expect(
+      trpc.authedCaller(actorDiscordId).competition.create({
+        ...createInput(guildId, "OPEN"),
+        initialPlayerIds: [playerId, playerId],
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(
+      await testPrisma.auditLog.count({ where: { serverId: guildId } }),
     ).toBe(0);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competition-edit-input.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competition-edit-input.ts
@@ -10,27 +10,13 @@ import {
   CompetitionVisibilitySchema,
   DiscordChannelIdSchema,
   DiscordGuildIdSchema,
-  SeasonIdSchema,
+  WebCompetitionDatesSchema,
   getCompetitionStatus,
   type CompetitionWithCriteria,
 } from "@scout-for-lol/data";
 import { CompetitionDatesSchema } from "#src/database/competition/competition-dates.ts";
 import type { UpdateCompetitionInput } from "#src/database/competition/queries.ts";
 import { ReportScheduleTimezoneSchema } from "@scout-for-lol/data/model/competition-cron.ts";
-
-/**
- * Web date input. The tRPC link carries no superjson transformer, so `Date`s
- * arrive as ISO strings — coerce them, then the existing duration/ordering
- * rules apply via `CompetitionDatesSchema.parse` in the handler.
- */
-export const WebCompetitionDatesSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("FIXED_DATES"),
-    startDate: z.coerce.date(),
-    endDate: z.coerce.date(),
-  }),
-  z.object({ type: z.literal("SEASON"), seasonId: SeasonIdSchema }),
-]);
 
 export const CompetitionEditInputSchema = z.object({
   guildId: DiscordGuildIdSchema,

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
@@ -12,31 +12,18 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import {
-  CompetitionDescriptionSchema,
-  CompetitionMaxParticipantsSchema,
-  CompetitionTitleSchema,
-  CompetitionCriteriaSchema,
-  CompetitionGameVariantSchema,
   CompetitionIdSchema,
-  CompetitionVisibilitySchema,
+  CompetitionWriteSchema,
   DiscordAccountIdSchema,
-  DiscordChannelIdSchema,
   DiscordGuildIdSchema,
   PlayerIdSchema,
   CompetitionStatusSchema,
   getCompetitionStatus,
   type CompetitionWithCriteria,
 } from "@scout-for-lol/data";
-import {
-  CompetitionScheduledUpdatesSchema,
-  DEFAULT_COMPETITION_CRON,
-  DEFAULT_SCHEDULE_TIMEZONE,
-  ReportScheduleTimezoneSchema,
-} from "@scout-for-lol/data/model/competition-cron.ts";
 import { validateCompetitionConfiguration } from "#src/database/competition/configuration-validation.ts";
 import {
   CompetitionEditInputSchema,
-  WebCompetitionDatesSchema,
   assertCompetitionEditable,
   buildCompetitionUpdateInput,
 } from "#src/trpc/router/competition-edit-input.ts";
@@ -49,27 +36,21 @@ import {
 import { prisma } from "#src/database/index.ts";
 import {
   cancelCompetition,
-  createCompetition,
   getCompetitionsByServerPaginated,
   updateCompetition,
 } from "#src/database/competition/queries.ts";
 import {
   addParticipant,
   bulkEnrollTrackedPlayers,
-  enrollInitialPlayers,
   InitialEntrantsValidationError,
   removeParticipant,
 } from "#src/database/competition/participants.ts";
+import { runAuditedMutation } from "#src/lib/audit/audited-mutation.ts";
 import {
-  validateOwnerLimit,
-  validateServerLimit,
-} from "#src/database/competition/validation.ts";
-import { CompetitionDatesSchema } from "#src/database/competition/competition-dates.ts";
-import {
-  checkRateLimit,
-  getTimeRemaining,
-  recordCreation,
-} from "#src/database/competition/rate-limit.ts";
+  createCompetitionForActor,
+  recordCompetitionCreation,
+  type CreateCompetitionResult,
+} from "#src/lib/competitions/create.ts";
 import { competitionAnalysisProcedures } from "#src/trpc/router/competition-analysis-procedures.ts";
 import { competitionDeliveryProcedures } from "#src/trpc/router/competition-delivery-procedures.ts";
 import {
@@ -81,26 +62,6 @@ import { isPolicyEnabled } from "#src/configuration/flags.ts";
 const GuildInput = z.object({ guildId: DiscordGuildIdSchema });
 const CompetitionIdInput = GuildInput.extend({
   competitionId: CompetitionIdSchema,
-});
-
-const CompetitionWriteSchema = z.object({
-  channelId: DiscordChannelIdSchema,
-  title: CompetitionTitleSchema,
-  description: CompetitionDescriptionSchema,
-  visibility: CompetitionVisibilitySchema,
-  maxParticipants: CompetitionMaxParticipantsSchema.default(100),
-  gameVariant: CompetitionGameVariantSchema.default("MODERN"),
-  dates: WebCompetitionDatesSchema,
-  criteria: CompetitionCriteriaSchema,
-  initialPlayerIds: z.array(PlayerIdSchema).max(100).default([]),
-  analysisTimezone: ReportScheduleTimezoneSchema.default(
-    DEFAULT_SCHEDULE_TIMEZONE,
-  ),
-  scheduledUpdates: CompetitionScheduledUpdatesSchema.default({
-    enabled: false,
-    cronExpression: DEFAULT_COMPETITION_CRON,
-    timezone: DEFAULT_SCHEDULE_TIMEZONE,
-  }),
 });
 
 export const competitionRouter = router({
@@ -198,114 +159,58 @@ export const competitionRouter = router({
         channelId: input.channelId,
       });
       const ownerId = DiscordAccountIdSchema.parse(ctx.user.discordId);
-      const dates = CompetitionDatesSchema.parse(input.dates);
-      try {
-        validateCompetitionConfiguration(input.criteria, input.gameVariant);
-      } catch (error) {
-        asCompetitionBadRequest(error);
-      }
 
-      if (!ctx.permissions.isRoot && !checkRateLimit(input.guildId, ownerId)) {
-        const remainingMinutes = Math.ceil(
-          getTimeRemaining(input.guildId, ownerId) / (60 * 1000),
+      // Creation, SERVER_WIDE enrollment and the audit row run in one
+      // transaction so an enrollment failure rolls the new competition back
+      // rather than leaving a partial/orphaned row the client would retry into
+      // a duplicate.
+      let result: CreateCompetitionResult;
+      try {
+        result = await runAuditedMutation(
+          ctx,
+          input.guildId,
+          (tx) =>
+            createCompetitionForActor({
+              db: tx,
+              permissions: ctx.permissions,
+              guildId: input.guildId,
+              ownerId,
+              input,
+            }),
+          (created) =>
+            created.kind === "created"
+              ? {
+                  action: "COMPETITION_CREATE",
+                  targetChannelId: input.channelId,
+                  payload: {
+                    competitionId: created.competition.id,
+                    title: input.title,
+                    visibility: input.visibility,
+                    gameVariant: input.gameVariant,
+                    maxParticipants: input.maxParticipants,
+                    initialPlayerIds: input.initialPlayerIds,
+                  },
+                }
+              : null,
         );
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: `Rate limited: You can create 1 competition per hour. Try again in ${remainingMinutes.toString()} minute${remainingMinutes === 1 ? "" : "s"}.`,
-        });
-      }
-
-      // Persistent active-competition limits (per server + per owner). The
-      // in-memory rate limiter above matches the Discord delegated-grant flow;
-      // Discord roots bypass it in both surfaces.
-      try {
-        await validateServerLimit(prisma, input.guildId, ownerId);
-        await validateOwnerLimit(prisma, input.guildId, ownerId);
-      } catch (error) {
-        asCompetitionBadRequest(error);
-      }
-
-      // SERVER_WIDE bulk-enrolls every tracked player, which is participant
-      // management — gate it on competitions:invite (the permission the invite /
-      // add-all-members procedures already require) rather than letting the
-      // create permission alone bypass it. Checked before insertion so a
-      // denied request never leaves a competition behind.
-      if (
-        (input.visibility === "SERVER_WIDE" ||
-          input.initialPlayerIds.length > 0) &&
-        !ctx.permissions.can("competitions", "invite")
-      ) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message:
-            input.visibility === "SERVER_WIDE"
-              ? "Server-wide competitions require the invite permission."
-              : "Choosing initial entrants requires the invite permission.",
-        });
-      }
-
-      const customizesSchedule =
-        input.scheduledUpdates.enabled ||
-        input.scheduledUpdates.cronExpression !== DEFAULT_COMPETITION_CRON ||
-        input.scheduledUpdates.timezone !== DEFAULT_SCHEDULE_TIMEZONE;
-      if (
-        customizesSchedule &&
-        !ctx.permissions.can("competitions", "schedule")
-      ) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message:
-            "Configuring leaderboard updates requires the schedule permission.",
-        });
-      }
-
-      // Creation and SERVER_WIDE enrollment run in one transaction so an
-      // enrollment failure rolls the new competition back rather than leaving a
-      // partial/orphaned row the client would retry into a duplicate.
-      let competition: CompetitionWithCriteria;
-      try {
-        competition = await prisma.$transaction(async (tx) => {
-          const created = await createCompetition(tx, {
-            serverId: input.guildId,
-            ownerId,
-            channelId: input.channelId,
-            title: input.title,
-            description: input.description,
-            gameVariant: input.gameVariant,
-            visibility: input.visibility,
-            maxParticipants: input.maxParticipants,
-            dates,
-            criteria: input.criteria,
-            analysisTimezone: input.analysisTimezone,
-            scheduledUpdates: input.scheduledUpdates,
-          });
-          if (input.visibility === "SERVER_WIDE") {
-            await bulkEnrollTrackedPlayers({
-              prisma: tx,
-              competitionId: created.id,
-              guildId: input.guildId,
-            });
-          } else {
-            await enrollInitialPlayers({
-              prisma: tx,
-              competitionId: created.id,
-              guildId: input.guildId,
-              playerIds: input.initialPlayerIds,
-              maxParticipants: input.maxParticipants,
-            });
-          }
-          return created;
-        });
       } catch (error) {
         if (error instanceof InitialEntrantsValidationError) {
           asCompetitionBadRequest(error);
         }
         throw error;
       }
-      if (!ctx.permissions.isRoot) {
-        recordCreation(input.guildId, ownerId);
+      if (result.kind === "missing_permission") {
+        throw new TRPCError({ code: "FORBIDDEN", message: result.message });
       }
-      return competition;
+      if (result.kind !== "created") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: result.message });
+      }
+      recordCompetitionCreation({
+        permissions: ctx.permissions,
+        guildId: input.guildId,
+        ownerId,
+      });
+      return result.competition;
     }),
 
   edit: guildMutationProcedure("competitions", "update")

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/guild.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/guild.router.ts
@@ -17,11 +17,6 @@ import {
   DiscordGuildIdSchema,
   parseStoredPermissionKey,
 } from "@scout-for-lol/data";
-import {
-  ChannelType,
-  PermissionFlagsBits,
-  type GuildBasedChannel,
-} from "discord.js";
 import { router, webProcedure } from "#src/trpc/trpc.ts";
 import {
   guildProcedure,
@@ -32,6 +27,7 @@ import {
   hasAdministrator,
   isDevGuildOverrideGuild,
 } from "#src/lib/discord-rest.ts";
+import { listPostableChannels } from "#src/lib/discord/postable-channels.ts";
 import { fetchUserGuildsForRequest } from "#src/trpc/discord-upstream.ts";
 import { prisma } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
@@ -128,39 +124,5 @@ export const guildRouter = router({
    */
   listChannels: guildProcedure("channels", "read")
     .input(z.object({ guildId: DiscordGuildIdSchema }))
-    .query(({ input }) => {
-      const guild = discordClient.guilds.cache.get(input.guildId);
-      if (guild === undefined) {
-        // resolveGuildPermissions already proved Scout is installed, but the
-        // cache lookup is still narrowed here for type-safety.
-        return [];
-      }
-
-      const me = guild.members.me;
-      const channels = guild.channels.cache
-        .filter((c: GuildBasedChannel) => {
-          const isText =
-            c.type === ChannelType.GuildText ||
-            c.type === ChannelType.GuildAnnouncement;
-          if (!isText) return false;
-          // Only offer channels the bot can actually post in. Without
-          // this we'd show channels Scout could read but never message.
-          const perms = me?.permissionsIn(c);
-          return (
-            perms !== undefined &&
-            perms.has(PermissionFlagsBits.ViewChannel) &&
-            perms.has(PermissionFlagsBits.SendMessages)
-          );
-        })
-        .map((c: GuildBasedChannel) => ({
-          id: c.id,
-          name: c.name,
-          parentId: c.parentId,
-        }));
-
-      // Keep the response deterministic.
-      channels.sort((a, b) => a.name.localeCompare(b.name));
-
-      return channels;
-    }),
+    .query(({ input }) => listPostableChannels(input.guildId)),
 });

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/report-create.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/report-create.router.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import {
+  DiscordAccountIdSchema,
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/data";
+import { createOfflineTrpcHarness } from "#src/testing/test-trpc-caller.ts";
+
+// Offline tRPC harness: real router + audit writes, no Discord OAuth, no real
+// Discord backing. See src/testing/test-trpc-caller.ts.
+const trpc = await createOfflineTrpcHarness("trpc-report-create-test");
+const { prisma: testPrisma } = trpc;
+
+const guildId = DiscordGuildIdSchema.parse("100000000000000021");
+const channelId = DiscordChannelIdSchema.parse("200000000000000021");
+const actorDiscordId = DiscordAccountIdSchema.parse("300000000000000021");
+
+const QUERY_TEXT =
+  "SELECT player, COUNT(*) AS games FROM match_participants GROUP BY player RENDER table";
+
+function createInput(overrides: Record<string, unknown> = {}) {
+  return {
+    guildId,
+    channelId,
+    title: "Weekly games",
+    description: null,
+    queryText: QUERY_TEXT,
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  await testPrisma.auditLog.deleteMany();
+  await testPrisma.reportScheduleOutbox.deleteMany();
+  await testPrisma.report.deleteMany();
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+describe("report.create", () => {
+  test("creates the report and writes a REPORT_CREATE audit row", async () => {
+    const report = await trpc
+      .authedCaller(actorDiscordId)
+      .report.create(createInput());
+
+    expect(report.serverId).toBe(guildId);
+    expect(report.queryText).toBe(QUERY_TEXT);
+
+    const audits = await testPrisma.auditLog.findMany({
+      where: { serverId: guildId },
+    });
+    expect(audits).toHaveLength(1);
+    const [audit] = audits;
+    expect(audit).toBeDefined();
+    if (audit === undefined) return;
+    expect(audit.action).toBe("REPORT_CREATE");
+    expect(audit.actorDiscordId).toBe(actorDiscordId);
+    expect(audit.targetChannelId).toBe(channelId);
+    expect(JSON.parse(audit.payload)).toMatchObject({
+      reportId: report.id,
+      title: "Weekly games",
+      queryText: QUERY_TEXT,
+    });
+  });
+
+  test("an uncompilable query is rejected and leaves no report or audit row", async () => {
+    await expect(
+      trpc
+        .authedCaller(actorDiscordId)
+        .report.create(createInput({ queryText: "SELECT nonsense FROM" })),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(
+      await testPrisma.report.count({ where: { serverId: guildId } }),
+    ).toBe(0);
+    expect(
+      await testPrisma.auditLog.count({ where: { serverId: guildId } }),
+    ).toBe(0);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/report.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/report.router.ts
@@ -36,7 +36,8 @@ import {
   guildMutationProcedure,
 } from "#src/trpc/guild-permission.ts";
 import { prisma } from "#src/database/index.ts";
-import { canCreateAnotherUserReport } from "#src/lib/reports/authorization.ts";
+import { runAuditedMutation } from "#src/lib/audit/audited-mutation.ts";
+import { createReportInTransaction } from "#src/lib/reports/create.ts";
 import { executeReportQuery } from "#src/reports/query-engine.ts";
 import { compileScoutQl } from "@scout-for-lol/data/model/scoutql/compile.ts";
 import { planResultColumns } from "#src/reports/plan-columns.ts";
@@ -199,51 +200,39 @@ export const reportRouter = router({
         channelId: input.channelId,
       });
       const ownerId = DiscordAccountIdSchema.parse(ctx.user.discordId);
-      const limitCheck = await canCreateAnotherUserReport({
-        prisma,
-        serverId: input.guildId,
-        ownerId,
-      });
-      if (!limitCheck.allowed) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: limitCheck.reason,
-        });
-      }
-      try {
-        compileScoutQl(input.queryText);
-      } catch (error) {
-        asBadRequest(error);
-      }
-      const now = new Date();
-      const report = await prisma.$transaction(async (tx) => {
-        const created = await tx.report.create({
-          data: {
+      const result = await runAuditedMutation(
+        ctx,
+        input.guildId,
+        (tx) =>
+          createReportInTransaction(tx, {
             serverId: input.guildId,
             ownerId,
-            // Already validated by ReportCreateInputSchema's DiscordChannelIdSchema.
-            channelId: input.channelId,
-            title: input.title,
-            description: input.description,
-            queryText: input.queryText,
-            isEnabled: input.isEnabled,
-            isSystemManaged: false,
-            cronExpression: input.cronExpression,
-            scheduleTimezone: input.scheduleTimezone,
-            nextScheduledRunAt: computeNextScheduledUpdateAt(
-              input.cronExpression,
-              now,
-              input.scheduleTimezone,
-            ),
-            createdTime: now,
-            updatedTime: now,
-          },
-        });
-        await enqueueReportScheduleUpsert(tx, created.id, created.revision);
-        return created;
-      });
+            input,
+          }),
+        (created) =>
+          created.kind === "created"
+            ? {
+                action: "REPORT_CREATE",
+                targetChannelId: input.channelId,
+                payload: {
+                  reportId: created.report.id,
+                  title: input.title,
+                  queryText: input.queryText,
+                  cronExpression: input.cronExpression,
+                  scheduleTimezone: input.scheduleTimezone,
+                  isEnabled: input.isEnabled,
+                },
+              }
+            : null,
+      );
+      if (result.kind === "limit_reached") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: result.reason });
+      }
+      if (result.kind === "invalid_query") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: result.message });
+      }
       await notifyReportScheduleReconciler();
-      return report;
+      return result.report;
     }),
 
   update: guildMutationProcedure("reports", "update")

--- a/packages/scout-for-lol/packages/data/src/model/competition-write.ts
+++ b/packages/scout-for-lol/packages/data/src/model/competition-write.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import {
+  CompetitionCriteriaSchema,
+  CompetitionGameVariantSchema,
+  CompetitionVisibilitySchema,
+  PlayerIdSchema,
+} from "#src/model/competition.ts";
+import {
+  CompetitionScheduledUpdatesSchema,
+  DEFAULT_COMPETITION_CRON,
+  DEFAULT_SCHEDULE_TIMEZONE,
+  ReportScheduleTimezoneSchema,
+} from "#src/model/competition-cron.ts";
+import { DiscordChannelIdSchema } from "#src/model/discord.ts";
+import {
+  CompetitionDescriptionSchema,
+  CompetitionMaxParticipantsSchema,
+  CompetitionTitleSchema,
+} from "#src/model/form-inputs.ts";
+import { SeasonIdSchema } from "#src/seasons.ts";
+
+/**
+ * Web date input. The tRPC link carries no superjson transformer, so `Date`s
+ * arrive as ISO strings — coerce them, then the existing duration/ordering
+ * rules apply via `CompetitionDatesSchema.parse` in the handler.
+ */
+export const WebCompetitionDatesSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("FIXED_DATES"),
+    startDate: z.coerce.date(),
+    endDate: z.coerce.date(),
+  }),
+  z.object({ type: z.literal("SEASON"), seasonId: SeasonIdSchema }),
+]);
+
+export type WebCompetitionDates = z.infer<typeof WebCompetitionDatesSchema>;
+
+/**
+ * Everything a caller supplies to create a competition, minus the guild it
+ * belongs to and the acting owner (both come from the authenticated caller).
+ *
+ * Shared rather than router-local because the competition create pipeline has
+ * more than one entry point: the dashboard form posts it directly, and a
+ * prepared confirmation intent carries the same payload for a human to
+ * approve. Both must describe the same competition, so the shape lives here
+ * next to the other competition models.
+ */
+export const CompetitionWriteSchema = z.object({
+  channelId: DiscordChannelIdSchema,
+  title: CompetitionTitleSchema,
+  description: CompetitionDescriptionSchema,
+  visibility: CompetitionVisibilitySchema,
+  maxParticipants: CompetitionMaxParticipantsSchema.default(100),
+  gameVariant: CompetitionGameVariantSchema.default("MODERN"),
+  dates: WebCompetitionDatesSchema,
+  criteria: CompetitionCriteriaSchema,
+  initialPlayerIds: z.array(PlayerIdSchema).max(100).default([]),
+  analysisTimezone: ReportScheduleTimezoneSchema.default(
+    DEFAULT_SCHEDULE_TIMEZONE,
+  ),
+  scheduledUpdates: CompetitionScheduledUpdatesSchema.default({
+    enabled: false,
+    cronExpression: DEFAULT_COMPETITION_CRON,
+    timezone: DEFAULT_SCHEDULE_TIMEZONE,
+  }),
+});
+
+export type CompetitionWrite = z.infer<typeof CompetitionWriteSchema>;

--- a/packages/scout-for-lol/packages/data/src/model/index.ts
+++ b/packages/scout-for-lol/packages/data/src/model/index.ts
@@ -2,6 +2,7 @@ export * from "./arena/index.ts";
 export * from "./champion.ts";
 export * from "./competition.ts";
 export * from "./competition-format.ts";
+export * from "./competition-write.ts";
 export * from "./discord.ts";
 export * from "./division.ts";
 export * from "./dare-contract-v2.ts";


### PR DESCRIPTION
## Why

A follow-up stack lets the Explore agent prepare "create a report / competition /
subscription" intents that a human confirms through a tRPC mutation. That confirm
path has to execute **the same domain code the web forms execute**, not a second
copy of it. Today both create pipelines live inside their router mutations — the
competition one is ~110 lines of policy — so a second caller would have to restate
them. That restatement would drift from the originals and would likely trip the
`jscpd` duplication gate.

Report and competition creation were also the only unaudited create routes, while
subscription creation has always written an `AuditLog` row. Auditing the agent path
while leaving the form path unaudited would be indefensible, so this closes the gap
at the same time.

## What

- **`lib/reports/create.ts`** and **`lib/competitions/create.ts`**. Neither throws
  `TRPCError`: they return discriminated results, because the confirm path is not a
  `guildMutationProcedure` and has to map failures onto its own transport. The
  routers map the same results back onto the errors they have always thrown, so
  client-visible behaviour is unchanged.
- **`createCompetitionForActor` takes the caller's `PermissionSet`**, so the
  `competitions:invite` gate (server-wide or pre-seeded rosters), the
  `competitions:schedule` gate, and root's rate-limit bypass live in one reviewed
  place every caller shares rather than being restated per surface.
- **Limit checks moved inside the caller's transaction**, so each sees the same
  snapshot as the insert it guards. `canCreateAnotherUserReport`,
  `validateOwnerLimit` and `validateServerLimit` now take a structural client type
  (`Pick<Db, "report">` / `Pick<Db, "competition">`) rather than the root client —
  a type, not an assertion.
- **Both create mutations wrapped in `runAuditedMutation`**, with `REPORT_CREATE`
  and `COMPETITION_CREATE` added to `AuditActionSchema`. `AuditLog.action` is a
  plain `String` column, so this needs no migration.
- **`lib/discord/postable-channels.ts`** extracted from `guild.router.ts`
  `listChannels`; a follow-up adds a second caller (an agent tool) and this keeps
  the two from drifting.
- **`CompetitionWriteSchema` and `WebCompetitionDatesSchema` moved into
  `@scout-for-lol/data`** so the router and a follow-up intent payload share one
  shape.
- **Pruned** the now-stale `competition.router.ts` cognitive-complexity
  suppression — the extraction dropped the file below its baselined count, which
  makes the stale entry itself a lint failure.

Two behaviours are deliberately left as exceptions rather than folded into the
result unions, and both are commented in place: a malformed `dates` payload throws
its `ZodError` before anything is written, and `InitialEntrantsValidationError` is
raised *after* the competition row is inserted, so turning it into a result would
commit an orphaned competition instead of rolling back.

## Verification

```
bunx turbo run typecheck test lint \
  --filter=@scout-for-lol/backend --filter=@scout-for-lol/data --filter=@scout-for-lol/app
```

24/24 tasks successful. backend 3089 tests / 343 files, data 1371 / 67, app 406 / 60
— all passing. `bunx lefthook run pre-commit` clean on the staged set.

New coverage asserts the two audit rows are written on report create and on
competition create.

This is a pure refactor apart from those two audit rows; the existing suites cover
both create routes unchanged. **Not run:** any live or deployed check.