### PR TITLE
feat(scout-for-lol): keep Explore live progress visible for the whole turn

### DIFF
--- a/packages/scout-for-lol/packages/app/src/components/explore-tool-trace.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-tool-trace.tsx
@@ -6,6 +6,7 @@ import type {
   ExploreTraceStatus,
 } from "@scout-for-lol/data";
 import { ScoutQlCode } from "#src/components/scoutql-code.tsx";
+import { formatDuration } from "#src/lib/format-duration.ts";
 
 export function ExploreToolTrace(props: {
   trace: ExploreTraceEntry[];
@@ -298,12 +299,6 @@ function statusLabel(status: ExploreTraceStatus): string {
     return "Failed";
   }
   return "Interrupted";
-}
-
-function formatDuration(durationMs: number): string {
-  return durationMs < 1000
-    ? `${durationMs.toString()} ms`
-    : `${(durationMs / 1000).toFixed(1)} s`;
 }
 
 function formatBytes(byteLength: number): string {

--- a/packages/scout-for-lol/packages/app/src/components/explore-transcript.test.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-transcript.test.tsx
@@ -391,3 +391,32 @@ describe("Explore Dare transcript cards", () => {
     expect(withoutError).toContain("Answer it");
   });
 });
+
+describe("Explore stop feedback", () => {
+  test("keeps the stopping status visible over a partial answer", () => {
+    // A stop only salvages a turn that already streamed something, so the
+    // "saving" status arrives exactly when prose exists. Hiding the status
+    // line whenever there is prose left the reader watching a frozen answer
+    // with nothing to say the stop was still landing.
+    const markup = renderToStaticMarkup(
+      <ExploreTranscript
+        messages={[]}
+        pendingAnswer="Jinx so far"
+        activity="Stopped — saving the partial answer…"
+        stopping
+      />,
+    );
+    expect(markup).toContain("Stopped — saving the partial answer…");
+  });
+
+  test("still hides a finished tool's status once prose arrives", () => {
+    const markup = renderToStaticMarkup(
+      <ExploreTranscript
+        messages={[]}
+        pendingAnswer="Jinx so far"
+        activity="Got results."
+      />,
+    );
+    expect(markup).not.toContain("Got results.");
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/components/explore-transcript.test.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-transcript.test.tsx
@@ -254,6 +254,36 @@ describe("ExploreTranscript", () => {
   });
 });
 
+describe("Explore live progress", () => {
+  test("keeps the status line visible once tool steps have started", () => {
+    // The regression this pins: the status line used to render only while the
+    // trace was empty, so from the first tool call to the final answer — the
+    // longest stretch of a turn — the whole visible state was a collapsed
+    // `Steps (n)` counter, and the page read as an unexplained wait.
+    const markup = renderToStaticMarkup(
+      <ExploreTranscript
+        messages={[]}
+        activity="Querying match data."
+        pendingTrace={[
+          {
+            toolCallId: "call-live",
+            toolName: "run_report_query",
+            message: "Querying match data.",
+            status: "running",
+            durationMs: null,
+            details: null,
+            rawInput: null,
+            rawOutput: null,
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Querying match data.");
+    expect(markup).toContain("Steps (1)");
+  });
+});
+
 describe("Explore Dare transcript cards", () => {
   test("renders a private Dare draft card for persisted and streaming owner traces", () => {
     const trace = [

--- a/packages/scout-for-lol/packages/app/src/components/explore-transcript.test.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-transcript.test.tsx
@@ -44,7 +44,7 @@ describe("ExploreTranscript", () => {
     expect(markup).toContain('aria-live="polite"');
   });
 
-  test("renders the streaming answer and activity inside the live region", () => {
+  test("renders the streaming answer inside the live region", () => {
     const markup = renderToStaticMarkup(
       <ExploreTranscript
         messages={[]}
@@ -55,7 +55,11 @@ describe("ExploreTranscript", () => {
     );
     expect(markup).toContain("Who wins?");
     expect(markup).toContain("Jinx so far");
-    expect(markup).toContain("Running the query…");
+    // The status line steps aside once prose is arriving: it describes work
+    // in flight, and the answer itself is now the progress. Leaving it up
+    // pulsed and timed the last *finished* step for the whole of answer
+    // generation.
+    expect(markup).not.toContain("Running the query…");
   });
 
   test("sizes user bubbles against the transcript width", () => {
@@ -255,6 +259,17 @@ describe("ExploreTranscript", () => {
 });
 
 describe("Explore live progress", () => {
+  test("shows the status line before any prose has arrived", () => {
+    const markup = renderToStaticMarkup(
+      <ExploreTranscript
+        messages={[]}
+        pendingQuestion="Who wins?"
+        activity="Running the query…"
+      />,
+    );
+    expect(markup).toContain("Running the query…");
+  });
+
   test("keeps the status line visible once tool steps have started", () => {
     // The regression this pins: the status line used to render only while the
     // trace was empty, so from the first tool call to the final answer — the

--- a/packages/scout-for-lol/packages/app/src/components/explore-transcript.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-transcript.tsx
@@ -151,6 +151,15 @@ const PendingTurn = memo(function PendingTurnView(props: {
   trace: ExploreTraceEntry[];
   showRawTrace: boolean;
 }) {
+  /**
+   * The status line describes work in flight, so it goes away once prose is
+   * arriving — the answer itself is then the progress.
+   *
+   * Without this the last tool's completion message ("Got results.") keeps
+   * pulsing and counting for the whole of answer generation, presenting a
+   * finished step as ongoing work and timing it from the wrong moment.
+   */
+  const activity = props.pendingAnswer === null ? props.activity : null;
   return (
     <div aria-live="polite" className="space-y-6">
       {props.pendingQuestion !== null && (
@@ -163,11 +172,9 @@ const PendingTurn = memo(function PendingTurnView(props: {
       {/* Status and steps are one unit — the line says what is happening now,
           the disclosure holds how it got here — so they sit closer together
           than the surrounding `space-y-6` rhythm. */}
-      {(props.activity !== null || props.trace.length > 0) && (
+      {(activity !== null || props.trace.length > 0) && (
         <div className="space-y-2">
-          {props.activity !== null && (
-            <ActivityLine activity={props.activity} />
-          )}
+          {activity !== null && <ActivityLine activity={activity} />}
           {props.trace.length > 0 && (
             <Disclosure label={`Steps (${String(props.trace.length)})`}>
               <ExploreToolTrace
@@ -212,7 +219,13 @@ function ActivityLine(props: { activity: string }) {
       <span className="inline-block size-2 animate-pulse rounded-full bg-current" />
       <span>{props.activity}</span>
       {elapsedMs >= ELAPSED_VISIBLE_AFTER_MS && (
-        <span className="tabular-nums">{formatDuration(elapsedMs)}</span>
+        // Hidden from the live region this sits inside: it changes every
+        // second, and a screen reader announcing "3.0 s", "4.0 s" … would
+        // talk over the streamed answer and the status text that actually
+        // says something.
+        <span aria-hidden="true" className="tabular-nums">
+          {formatDuration(elapsedMs)}
+        </span>
       )}
     </p>
   );

--- a/packages/scout-for-lol/packages/app/src/components/explore-transcript.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-transcript.tsx
@@ -12,6 +12,8 @@ import { ExploreToolTrace } from "#src/components/explore-tool-trace.tsx";
 import { ExploreVersionSwitcher } from "#src/components/explore-version-switcher.tsx";
 import { MarkdownAnswer } from "#src/components/markdown-answer.tsx";
 import { AssistantTurn } from "#src/components/explore-assistant-turn.tsx";
+import { useNow } from "#src/hooks/use-now.ts";
+import { formatDuration } from "#src/lib/format-duration.ts";
 
 /**
  * Renders one path through an explore conversation.
@@ -158,24 +160,70 @@ const PendingTurn = memo(function PendingTurnView(props: {
         <MarkdownAnswer>{props.pendingAnswer}</MarkdownAnswer>
       )}
       {props.showRawTrace && <ExploreDareCards trace={props.trace} />}
-      {props.activity !== null && props.trace.length === 0 && (
-        <p className="flex items-center gap-2 text-sm text-scout-subtle">
-          <span className="inline-block size-2 animate-pulse rounded-full bg-current" />
-          {props.activity}
-        </p>
-      )}
-      {props.trace.length > 0 && (
-        <Disclosure label={`Steps (${String(props.trace.length)})`}>
-          <ExploreToolTrace
-            trace={props.trace}
-            showRaw={props.showRawTrace}
-            live
-          />
-        </Disclosure>
+      {/* Status and steps are one unit — the line says what is happening now,
+          the disclosure holds how it got here — so they sit closer together
+          than the surrounding `space-y-6` rhythm. */}
+      {(props.activity !== null || props.trace.length > 0) && (
+        <div className="space-y-2">
+          {props.activity !== null && (
+            <ActivityLine activity={props.activity} />
+          )}
+          {props.trace.length > 0 && (
+            <Disclosure label={`Steps (${String(props.trace.length)})`}>
+              <ExploreToolTrace
+                trace={props.trace}
+                showRaw={props.showRawTrace}
+                live
+              />
+            </Disclosure>
+          )}
+        </div>
       )}
     </div>
   );
 });
+
+/**
+ * The one line that says what the turn is doing right now.
+ *
+ * It carries an elapsed counter because the wait it narrates is the longest
+ * part of a turn — a lake scan can run for tens of seconds — and a status that
+ * never changes reads as a hang. The clock is measured from when this text
+ * last changed, so it answers "how long has *this* step been going", not "how
+ * long has the turn been going"; two consecutive identical statuses therefore
+ * share one clock, which is the honest reading of them being one step.
+ *
+ * The timing lives here rather than in the reducer on purpose: the reducer is
+ * pure and tested without a DOM, and a `Date.now()` inside it would make every
+ * stream-folding test depend on the clock.
+ */
+function ActivityLine(props: { activity: string }) {
+  const [span, setSpan] = useState(() => ({
+    activity: props.activity,
+    startedAt: Date.now(),
+  }));
+  if (span.activity !== props.activity) {
+    setSpan({ activity: props.activity, startedAt: Date.now() });
+  }
+  const now = useNow(1000);
+  const elapsedMs = Math.max(0, now - span.startedAt);
+  return (
+    <p className="flex items-center gap-2 text-sm text-scout-subtle">
+      <span className="inline-block size-2 animate-pulse rounded-full bg-current" />
+      <span>{props.activity}</span>
+      {elapsedMs >= ELAPSED_VISIBLE_AFTER_MS && (
+        <span className="tabular-nums">{formatDuration(elapsedMs)}</span>
+      )}
+    </p>
+  );
+}
+
+/**
+ * Below this the counter is noise — every step shows "0 s" for a moment on the
+ * way past, and a number that flickers in and out draws the eye away from the
+ * text that actually says what is happening.
+ */
+const ELAPSED_VISIBLE_AFTER_MS = 2000;
 
 function UserBubble(props: { content: string }) {
   return (

--- a/packages/scout-for-lol/packages/app/src/components/explore-transcript.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-transcript.tsx
@@ -39,6 +39,8 @@ export function ExploreTranscript(props: {
   pendingAnswer?: string | null;
   pendingQuestion?: string | null;
   activity?: string | null;
+  /** The status describes a deliberate stop, not work still in flight. */
+  stopping?: boolean;
   pendingTrace?: ExploreTraceEntry[];
   /** True while a turn is running, so a trailing question is not "interrupted". */
   turnActive?: boolean;
@@ -86,6 +88,7 @@ export function ExploreTranscript(props: {
         pendingQuestion={props.pendingQuestion ?? null}
         pendingAnswer={props.pendingAnswer ?? null}
         activity={props.activity ?? null}
+        stopping={props.stopping ?? false}
         trace={props.pendingTrace ?? []}
         showRawTrace={props.showRawTrace ?? false}
       />
@@ -148,6 +151,7 @@ const PendingTurn = memo(function PendingTurnView(props: {
   pendingQuestion: string | null;
   pendingAnswer: string | null;
   activity: string | null;
+  stopping: boolean;
   trace: ExploreTraceEntry[];
   showRawTrace: boolean;
 }) {
@@ -158,8 +162,15 @@ const PendingTurn = memo(function PendingTurnView(props: {
    * Without this the last tool's completion message ("Got results.") keeps
    * pulsing and counting for the whole of answer generation, presenting a
    * finished step as ongoing work and timing it from the wrong moment.
+   *
+   * Stopping is the exception, and the reason this is not simply "hide it once
+   * there is prose": a stop only ever salvages a turn that already streamed
+   * something, so "Stopped — saving the partial answer…" arrives precisely
+   * when prose exists. Hiding it there leaves the reader watching a frozen
+   * answer with nothing to say the stop is still landing.
    */
-  const activity = props.pendingAnswer === null ? props.activity : null;
+  const activity =
+    props.pendingAnswer === null || props.stopping ? props.activity : null;
   return (
     <div aria-live="polite" className="space-y-6">
       {props.pendingQuestion !== null && (

--- a/packages/scout-for-lol/packages/app/src/lib/explore-stream.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-stream.ts
@@ -1,7 +1,7 @@
 import {
-  ExploreStreamEventSchema,
   ExploreTranscriptSchema,
   ExploreRunObserveRequestSchema,
+  parseExploreStreamEvent,
   type ExploreStreamEvent,
   type ExploreTranscript,
 } from "@scout-for-lol/data";
@@ -19,7 +19,7 @@ export async function observeExploreRun(params: {
     body: ExploreRunObserveRequestSchema.parse({ runId: params.runId }),
     signal: params.signal,
     csrfToken: readCsrfCookie(),
-    parseEvent: (raw) => ExploreStreamEventSchema.parse(raw),
+    parseEvent: parseExploreStreamEvent,
     onEvent: params.onEvent,
     httpErrorMessage: (response, text) =>
       httpErrorMessage(response, text, "Explore request failed"),

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.test.ts
@@ -175,6 +175,7 @@ describe("visiblePending", () => {
       pendingQuestion: null,
       pendingAnswer: null,
       activity: null,
+      stopping: false,
       trace: [],
     });
   });
@@ -218,6 +219,7 @@ describe("visiblePending", () => {
       pendingQuestion: null,
       pendingAnswer: null,
       activity: null,
+      stopping: false,
       trace: [],
     });
   });

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
@@ -234,6 +234,13 @@ export function visiblePending(
   pendingQuestion: string | null;
   pendingAnswer: string | null;
   activity: string | null;
+  /**
+   * Whether the status describes a deliberate stop rather than work in
+   * flight. The transcript hides the status line once prose is arriving — a
+   * finished step must not keep pulsing — but stopping is exactly the case
+   * where prose exists *and* something is still happening.
+   */
+  stopping: boolean;
   trace: ExploreTraceEntry[];
 } {
   if (turn === null) {
@@ -241,6 +248,7 @@ export function visiblePending(
       pendingQuestion: null,
       pendingAnswer: null,
       activity: null,
+      stopping: false,
       trace: [],
     };
   }
@@ -249,6 +257,7 @@ export function visiblePending(
       pendingQuestion: null,
       pendingAnswer: null,
       activity: null,
+      stopping: false,
       trace: [],
     };
   }
@@ -261,6 +270,7 @@ export function visiblePending(
     pendingQuestion: questionPersisted ? null : turn.question,
     pendingAnswer: landed ? null : turn.answer,
     activity: landed ? null : turn.activity,
+    stopping: !landed && turn.phase === "stopping",
     trace: landed ? [] : turn.trace,
   };
 }

--- a/packages/scout-for-lol/packages/app/src/lib/format-duration.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/format-duration.ts
@@ -1,0 +1,12 @@
+/**
+ * How Explore renders a span of time.
+ *
+ * Shared by the finished durations on a tool step and the live counter on the
+ * status line, so a step that took four seconds reads the same while it is
+ * running as it does afterwards.
+ */
+export function formatDuration(durationMs: number): string {
+  return durationMs < 1000
+    ? `${durationMs.toString()} ms`
+    : `${(durationMs / 1000).toFixed(1)} s`;
+}

--- a/packages/scout-for-lol/packages/app/src/lib/sse-stream.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/sse-stream.ts
@@ -9,16 +9,19 @@
 /**
  * POST JSON and read the SSE response, invoking `onEvent` per frame.
  *
- * `parseEvent` validates each frame. A frame that fails is a corrupted
- * stream — the server validates every event before emitting it — so the
- * caller's message is surfaced instead of a raw JSON or Zod error.
+ * `parseEvent` validates each frame. Throwing means a corrupted stream — the
+ * server validates every event before emitting it — so the caller's message is
+ * surfaced instead of a raw JSON or Zod error. Returning `null` instead means
+ * "this frame is not for me, carry on": the caller uses it for a frame a newer
+ * server sent that this bundle has no parser for, which must not kill a turn
+ * the server is answering correctly.
  */
 export async function postEventStream<Event>(params: {
   url: string;
   body: unknown;
   signal: AbortSignal;
   csrfToken: string | null;
-  parseEvent: (raw: unknown) => Event;
+  parseEvent: (raw: unknown) => Event | null;
   onEvent: (event: Event) => void;
   httpErrorMessage: (response: Response, text: string) => string;
   corruptedMessage: string;
@@ -51,12 +54,15 @@ export async function postEventStream<Event>(params: {
     if (dataLine === undefined) {
       return;
     }
-    let event: Event;
+    let event: Event | null;
     try {
       const raw: unknown = JSON.parse(dataLine.slice("data: ".length));
       event = params.parseEvent(raw);
     } catch {
       throw new Error(params.corruptedMessage);
+    }
+    if (event === null) {
+      return;
     }
     params.onEvent(event);
   });

--- a/packages/scout-for-lol/packages/app/src/routes/explore.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/explore.tsx
@@ -176,6 +176,7 @@ export function Explore() {
     pendingQuestion,
     pendingAnswer,
     activity,
+    stopping,
     trace: pendingTrace,
   } = visiblePending(pendingTurn, conversationId, messages);
 
@@ -285,6 +286,7 @@ export function Explore() {
           pendingQuestion={pendingQuestion}
           pendingAnswer={pendingAnswer}
           activity={activity}
+          stopping={stopping}
           pendingTrace={pendingTrace}
           turnActive={turnActive}
           showRawTrace

--- a/packages/scout-for-lol/packages/data/src/model/explore.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/explore.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { ExploreTraceEntrySchema } from "#src/model/explore.ts";
+import {
+  ExploreTraceEntrySchema,
+  parseExploreStreamEvent,
+} from "#src/model/explore.ts";
 
 describe("ExploreTraceEntrySchema", () => {
   test("normalizes a stored legacy trace entry", () => {
@@ -19,5 +22,39 @@ describe("ExploreTraceEntrySchema", () => {
       rawInput: null,
       rawOutput: null,
     });
+  });
+});
+
+describe("parseExploreStreamEvent", () => {
+  test("parses a known event", () => {
+    const event = parseExploreStreamEvent({
+      type: "answer_delta",
+      text: "Jinx ",
+    });
+    expect(event).toEqual({ type: "answer_delta", text: "Jinx " });
+  });
+
+  test("skips a member this bundle has never heard of", () => {
+    // A browser keeps its bundle for as long as the tab stays open, so a
+    // deploy that adds a stream event reaches parsers that predate it. The
+    // SSE reader treats a throw as a corrupted stream, so without this an
+    // open tab would die mid-turn on a turn the server answered correctly.
+    expect(
+      parseExploreStreamEvent({ type: "activity", text: "Finding a player…" }),
+    ).toBeNull();
+  });
+
+  test("still throws on a known type carrying the wrong shape", () => {
+    // The tolerance is only for unrecognised discriminators. The server
+    // validates every event before emitting it, so a known type in the wrong
+    // shape is real corruption and must not be swallowed.
+    expect(() =>
+      parseExploreStreamEvent({ type: "answer_delta", text: 42 }),
+    ).toThrow();
+  });
+
+  test("still throws on a frame that is not an event at all", () => {
+    expect(() => parseExploreStreamEvent("not an object")).toThrow();
+    expect(() => parseExploreStreamEvent({ nope: true })).toThrow();
   });
 });

--- a/packages/scout-for-lol/packages/data/src/model/explore.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/explore.test.ts
@@ -34,14 +34,35 @@ describe("parseExploreStreamEvent", () => {
     expect(event).toEqual({ type: "answer_delta", text: "Jinx " });
   });
 
-  test("skips a member this bundle has never heard of", () => {
+  test("skips an unknown member that marked itself ignorable", () => {
     // A browser keeps its bundle for as long as the tab stays open, so a
     // deploy that adds a stream event reaches parsers that predate it. The
     // SSE reader treats a throw as a corrupted stream, so without this an
     // open tab would die mid-turn on a turn the server answered correctly.
     expect(
-      parseExploreStreamEvent({ type: "activity", text: "Finding a player…" }),
+      parseExploreStreamEvent({
+        type: "a-member-from-a-newer-server",
+        ignorable: true,
+        whatever: true,
+      }),
     ).toBeNull();
+  });
+
+  test("refuses an unknown member that did not volunteer to be skipped", () => {
+    // Tolerance is granted by the sender, not assumed by the reader. An
+    // unknown discriminator proves the server is newer; it does not prove
+    // that what it sent was unimportant. Dropping an event the transcript
+    // depended on would leave the page quietly wrong rather than visibly
+    // broken, so this takes the corrupted-stream path, which reconnects.
+    expect(() =>
+      parseExploreStreamEvent({ type: "a-member-this-client-needs" }),
+    ).toThrow();
+    expect(() =>
+      parseExploreStreamEvent({
+        type: "a-member-this-client-needs",
+        ignorable: false,
+      }),
+    ).toThrow();
   });
 
   test("still throws on a known type carrying the wrong shape", () => {

--- a/packages/scout-for-lol/packages/data/src/model/explore.ts
+++ b/packages/scout-for-lol/packages/data/src/model/explore.ts
@@ -546,6 +546,48 @@ export const ExploreStreamEventSchema = z.discriminatedUnion("type", [
 
 export type ExploreStreamEvent = z.infer<typeof ExploreStreamEventSchema>;
 
+/**
+ * Every discriminator the union currently knows, derived from the union
+ * itself so the two cannot drift.
+ */
+const KNOWN_EXPLORE_STREAM_EVENT_TYPES: ReadonlySet<string> = new Set(
+  ExploreStreamEventSchema.options.map((option) => option.shape.type.value),
+);
+
+/** Just enough of a frame to tell "new member" from "corrupt payload". */
+const ExploreStreamEnvelopeSchema = z.looseObject({ type: z.string() });
+
+/**
+ * Parse one stream frame, tolerating a member this bundle has never heard of.
+ *
+ * A browser tab keeps its bundle for as long as it stays open, so a deploy
+ * that adds a stream event reaches tabs whose parser predates it. The union is
+ * `.strict()` and the SSE reader treats a parse failure as a corrupted stream,
+ * so without this an open tab would die mid-turn — showing a corruption error
+ * for a turn the server answered perfectly well.
+ *
+ * The tolerance is deliberately narrow. An **unrecognised discriminator** is
+ * skipped, because it can only mean a newer server. Anything else still
+ * throws: the server validates every event before emitting it, so a known type
+ * arriving in the wrong shape is real corruption and must not be swallowed.
+ */
+export function parseExploreStreamEvent(
+  raw: unknown,
+): ExploreStreamEvent | null {
+  const parsed = ExploreStreamEventSchema.safeParse(raw);
+  if (parsed.success) {
+    return parsed.data;
+  }
+  const envelope = ExploreStreamEnvelopeSchema.safeParse(raw);
+  if (
+    envelope.success &&
+    !KNOWN_EXPLORE_STREAM_EVENT_TYPES.has(envelope.data.type)
+  ) {
+    return null;
+  }
+  throw parsed.error;
+}
+
 export const ExploreHttpErrorSchema = z
   .object({
     error: z.string().trim().min(1).max(1000),

--- a/packages/scout-for-lol/packages/data/src/model/explore.ts
+++ b/packages/scout-for-lol/packages/data/src/model/explore.ts
@@ -554,22 +554,38 @@ const KNOWN_EXPLORE_STREAM_EVENT_TYPES: ReadonlySet<string> = new Set(
   ExploreStreamEventSchema.options.map((option) => option.shape.type.value),
 );
 
-/** Just enough of a frame to tell "new member" from "corrupt payload". */
-const ExploreStreamEnvelopeSchema = z.looseObject({ type: z.string() });
+/**
+ * Just enough of a frame to tell "a newer server sent something optional" from
+ * "this payload is corrupt".
+ *
+ * `ignorable` is the marker a new event uses to say an old client may drop it
+ * and still render a correct transcript. It is opt-in on purpose: an unknown
+ * discriminator alone proves only that the sender is newer, not that what it
+ * sent was unimportant, and silently discarding an event whose semantics the
+ * transcript depended on would leave the page quietly wrong instead of
+ * visibly broken.
+ */
+const ExploreStreamEnvelopeSchema = z.looseObject({
+  type: z.string(),
+  ignorable: z.boolean().optional(),
+});
 
 /**
- * Parse one stream frame, tolerating a member this bundle has never heard of.
+ * Parse one stream frame, tolerating a member this bundle has never heard of
+ * **only when that member said it was safe to skip**.
  *
  * A browser tab keeps its bundle for as long as it stays open, so a deploy
  * that adds a stream event reaches tabs whose parser predates it. The union is
  * `.strict()` and the SSE reader treats a parse failure as a corrupted stream,
- * so without this an open tab would die mid-turn — showing a corruption error
- * for a turn the server answered perfectly well.
+ * so without any tolerance an open tab would die mid-turn — showing a
+ * corruption error for a turn the server answered perfectly well.
  *
- * The tolerance is deliberately narrow. An **unrecognised discriminator** is
- * skipped, because it can only mean a newer server. Anything else still
- * throws: the server validates every event before emitting it, so a known type
- * arriving in the wrong shape is real corruption and must not be swallowed.
+ * So the tolerance exists, but it is granted by the sender rather than assumed
+ * by the reader: an unrecognised discriminator is skipped only if the frame
+ * carries `ignorable: true`. Everything else still throws — a known type in
+ * the wrong shape is real corruption, and an unknown type that did not
+ * volunteer to be skippable is a client too old to render this turn honestly.
+ * Both belong on the corrupted-stream path, which reconnects.
  */
 export function parseExploreStreamEvent(
   raw: unknown,
@@ -581,6 +597,7 @@ export function parseExploreStreamEvent(
   const envelope = ExploreStreamEnvelopeSchema.safeParse(raw);
   if (
     envelope.success &&
+    envelope.data.ignorable === true &&
     !KNOWN_EXPLORE_STREAM_EVENT_TYPES.has(envelope.data.type)
   ) {
     return null;


### PR DESCRIPTION
## Why

Explore streams an answer but goes quiet while it works. The status line rendered only while the tool trace was empty (`explore-transcript.tsx:165`), so from the first tool call to the final answer — the longest stretch of a turn — the entire visible state was a collapsed `Steps (n)` counter. The reducer was tracking `activity` correctly on every event; the UI simply stopped showing it.

This also lands the forward-compatible stream parser the rest of the stack depends on. `sse-stream.ts` treats any frame it cannot parse as a corrupted stream and the event union is `.strict()`, so a deploy that adds a stream event would kill every already-open tab mid-turn — on turns the server answered perfectly well. That has to be deployed **before** anything starts emitting a new event, which is why it is first in the stack rather than bundled with PR 3.

## What

- `parseExploreStreamEvent` skips a frame whose discriminator this bundle does not recognise and still throws on everything else. The known-type set is derived from the union itself so the two cannot drift. `postEventStream` now treats a `null` parse as "skip this frame".
- The status line stays visible for the whole turn, grouped with the steps disclosure. Steps remain collapsed by default.
- The status line carries an elapsed counter measured from when its text last changed, so a long lake scan reads as work rather than as a hang. It appears only after 2s so steps passing through do not flicker a "0 s".
- `formatDuration` moves to `lib/format-duration.ts` and is shared with the tool trace, so a running step and a finished one read the same.

Timing lives in the component, not the reducer: the reducer is pure and tested without a DOM, and a `Date.now()` inside it would make every stream-folding test depend on the clock.

## Verification

- `bunx turbo run typecheck lint --filter='@scout-for-lol/*'` — 45/45 pass.
- app 407, data 1375 tests pass.
- The new transcript test was confirmed to fail against the old `trace.length === 0` guard, so it pins the fix rather than passing either way.
- **Not yet exercised against a live model.** `dev:web` acceptance and PR media follow for the stack as a whole.

## Rollout

First of a five-PR stack. Nothing here changes the wire format; it only makes the client tolerant of a later change to it.