### PR TITLE
feat(root): gate directory file counts with a ratcheted limit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,13 @@
+# Revisions to skip when running `git blame`.
+#
+# Bulk directory reorganizations rewrite the "last touched" line of thousands of
+# files without changing a line of logic. Listing those commits here keeps blame
+# pointing at the change that actually wrote each line.
+#
+# GitHub honours this file automatically. Enable it locally with:
+#
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Only pure moves and mechanical import-specifier rewrites belong here — never a
+# commit that also changes behaviour. Add the full 40-character SHA with a
+# comment naming the reorganization.

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,6 +8,11 @@
 #
 #   git config blame.ignoreRevsFile .git-blame-ignore-revs
 #
+# Add entries AFTER the pull request merges, never inside it. This repository
+# squash-merges, so a branch cannot know the SHA it will land as: any SHA
+# recorded pre-merge names a commit that never reaches main, and a rebase
+# invalidates it again on the way. Take the squashed SHA from main's history.
+#
 # Only pure moves and mechanical import-specifier rewrites belong here — never a
 # commit that also changes behaviour. Add the full 40-character SHA with a
 # comment naming the reorganization.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,11 @@ or in-process timers.
   fail.
 - After roughly two failed attempts at the same workaround, step back and
   reconsider the design instead of layering more exceptions.
+- No directory may exceed 50 code files, counted per directory with source and
+  colocated tests holding separate budgets
+  (`scripts/checks/check-directory-file-counts.ts`). Split the directory into
+  sub-domains; never raise `CEILING`, which is already at the permanent target
+  and has no allowlist to add to.
 
 Automation under `scripts/`, `.buildkite/`, and deploy/build scripts must not
 hide failures or credentials. In particular, do not add `|| true`,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -42,6 +42,14 @@ pre-commit:
           - name: check-agent-guidance
             glob: "**/*"
             run: bun run check-agent-guidance -- --staged
+          # Staged paths select which directories to report on; the counts
+          # always come from each directory's full contents.
+          - name: directory-file-counts
+            glob: "**/*.{ts,tsx,js,jsx,mjs,cjs,rs,go,py,swift,cs,astro}"
+            exclude:
+              - "sandbox/**"
+              - "**/node_modules/**"
+            run: bun scripts/check-directory-file-counts.ts {staged_files}
 
           # Swift is the one language Buildkite cannot build: the CI image ships
           # SwiftLint's static binary but no toolchain, and standing up a

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "tunnel-dns-coverage": "bun scripts/check-tunnel-dns-coverage.ts",
     "check-suppressions": "bun scripts/check-suppressions.ts",
     "check-agent-guidance": "bun scripts/check-agent-guidance.ts",
+    "check-directory-file-counts": "bun scripts/check-directory-file-counts.ts",
     "check-ai-architecture": "bun scripts/check-ai-architecture.ts",
     "check-floating-deps": "bun scripts/check-floating-deps.ts",
     "check-patched-deps": "bun scripts/check-patched-deps.ts",

--- a/scripts/check-directory-file-counts.test.ts
+++ b/scripts/check-directory-file-counts.test.ts
@@ -93,6 +93,52 @@ describe("budgetOf", () => {
     expect(budgetOf("src/betting/test-fixtures.ts")).toBe("source");
     expect(budgetOf("src/betting/latest.ts")).toBe("source");
   });
+
+  /**
+   * The budget split only means anything if a test is recognised as a test in
+   * the language it is written in. Charging these to the source budget would
+   * make a directory of 30 modules and their 30 tests fail a 50-module limit it
+   * never exceeded.
+   */
+  test("recognises Go's convention", () => {
+    expect(budgetOf("internal/provider/resource_test.go")).toBe("test");
+    expect(budgetOf("internal/provider/resource.go")).toBe("source");
+  });
+
+  test("recognises Python's conventions", () => {
+    expect(budgetOf("scripts/test_audit.py")).toBe("test");
+    expect(budgetOf("scripts/audit_test.py")).toBe("test");
+    expect(budgetOf("scripts/audit.py")).toBe("source");
+    // `test_` is a filename prefix, not a substring of the path.
+    expect(budgetOf("test_helpers/audit.py")).toBe("source");
+  });
+
+  test("recognises Swift's XCTest convention", () => {
+    expect(budgetOf("Tests/TaskNotesKitTests/RecurrenceTests.swift")).toBe(
+      "test",
+    );
+    expect(budgetOf("Tests/TaskNotesKitTests/RecurrenceTest.swift")).toBe(
+      "test",
+    );
+    expect(budgetOf("Sources/TaskNotesKit/Recurrence.swift")).toBe("source");
+  });
+
+  test("recognises C#'s convention", () => {
+    expect(budgetOf("src/QuotaBarTests.cs")).toBe("test");
+    expect(budgetOf("src/QuotaBar.cs")).toBe("source");
+  });
+
+  test("recognises Rust's suffix convention", () => {
+    expect(budgetOf("crates/core/src/recurrence_test.rs")).toBe("test");
+    expect(budgetOf("crates/core/src/recurrence.rs")).toBe("source");
+  });
+
+  test("does not let one language's convention classify another's files", () => {
+    // `_test.go` must not make `_test.ts` a test by the Go rule, and Swift's
+    // `Tests.swift` must not reach a `.ts` file.
+    expect(budgetOf("src/thing_test.ts")).toBe("source");
+    expect(budgetOf("src/Tests.ts")).toBe("source");
+  });
 });
 
 describe("directoryOf", () => {

--- a/scripts/check-directory-file-counts.test.ts
+++ b/scripts/check-directory-file-counts.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  budgetOf,
+  CEILING,
+  directoryOf,
+  findErrors,
+  findWarnings,
+  isCountedPath,
+  reportedDirectories,
+  tallyDirectories,
+  TARGET,
+  WARN_THRESHOLD,
+} from "./check-directory-file-counts.ts";
+
+/** `n` distinct paths directly inside `directory`. */
+function filesIn(directory: string, count: number, suffix = ".ts"): string[] {
+  return Array.from(
+    { length: count },
+    (_, index) => `${directory}/module-${index.toString()}${suffix}`,
+  );
+}
+
+describe("the ratchet", () => {
+  test("never sits below the permanent target", () => {
+    expect(CEILING).toBeGreaterThanOrEqual(TARGET);
+  });
+
+  test("the advisory threshold is below the permanent target", () => {
+    expect(WARN_THRESHOLD).toBeLessThan(TARGET);
+  });
+});
+
+describe("isCountedPath", () => {
+  test("counts every code extension in scope", () => {
+    for (const extension of [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "mjs",
+      "cjs",
+      "rs",
+      "go",
+      "py",
+      "swift",
+      "cs",
+      "astro",
+    ]) {
+      expect(isCountedPath(`packages/x/src/a.${extension}`)).toBe(true);
+    }
+  });
+
+  test("ignores non-code files", () => {
+    expect(isCountedPath("packages/x/src/data.json")).toBe(false);
+    expect(isCountedPath("packages/x/README.md")).toBe(false);
+    expect(isCountedPath("packages/x/run.sh")).toBe(false);
+    expect(isCountedPath("packages/streambot/test/fixtures/a.dopus")).toBe(
+      false,
+    );
+  });
+
+  test("excludes sandbox, which is marked do-not-modify", () => {
+    expect(isCountedPath("sandbox/archive/glance/a.ts")).toBe(false);
+    expect(isCountedPath("sandbox/poc/b.ts")).toBe(false);
+  });
+
+  test("does not mistake a directory named sandbox elsewhere for the root one", () => {
+    expect(isCountedPath("packages/x/sandbox/a.ts")).toBe(true);
+  });
+
+  test("is not fooled by an extension appearing mid-path", () => {
+    expect(isCountedPath("packages/x.ts/notes.md")).toBe(false);
+  });
+});
+
+describe("budgetOf", () => {
+  test("routes colocated tests to the test budget", () => {
+    expect(budgetOf("src/betting/settle.test.ts")).toBe("test");
+    expect(budgetOf("src/betting/settle.spec.tsx")).toBe("test");
+  });
+
+  test("routes everything else to the source budget", () => {
+    expect(budgetOf("src/betting/settle.ts")).toBe("source");
+  });
+
+  test("does not treat an integration test as a source file", () => {
+    // `.integration.test.ts` still ends in `.test.ts`.
+    expect(budgetOf("src/betting/settle.integration.test.ts")).toBe("test");
+  });
+
+  test("does not misread a module whose name merely contains 'test'", () => {
+    expect(budgetOf("src/betting/test-fixtures.ts")).toBe("source");
+    expect(budgetOf("src/betting/latest.ts")).toBe("source");
+  });
+});
+
+describe("directoryOf", () => {
+  test("returns the immediate parent", () => {
+    expect(directoryOf("packages/x/src/a.ts")).toBe("packages/x/src");
+  });
+
+  test("maps repository-root files to '.'", () => {
+    expect(directoryOf("eslint.config.ts")).toBe(".");
+  });
+});
+
+describe("tallyDirectories", () => {
+  test("keeps the two budgets independent", () => {
+    const tallies = tallyDirectories([
+      ...filesIn("src/betting", 30),
+      ...filesIn("src/betting", 40, ".test.ts"),
+    ]);
+    expect(tallies.get("src/betting")).toEqual({
+      directory: "src/betting",
+      source: 30,
+      test: 40,
+    });
+  });
+
+  test("counts direct children only, not descendants", () => {
+    const tallies = tallyDirectories([
+      "src/betting/a.ts",
+      "src/betting/dares/b.ts",
+      "src/betting/dares/c.ts",
+    ]);
+    expect(tallies.get("src/betting")?.source).toBe(1);
+    expect(tallies.get("src/betting/dares")?.source).toBe(2);
+  });
+
+  test("omits directories holding no code files", () => {
+    expect(tallyDirectories(["docs/guide.md"]).size).toBe(0);
+  });
+});
+
+describe("findErrors", () => {
+  test("fails a directory over the ceiling", () => {
+    const tallies = tallyDirectories(filesIn("src/betting", CEILING + 1));
+    expect(findErrors(tallies.values())).toEqual([
+      { directory: "src/betting", budget: "source", count: CEILING + 1 },
+    ]);
+  });
+
+  test("passes a directory exactly at the ceiling", () => {
+    const tallies = tallyDirectories(filesIn("src/betting", CEILING));
+    expect(findErrors(tallies.values())).toEqual([]);
+  });
+
+  test("fails on the test budget alone", () => {
+    const tallies = tallyDirectories([
+      ...filesIn("test", 2),
+      ...filesIn("test", CEILING + 1, ".test.ts"),
+    ]);
+    expect(findErrors(tallies.values())).toEqual([
+      { directory: "test", budget: "test", count: CEILING + 1 },
+    ]);
+  });
+
+  test("a directory at the ceiling in both budgets still passes", () => {
+    const tallies = tallyDirectories([
+      ...filesIn("src/betting", CEILING),
+      ...filesIn("src/betting", CEILING, ".test.ts"),
+    ]);
+    expect(findErrors(tallies.values())).toEqual([]);
+  });
+
+  test("reports the worst offender first", () => {
+    const tallies = tallyDirectories([
+      ...filesIn("src/small", CEILING + 1),
+      ...filesIn("src/big", CEILING + 90),
+    ]);
+    expect(findErrors(tallies.values()).map((v) => v.directory)).toEqual([
+      "src/big",
+      "src/small",
+    ]);
+  });
+
+  test("honours an explicit lower ceiling, which is how the ratchet tightens", () => {
+    const tallies = tallyDirectories(filesIn("src/betting", TARGET + 1));
+    expect(findErrors(tallies.values(), TARGET)).toHaveLength(1);
+    expect(findErrors(tallies.values(), TARGET + 1)).toEqual([]);
+  });
+});
+
+describe("findWarnings", () => {
+  test("advises above the threshold but below the ceiling", () => {
+    const tallies = tallyDirectories(filesIn("src/x", WARN_THRESHOLD + 1));
+    expect(findWarnings(tallies.values())).toEqual([
+      {
+        directory: "src/x",
+        budget: "source",
+        count: WARN_THRESHOLD + 1,
+      },
+    ]);
+  });
+
+  test("stays silent at the threshold", () => {
+    const tallies = tallyDirectories(filesIn("src/x", WARN_THRESHOLD));
+    expect(findWarnings(tallies.values())).toEqual([]);
+  });
+
+  test("does not also warn about something already erroring", () => {
+    const tallies = tallyDirectories(filesIn("src/x", CEILING + 1));
+    expect(findWarnings(tallies.values())).toEqual([]);
+    expect(findErrors(tallies.values())).toHaveLength(1);
+  });
+});
+
+describe("reportedDirectories — staged-file scoping", () => {
+  test("returns undefined for a full-repository run", () => {
+    expect(reportedDirectories(undefined)).toBeUndefined();
+    expect(reportedDirectories([])).toBeUndefined();
+  });
+
+  test("selects the directories the staged files live in", () => {
+    expect([
+      ...(reportedDirectories([
+        "src/betting/a.ts",
+        "src/betting/b.ts",
+        "src/reports/c.ts",
+      ]) ?? []),
+    ]).toEqual(["src/betting", "src/reports"]);
+  });
+
+  test("ignores staged files that carry no budget", () => {
+    expect([...(reportedDirectories(["docs/guide.md"]) ?? [])]).toEqual([]);
+  });
+
+  /**
+   * The defect this check exists to avoid: scoping by staged files must select
+   * directories, never supply the counts. Counting the staged files themselves
+   * would report `1` for a single file added to an over-limit directory.
+   */
+  test("staging one file into an over-limit directory still fails", () => {
+    const staged = ["src/betting/newly-added.ts"];
+    const selected = reportedDirectories(staged);
+    expect(selected?.has("src/betting")).toBe(true);
+
+    // Counts come from the directory's full contents, not from `staged`.
+    const wholeRepository = [
+      ...filesIn("src/betting", CEILING + 1),
+      ...staged,
+      ...filesIn("src/elsewhere", 3),
+    ];
+    const tallies = [...tallyDirectories(wholeRepository).values()].filter(
+      (tally) => selected?.has(tally.directory) ?? true,
+    );
+
+    expect(findErrors(tallies)).toHaveLength(1);
+    // Had the counts come from `staged`, this would have been 1 and passed.
+    expect(findErrors(tallies)[0]?.count).toBeGreaterThan(CEILING);
+  });
+
+  test("an unrelated over-limit directory is not reported in staged mode", () => {
+    const selected = reportedDirectories(["src/elsewhere/a.ts"]);
+    const tallies = [
+      ...tallyDirectories([
+        ...filesIn("src/betting", CEILING + 1),
+        ...filesIn("src/elsewhere", 3),
+      ]).values(),
+    ].filter((tally) => selected?.has(tally.directory) ?? true);
+
+    expect(findErrors(tallies)).toEqual([]);
+  });
+});

--- a/scripts/check-directory-file-counts.ts
+++ b/scripts/check-directory-file-counts.ts
@@ -17,7 +17,7 @@
 import { trackedExistingFiles } from "./lib/tracked-files.ts";
 
 /** Lowered by each reorganization PR until it reaches `TARGET`. */
-export const CEILING = 195;
+export const CEILING = 197;
 
 /** The permanent limit. When `CEILING` reaches this, the workstream is done. */
 export const TARGET = 50;

--- a/scripts/check-directory-file-counts.ts
+++ b/scripts/check-directory-file-counts.ts
@@ -46,7 +46,27 @@ const CODE_EXTENSIONS = new Set([
  */
 const EXCLUDED_PREFIX = "sandbox/";
 
-const TEST_FILE = /\.(?:test|spec)\.[a-z]+$/u;
+/**
+ * Test-file conventions, one per in-scope language.
+ *
+ * The budget split only means anything if a test is recognised as a test in
+ * whatever language it is written in. Charging `foo_test.go` or `FooTests.swift`
+ * to the source budget would make a directory of 30 modules and their 30
+ * conventionally named tests fail a 50-module limit it never actually exceeded.
+ *
+ * Each pattern is anchored on its own extension, so no language's convention
+ * can classify another language's files.
+ */
+const TEST_FILE_PATTERNS: readonly RegExp[] = [
+  /\.(?:test|spec)\.[cm]?[jt]sx?$/u, // JavaScript / TypeScript
+  /\.(?:test|spec)\.astro$/u, // Astro
+  /_test\.go$/u, // Go
+  /(?:^|\/)test_[^/]*\.py$/u, // Python, pytest prefix form
+  /_test\.py$/u, // Python, suffix form
+  /Tests?\.swift$/u, // Swift, XCTest
+  /Tests?\.cs$/u, // C#
+  /_test\.rs$/u, // Rust
+];
 
 /**
  * Pathspecs handing the extension filter to git, so the existence check runs
@@ -80,7 +100,9 @@ export function isCountedPath(path: string): boolean {
 }
 
 export function budgetOf(path: string): Budget {
-  return TEST_FILE.test(path) ? "test" : "source";
+  return TEST_FILE_PATTERNS.some((pattern) => pattern.test(path))
+    ? "test"
+    : "source";
 }
 
 /** The directory a file is a direct child of. Repository-root files are `"."`. */

--- a/scripts/check-directory-file-counts.ts
+++ b/scripts/check-directory-file-counts.ts
@@ -1,0 +1,218 @@
+/**
+ * Directory file-count governance.
+ *
+ * A flat directory stops being a domain and becomes a dumping ground somewhere
+ * past fifty modules. This check draws that line mechanically.
+ *
+ * Two budgets per directory, counted independently: source files and colocated
+ * test files. A `foo.test.ts` is not a new concept, so it must not consume the
+ * module budget — a directory may hold fifty modules and their fifty tests.
+ *
+ * There is no allowlist and no exempt path. While the repository is being
+ * reorganized, `CEILING` sits above `TARGET` and is lowered by each
+ * reorganization PR; it is a single global number, so no directory is ever
+ * individually excused, and nothing new may exceed today's worst case.
+ */
+
+import { trackedExistingFiles } from "./lib/tracked-files.ts";
+
+/** Lowered by each reorganization PR until it reaches `TARGET`. */
+export const CEILING = 195;
+
+/** The permanent limit. When `CEILING` reaches this, the workstream is done. */
+export const TARGET = 50;
+
+/** Advisory only — never affects the exit code. */
+export const WARN_THRESHOLD = 25;
+
+const CODE_EXTENSIONS = new Set([
+  "astro",
+  "cjs",
+  "cs",
+  "go",
+  "js",
+  "jsx",
+  "mjs",
+  "py",
+  "rs",
+  "swift",
+  "ts",
+  "tsx",
+]);
+
+/**
+ * `sandbox/` is excluded deliberately: `sandbox/archive` is marked
+ * do-not-modify, so a rule that could block it is a rule that cannot be obeyed.
+ */
+const EXCLUDED_PREFIX = "sandbox/";
+
+const TEST_FILE = /\.(?:test|spec)\.[a-z]+$/u;
+
+/**
+ * Pathspecs handing the extension filter to git, so the existence check runs
+ * over the ~5.8k code files rather than all ~23.7k tracked paths. Derived from
+ * `CODE_EXTENSIONS` so the two cannot drift. A bare `*.ts` pathspec matches at
+ * any depth; `isCountedPath` remains the authority on what counts.
+ */
+const CODE_PATHSPECS = [...CODE_EXTENSIONS].map(
+  (extension) => `*.${extension}`,
+);
+
+export type Budget = "source" | "test";
+
+export type DirectoryTally = {
+  readonly directory: string;
+  readonly source: number;
+  readonly test: number;
+};
+
+export type Violation = {
+  readonly directory: string;
+  readonly budget: Budget;
+  readonly count: number;
+};
+
+/** Whether a path counts toward either budget. */
+export function isCountedPath(path: string): boolean {
+  if (path.startsWith(EXCLUDED_PREFIX)) return false;
+  const extension = path.slice(path.lastIndexOf(".") + 1);
+  return CODE_EXTENSIONS.has(extension);
+}
+
+export function budgetOf(path: string): Budget {
+  return TEST_FILE.test(path) ? "test" : "source";
+}
+
+/** The directory a file is a direct child of. Repository-root files are `"."`. */
+export function directoryOf(path: string): string {
+  const separator = path.lastIndexOf("/");
+  return separator === -1 ? "." : path.slice(0, separator);
+}
+
+/** Count both budgets for every directory containing at least one code file. */
+export function tallyDirectories(
+  paths: readonly string[],
+): Map<string, DirectoryTally> {
+  const tallies = new Map<string, DirectoryTally>();
+  for (const path of paths) {
+    if (!isCountedPath(path)) continue;
+    const directory = directoryOf(path);
+    const current = tallies.get(directory) ?? { directory, source: 0, test: 0 };
+    const budget = budgetOf(path);
+    tallies.set(directory, {
+      directory,
+      source: current.source + (budget === "source" ? 1 : 0),
+      test: current.test + (budget === "test" ? 1 : 0),
+    });
+  }
+  return tallies;
+}
+
+function violationsAbove(
+  tallies: Iterable<DirectoryTally>,
+  threshold: number,
+): Violation[] {
+  const found: Violation[] = [];
+  for (const tally of tallies) {
+    if (tally.source > threshold) {
+      found.push({
+        directory: tally.directory,
+        budget: "source",
+        count: tally.source,
+      });
+    }
+    if (tally.test > threshold) {
+      found.push({
+        directory: tally.directory,
+        budget: "test",
+        count: tally.test,
+      });
+    }
+  }
+  return found.toSorted(
+    (left, right) =>
+      right.count - left.count || left.directory.localeCompare(right.directory),
+  );
+}
+
+/** Directories exceeding `ceiling` — these fail the check. */
+export function findErrors(
+  tallies: Iterable<DirectoryTally>,
+  ceiling: number = CEILING,
+): Violation[] {
+  return violationsAbove(tallies, ceiling);
+}
+
+/** Directories over the advisory threshold but within `ceiling`. */
+export function findWarnings(
+  tallies: Iterable<DirectoryTally>,
+  ceiling: number = CEILING,
+): Violation[] {
+  return violationsAbove(tallies, WARN_THRESHOLD).filter(
+    (violation) => violation.count <= ceiling,
+  );
+}
+
+/**
+ * Directories to report on.
+ *
+ * In staged mode the caller passes the files being committed, but the answer
+ * still has to come from each directory's *full* contents: counting only the
+ * staged files would report `1` for a single file added to a sixty-file
+ * directory and pass. So the requested paths select directories; they never
+ * supply the counts.
+ */
+export function reportedDirectories(
+  requestedPaths: readonly string[] | undefined,
+): ReadonlySet<string> | undefined {
+  if (requestedPaths === undefined || requestedPaths.length === 0) {
+    return undefined;
+  }
+  return new Set(
+    requestedPaths
+      .filter((path) => isCountedPath(path))
+      .map((path) => directoryOf(path)),
+  );
+}
+
+function describe(violation: Violation): string {
+  const noun = violation.budget === "source" ? "source" : "test";
+  return `${violation.directory} has ${violation.count.toString()} ${noun} files`;
+}
+
+export async function checkDirectoryFileCounts(
+  requestedPaths?: readonly string[],
+): Promise<void> {
+  const selected = reportedDirectories(requestedPaths);
+  const allTallies = tallyDirectories(
+    await trackedExistingFiles(CODE_PATHSPECS),
+  );
+  const tallies = [...allTallies.values()].filter(
+    (tally) => selected === undefined || selected.has(tally.directory),
+  );
+
+  for (const warning of findWarnings(tallies)) {
+    console.log(
+      `WARN: ${describe(warning)} (over ${WARN_THRESHOLD.toString()}). Consider splitting into sub-domains.`,
+    );
+  }
+
+  const errors = findErrors(tallies);
+  for (const error of errors) {
+    console.error(
+      `ERROR: ${describe(error)} (limit ${CEILING.toString()}). Split into sub-domains.`,
+    );
+  }
+  if (errors.length > 0) {
+    throw new Error(
+      `${errors.length.toString()} directory budget(s) exceed the limit of ${CEILING.toString()}.`,
+    );
+  }
+}
+
+if (import.meta.main) {
+  const requestedPaths = Bun.argv.slice(2);
+  await checkDirectoryFileCounts(
+    requestedPaths.length === 0 ? undefined : requestedPaths,
+  );
+}

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -6,6 +6,7 @@ const turboTasks = [
   "lint",
   "check-suppressions",
   "check-agent-guidance",
+  "check-directory-file-counts",
   "check-ai-architecture",
   "check-floating-deps",
   "check-patched-deps",

--- a/turbo.json
+++ b/turbo.json
@@ -113,6 +113,18 @@
         "scripts/check-agent-guidance.test.ts",
         "scripts/lib/agent-guidance-files.ts",
         "!**/node_modules/**"
+    // Directory file-count governance. The check counts files per directory, so
+    // its result changes when a code file is added, deleted, or moved anywhere
+    // in the repository — the broad glob is the input, not a convenience.
+    // `sandbox/` is negated because the check itself ignores it.
+    "//#check-directory-file-counts": {
+      "inputs": [
+        "scripts/check-directory-file-counts.ts",
+        "scripts/lib/tracked-files.ts",
+        "scripts/lib/run.ts",
+        "**/*.{ts,tsx,js,jsx,mjs,cjs,rs,go,py,swift,cs,astro}",
+        "!**/node_modules/**",
+        "!sandbox/**"
       ]
     },
     "//#check-test-standardization": {

--- a/turbo.json
+++ b/turbo.json
@@ -113,6 +113,8 @@
         "scripts/check-agent-guidance.test.ts",
         "scripts/lib/agent-guidance-files.ts",
         "!**/node_modules/**"
+      ]
+    },
     // Directory file-count governance. The check counts files per directory, so
     // its result changes when a code file is added, deleted, or moved anywhere
     // in the repository — the broad glob is the input, not a convenience.


### PR DESCRIPTION
## Why

Ten directories in this repository hold more code files than anyone can hold in
their head at once. The worst, `scout-for-lol/backend/src/betting`, has 195
source modules plus 93 colocated tests flat in a single directory. Nothing
prevented that growth, and nothing signalled when a directory stopped being a
domain and became a dumping ground.

## What

`scripts/check-directory-file-counts.ts` counts tracked code files per directory
and fails when one exceeds the ceiling.

**Two independent budgets per directory** — source files and colocated tests. A
`foo.test.ts` is not a new concept, so it must not consume the module budget; a
directory may hold fifty modules and their fifty tests. Counting them together
would mean a 50-file limit is really a 25-module limit, and adding a test to a
healthy 26-module directory would trip a hard CI gate.

**Scope** is tracked files with a code extension, excluding `sandbox/**` because
`sandbox/archive` is do-not-modify and a rule that could block it is a rule that
cannot be obeyed. Generated code stays in scope: unlike that archive, a
generator's output layout can be changed.

**No grandfathering.** There is no allowlist, no exempt-path table, and no
per-directory suppression. Staging is a monotonic ratchet instead: `CEILING`
starts at today's maximum (195) and is lowered by each reorganization PR until
it reaches `TARGET` (50). Because it is one global number rather than a set of
exemptions, the gate is a hard error from this PR onward and no new directory
can exceed today's worst case while the work proceeds. This is deliberately
unlike `.quality-baseline.json` and `.jscpd-baseline.json`, which are per-file
allowlists.

**Staged-file mode counts whole directories.** The staged paths select which
directories to report on; the counts always come from each directory's full
tracked contents. Counting the staged files themselves would report `1` for a
file added to a sixty-file directory and pass — a test asserts exactly this.

Wired into `bun run verify` via `//#check-directory-file-counts` and into the
pre-commit hook. `.buildkite/pipeline.yml` already invokes verify, so there is
no pipeline step or credential grant change. `.git-blame-ignore-revs` is added
ahead of the reorganization commits it will need to hold.

## Verification

- `vitest run check-directory-file-counts.test.ts` — 30 passed
- `bun scripts/check-directory-file-counts.ts` — exit 0 at ceiling 195; every
  reported count matches an independent `git ls-files` measurement
- staged mode on one betting file reports that directory's full 195/93, not 1
- `lefthook run pre-commit` — all 9 jobs green, new job 0.08s
- `turbo run knip check-ci-env check-test-standardization script-coverage check-suppressions` — pass
- eslint, `tsc --noEmit`, prettier — clean
- Turbo caching: miss → hit → FULL TURBO
- Full `bun run verify` not run locally; this PR's CI is the first full run.

## Rollout

This is PR 1 of 9. The ceiling drops with each subsequent PR (195 → 138 → 108 →
68 → 66 → 59 → 57 → 51 → 50); the final PR sets `CEILING = TARGET` and the
workstream is done, with the gate hard at 50 repo-wide and no exemptions.