### PR TITLE
refactor(scout-for-lol): unify confirmation intents onto one framework

### DIFF
--- a/packages/scout-for-lol/packages/app/src/components/bucks-dare-actions.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/bucks-dare-actions.tsx
@@ -23,7 +23,7 @@ function contributionPayload(amount: number | undefined) {
   if (amount === undefined) {
     throw new Error("A contribution action requires an amount.");
   }
-  return { action: "contribute" as const, amount };
+  return { kind: "dare_contribute" as const, amount };
 }
 
 export function BucksDareActions(props: {
@@ -72,12 +72,12 @@ export function BucksDareActions(props: {
       action === "contribute"
         ? contributionPayload(contributionAmount)
         : action === "fund"
-          ? ({ action: "fund" } as const)
+          ? ({ kind: "dare_fund" } as const)
           : action === "accept"
-            ? ({ action: "accept" } as const)
+            ? ({ kind: "dare_accept" } as const)
             : action === "decline"
-              ? ({ action: "decline" } as const)
-              : ({ action: "cancel" } as const);
+              ? ({ kind: "dare_decline" } as const)
+              : ({ kind: "dare_cancel" } as const);
     prepare.mutate(
       {
         guildId: props.guildId,

--- a/packages/scout-for-lol/packages/app/src/components/explore-dare-cards.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-dare-cards.tsx
@@ -198,7 +198,7 @@ function IntentCard(props: { intent: z.infer<typeof IntentDataSchema> }) {
     trpc.explore.confirmDareIntent.mutationOptions(),
   );
   const persisted = useQuery(
-    trpc.explore.dareIntentStatus.queryOptions({
+    trpc.explore.intentStatus.queryOptions({
       intentId: props.intent.intentId,
     }),
   );
@@ -268,7 +268,7 @@ function IntentCard(props: { intent: z.infer<typeof IntentDataSchema> }) {
                       queryKey: trpc.bucks.dareInspect.pathKey(),
                     });
                     void queryClient.invalidateQueries({
-                      queryKey: trpc.explore.dareIntentStatus.queryKey({
+                      queryKey: trpc.explore.intentStatus.queryKey({
                         intentId: props.intent.intentId,
                       }),
                     });

--- a/packages/scout-for-lol/packages/backend/prisma/migrations/20260904000000_confirmation_intent/migration.sql
+++ b/packages/scout-for-lol/packages/backend/prisma/migrations/20260904000000_confirmation_intent/migration.sql
@@ -1,0 +1,76 @@
+-- One confirmation-intent table replaces the dare-only one. The protocol is
+-- unchanged — actor-bound, single-use, expiring, idempotent — but the row no
+-- longer assumes its target is a dare, and the action is stored exactly once.
+--
+-- `kind` folds in the old `action` column: it used to live both there and
+-- inside `actionPayload`, and consuming an intent carried a runtime assertion
+-- that threw when the two disagreed. With one discriminator that state is
+-- unrepresentable.
+--
+-- `serverId` is denormalized from the dare. Guild visibility used to be
+-- checked by joining through `dare.serverId`; it becomes a direct column
+-- comparison, which is only equivalent if the stored value comes from the
+-- target row rather than from a caller.
+CREATE TABLE "ConfirmationIntent" (
+    "id" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "serverId" TEXT NOT NULL,
+    "actorDiscordId" TEXT NOT NULL,
+    "payload" TEXT NOT NULL,
+    "idempotencyKey" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "consumedAt" TIMESTAMP(3),
+    "resultJson" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dareId" INTEGER,
+    "expectedRevision" INTEGER,
+    CONSTRAINT "ConfirmationIntent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ConfirmationIntent_idempotencyKey_key" ON "ConfirmationIntent"("idempotencyKey");
+CREATE INDEX "ConfirmationIntent_dareId_expiresAt_idx" ON "ConfirmationIntent"("dareId", "expiresAt");
+
+ALTER TABLE "ConfirmationIntent" ADD CONSTRAINT "ConfirmationIntent_dareId_fkey" FOREIGN KEY ("dareId") REFERENCES "BucksDareV2"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Copy every existing intent. Three columns here are load-bearing:
+--
+-- * The payload is rewritten, not copied. Stored payloads discriminate on
+--   `action` (`{"action":"contribute","amount":5}`) and the new union
+--   discriminates on `kind`, so a straight copy would leave every in-flight
+--   confirmation failing Zod validation at confirm time — and only when
+--   someone clicks. The text is rebuilt to match what the application would
+--   serialize byte for byte, because minting with an existing idempotency key
+--   compares the stored payload against a freshly serialized one. Reading the
+--   contribution amount through jsonb and casting it to int means an
+--   unexpected payload fails this migration rather than writing malformed
+--   JSON that only breaks at confirm time.
+-- * `id` is preserved: a pending confirmation card in an open browser tab, and
+--   the custom id of a live Discord button, both hold it.
+-- * `consumedAt` and `resultJson` are preserved. Dropping them would make an
+--   already-consumed intent confirmable again, which on `dare_fund` and
+--   `dare_contribute` is a double-spend of real balances.
+INSERT INTO "ConfirmationIntent" (
+    id, kind, "serverId", "dareId", "expectedRevision", "actorDiscordId",
+    payload, "idempotencyKey", "expiresAt", "consumedAt", "resultJson", "createdAt"
+)
+SELECT
+    i.id,
+    'dare_' || i.action,
+    d."serverId",
+    i."dareId",
+    i.revision,
+    i."actorDiscordId",
+    CASE
+        WHEN i.action = 'contribute'
+            THEN '{"kind":"dare_contribute","amount":' || ((i."actionPayload"::jsonb ->> 'amount')::int)::text || '}'
+        ELSE '{"kind":"dare_' || i.action || '"}'
+    END,
+    i."idempotencyKey",
+    i."expiresAt",
+    i."consumedAt",
+    i."resultJson",
+    i."createdAt"
+FROM "BucksDareV2ConfirmationIntent" i
+JOIN "BucksDareV2" d ON d.id = i."dareId";
+
+DROP TABLE "BucksDareV2ConfirmationIntent";

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -1509,7 +1509,7 @@ model BucksDareV2 {
   targets            BucksDareV2Target[]
   contributions      BucksDareV2Contribution[]
   evidence           BucksDareV2Evidence[]
-  intents            BucksDareV2ConfirmationIntent[]
+  intents            ConfirmationIntent[]
   notificationEvents BucksDareNotificationEvent[]
   activation         BucksDareV2Activation?
 
@@ -1622,21 +1622,32 @@ model BucksDareV2Evidence {
   @@index([dareId, gameEndAt, matchId])
 }
 
-// Binding or financial actions are prepared as revision-bound, single-use
-// intents. The button/control consumes the intent idempotently after approval.
-model BucksDareV2ConfirmationIntent {
-  id             String      @id @default(uuid())
-  dareId         Int
-  dare           BucksDareV2 @relation(fields: [dareId], references: [id], onDelete: Cascade)
-  revision       Int
-  actorDiscordId String
-  action         String
-  actionPayload  String
-  idempotencyKey String      @unique
-  expiresAt      DateTime
-  consumedAt     DateTime?
-  resultJson     String?
-  createdAt      DateTime    @default(now())
+// Binding or financial actions are prepared as single-use, actor-bound,
+// expiring intents. The button/control consumes the intent idempotently after
+// a human approves it; nothing writes domain state before that.
+//
+// `kind` is the sole discriminator and `payload` is its Zod-validated JSON
+// body, so the action can never disagree with the payload describing it.
+// `serverId` is denormalized from the target at mint time — every guild
+// visibility check is a comparison against this column, so it must be derived
+// from the row being acted on rather than taken from the caller.
+//
+// `dareId`/`expectedRevision` are nullable because an intent need not have an
+// existing target; a dare intent always sets both, keeping its cascade delete.
+model ConfirmationIntent {
+  id               String       @id @default(uuid())
+  kind             String
+  serverId         String
+  actorDiscordId   String
+  payload          String
+  idempotencyKey   String       @unique
+  expiresAt        DateTime
+  consumedAt       DateTime?
+  resultJson       String?
+  createdAt        DateTime     @default(now())
+  dareId           Int?
+  dare             BucksDareV2? @relation(fields: [dareId], references: [id], onDelete: Cascade)
+  expectedRevision Int?
 
   @@index([dareId, expiresAt])
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-discord-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-discord-v2.ts
@@ -41,11 +41,11 @@ function actionPayload(parsed: Extract<DareV2CustomId, { kind: "prepare" }>) {
     if (parsed.amount === null) {
       throw new Error("Dare v2 contribution button has no amount.");
     }
-    return { action: "contribute" as const, amount: parsed.amount };
+    return { kind: "dare_contribute" as const, amount: parsed.amount };
   }
-  if (parsed.action === "accept") return { action: "accept" as const };
-  if (parsed.action === "decline") return { action: "decline" as const };
-  return { action: "cancel" as const };
+  if (parsed.action === "accept") return { kind: "dare_accept" as const };
+  if (parsed.action === "decline") return { kind: "dare_decline" as const };
+  return { kind: "dare_cancel" as const };
 }
 
 type DareV2DiscordContext = {
@@ -92,12 +92,10 @@ async function consumeIntent(
   intentId: string,
 ): Promise<void> {
   const intent =
-    await context.dependencies.prismaClient.bucksDareV2ConfirmationIntent.findUnique(
-      {
-        where: { id: intentId },
-        select: { dareId: true },
-      },
-    );
+    await context.dependencies.prismaClient.confirmationIntent.findUnique({
+      where: { id: intentId },
+      select: { dareId: true },
+    });
   await context.interaction.deferUpdate();
   const outcome = await context.dependencies.consumeIntent(
     {
@@ -111,13 +109,14 @@ async function consumeIntent(
     },
   );
   let deliveryFailed = false;
-  if (intent !== null) {
+  const dareId = intent?.dareId ?? null;
+  if (dareId !== null) {
     try {
-      await ensureDareV2Callout(intent.dareId, context.dependencies);
+      await ensureDareV2Callout(dareId, context.dependencies);
     } catch (error) {
       deliveryFailed = true;
       logger.error(
-        `Dare v2 ${intent.dareId.toString()} action committed but its callout failed:`,
+        `Dare v2 ${dareId.toString()} action committed but its callout failed:`,
         error,
       );
     }

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-intent-consume-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-intent-consume-v2.ts
@@ -1,5 +1,4 @@
 import {
-  ConfirmationIntentPayloadSchema,
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
   type ConfirmationIntentPayload,
@@ -23,6 +22,7 @@ import {
 } from "#src/betting/dare-v2-common.ts";
 import { InsufficientBucksError } from "#src/betting/ledger.ts";
 import type { Db } from "#src/database/index.ts";
+import { readConfirmationIntentPayload } from "#src/lib/confirmation-intent/payload.ts";
 import type { ConfirmationIntent } from "#generated/prisma/client/index.js";
 import { claimAndExecute } from "#src/lib/confirmation-intent/claim.ts";
 
@@ -175,9 +175,7 @@ export async function consumeDareV2ConfirmationIntent(
   if (intent.actorDiscordId !== input.actorDiscordId) {
     return { kind: "forbidden" } as const;
   }
-  const payload = ConfirmationIntentPayloadSchema.parse(
-    JSON.parse(intent.payload),
-  );
+  const payload = readConfirmationIntentPayload(intent);
   if (intent.consumedAt !== null) {
     return {
       kind: "already_consumed",

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-intent-consume-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-intent-consume-v2.ts
@@ -1,6 +1,8 @@
 import {
+  ConfirmationIntentPayloadSchema,
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
+  type ConfirmationIntentPayload,
   type DiscordAccountId,
   type DiscordGuildId,
 } from "@scout-for-lol/data";
@@ -10,10 +12,6 @@ import {
   acceptDareV2InTransaction,
   fundDareV2InTransaction,
 } from "#src/betting/dare-fund-consent-v2.ts";
-import {
-  DareV2IntentPayloadSchema,
-  type DareV2IntentPayload,
-} from "#src/betting/dare-intent-v2.ts";
 import {
   cancelDareV2InTransaction,
   declineDareV2InTransaction,
@@ -25,43 +23,62 @@ import {
 } from "#src/betting/dare-v2-common.ts";
 import { InsufficientBucksError } from "#src/betting/ledger.ts";
 import type { Db } from "#src/database/index.ts";
+import type { ConfirmationIntent } from "#generated/prisma/client/index.js";
+import { claimAndExecute } from "#src/lib/confirmation-intent/claim.ts";
 
 type IntentAccount = { id: number } | undefined;
 
-function needsFeature(payload: DareV2IntentPayload): boolean {
+/** The dare an intent acts on, together with the revision it was minted for. */
+type DareIntentTarget = { dareId: number; revision: number };
+
+function needsFeature(payload: ConfirmationIntentPayload): boolean {
   return (
-    payload.action === "fund" ||
-    payload.action === "accept" ||
-    payload.action === "contribute"
+    payload.kind === "dare_fund" ||
+    payload.kind === "dare_accept" ||
+    payload.kind === "dare_contribute"
   );
 }
 
-function needsAccount(payload: DareV2IntentPayload): boolean {
+function needsAccount(payload: ConfirmationIntentPayload): boolean {
   return (
-    payload.action === "fund" ||
-    payload.action === "accept" ||
-    payload.action === "contribute"
+    payload.kind === "dare_fund" ||
+    payload.kind === "dare_accept" ||
+    payload.kind === "dare_contribute"
   );
+}
+
+/**
+ * A dare intent always carries its dare and revision; the columns are nullable
+ * only because an intent need not act on an existing row. Missing values here
+ * mean a broken caller contract, so they are let through as an error rather
+ * than defaulted.
+ */
+function dareTarget(intent: ConfirmationIntent): DareIntentTarget {
+  if (intent.dareId === null || intent.expectedRevision === null) {
+    throw new Error(
+      `Confirmation intent ${intent.id} of kind ${intent.kind} has no dare target.`,
+    );
+  }
+  return { dareId: intent.dareId, revision: intent.expectedRevision };
 }
 
 async function executeAction(
   tx: Db,
   input: {
-    dareId: number;
-    revision: number;
+    target: DareIntentTarget;
     actorDiscordId: DiscordAccountId;
-    payload: DareV2IntentPayload;
+    payload: ConfirmationIntentPayload;
     account: IntentAccount;
     now: Date;
   },
 ) {
   const common = {
-    dareId: input.dareId,
-    revision: input.revision,
+    dareId: input.target.dareId,
+    revision: input.target.revision,
     actorDiscordId: input.actorDiscordId,
     now: input.now,
   };
-  if (input.payload.action === "fund") {
+  if (input.payload.kind === "dare_fund") {
     if (input.account === undefined)
       throw new Error("Fund intent has no wallet.");
     return await fundDareV2InTransaction(tx, {
@@ -69,7 +86,7 @@ async function executeAction(
       bucksAccountId: input.account.id,
     });
   }
-  if (input.payload.action === "accept") {
+  if (input.payload.kind === "dare_accept") {
     if (input.account === undefined)
       throw new Error("Accept intent has no wallet.");
     return await acceptDareV2InTransaction(tx, {
@@ -77,10 +94,10 @@ async function executeAction(
       bucksAccountId: input.account.id,
     });
   }
-  if (input.payload.action === "decline") {
+  if (input.payload.kind === "dare_decline") {
     return await declineDareV2InTransaction(tx, common);
   }
-  if (input.payload.action === "cancel") {
+  if (input.payload.kind === "dare_cancel") {
     return await cancelDareV2InTransaction(tx, common);
   }
   if (input.account === undefined)
@@ -92,58 +109,8 @@ async function executeAction(
   });
 }
 
-async function consumeClaim(
-  input: {
-    intent: { id: string; dareId: number; revision: number };
-    actorDiscordId: DiscordAccountId;
-    payload: DareV2IntentPayload;
-    account: IntentAccount;
-    now: Date;
-  },
-  dependencies: DareV2Dependencies,
-) {
-  return await dependencies.prismaClient.$transaction(async (tx) => {
-    const claimed = await tx.bucksDareV2ConfirmationIntent.updateMany({
-      where: {
-        id: input.intent.id,
-        actorDiscordId: input.actorDiscordId,
-        consumedAt: null,
-        expiresAt: { gt: input.now },
-      },
-      data: { consumedAt: input.now },
-    });
-    if (claimed.count !== 1) {
-      const current = await tx.bucksDareV2ConfirmationIntent.findUniqueOrThrow({
-        where: { id: input.intent.id },
-      });
-      return current.consumedAt === null
-        ? ({ kind: "intent_expired" } as const)
-        : ({
-            kind: "already_consumed",
-            result:
-              current.resultJson === null
-                ? null
-                : JSON.parse(current.resultJson),
-          } as const);
-    }
-    const result = await executeAction(tx, {
-      dareId: input.intent.dareId,
-      revision: input.intent.revision,
-      actorDiscordId: input.actorDiscordId,
-      payload: input.payload,
-      account: input.account,
-      now: input.now,
-    });
-    await tx.bucksDareV2ConfirmationIntent.update({
-      where: { id: input.intent.id },
-      data: { resultJson: JSON.stringify(result) },
-    });
-    return result;
-  });
-}
-
 async function openingStakeNeeded(
-  input: { dareId: number; revision: number },
+  input: DareIntentTarget,
   dependencies: DareV2Dependencies,
 ): Promise<number> {
   const revision =
@@ -163,8 +130,8 @@ async function insufficientOutcome(
   input: {
     error: unknown;
     account: IntentAccount;
-    payload: DareV2IntentPayload;
-    intent: { dareId: number; revision: number };
+    payload: ConfirmationIntentPayload;
+    target: DareIntentTarget;
   },
   dependencies: DareV2Dependencies,
 ) {
@@ -180,10 +147,10 @@ async function insufficientOutcome(
       select: { balance: true },
     });
   const needed =
-    input.payload.action === "contribute"
+    input.payload.kind === "dare_contribute"
       ? input.payload.amount
-      : input.payload.action === "fund"
-        ? await openingStakeNeeded(input.intent, dependencies)
+      : input.payload.kind === "dare_fund"
+        ? await openingStakeNeeded(input.target, dependencies)
         : undefined;
   return { kind: "insufficient", balance: current.balance, needed } as const;
 }
@@ -197,27 +164,20 @@ export async function consumeDareV2ConfirmationIntent(
   dependencies: DareV2Dependencies = defaultDareV2Dependencies,
   now: Date = new Date(),
 ) {
-  const intent =
-    await dependencies.prismaClient.bucksDareV2ConfirmationIntent.findUnique({
-      where: { id: input.intentId },
-      include: {
-        dare: { select: { serverId: true } },
-      },
-    });
-  if (intent?.dare.serverId !== input.serverId) {
+  const intent = await dependencies.prismaClient.confirmationIntent.findUnique({
+    where: { id: input.intentId },
+  });
+  // The guild is stored on the intent, so this is the same check the join
+  // through `dare.serverId` used to make.
+  if (intent?.serverId !== input.serverId) {
     return { kind: "not_found" } as const;
   }
   if (intent.actorDiscordId !== input.actorDiscordId) {
     return { kind: "forbidden" } as const;
   }
-  const payload = DareV2IntentPayloadSchema.parse(
-    JSON.parse(intent.actionPayload),
+  const payload = ConfirmationIntentPayloadSchema.parse(
+    JSON.parse(intent.payload),
   );
-  if (intent.action !== payload.action) {
-    throw new Error(
-      `Dare v2 intent ${intent.id} action does not match its payload.`,
-    );
-  }
   if (intent.consumedAt !== null) {
     return {
       kind: "already_consumed",
@@ -227,12 +187,13 @@ export async function consumeDareV2ConfirmationIntent(
   if (intent.expiresAt.getTime() <= now.getTime()) {
     return { kind: "intent_expired" } as const;
   }
+  const target = dareTarget(intent);
   const revision =
     await dependencies.prismaClient.bucksDareV2Revision.findUniqueOrThrow({
       where: {
         dareId_revision: {
-          dareId: intent.dareId,
-          revision: intent.revision,
+          dareId: target.dareId,
+          revision: target.revision,
         },
       },
       select: { compilerVersion: true },
@@ -242,7 +203,7 @@ export async function consumeDareV2ConfirmationIntent(
     !(await relationalDareActionEnabled(
       input.serverId,
       revision.compilerVersion,
-      payload.action === "fund",
+      payload.kind === "dare_fund",
       dependencies,
     ))
   ) {
@@ -258,19 +219,25 @@ export async function consumeDareV2ConfirmationIntent(
       )
     : undefined;
   try {
-    return await consumeClaim(
+    return await claimAndExecute(
+      dependencies.prismaClient,
       {
-        intent,
+        intentId: intent.id,
         actorDiscordId: input.actorDiscordId,
-        payload,
-        account,
         now,
       },
-      dependencies,
+      async (tx) =>
+        await executeAction(tx, {
+          target,
+          actorDiscordId: input.actorDiscordId,
+          payload,
+          account,
+          now,
+        }),
     );
   } catch (error) {
     return await insufficientOutcome(
-      { error, account, payload, intent },
+      { error, account, payload, target },
       dependencies,
     );
   }

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-intent-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-intent-v2.ts
@@ -1,39 +1,42 @@
 import {
-  BucksStakeSchema,
-  DiscordAccountIdSchema,
+  ConfirmationIntentPayloadSchema,
+  DiscordGuildIdSchema,
+  type ConfirmationIntentKind,
+  type ConfirmationIntentPayload,
   type DiscordAccountId,
   type DiscordGuildId,
 } from "@scout-for-lol/data";
-import { z } from "zod";
 import {
   defaultDareV2Dependencies,
   relationalDareActionEnabled,
   type DareV2Dependencies,
 } from "#src/betting/dare-v2-common.ts";
 import { DARE_V2_INTENT_TTL_MS } from "#src/betting/constants.ts";
+import { createConfirmationIntent } from "#src/lib/confirmation-intent/create.ts";
 
-const UniqueViolationSchema = z.object({ code: z.literal("P2002") });
+/**
+ * The bare action behind a dare confirmation kind.
+ *
+ * Storage and the shared protocol speak the prefixed kind, but the word a
+ * person reads — in the Discord confirmation, in the web confirmation card, in
+ * the Explore tool result — has always been the bare action, so the two views
+ * are mapped rather than merged.
+ */
+const DARE_ACTION_BY_KIND = {
+  dare_fund: "fund",
+  dare_accept: "accept",
+  dare_decline: "decline",
+  dare_contribute: "contribute",
+  dare_cancel: "cancel",
+} as const satisfies Record<ConfirmationIntentKind, string>;
 
-export const DareV2IntentActionSchema = z.enum([
-  "fund",
-  "accept",
-  "decline",
-  "contribute",
-  "cancel",
-]);
-export type DareV2IntentAction = z.infer<typeof DareV2IntentActionSchema>;
+type DareV2IntentAction = (typeof DARE_ACTION_BY_KIND)[ConfirmationIntentKind];
 
-export const DareV2IntentPayloadSchema = z.discriminatedUnion("action", [
-  z.strictObject({ action: z.literal("fund") }),
-  z.strictObject({ action: z.literal("accept") }),
-  z.strictObject({ action: z.literal("decline") }),
-  z.strictObject({
-    action: z.literal("contribute"),
-    amount: BucksStakeSchema,
-  }),
-  z.strictObject({ action: z.literal("cancel") }),
-]);
-export type DareV2IntentPayload = z.infer<typeof DareV2IntentPayloadSchema>;
+export function dareV2IntentAction(
+  kind: ConfirmationIntentKind,
+): DareV2IntentAction {
+  return DARE_ACTION_BY_KIND[kind];
+}
 
 function actionNeedsFeature(action: DareV2IntentAction): boolean {
   return action === "fund" || action === "accept" || action === "contribute";
@@ -55,38 +58,20 @@ function actorAuthorized(
   return !target;
 }
 
-async function createOrReadConfirmationIntent(
-  input: Parameters<
-    DareV2Dependencies["prismaClient"]["bucksDareV2ConfirmationIntent"]["create"]
-  >[0],
-  idempotencyKey: string,
-  dependencies: DareV2Dependencies,
-) {
-  try {
-    return await dependencies.prismaClient.bucksDareV2ConfirmationIntent.create(
-      input,
-    );
-  } catch (error) {
-    if (!UniqueViolationSchema.safeParse(error).success) throw error;
-    return await dependencies.prismaClient.bucksDareV2ConfirmationIntent.findUniqueOrThrow(
-      { where: { idempotencyKey } },
-    );
-  }
-}
-
 export async function createDareV2ConfirmationIntent(
   input: {
     dareId: number;
     serverId: DiscordGuildId;
     actorDiscordId: DiscordAccountId;
     expectedRevision: number;
-    payload: DareV2IntentPayload;
+    payload: ConfirmationIntentPayload;
     idempotencyKey: string;
   },
   dependencies: DareV2Dependencies = defaultDareV2Dependencies,
   now: Date = new Date(),
 ) {
-  const payload = DareV2IntentPayloadSchema.parse(input.payload);
+  const payload = ConfirmationIntentPayloadSchema.parse(input.payload);
+  const action = dareV2IntentAction(payload.kind);
   const dare = await dependencies.prismaClient.bucksDareV2.findUnique({
     where: { id: input.dareId },
     include: {
@@ -101,7 +86,7 @@ export async function createDareV2ConfirmationIntent(
   if (dare?.serverId !== input.serverId) {
     return { kind: "not_found" } as const;
   }
-  if (!actorAuthorized(payload.action, input.actorDiscordId, dare)) {
+  if (!actorAuthorized(action, input.actorDiscordId, dare)) {
     return { kind: "forbidden" } as const;
   }
   const revision = dare.revisions[0];
@@ -112,11 +97,11 @@ export async function createDareV2ConfirmationIntent(
     } as const;
   }
   if (
-    actionNeedsFeature(payload.action) &&
+    actionNeedsFeature(action) &&
     !(await relationalDareActionEnabled(
       input.serverId,
       revision.compilerVersion,
-      payload.action === "fund",
+      action === "fund",
       dependencies,
     ))
   ) {
@@ -125,43 +110,31 @@ export async function createDareV2ConfirmationIntent(
   const applicableRevision = dare.fundedRevision ?? dare.currentRevision;
   if (
     applicableRevision !== input.expectedRevision ||
-    (payload.action === "fund" && dare.dareState !== "draft")
+    (action === "fund" && dare.dareState !== "draft")
   ) {
     return {
       kind: "stale_revision",
       currentRevision: applicableRevision,
     } as const;
   }
-  const expiresAt = new Date(now.getTime() + DARE_V2_INTENT_TTL_MS);
-  const actionPayload = JSON.stringify(payload);
-  const created = await createOrReadConfirmationIntent(
-    {
-      data: {
-        dareId: dare.id,
-        revision: input.expectedRevision,
-        actorDiscordId: DiscordAccountIdSchema.parse(input.actorDiscordId),
-        action: payload.action,
-        actionPayload,
-        idempotencyKey: input.idempotencyKey,
-        expiresAt,
-      },
-    },
-    input.idempotencyKey,
-    dependencies,
-  );
-  if (
-    created.dareId !== dare.id ||
-    created.actorDiscordId !== input.actorDiscordId ||
-    created.action !== payload.action ||
-    created.actionPayload !== actionPayload ||
-    created.revision !== input.expectedRevision
-  ) {
+  const created = await createConfirmationIntent(dependencies.prismaClient, {
+    // Taken from the dare, never from the caller: the stored guild is what
+    // every later visibility check compares against.
+    serverId: DiscordGuildIdSchema.parse(dare.serverId),
+    actorDiscordId: input.actorDiscordId,
+    payload,
+    idempotencyKey: input.idempotencyKey,
+    expiresAt: new Date(now.getTime() + DARE_V2_INTENT_TTL_MS),
+    dareId: dare.id,
+    expectedRevision: input.expectedRevision,
+  });
+  if (created.kind === "idempotency_conflict") {
     return { kind: "idempotency_conflict" } as const;
   }
   return {
     kind: "intent_created",
-    intentId: created.id,
-    expiresAt: created.expiresAt,
-    action: payload.action,
+    intentId: created.intent.id,
+    expiresAt: created.intent.expiresAt,
+    action,
   } as const;
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
@@ -145,7 +145,7 @@ const deps = {
 };
 
 async function clearAll(): Promise<void> {
-  await db.bucksDareV2ConfirmationIntent.deleteMany();
+  await db.confirmationIntent.deleteMany();
   await db.bucksDareV2Evidence.deleteMany();
   await db.bucksDareV2Contribution.deleteMany();
   await db.bucksDareV2Target.deleteMany();
@@ -278,13 +278,21 @@ async function intent(input: {
   action: "fund" | "accept" | "decline" | "cancel";
   key: string;
 }) {
+  const payload =
+    input.action === "fund"
+      ? ({ kind: "dare_fund" } as const)
+      : input.action === "accept"
+        ? ({ kind: "dare_accept" } as const)
+        : input.action === "decline"
+          ? ({ kind: "dare_decline" } as const)
+          : ({ kind: "dare_cancel" } as const);
   const result = await createDareV2ConfirmationIntent(
     {
       dareId: input.dareId,
       serverId: SERVER,
       actorDiscordId: input.actor,
       expectedRevision: 1,
-      payload: { action: input.action },
+      payload,
       idempotencyKey: input.key,
     },
     deps,
@@ -315,7 +323,7 @@ async function makeContribution(
       serverId: SERVER,
       actorDiscordId: actor,
       expectedRevision: 1,
-      payload: { action: "contribute", amount },
+      payload: { kind: "dare_contribute", amount },
       idempotencyKey: key,
     },
     deps,
@@ -701,7 +709,7 @@ describe("Dare v2 draft mutation and cancellation", () => {
         serverId: SERVER,
         actorDiscordId: CHALLENGER,
         expectedRevision: 1,
-        payload: { action: "fund" },
+        payload: { kind: "dare_fund" },
         idempotencyKey: "stale-fund",
       },
       deps,
@@ -718,7 +726,7 @@ describe("Dare v2 draft mutation and cancellation", () => {
         serverId: SERVER,
         actorDiscordId: CHALLENGER,
         expectedRevision: 1,
-        payload: { action: "contribute", amount: 5 },
+        payload: { kind: "dare_contribute", amount: 5 },
         idempotencyKey: "contribute-payload",
       },
       deps,
@@ -732,7 +740,7 @@ describe("Dare v2 draft mutation and cancellation", () => {
         serverId: SERVER,
         actorDiscordId: CHALLENGER,
         expectedRevision: 1,
-        payload: { action: "contribute", amount: 10 },
+        payload: { kind: "dare_contribute", amount: 10 },
         idempotencyKey: "contribute-payload",
       },
       deps,
@@ -748,7 +756,7 @@ describe("Dare v2 draft mutation and cancellation", () => {
       serverId: SERVER,
       actorDiscordId: CHALLENGER,
       expectedRevision: 1,
-      payload: { action: "fund" } as const,
+      payload: { kind: "dare_fund" } as const,
       idempotencyKey: "concurrent-fund-intent",
     };
 
@@ -764,7 +772,7 @@ describe("Dare v2 draft mutation and cancellation", () => {
     }
     expect(second.intentId).toBe(first.intentId);
     expect(
-      await db.bucksDareV2ConfirmationIntent.count({
+      await db.confirmationIntent.count({
         where: { idempotencyKey: input.idempotencyKey },
       }),
     ).toBe(1);
@@ -806,7 +814,7 @@ describe("Dare v2 funded lifecycle", () => {
         serverId: SERVER,
         actorDiscordId: CHALLENGER,
         expectedRevision: 1,
-        payload: { action: "contribute", amount: 5 },
+        payload: { kind: "dare_contribute", amount: 5 },
         idempotencyKey: "contribution-after-deadline",
       },
       deps,
@@ -980,7 +988,7 @@ describe("Dare v2 partial settlement", () => {
         serverId: SERVER,
         actorDiscordId: CONTRIBUTOR,
         expectedRevision: 1,
-        payload: { action: "contribute", amount: 15 },
+        payload: { kind: "dare_contribute", amount: 15 },
         idempotencyKey: "contribute-first-fifteen",
       },
       deps,
@@ -992,7 +1000,7 @@ describe("Dare v2 partial settlement", () => {
         serverId: SERVER,
         actorDiscordId: CONTRIBUTOR,
         expectedRevision: 1,
-        payload: { action: "contribute", amount: 15 },
+        payload: { kind: "dare_contribute", amount: 15 },
         idempotencyKey: "contribute-second-fifteen",
       },
       deps,

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-dare-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-dare-v2.ts
@@ -287,7 +287,7 @@ export async function replyBbDareV2(
         serverId: input.serverId,
         actorDiscordId: input.challengerDiscordId,
         expectedRevision: draft.dare.currentRevision,
-        payload: { action: "fund" },
+        payload: { kind: "dare_fund" },
         idempotencyKey: `discord:${interaction.id}:fund`,
       },
       {

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-tool-schemas.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-tool-schemas.ts
@@ -8,8 +8,8 @@ import {
   DareDeadlineSpecV2Schema,
   DareSqlV3CompetitionSchema,
   DareActivationV3Schema,
+  ConfirmationIntentPayloadSchema,
 } from "@scout-for-lol/data";
-import { DareV2IntentPayloadSchema } from "#src/betting/dare-intent-v2.ts";
 
 export const DareToolResultSchema = z.strictObject({
   kind: z.string().min(1),
@@ -99,7 +99,7 @@ export const DareInspectToolInputSchema = z.strictObject({
 export const DareActionToolInputSchema = z.strictObject({
   dareId: z.number().int().positive(),
   expectedRevision: z.number().int().positive(),
-  payload: DareV2IntentPayloadSchema,
+  payload: ConfirmationIntentPayloadSchema,
 });
 
 export const DareDeleteToolInputSchema = z.strictObject({

--- a/packages/scout-for-lol/packages/backend/src/lib/confirmation-intent/claim.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/confirmation-intent/claim.ts
@@ -1,0 +1,65 @@
+import type { DiscordAccountId } from "@scout-for-lol/data";
+import type { ConfirmationIntent } from "#generated/prisma/client/index.js";
+import type { Db, ExtendedPrismaClient } from "#src/database/index.ts";
+
+export type ClaimConfirmationIntentInput = {
+  intentId: string;
+  actorDiscordId: DiscordAccountId;
+  now: Date;
+};
+
+export type ClaimRefusal =
+  { kind: "intent_expired" } | { kind: "already_consumed"; result: unknown };
+
+/**
+ * Claims an intent for exactly one confirmation and runs the real action in
+ * the same transaction.
+ *
+ * The guarded write is deliberately the first statement in the transaction: it
+ * is the whole double-spend guard. Two concurrent confirmations both open a
+ * transaction, but only one of them updates a row, and the loser learns that
+ * from the empty result before it has done anything. Reading the intent first
+ * and deciding afterwards would let both pass the check, so the claimed row is
+ * taken from the guarded write itself rather than re-read.
+ *
+ * The result of `run` is persisted on the intent, so a later confirmation of
+ * the same intent replays the original outcome instead of acting again.
+ */
+export async function claimAndExecute<Result>(
+  prismaClient: ExtendedPrismaClient,
+  input: ClaimConfirmationIntentInput,
+  run: (tx: Db, intent: ConfirmationIntent) => Promise<Result>,
+): Promise<Result | ClaimRefusal> {
+  return await prismaClient.$transaction(async (tx) => {
+    const claimed = await tx.confirmationIntent.updateManyAndReturn({
+      where: {
+        id: input.intentId,
+        actorDiscordId: input.actorDiscordId,
+        consumedAt: null,
+        expiresAt: { gt: input.now },
+      },
+      data: { consumedAt: input.now },
+    });
+    const intent = claimed[0];
+    if (intent === undefined || claimed.length !== 1) {
+      const current = await tx.confirmationIntent.findUniqueOrThrow({
+        where: { id: input.intentId },
+      });
+      return current.consumedAt === null
+        ? ({ kind: "intent_expired" } as const)
+        : ({
+            kind: "already_consumed",
+            result:
+              current.resultJson === null
+                ? null
+                : JSON.parse(current.resultJson),
+          } as const);
+    }
+    const result = await run(tx, intent);
+    await tx.confirmationIntent.update({
+      where: { id: input.intentId },
+      data: { resultJson: JSON.stringify(result) },
+    });
+    return result;
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/confirmation-intent/create.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/confirmation-intent/create.ts
@@ -1,0 +1,90 @@
+import {
+  ConfirmationIntentPayloadSchema,
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+  type ConfirmationIntentPayload,
+  type DiscordAccountId,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import { z } from "zod";
+import type { ConfirmationIntent } from "#generated/prisma/client/index.js";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+
+const UniqueViolationSchema = z.object({ code: z.literal("P2002") });
+
+export type CreateConfirmationIntentInput = {
+  /**
+   * The guild the intent belongs to. Every later visibility check compares
+   * this column, so it must be read off the row being acted on rather than
+   * taken from whoever asked for the intent.
+   */
+  serverId: DiscordGuildId;
+  actorDiscordId: DiscordAccountId;
+  payload: ConfirmationIntentPayload;
+  idempotencyKey: string;
+  expiresAt: Date;
+  /** Set only by intents that act on an existing dare. */
+  dareId?: number | undefined;
+  /** The dare revision the actor saw, for staleness detection. */
+  expectedRevision?: number | undefined;
+};
+
+export type CreateConfirmationIntentResult =
+  | { kind: "intent_created"; intent: ConfirmationIntent }
+  | { kind: "idempotency_conflict" };
+
+async function createOrRead(
+  prismaClient: ExtendedPrismaClient,
+  data: Parameters<
+    ExtendedPrismaClient["confirmationIntent"]["create"]
+  >[0]["data"],
+  idempotencyKey: string,
+): Promise<ConfirmationIntent> {
+  try {
+    return await prismaClient.confirmationIntent.create({ data });
+  } catch (error) {
+    if (!UniqueViolationSchema.safeParse(error).success) throw error;
+    return await prismaClient.confirmationIntent.findUniqueOrThrow({
+      where: { idempotencyKey },
+    });
+  }
+}
+
+/**
+ * Mints an intent, or returns the one an earlier identical request already
+ * minted.
+ *
+ * A retry with the same idempotency key must be a no-op, but a *different*
+ * request reusing someone's key must not silently inherit their intent — so
+ * the row that comes back is compared field by field against what was asked
+ * for, and a mismatch is reported rather than confirmed.
+ */
+export async function createConfirmationIntent(
+  prismaClient: ExtendedPrismaClient,
+  input: CreateConfirmationIntentInput,
+): Promise<CreateConfirmationIntentResult> {
+  const payload = ConfirmationIntentPayloadSchema.parse(input.payload);
+  const serialized = JSON.stringify(payload);
+  const data = {
+    kind: payload.kind,
+    serverId: DiscordGuildIdSchema.parse(input.serverId),
+    actorDiscordId: DiscordAccountIdSchema.parse(input.actorDiscordId),
+    payload: serialized,
+    idempotencyKey: input.idempotencyKey,
+    expiresAt: input.expiresAt,
+    dareId: input.dareId ?? null,
+    expectedRevision: input.expectedRevision ?? null,
+  };
+  const intent = await createOrRead(prismaClient, data, input.idempotencyKey);
+  if (
+    intent.kind !== data.kind ||
+    intent.serverId !== data.serverId ||
+    intent.actorDiscordId !== data.actorDiscordId ||
+    intent.payload !== data.payload ||
+    intent.dareId !== data.dareId ||
+    intent.expectedRevision !== data.expectedRevision
+  ) {
+    return { kind: "idempotency_conflict" };
+  }
+  return { kind: "intent_created", intent };
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/confirmation-intent/migration.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/confirmation-intent/migration.integration.test.ts
@@ -1,0 +1,248 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { z } from "zod";
+import { ConfirmationIntentPayloadSchema } from "@scout-for-lol/data";
+import {
+  devPostgresPort,
+  ensureDevPostgres,
+  psqlMaintenance,
+} from "#src/testing/postgres-server.ts";
+
+/**
+ * The confirmation-intent migration moves live rows, so it is verified against
+ * a real Postgres rather than reasoned about.
+ *
+ * What matters is not that the table exists afterwards but that nothing in a
+ * pending confirmation changed meaning: an id a browser tab or a Discord
+ * button still holds, a `consumedAt`/`resultJson` pair that stops an already
+ * spent intent from being spent again, and a payload the new discriminated
+ * union can actually parse.
+ */
+
+const MIGRATION = "20260904000000_confirmation_intent";
+const MIGRATIONS_DIR = `${import.meta.dir}/../../../prisma/migrations`;
+
+const SERVER_A = "100000000000000001";
+const SERVER_B = "100000000000000002";
+const ACTOR = "200000000000000001";
+const FUND_INTENT = "11111111-1111-4111-8111-111111111111";
+const CONTRIBUTE_INTENT = "22222222-2222-4222-8222-222222222222";
+const CANCEL_INTENT = "33333333-3333-4333-8333-333333333333";
+const CONSUMED_AT = "2026-09-01 12:00:00";
+const CONSUMED_RESULT = '{"kind":"contributed","potTotal":25}';
+
+const MigratedRowSchema = z.object({
+  id: z.string(),
+  kind: z.string(),
+  serverId: z.string(),
+  actorDiscordId: z.string(),
+  payload: z.string(),
+  idempotencyKey: z.string(),
+  consumedAt: z.string().nullable(),
+  resultJson: z.string().nullable(),
+  dareId: z.number().int(),
+  expectedRevision: z.number().int(),
+});
+type MigratedRow = z.infer<typeof MigratedRowSchema>;
+
+let databaseName = "";
+
+function psql(sql: string): string {
+  const result = Bun.spawnSync(
+    [
+      "psql",
+      "-h",
+      "127.0.0.1",
+      "-p",
+      devPostgresPort().toString(),
+      "-U",
+      "scout",
+      "-d",
+      databaseName,
+      "-v",
+      "ON_ERROR_STOP=1",
+      "-At",
+      "-c",
+      sql,
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(`psql failed (${sql}): ${result.stderr.toString()}`);
+  }
+  return result.stdout.toString().trim();
+}
+
+function applyMigration(name: string): void {
+  const result = Bun.spawnSync(
+    [
+      "psql",
+      "-h",
+      "127.0.0.1",
+      "-p",
+      devPostgresPort().toString(),
+      "-U",
+      "scout",
+      "-d",
+      databaseName,
+      "-v",
+      "ON_ERROR_STOP=1",
+      "-f",
+      `${MIGRATIONS_DIR}/${name}/migration.sql`,
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `applying ${name} failed: ${result.stderr.toString()}${result.stdout.toString()}`,
+    );
+  }
+}
+
+/** Every migration directory, in the order Prisma applies them. */
+function migrationNames(): string[] {
+  const glob = new Bun.Glob("*/migration.sql");
+  return [...glob.scanSync({ cwd: MIGRATIONS_DIR })]
+    .map((file) => file.slice(0, file.indexOf("/")))
+    .sort();
+}
+
+/** The dares and old-shape intents that stand in for live production rows. */
+function seedPreMigrationRows(): void {
+  psql(`
+    INSERT INTO "BucksDareV2"
+      (id, "serverId", "channelId", "challengerDiscordId", "openingStake", "updatedAt")
+    VALUES
+      (1, '${SERVER_A}', '300000000000000001', '${ACTOR}', 20, NOW()),
+      (2, '${SERVER_B}', '300000000000000002', '${ACTOR}', 30, NOW());
+
+    INSERT INTO "BucksDareV2ConfirmationIntent"
+      (id, "dareId", revision, "actorDiscordId", action, "actionPayload",
+       "idempotencyKey", "expiresAt", "consumedAt", "resultJson")
+    VALUES
+      ('${FUND_INTENT}', 1, 1, '${ACTOR}', 'fund', '{"action":"fund"}',
+       'key-fund', NOW() + INTERVAL '10 minutes', NULL, NULL),
+      ('${CONTRIBUTE_INTENT}', 1, 2, '${ACTOR}', 'contribute',
+       '{"action":"contribute","amount":5}',
+       'key-contribute', NOW() + INTERVAL '10 minutes',
+       TIMESTAMP '${CONSUMED_AT}', '${CONSUMED_RESULT}'),
+      ('${CANCEL_INTENT}', 2, 1, '${ACTOR}', 'cancel', '{"action":"cancel"}',
+       'key-cancel', NOW() + INTERVAL '10 minutes', NULL, NULL);
+  `);
+}
+
+function migratedRows(): Map<string, MigratedRow> {
+  const raw = psql(`
+    SELECT COALESCE(json_agg(row_to_json(t) ORDER BY t.id), '[]')
+      FROM (
+        SELECT id, kind, "serverId", "actorDiscordId", payload, "idempotencyKey",
+               to_char("consumedAt", 'YYYY-MM-DD HH24:MI:SS') AS "consumedAt",
+               "resultJson", "dareId", "expectedRevision"
+          FROM "ConfirmationIntent"
+      ) t;
+  `);
+  const parsed: unknown = JSON.parse(raw);
+  const rows = MigratedRowSchema.array().parse(parsed);
+  return new Map(rows.map((row) => [row.id, row]));
+}
+
+let rows: Map<string, MigratedRow>;
+
+beforeAll(() => {
+  ensureDevPostgres();
+  databaseName = `scout_test_${Date.now().toString()}_intent_migration`;
+  psqlMaintenance(`DROP DATABASE IF EXISTS "${databaseName}" WITH (FORCE)`);
+  psqlMaintenance(`CREATE DATABASE "${databaseName}"`);
+  const names = migrationNames();
+  const target = names.indexOf(MIGRATION);
+  if (target === -1) {
+    throw new Error(`${MIGRATION} is missing from ${MIGRATIONS_DIR}`);
+  }
+  for (const name of names.slice(0, target)) {
+    applyMigration(name);
+  }
+  seedPreMigrationRows();
+  applyMigration(MIGRATION);
+  rows = migratedRows();
+}, 180_000);
+
+afterAll(() => {
+  if (databaseName !== "") {
+    psqlMaintenance(`DROP DATABASE IF EXISTS "${databaseName}" WITH (FORCE)`);
+  }
+});
+
+describe("the confirmation intent migration", () => {
+  test("carries every intent across under its stable id", () => {
+    expect([...rows.keys()].toSorted()).toEqual(
+      [FUND_INTENT, CONTRIBUTE_INTENT, CANCEL_INTENT].toSorted(),
+    );
+  });
+
+  test("prefixes the folded action column into the kind discriminator", () => {
+    expect(rows.get(FUND_INTENT)?.kind).toBe("dare_fund");
+    expect(rows.get(CONTRIBUTE_INTENT)?.kind).toBe("dare_contribute");
+    expect(rows.get(CANCEL_INTENT)?.kind).toBe("dare_cancel");
+  });
+
+  test("denormalizes each intent's guild from the dare it targets", () => {
+    expect(rows.get(FUND_INTENT)?.serverId).toBe(SERVER_A);
+    expect(rows.get(CONTRIBUTE_INTENT)?.serverId).toBe(SERVER_A);
+    expect(rows.get(CANCEL_INTENT)?.serverId).toBe(SERVER_B);
+  });
+
+  test("keeps the dare target and the revision the actor saw", () => {
+    expect(rows.get(FUND_INTENT)).toMatchObject({
+      dareId: 1,
+      expectedRevision: 1,
+      actorDiscordId: ACTOR,
+      idempotencyKey: "key-fund",
+    });
+    expect(rows.get(CONTRIBUTE_INTENT)).toMatchObject({
+      dareId: 1,
+      expectedRevision: 2,
+    });
+    expect(rows.get(CANCEL_INTENT)).toMatchObject({
+      dareId: 2,
+      expectedRevision: 1,
+    });
+  });
+
+  /**
+   * The double-spend line. An intent that has already been confirmed must stay
+   * confirmed, or its `dare_fund`/`dare_contribute` action runs a second time
+   * against a real balance.
+   */
+  test("preserves the consumed marker and the recorded outcome", () => {
+    expect(rows.get(CONTRIBUTE_INTENT)?.consumedAt).toBe(CONSUMED_AT);
+    expect(rows.get(CONTRIBUTE_INTENT)?.resultJson).toBe(CONSUMED_RESULT);
+    expect(rows.get(FUND_INTENT)?.consumedAt).toBeNull();
+    expect(rows.get(FUND_INTENT)?.resultJson).toBeNull();
+    expect(rows.get(CANCEL_INTENT)?.consumedAt).toBeNull();
+  });
+
+  test("rewrites every payload into the new discriminated union", () => {
+    for (const row of rows.values()) {
+      const payload = ConfirmationIntentPayloadSchema.parse(
+        JSON.parse(row.payload),
+      );
+      expect(payload.kind).toBe(row.kind);
+      // Minting with an existing idempotency key compares the stored payload
+      // against a freshly serialized one, so the migrated text has to match
+      // byte for byte, not merely parse.
+      expect(row.payload).toBe(JSON.stringify(payload));
+    }
+  });
+
+  test("keeps a contribution's amount", () => {
+    const payload = ConfirmationIntentPayloadSchema.parse(
+      JSON.parse(rows.get(CONTRIBUTE_INTENT)?.payload ?? "null"),
+    );
+    expect(payload).toEqual({ kind: "dare_contribute", amount: 5 });
+  });
+
+  test("leaves no dare-only intent table behind", () => {
+    expect(psql(`SELECT to_regclass('"BucksDareV2ConfirmationIntent"')`)).toBe(
+      "",
+    );
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/lib/confirmation-intent/payload.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/confirmation-intent/payload.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import { readConfirmationIntentPayload } from "#src/lib/confirmation-intent/payload.ts";
+
+const row = (kind: string, payload: string) => ({
+  id: "3f1a0c8e-0000-4000-8000-000000000001",
+  kind,
+  payload,
+});
+
+describe("readConfirmationIntentPayload", () => {
+  test("returns the parsed payload when both discriminators agree", () => {
+    expect(
+      readConfirmationIntentPayload(
+        row("dare_contribute", '{"kind":"dare_contribute","amount":5}'),
+      ),
+    ).toEqual({ kind: "dare_contribute", amount: 5 });
+  });
+
+  test("refuses a row whose column and payload disagree", () => {
+    // The executed action comes from the payload while status responses report
+    // the column, so silently preferring either one would run something the
+    // user was never shown — on a dare, something that moves real balances.
+    expect(() =>
+      readConfirmationIntentPayload(
+        row("dare_decline", '{"kind":"dare_fund"}'),
+      ),
+    ).toThrow(
+      /stores kind "dare_decline" but its payload declares "dare_fund"/,
+    );
+  });
+
+  test("refuses a payload that is not a known intent shape", () => {
+    expect(() =>
+      readConfirmationIntentPayload(row("dare_fund", '{"kind":"nonsense"}')),
+    ).toThrow();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/lib/confirmation-intent/payload.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/confirmation-intent/payload.ts
@@ -1,0 +1,35 @@
+import {
+  ConfirmationIntentPayloadSchema,
+  type ConfirmationIntentPayload,
+} from "@scout-for-lol/data";
+import type { ConfirmationIntent } from "#generated/prisma/client/index.js";
+
+/**
+ * Read an intent's stored payload, proving it agrees with the row's `kind`.
+ *
+ * The discriminator is stored twice on purpose: the `kind` column is what
+ * queries, indexes and status responses read, while the copy inside `payload`
+ * is what makes the payload a discriminated union its consumers can narrow.
+ * `createConfirmationIntent` derives the column from the payload, so the mint
+ * path cannot produce a disagreement — but a migration, an administrative
+ * repair, or a future writer could.
+ *
+ * Trusting either side alone is what makes that dangerous. A row whose column
+ * says one kind and whose payload says another would be reported to the user
+ * as the first and executed as the second, and on `dare_fund` or
+ * `dare_contribute` the executed one moves real balances. So a mismatch is a
+ * hard failure rather than a silent preference for one column over the other.
+ */
+export function readConfirmationIntentPayload(
+  intent: Pick<ConfirmationIntent, "id" | "kind" | "payload">,
+): ConfirmationIntentPayload {
+  const payload = ConfirmationIntentPayloadSchema.parse(
+    JSON.parse(intent.payload),
+  );
+  if (payload.kind !== intent.kind) {
+    throw new Error(
+      `Confirmation intent ${intent.id} stores kind "${intent.kind}" but its payload declares "${payload.kind}".`,
+    );
+  }
+  return payload;
+}

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/bucks-dare-action-procedures.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/bucks-dare-action-procedures.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import {
+  ConfirmationIntentPayloadSchema,
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
 } from "@scout-for-lol/data";
@@ -10,7 +11,7 @@ import { listDareEvidenceV2 } from "#src/betting/dare-evidence-view-v2.ts";
 import { consumeDareV2ConfirmationIntent } from "#src/betting/dare-intent-consume-v2.ts";
 import {
   createDareV2ConfirmationIntent,
-  DareV2IntentPayloadSchema,
+  dareV2IntentAction,
 } from "#src/betting/dare-intent-v2.ts";
 import { assertBucksScope } from "#src/consumer/bucks-access.ts";
 import { prisma } from "#src/database/index.ts";
@@ -24,7 +25,7 @@ const DareEvidenceInput = DareInput.extend({
 });
 const DarePrepareActionInput = DareInput.extend({
   expectedRevision: z.number().int().positive(),
-  payload: DareV2IntentPayloadSchema,
+  payload: ConfirmationIntentPayloadSchema,
   idempotencyKey: z.uuid(),
 });
 const DareConfirmActionInput = GuildInput.extend({ intentId: z.uuid() });
@@ -75,20 +76,19 @@ export const bucksDareActionProcedures = {
         },
       });
       const amount =
-        input.payload.action === "contribute"
+        input.payload.kind === "dare_contribute"
           ? `${input.payload.amount.toString()} BB to a ${dare.potTotal.toString()} BB pot`
-          : input.payload.action === "fund"
+          : input.payload.kind === "dare_fund"
             ? `${dare.openingStake.toString()} BB`
             : null;
+      const action = dareV2IntentAction(input.payload.kind);
       return {
         ...outcome,
         confirmation: {
-          action: input.payload.action,
+          action,
           amount,
           targets: dare.targets.map((target) => target.alias),
-          irreversible: ["fund", "accept", "contribute"].includes(
-            input.payload.action,
-          ),
+          irreversible: ["fund", "accept", "contribute"].includes(action),
         },
       };
     }),
@@ -97,7 +97,7 @@ export const bucksDareActionProcedures = {
     .input(DareConfirmActionInput)
     .mutation(async ({ ctx, input }) => {
       await assertBucksScope(ctx.user, input.guildId);
-      const intent = await prisma.bucksDareV2ConfirmationIntent.findUnique({
+      const intent = await prisma.confirmationIntent.findUnique({
         where: { id: input.intentId },
         select: { dareId: true },
       });
@@ -113,10 +113,9 @@ export const bucksDareActionProcedures = {
         "feature_disabled",
         "insufficient",
       ].includes(outcome.kind);
+      const dareId = intent?.dareId ?? null;
       const callout =
-        intent === null || failed
-          ? null
-          : await tryEnsureDareV2Callout(intent.dareId);
+        dareId === null || failed ? null : await tryEnsureDareV2Callout(dareId);
       return { ...outcome, callout };
     }),
 

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/bucks-dare-action-procedures.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/bucks-dare-action-procedures.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import {
+  BucksStakeSchema,
   ConfirmationIntentPayloadSchema,
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
@@ -17,6 +18,48 @@ import { assertBucksScope } from "#src/consumer/bucks-access.ts";
 import { prisma } from "#src/database/index.ts";
 import { webMutationProcedure, webProcedure } from "#src/trpc/trpc.ts";
 
+/**
+ * Dare action payloads accepted from the management app.
+ *
+ * Confirmation intents used to discriminate on `action` (`{action: "fund"}`)
+ * and now discriminate on `kind`. A tab loaded before that deployment is still
+ * running the old client, so rejecting its shape would take every Dare action
+ * in that tab out of service until the user happened to reload. Both shapes
+ * are accepted for one release; delete the legacy branch after stale clients
+ * have aged out.
+ *
+ * The new shape is tried first, and the legacy objects are strict, so this
+ * widens what is accepted without loosening validation of either form.
+ */
+const LEGACY_ACTION_KINDS = {
+  fund: "dare_fund",
+  accept: "dare_accept",
+  decline: "dare_decline",
+  cancel: "dare_cancel",
+  contribute: "dare_contribute",
+} as const;
+
+const LegacyDarePayloadSchema = z
+  .union([
+    z.strictObject({
+      action: z.enum(["fund", "accept", "decline", "cancel"]),
+    }),
+    z.strictObject({
+      action: z.literal("contribute"),
+      amount: BucksStakeSchema,
+    }),
+  ])
+  .transform((legacy) =>
+    legacy.action === "contribute"
+      ? { kind: LEGACY_ACTION_KINDS.contribute, amount: legacy.amount }
+      : { kind: LEGACY_ACTION_KINDS[legacy.action] },
+  );
+
+export const DarePayloadInputSchema = z.union([
+  ConfirmationIntentPayloadSchema,
+  LegacyDarePayloadSchema.pipe(ConfirmationIntentPayloadSchema),
+]);
+
 const GuildInput = z.object({ guildId: DiscordGuildIdSchema });
 const DareInput = GuildInput.extend({ dareId: z.number().int().positive() });
 const DareEvidenceInput = DareInput.extend({
@@ -25,7 +68,7 @@ const DareEvidenceInput = DareInput.extend({
 });
 const DarePrepareActionInput = DareInput.extend({
   expectedRevision: z.number().int().positive(),
-  payload: ConfirmationIntentPayloadSchema,
+  payload: DarePayloadInputSchema,
   idempotencyKey: z.uuid(),
 });
 const DareConfirmActionInput = GuildInput.extend({ intentId: z.uuid() });

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/bucks-dare-payload-compat.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/bucks-dare-payload-compat.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import { DarePayloadInputSchema } from "#src/trpc/router/bucks-dare-action-procedures.ts";
+
+/**
+ * Covers the rollout shim that accepts the pre-rename dare action payload.
+ * When the legacy branch is deleted a release from now, these cases go with it.
+ */
+describe("DarePayloadInputSchema", () => {
+  test("accepts the current kind-discriminated shape unchanged", () => {
+    expect(DarePayloadInputSchema.parse({ kind: "dare_fund" })).toEqual({
+      kind: "dare_fund",
+    });
+    expect(
+      DarePayloadInputSchema.parse({ kind: "dare_contribute", amount: 7 }),
+    ).toEqual({ kind: "dare_contribute", amount: 7 });
+  });
+
+  test("normalizes a payload from a tab loaded before the rename", () => {
+    // Rejecting this would take every Dare action in that tab out of service
+    // until the user happened to reload.
+    expect(DarePayloadInputSchema.parse({ action: "fund" })).toEqual({
+      kind: "dare_fund",
+    });
+    expect(DarePayloadInputSchema.parse({ action: "cancel" })).toEqual({
+      kind: "dare_cancel",
+    });
+    expect(
+      DarePayloadInputSchema.parse({ action: "contribute", amount: 3 }),
+    ).toEqual({ kind: "dare_contribute", amount: 3 });
+  });
+
+  test("still rejects shapes that are neither form", () => {
+    expect(() =>
+      DarePayloadInputSchema.parse({ action: "nonsense" }),
+    ).toThrow();
+    expect(() =>
+      DarePayloadInputSchema.parse({ kind: "dare_fund", extra: 1 }),
+    ).toThrow();
+    // A contribution must carry its amount in either form.
+    expect(() =>
+      DarePayloadInputSchema.parse({ action: "contribute" }),
+    ).toThrow();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/bucks.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/bucks.router.test.ts
@@ -49,7 +49,7 @@ function caller() {
 }
 
 async function clearAll(): Promise<void> {
-  await db.bucksDareV2ConfirmationIntent.deleteMany();
+  await db.confirmationIntent.deleteMany();
   await db.bucksDareV2.deleteMany();
   await db.bucksLedgerEntry.deleteMany();
   await db.bucksOpenPosition.deleteMany();

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
@@ -7,6 +7,11 @@
  * `guildProcedure`/`guildMutationProcedure` (Discord admins/owners hold all
  * permissions). Any fetch-by-id additionally verifies the row belongs to the
  * requested guild (NOT_FOUND otherwise) to prevent cross-guild ID probing.
+ *
+ * `create` is a thin caller: the pipeline — including the `competitions:invite`
+ * and `competitions:schedule` sub-gates and root's rate-limit bypass — lives in
+ * `#src/lib/competitions/create.ts` so other surfaces run the same policy, and
+ * it commits with its `COMPETITION_CREATE` audit row in one transaction.
  */
 
 import { z } from "zod";

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.test.ts
@@ -46,7 +46,7 @@ async function seedUsers(): Promise<void> {
 }
 
 beforeEach(async () => {
-  await trpc.prisma.bucksDareV2ConfirmationIntent.deleteMany();
+  await trpc.prisma.confirmationIntent.deleteMany();
   await trpc.prisma.bucksDareV2.deleteMany();
   await trpc.prisma.exploreMessage.deleteMany();
   await trpc.prisma.exploreConversation.deleteMany();
@@ -103,13 +103,14 @@ describe("explore router", () => {
         openingStake: 20,
       },
     });
-    const intent = await trpc.prisma.bucksDareV2ConfirmationIntent.create({
+    const intent = await trpc.prisma.confirmationIntent.create({
       data: {
+        kind: "dare_fund",
+        serverId: ALLOWED_GUILD,
         dareId: dare.id,
-        revision: 1,
+        expectedRevision: 1,
         actorDiscordId: OWNER,
-        action: "fund",
-        actionPayload: JSON.stringify({ action: "fund" }),
+        payload: JSON.stringify({ kind: "dare_fund" }),
         idempotencyKey: "explore-router-durable-intent",
         expiresAt: new Date(Date.now() + 60_000),
       },
@@ -117,10 +118,10 @@ describe("explore router", () => {
     const owner = trpc.authedCaller(OWNER);
 
     expect(
-      await owner.explore.dareIntentStatus({ intentId: intent.id }),
-    ).toMatchObject({ state: "pending", action: "fund", result: null });
+      await owner.explore.intentStatus({ intentId: intent.id }),
+    ).toMatchObject({ state: "pending", kind: "dare_fund", result: null });
 
-    await trpc.prisma.bucksDareV2ConfirmationIntent.update({
+    await trpc.prisma.confirmationIntent.update({
       where: { id: intent.id },
       data: {
         consumedAt: new Date(),
@@ -128,16 +129,14 @@ describe("explore router", () => {
       },
     });
     expect(
-      await owner.explore.dareIntentStatus({ intentId: intent.id }),
+      await owner.explore.intentStatus({ intentId: intent.id }),
     ).toMatchObject({
       state: "consumed",
-      action: "fund",
+      kind: "dare_fund",
       result: { kind: "funded" },
     });
     await expect(
-      trpc
-        .authedCaller(STRANGER)
-        .explore.dareIntentStatus({ intentId: intent.id }),
+      trpc.authedCaller(STRANGER).explore.intentStatus({ intentId: intent.id }),
     ).rejects.toThrow(/not found/i);
   });
 

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.ts
@@ -111,6 +111,44 @@ async function requireGuildIntent(intentId: string, guildIds: string[]) {
 
 const exploreProcedure = protectedProcedure;
 
+/**
+ * The status of one confirmation intent the caller owns.
+ *
+ * Registered under two names. `dareIntentStatus` is what this procedure was
+ * called before confirmation intents stopped being dare-only, and a tab loaded
+ * before that deployment keeps polling the old name for a confirmation card it
+ * is still showing. The intent migration deliberately preserved those ids so
+ * the cards keep working, and dropping the procedure they poll would have
+ * undone exactly that. Remove the alias one release after deploy, once stale
+ * clients have aged out.
+ */
+const intentStatusProcedure = exploreProcedure
+  .input(z.strictObject({ intentId: z.uuid() }))
+  .query(async ({ ctx, input }) => {
+    const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
+    const intent = await requireGuildIntent(input.intentId, guildIds);
+    if (intent.actorDiscordId !== userId) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Confirmation not found.",
+      });
+    }
+    return {
+      state:
+        intent.consumedAt === null
+          ? intent.expiresAt.getTime() <= Date.now()
+            ? ("expired" as const)
+            : ("pending" as const)
+          : ("consumed" as const),
+      kind: ConfirmationIntentKindSchema.parse(intent.kind),
+      expiresAt: intent.expiresAt.toISOString(),
+      result:
+        intent.resultJson === null
+          ? null
+          : z.json().parse(JSON.parse(intent.resultJson)),
+    };
+  });
+
 export const exploreRouter = router({
   /**
    * Whether the caller may use explore, plus their remaining quota. Answers
@@ -140,32 +178,10 @@ export const exploreRouter = router({
     return await listExploreConversations(prisma, userId);
   }),
 
-  intentStatus: exploreProcedure
-    .input(z.strictObject({ intentId: z.uuid() }))
-    .query(async ({ ctx, input }) => {
-      const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
-      const intent = await requireGuildIntent(input.intentId, guildIds);
-      if (intent.actorDiscordId !== userId) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Confirmation not found.",
-        });
-      }
-      return {
-        state:
-          intent.consumedAt === null
-            ? intent.expiresAt.getTime() <= Date.now()
-              ? ("expired" as const)
-              : ("pending" as const)
-            : ("consumed" as const),
-        kind: ConfirmationIntentKindSchema.parse(intent.kind),
-        expiresAt: intent.expiresAt.toISOString(),
-        result:
-          intent.resultJson === null
-            ? null
-            : z.json().parse(JSON.parse(intent.resultJson)),
-      };
-    }),
+  intentStatus: intentStatusProcedure,
+
+  /** @deprecated Pre-rename alias; see {@link intentStatusProcedure}. */
+  dareIntentStatus: intentStatusProcedure,
 
   confirmDareIntent: webMutationProcedure
     .input(z.strictObject({ intentId: z.uuid() }))

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import type { User } from "#generated/prisma/client/index.js";
 import {
+  ConfirmationIntentKindSchema,
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
   type DiscordAccountId,
@@ -14,7 +15,6 @@ import {
 } from "@scout-for-lol/data";
 import { consumeDareV2ConfirmationIntent } from "#src/betting/dare-intent-consume-v2.ts";
 import { tryEnsureDareV2Callout } from "#src/betting/dare-callout-v2.ts";
-import { DareV2IntentActionSchema } from "#src/betting/dare-intent-v2.ts";
 import { prisma } from "#src/database/index.ts";
 import {
   assertExploreAccess,
@@ -85,19 +85,26 @@ async function requireExploreUserAndGuilds(
   };
 }
 
-async function requireGuildDareIntent(intentId: string, guildIds: string[]) {
-  const intent = await prisma.bucksDareV2ConfirmationIntent.findUnique({
+/**
+ * Loads a confirmation intent the caller's servers can see.
+ *
+ * The guild is stored on the intent, so this is a direct column comparison
+ * rather than a join through the dare it targets. Probing an intent in another
+ * server has to stay indistinguishable from it not existing, hence NOT_FOUND
+ * for both.
+ */
+async function requireGuildIntent(intentId: string, guildIds: string[]) {
+  const intent = await prisma.confirmationIntent.findUnique({
     where: { id: intentId },
-    include: { dare: { select: { serverId: true } } },
   });
-  if (!guildIds.includes(intent?.dare.serverId ?? "")) {
+  if (!guildIds.includes(intent?.serverId ?? "")) {
     throw new TRPCError({
       code: "NOT_FOUND",
       message: "Confirmation not found.",
     });
   }
   if (intent === null) {
-    throw new Error("A visible Dare confirmation unexpectedly disappeared.");
+    throw new Error("A visible confirmation unexpectedly disappeared.");
   }
   return intent;
 }
@@ -133,11 +140,11 @@ export const exploreRouter = router({
     return await listExploreConversations(prisma, userId);
   }),
 
-  dareIntentStatus: exploreProcedure
+  intentStatus: exploreProcedure
     .input(z.strictObject({ intentId: z.uuid() }))
     .query(async ({ ctx, input }) => {
       const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
-      const intent = await requireGuildDareIntent(input.intentId, guildIds);
+      const intent = await requireGuildIntent(input.intentId, guildIds);
       if (intent.actorDiscordId !== userId) {
         throw new TRPCError({
           code: "NOT_FOUND",
@@ -151,7 +158,7 @@ export const exploreRouter = router({
               ? ("expired" as const)
               : ("pending" as const)
             : ("consumed" as const),
-        action: DareV2IntentActionSchema.parse(intent.action),
+        kind: ConfirmationIntentKindSchema.parse(intent.kind),
         expiresAt: intent.expiresAt.toISOString(),
         result:
           intent.resultJson === null
@@ -164,10 +171,16 @@ export const exploreRouter = router({
     .input(z.strictObject({ intentId: z.uuid() }))
     .mutation(async ({ ctx, input }) => {
       const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
-      const intent = await requireGuildDareIntent(input.intentId, guildIds);
+      const intent = await requireGuildIntent(input.intentId, guildIds);
+      if (intent.dareId === null) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Confirmation not found.",
+        });
+      }
       const outcome = await consumeDareV2ConfirmationIntent({
         intentId: input.intentId,
-        serverId: DiscordGuildIdSchema.parse(intent.dare.serverId),
+        serverId: DiscordGuildIdSchema.parse(intent.serverId),
         actorDiscordId: userId,
       });
       const callout = [

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/report.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/report.router.ts
@@ -6,6 +6,10 @@
  * Gated on `reports:<action>` permissions via `guildProcedure`/
  * `guildMutationProcedure` (Discord admins/owners hold all permissions).
  * System-managed reports are read-only (`assertReportMutable`).
+ *
+ * `create` is a thin caller: the pipeline lives in `#src/lib/reports/create.ts`
+ * so other surfaces run the same policy, and it commits with its
+ * `REPORT_CREATE` audit row in one transaction.
  */
 
 import { z } from "zod";

--- a/packages/scout-for-lol/packages/data/src/model/confirmation-intent.ts
+++ b/packages/scout-for-lol/packages/data/src/model/confirmation-intent.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { BucksStakeSchema } from "./bryan-bucks.ts";
+
+/**
+ * The payload of a confirmation intent: an actor-bound, single-use, expiring
+ * row that a human confirms, at which point the real action executes.
+ *
+ * `kind` is the only discriminator. It used to be stored twice — a column
+ * beside the payload and a field inside it — which made a disagreement
+ * representable and forced a runtime assertion at confirm time. One field
+ * makes that state unrepresentable instead.
+ */
+export const ConfirmationIntentPayloadSchema = z.discriminatedUnion("kind", [
+  z.strictObject({ kind: z.literal("dare_fund") }),
+  z.strictObject({ kind: z.literal("dare_accept") }),
+  z.strictObject({ kind: z.literal("dare_decline") }),
+  z.strictObject({
+    kind: z.literal("dare_contribute"),
+    amount: BucksStakeSchema,
+  }),
+  z.strictObject({ kind: z.literal("dare_cancel") }),
+]);
+export type ConfirmationIntentPayload = z.infer<
+  typeof ConfirmationIntentPayloadSchema
+>;
+
+/** Every kind a stored confirmation intent may carry. */
+export const ConfirmationIntentKindSchema = z.enum([
+  "dare_fund",
+  "dare_accept",
+  "dare_decline",
+  "dare_contribute",
+  "dare_cancel",
+]);
+export type ConfirmationIntentKind = z.infer<
+  typeof ConfirmationIntentKindSchema
+>;

--- a/packages/scout-for-lol/packages/data/src/model/index.ts
+++ b/packages/scout-for-lol/packages/data/src/model/index.ts
@@ -3,6 +3,7 @@ export * from "./champion.ts";
 export * from "./competition.ts";
 export * from "./competition-format.ts";
 export * from "./competition-write.ts";
+export * from "./confirmation-intent.ts";
 export * from "./discord.ts";
 export * from "./division.ts";
 export * from "./dare-contract-v2.ts";


### PR DESCRIPTION
Stacked on #2703.

## Why

Dares already implement an actor-bound, single-use, expiring, idempotent
**confirmation intent**: a human confirms, and only then does the real action run.
A follow-up reuses exactly that protocol so the Explore agent can prepare
report/competition/subscription creations for a human to confirm — the model never
writes domain state itself.

Building a second implementation beside the dare one would leave **two copies of a
single-use claim protocol guarding real balances**, free to drift. This migrates
dares onto one shared framework instead.

**This PR ships no product behavior change.** Dares behave exactly as before, on
both the web and Discord surfaces.

## What

- **One table.** `BucksDareV2ConfirmationIntent` becomes `ConfirmationIntent`: a
  `kind` discriminator, a stored `serverId`, and the dare-only columns (`dareId`,
  `expectedRevision`) kept as a **nullable relation**, so dares retain the foreign
  key and `onDelete: Cascade` they have today.
- **`action` folded into `kind`.** It was stored twice — a column *and* inside the
  payload — and consuming an intent carried a runtime assertion that threw when the
  two disagreed. One discriminator makes that unrepresentable, so the assertion is
  deleted. (Verified first: nothing queries or filters on `action`, and there is no
  expired-intent sweep.)
- **`serverId` denormalized from the dare**, turning the guild-visibility join into
  a direct column comparison. It is derived from the target row at mint time, never
  from the caller — that is what keeps the two equivalent, and it is the one
  security-relevant detail of the denormalization.
- **`lib/confirmation-intent`**: `createConfirmationIntent` (create-or-read on the
  idempotency key, unique-violation fallback, field-equality conflict check) and
  `claimAndExecute` (guarded write first, then the caller's action and its result in
  the same transaction). Dispatch stays explicit at each consumer rather than going
  through a kind→handler registry, which would couple the shared module to every
  domain it serves and create an import edge the architecture rule rejects.
- **All five call sites moved**: both dare intent modules, the Discord button flow,
  `/bb dare`, and the two routers. `explore.dareIntentStatus` → `explore.intentStatus`
  (it only ever returned `expiresAt` and `result`), with its web callers updated.

`confirmDareIntent` deliberately stays its own procedure — it carries a dare-shaped
outcome union and exists on two routers, so merging it with the later creation
confirm would widen the blast radius for nothing.

### The migration

Preserves **ids** (a pending confirmation card in an open tab and a live Discord
button's custom id both hold one) and **`consumedAt`/`resultJson`** — dropping the
consumption markers would make an already-consumed intent confirmable again, which
on `dare_fund` and `dare_contribute` is a double-spend of real balances.

Each payload is **rewritten, not copied**: stored payloads discriminate on `action`
and the new union discriminates on `kind`, so a straight copy would leave every
in-flight confirmation failing validation at confirm time — and only when someone
clicks. The rewrite reproduces `JSON.stringify` output byte-for-byte, and reads the
contribution amount through `::int` so an unexpected payload fails the migration
loudly rather than writing JSON that breaks later.

**Accepted cost:** during a rolling deploy an old pod can mint into the dropped
table, so a confirmation may need one retry. No balance can move, because nothing
moves until consume. With a 10-minute TTL in one beta guild, that beats keeping a
fallback read path against a dropped table — which would restore exactly the two
implementations this PR removes.

## Verification

```
bunx turbo run generate --filter=@scout-for-lol/backend
bunx turbo run typecheck test lint \
  --filter=@scout-for-lol/backend --filter=@scout-for-lol/data --filter=@scout-for-lol/app
```

24/24 tasks successful — backend 3097 tests / 344 files (+8, the new migration
suite), data 1371 / 67, app 406 / 60.

The dare integration suites pass with changes **only** where they name the table or
the discriminator; no dare assertion changed meaning. The migration is exercised
against real PostgreSQL: legacy rows inserted, migrated, then checked for preserved
ids, preserved consumption markers, payloads that parse under the new union, and the
old table being gone.

**Not run:** any live or deployed check.

The two router module-header comments describing where the create pipelines now live
belong to #2703; they are carried here rather than re-pushing an already-green PR.