### PR TITLE
feat(scout-for-lol): render Explore query results while the answer streams

### DIFF
--- a/packages/scout-for-lol/packages/app/src/components/explore-assistant-turn.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-assistant-turn.tsx
@@ -194,7 +194,11 @@ export const AssistantTurn = memo(function AssistantTurnView(props: {
 
       {props.showRawTrace && <ExploreDareCards trace={message.trace} />}
 
-      <ExploreVisualResult message={message} onFollowUp={actions.onFollowUp} />
+      <ExploreVisualResult
+        preview={message.preview}
+        visualization={message.visualization}
+        onFollowUp={actions.onFollowUp}
+      />
 
       {message.caveats.length > 0 && (
         <ul className="space-y-1 rounded-md border-l-2 border-scout-border bg-scout-surface py-2 pr-3 pl-3 text-xs">

--- a/packages/scout-for-lol/packages/app/src/components/explore-transcript.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-transcript.tsx
@@ -1,6 +1,11 @@
 import { memo, useEffect, useState } from "react";
 import { Pencil } from "lucide-react";
-import type { ExploreMessage, ExploreTraceEntry } from "@scout-for-lol/data";
+import type {
+  ExploreMessage,
+  ExploreTraceEntry,
+  ReportAiPreviewSummary,
+  VisualizationSnapshot,
+} from "@scout-for-lol/data";
 import {
   Button,
   IconButton,
@@ -12,6 +17,7 @@ import { ExploreToolTrace } from "#src/components/explore-tool-trace.tsx";
 import { ExploreVersionSwitcher } from "#src/components/explore-version-switcher.tsx";
 import { MarkdownAnswer } from "#src/components/markdown-answer.tsx";
 import { AssistantTurn } from "#src/components/explore-assistant-turn.tsx";
+import { ExploreVisualResult } from "#src/components/explore-visual-result.tsx";
 import { useNow } from "#src/hooks/use-now.ts";
 import { formatDuration } from "#src/lib/format-duration.ts";
 
@@ -42,6 +48,9 @@ export function ExploreTranscript(props: {
   /** The status describes a deliberate stop, not work still in flight. */
   stopping?: boolean;
   pendingTrace?: ExploreTraceEntry[];
+  /** The streaming turn's newest query result, rendered before it lands. */
+  pendingPreview?: ReportAiPreviewSummary | null;
+  pendingVisualization?: VisualizationSnapshot | null;
   /** True while a turn is running, so a trailing question is not "interrupted". */
   turnActive?: boolean;
   /** Owner-only raw tool payloads are never offered on the shared route. */
@@ -90,6 +99,8 @@ export function ExploreTranscript(props: {
         activity={props.activity ?? null}
         stopping={props.stopping ?? false}
         trace={props.pendingTrace ?? []}
+        preview={props.pendingPreview ?? null}
+        visualization={props.pendingVisualization ?? null}
         showRawTrace={props.showRawTrace ?? false}
       />
     </div>
@@ -153,6 +164,8 @@ const PendingTurn = memo(function PendingTurnView(props: {
   activity: string | null;
   stopping: boolean;
   trace: ExploreTraceEntry[];
+  preview: ReportAiPreviewSummary | null;
+  visualization: VisualizationSnapshot | null;
   showRawTrace: boolean;
 }) {
   /**
@@ -180,6 +193,13 @@ const PendingTurn = memo(function PendingTurnView(props: {
         <MarkdownAnswer>{props.pendingAnswer}</MarkdownAnswer>
       )}
       {props.showRawTrace && <ExploreDareCards trace={props.trace} />}
+      {/* The query result the moment the query returns, rather than at the end
+          of the turn. The same component renders it after the turn lands, so
+          the hand-off to the persisted message does not reflow the table. */}
+      <ExploreVisualResult
+        preview={props.preview}
+        visualization={props.visualization}
+      />
       {/* Status and steps are one unit — the line says what is happening now,
           the disclosure holds how it got here — so they sit closer together
           than the surrounding `space-y-6` rhythm. */}

--- a/packages/scout-for-lol/packages/app/src/components/explore-visual-result.test.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-visual-result.test.tsx
@@ -157,7 +157,10 @@ describe("ExploreVisualResult", () => {
   test("renders both Chart and Table tab controls for chartable results", () => {
     const message = createMessage({ preview: chartablePreview });
     const markup = renderToStaticMarkup(
-      <ExploreVisualResult message={message} />,
+      <ExploreVisualResult
+        preview={message.preview}
+        visualization={message.visualization}
+      />,
     );
 
     expect(markup).toContain("Chart");
@@ -183,7 +186,10 @@ describe("ExploreVisualResult", () => {
     };
     const message = createMessage({ preview: ungrouped });
     const markup = renderToStaticMarkup(
-      <ExploreVisualResult message={message} />,
+      <ExploreVisualResult
+        preview={message.preview}
+        visualization={message.visualization}
+      />,
     );
 
     expect(markup).not.toContain("Chart");
@@ -200,7 +206,10 @@ describe("ExploreVisualResult", () => {
     };
     const message = createMessage({ preview: emptyPreview });
     const markup = renderToStaticMarkup(
-      <ExploreVisualResult message={message} />,
+      <ExploreVisualResult
+        preview={message.preview}
+        visualization={message.visualization}
+      />,
     );
 
     expect(markup).toBe("");

--- a/packages/scout-for-lol/packages/app/src/components/explore-visual-result.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-visual-result.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from "react";
 import { BarChart2, Table as TableIcon, X } from "lucide-react";
 import {
   ReportOutputFormatSchema,
-  type ExploreMessage,
   type ReportAiPreviewSummary,
   type ReportOutputFormat,
   type ReportResultColumn,
@@ -86,7 +85,8 @@ export function initialMetricKey(
 }
 
 export type ExploreVisualResultProps = {
-  readonly message: ExploreMessage;
+  readonly preview: ReportAiPreviewSummary | null;
+  readonly visualization: VisualizationSnapshot | null;
   readonly onFollowUp?: ((text: string) => void) | undefined;
 };
 
@@ -345,13 +345,22 @@ export function resolveActiveSnapshot(options: {
   return null;
 }
 
+/**
+ * Takes the result rather than the message because a turn shows this twice in
+ * its life: while streaming, from the `preview` event the server sends the
+ * moment a query returns, and again from the persisted message once the turn
+ * lands. Those arrive in different shapes and must render identically, or the
+ * table visibly reflows at the hand-off. Only these two fields were ever read
+ * off the message.
+ */
 export function ExploreVisualResult(props: {
-  readonly message: ExploreMessage;
+  readonly preview: ReportAiPreviewSummary | null;
+  readonly visualization: VisualizationSnapshot | null;
   readonly onFollowUp?: ((text: string) => void) | undefined;
 }) {
-  const { message, onFollowUp } = props;
-  const rawChart = chartableSnapshot(message.visualization);
-  const preview = message.preview;
+  const { onFollowUp } = props;
+  const rawChart = chartableSnapshot(props.visualization);
+  const preview = props.preview;
 
   const isUngrouped = preview !== null && isUngroupedResult(preview);
   const isPreviewChartable = isChartablePreview(preview);
@@ -455,7 +464,7 @@ export function ExploreVisualResult(props: {
           columns={preview.columns}
           rows={preview.rows}
           rowsReturned={preview.rowsReturned}
-          visualization={message.visualization}
+          visualization={props.visualization}
           interactive={true}
           onRowClick={(row) => {
             setSelectedPoint({ label: row.label, value: null });

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { ExploreMessageSchema, type ExploreMessage } from "@scout-for-lol/data";
+import {
+  ExploreMessageSchema,
+  ReportAiPreviewSummarySchema,
+  type ExploreMessage,
+} from "@scout-for-lol/data";
 import {
   applyStreamEvent,
   createPendingTurn,
@@ -87,6 +91,7 @@ describe("applyStreamEvent", () => {
       answer: "Jinx",
       activity: "Querying match data.",
       trace: [],
+      preview: null,
     });
     turn = applyStreamEvent(turn, { type: "answer_delta", text: " wins." });
 
@@ -177,6 +182,8 @@ describe("visiblePending", () => {
       activity: null,
       stopping: false,
       trace: [],
+      preview: null,
+      visualization: null,
     });
   });
 
@@ -221,6 +228,8 @@ describe("visiblePending", () => {
       activity: null,
       stopping: false,
       trace: [],
+      preview: null,
+      visualization: null,
     });
   });
 });
@@ -355,5 +364,98 @@ describe("visiblePending before `started` arrives", () => {
     expect(visiblePending(turn, CONVERSATION, persisted).pendingQuestion).toBe(
       null,
     );
+  });
+});
+
+describe("streamed query results", () => {
+  const PREVIEW = ReportAiPreviewSummarySchema.parse({
+    columns: [
+      { key: "label", label: "Champion", format: "text" },
+      { key: "games", label: "Games", format: "integer" },
+    ],
+    rows: [{ label: "Jinx", values: [{ column: "games", value: 84 }] }],
+    visualizationRows: [],
+    rowsReturned: 1,
+    rowsScanned: 1284,
+    renderKind: "TABLE",
+  });
+
+  test("renders a query result as soon as the preview event arrives", () => {
+    // The regression this pins: `preview` used to be folded into the same
+    // no-op branch as `done`, so the table the server had already sent only
+    // appeared once the whole turn landed.
+    const turn = applyStreamEvent(startedTurn(), {
+      type: "preview",
+      preview: PREVIEW,
+      visualization: null,
+    });
+    expect(turn.preview?.rows).toHaveLength(1);
+    expect(turn.preview?.rowsScanned).toBe(1284);
+  });
+
+  test("a later query replaces an earlier one", () => {
+    // Last write wins, matching the agent's own `lastPreview`, so a
+    // reconnecting reader never sees an earlier query's table beside a later
+    // query's answer.
+    let turn = applyStreamEvent(startedTurn(), {
+      type: "preview",
+      preview: PREVIEW,
+      visualization: null,
+    });
+    turn = applyStreamEvent(turn, {
+      type: "preview",
+      preview: { ...PREVIEW, rows: [], rowsReturned: 0, rowsScanned: 7 },
+      visualization: null,
+    });
+    expect(turn.preview?.rowsScanned).toBe(7);
+  });
+
+  test("a reconnect restores the table and leaves an existing chart alone", () => {
+    // The snapshot deliberately carries no visualization — it can be far
+    // larger than the table and the durable observer re-sends the whole
+    // snapshot roughly once a second — so a client that already received one
+    // live must not have it blanked by reconnecting.
+    let turn = applyStreamEvent(startedTurn(), {
+      type: "preview",
+      preview: PREVIEW,
+      visualization: null,
+    });
+    turn = applyStreamEvent(turn, {
+      type: "snapshot",
+      runId: RUN_ID,
+      conversationId: CONVERSATION,
+      questionMessageId: QUESTION_ID,
+      leafIdAtStart: null,
+      versionCountAtStart: 0,
+      startedAt: "2026-08-18T12:00:00.000Z",
+      answer: "Jinx",
+      activity: "Querying match data.",
+      trace: [],
+      preview: PREVIEW,
+    });
+    expect(turn.preview?.rowsScanned).toBe(1284);
+    expect(turn.visualization).toBeNull();
+  });
+
+  test("stops rendering its own copy once the turn has landed", () => {
+    let turn = applyStreamEvent(startedTurn(), {
+      type: "preview",
+      preview: PREVIEW,
+      visualization: null,
+    });
+    const persisted = message({
+      id: ANSWER_ID,
+      role: "assistant",
+      parentId: QUESTION_ID,
+    });
+    turn = applyStreamEvent(turn, {
+      type: "final",
+      message: persisted,
+      title: "Who wins?",
+      quota: [],
+    });
+    // The persisted message owns the result from here on; a pending copy
+    // beside it would render the table twice.
+    expect(visiblePending(turn, CONVERSATION, [persisted]).preview).toBeNull();
   });
 });

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.test.ts
@@ -92,7 +92,6 @@ describe("applyStreamEvent", () => {
       answer: "Jinx",
       activity: "Querying match data.",
       trace: [],
-      preview: null,
     });
     turn = applyStreamEvent(turn, { type: "answer_delta", text: " wins." });
 
@@ -434,7 +433,14 @@ describe("streamed query results", () => {
       answer: "Jinx",
       activity: "Querying match data.",
       trace: [],
+    });
+    // The snapshot clears the result; the companion event restores it.
+    expect(turn.preview).toBeNull();
+
+    turn = applyStreamEvent(turn, {
+      type: "run_preview",
       preview: PREVIEW,
+      ignorable: true,
     });
     expect(turn.preview?.rowsScanned).toBe(1284);
     expect(turn.visualization).toBeNull();
@@ -479,7 +485,11 @@ describe("streamed query results", () => {
       answer: "Jinx",
       activity: "Querying match data.",
       trace: [],
+    });
+    turn = applyStreamEvent(turn, {
+      type: "run_preview",
       preview: { ...PREVIEW, rowsScanned: 7 },
+      ignorable: true,
     });
 
     // The newest table with no chart, rather than the newest table under the

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   ExploreMessageSchema,
   ReportAiPreviewSummarySchema,
+  VisualizationSnapshotSchema,
   type ExploreMessage,
 } from "@scout-for-lol/data";
 import {
@@ -410,11 +411,13 @@ describe("streamed query results", () => {
     expect(turn.preview?.rowsScanned).toBe(7);
   });
 
-  test("a reconnect restores the table and leaves an existing chart alone", () => {
+  test("a reconnect restores the table and drops a possibly stale chart", () => {
     // The snapshot deliberately carries no visualization — it can be far
-    // larger than the table and the durable observer re-sends the whole
-    // snapshot roughly once a second — so a client that already received one
-    // live must not have it blanked by reconnecting.
+    // larger than the table, and the durable observer re-sends the whole
+    // snapshot roughly once a second. So the chart this client is holding may
+    // belong to an earlier query than the preview the snapshot just brought,
+    // and `ExploreTurnResult` gives a chart precedence over a table: keeping
+    // it would render query A's chart above query B's numbers.
     let turn = applyStreamEvent(startedTurn(), {
       type: "preview",
       preview: PREVIEW,
@@ -434,6 +437,54 @@ describe("streamed query results", () => {
       preview: PREVIEW,
     });
     expect(turn.preview?.rowsScanned).toBe(1284);
+    expect(turn.visualization).toBeNull();
+  });
+
+  test("a reconnect after a second query does not keep the first chart", () => {
+    const chart = VisualizationSnapshotSchema.parse({
+      version: 1,
+      generatedAt: "2026-08-18T12:00:00.000Z",
+      kind: "line_chart",
+      title: "Games per week",
+      temporal: null,
+      bucket: null,
+      display: {
+        theme: null,
+        palette: null,
+        smooth: false,
+        stack: "none",
+        rollingWindow: null,
+        cumulative: false,
+        sparkline: false,
+      },
+      series: [],
+      annotations: [],
+      trends: [],
+    });
+    let turn = applyStreamEvent(startedTurn(), {
+      type: "preview",
+      preview: PREVIEW,
+      visualization: chart,
+    });
+    expect(turn.visualization).not.toBeNull();
+
+    turn = applyStreamEvent(turn, {
+      type: "snapshot",
+      runId: RUN_ID,
+      conversationId: CONVERSATION,
+      questionMessageId: QUESTION_ID,
+      leafIdAtStart: null,
+      versionCountAtStart: 0,
+      startedAt: "2026-08-18T12:00:00.000Z",
+      answer: "Jinx",
+      activity: "Querying match data.",
+      trace: [],
+      preview: { ...PREVIEW, rowsScanned: 7 },
+    });
+
+    // The newest table with no chart, rather than the newest table under the
+    // previous query's chart.
+    expect(turn.preview?.rowsScanned).toBe(7);
     expect(turn.visualization).toBeNull();
   });
 

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
@@ -112,9 +112,13 @@ export function applyStreamEvent(
         activity: event.activity,
         trace: event.trace,
         preview: event.preview,
-        // The snapshot carries no chart; keep whatever this client already
-        // received live rather than blanking a chart it is already showing.
-        visualization: turn.visualization,
+        // Cleared, not kept. The snapshot's preview is the newest result, but
+        // the snapshot carries no chart to go with it — so a chart this client
+        // received live may belong to an earlier query. `ExploreTurnResult`
+        // gives a chart precedence over a table, so keeping it would render
+        // query A's chart above query B's numbers. The chart comes back with
+        // the next preview or with `final`.
+        visualization: null,
       };
     }
     case "started": {

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
@@ -111,13 +111,14 @@ export function applyStreamEvent(
         answer: event.answer,
         activity: event.activity,
         trace: event.trace,
-        preview: event.preview,
-        // Cleared, not kept. The snapshot's preview is the newest result, but
-        // the snapshot carries no chart to go with it — so a chart this client
-        // received live may belong to an earlier query. `ExploreTurnResult`
-        // gives a chart precedence over a table, so keeping it would render
-        // query A's chart above query B's numbers. The chart comes back with
-        // the next preview or with `final`.
+        // The snapshot itself carries no result; `run_preview` follows it
+        // when there is one. Both are cleared here so a reconnect that
+        // restores an *older* run cannot leave the previous one's table and
+        // chart on screen, and so a chart received live — which may belong to
+        // an earlier query than the preview about to arrive — cannot sit
+        // above newer numbers. `ExploreTurnResult` gives a chart precedence
+        // over a table, which is what makes that mismatch invisible.
+        preview: null,
         visualization: null,
       };
     }
@@ -158,6 +159,11 @@ export function applyStreamEvent(
         preview: event.preview,
         visualization: event.visualization,
       };
+    }
+    case "run_preview": {
+      // The reconnect companion: the newest table, with no chart to go with
+      // it. The chart returns with the next `preview` or with `final`.
+      return { ...turn, preview: event.preview, visualization: null };
     }
     case "error":
     case "done": {

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
@@ -3,6 +3,8 @@ import {
   type ExploreMessage,
   type ExploreStreamEvent,
   type ExploreTraceEntry,
+  type ReportAiPreviewSummary,
+  type VisualizationSnapshot,
 } from "@scout-for-lol/data";
 
 /**
@@ -29,6 +31,20 @@ export type ExplorePendingTurn = {
   activity: string | null;
   /** Provider-id-keyed steps, updated in place as their results arrive. */
   trace: ExploreTraceEntry[];
+  /**
+   * The newest query result, rendered while the answer is still streaming.
+   *
+   * The server has these the instant a query returns and the page used to
+   * throw them away, so a table the reader could have seen seconds earlier
+   * only appeared once the whole turn landed. Last write wins, matching what
+   * `final` will persist.
+   *
+   * A reconnect restores `preview` without `visualization` — the snapshot
+   * deliberately omits the chart — so these two are independently nullable
+   * and a null chart beside a present table is a normal state, not a bug.
+   */
+  preview: ReportAiPreviewSummary | null;
+  visualization: VisualizationSnapshot | null;
   /**
    * The on-screen leaf id when the turn began — how a stop tells a fresh
    * salvage row apart from the answer that was already there.
@@ -63,6 +79,8 @@ export function createPendingTurn(input: {
     answer: null,
     activity: "Thinking…",
     trace: [],
+    preview: null,
+    visualization: null,
     leafIdAtStart: input.leafIdAtStart,
     finalMessageId: null,
     phase: "streaming",
@@ -93,6 +111,10 @@ export function applyStreamEvent(
         answer: event.answer,
         activity: event.activity,
         trace: event.trace,
+        preview: event.preview,
+        // The snapshot carries no chart; keep whatever this client already
+        // received live rather than blanking a chart it is already showing.
+        visualization: turn.visualization,
       };
     }
     case "started": {
@@ -120,9 +142,19 @@ export function applyStreamEvent(
         finalMessageId: event.message.id,
         activity: null,
         trace: event.message.trace,
+        // The persisted message owns the result from here on, and the turn
+        // stops rendering its own copy the moment it lands.
+        preview: event.message.preview,
+        visualization: event.message.visualization,
       };
     }
-    case "preview":
+    case "preview": {
+      return {
+        ...turn,
+        preview: event.preview,
+        visualization: event.visualization,
+      };
+    }
     case "error":
     case "done": {
       return turn;
@@ -242,6 +274,8 @@ export function visiblePending(
    */
   stopping: boolean;
   trace: ExploreTraceEntry[];
+  preview: ReportAiPreviewSummary | null;
+  visualization: VisualizationSnapshot | null;
 } {
   if (turn === null) {
     return {
@@ -250,6 +284,8 @@ export function visiblePending(
       activity: null,
       stopping: false,
       trace: [],
+      preview: null,
+      visualization: null,
     };
   }
   if (turn.conversationId !== displayedConversationId) {
@@ -259,6 +295,8 @@ export function visiblePending(
       activity: null,
       stopping: false,
       trace: [],
+      preview: null,
+      visualization: null,
     };
   }
   const questionPersisted =
@@ -272,6 +310,10 @@ export function visiblePending(
     activity: landed ? null : turn.activity,
     stopping: !landed && turn.phase === "stopping",
     trace: landed ? [] : turn.trace,
+    // Dropped the moment the persisted message renders its own copy, so
+    // there is never a frame showing the table twice.
+    preview: landed ? null : turn.preview,
+    visualization: landed ? null : turn.visualization,
   };
 }
 

--- a/packages/scout-for-lol/packages/app/src/routes/explore.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/explore.tsx
@@ -178,12 +178,21 @@ export function Explore() {
     activity,
     stopping,
     trace: pendingTrace,
+    preview: pendingPreview,
+    visualization: pendingVisualization,
   } = visiblePending(pendingTurn, conversationId, messages);
 
   const { bottomRef, scrollIfPinned } = usePinnedScroll();
   useEffect(() => {
     scrollIfPinned();
-  }, [transcript.data, pendingAnswer, activity, pendingTrace, scrollIfPinned]);
+  }, [
+    transcript.data,
+    pendingAnswer,
+    activity,
+    pendingTrace,
+    pendingPreview,
+    scrollIfPinned,
+  ]);
 
   if (status.isLoading) {
     return <SectionSkeleton />;
@@ -288,6 +297,8 @@ export function Explore() {
           activity={activity}
           stopping={stopping}
           pendingTrace={pendingTrace}
+          pendingPreview={pendingPreview}
+          pendingVisualization={pendingVisualization}
           turnActive={turnActive}
           showRawTrace
           actions={transcriptActions}

--- a/packages/scout-for-lol/packages/backend/src/explore/durable-runs.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/durable-runs.ts
@@ -160,6 +160,12 @@ export async function subscribeDurableExploreRun(
         answer: lastPartial.length === 0 ? null : lastPartial,
         activity: row.state === "PENDING" ? "Waiting to start…" : "Thinking…",
         trace,
+        // Stated rather than defaulted: the run row has no column for it, so
+        // an observer that reached this path instead of the in-process one
+        // gets no table back until the next query or `final`. The schema
+        // would default this to null anyway; spelling it out keeps the gap
+        // visible to whoever reads this next.
+        preview: null,
       }),
     );
     return false;

--- a/packages/scout-for-lol/packages/backend/src/explore/durable-runs.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/durable-runs.ts
@@ -160,14 +160,12 @@ export async function subscribeDurableExploreRun(
         answer: lastPartial.length === 0 ? null : lastPartial,
         activity: row.state === "PENDING" ? "Waiting to start…" : "Thinking…",
         trace,
-        // Stated rather than defaulted: the run row has no column for it, so
-        // an observer that reached this path instead of the in-process one
-        // gets no table back until the next query or `final`. The schema
-        // would default this to null anyway; spelling it out keeps the gap
-        // visible to whoever reads this next.
-        preview: null,
       }),
     );
+    // No companion `run_preview` here: the run row has no column for it, so
+    // an observer that reached this path instead of the in-process one gets
+    // no table back until the next query or `final`. Stated rather than left
+    // implicit, so the gap is visible to whoever reads this next.
     return false;
   };
   if (emitRow(initial)) {

--- a/packages/scout-for-lol/packages/backend/src/explore/run-events.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-events.ts
@@ -39,6 +39,11 @@ export function recordExploreEvent(
   if (event.type === "tool_call" || event.type === "tool_result") {
     run.activity = event.message;
   }
+  if (event.type === "preview") {
+    // Retained without its visualization: see the snapshot schema's comment
+    // on why the chart deliberately does not survive a reconnect.
+    run.preview = event.preview;
+  }
   recordExploreTraceEvent(run.trace, event);
   broadcastExploreEvent(run, event);
 }

--- a/packages/scout-for-lol/packages/backend/src/explore/run-manager-helpers.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-manager-helpers.ts
@@ -1,11 +1,16 @@
 import * as Sentry from "@sentry/bun";
 import type {
+  ExploreActiveRun,
+  ExploreMessage,
   ExploreRunOutcome,
   ExploreStreamEvent,
   ExploreTurnRequest,
 } from "@scout-for-lol/data";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
-import type { ExploreRateLimitIdentity } from "#src/explore/rate-limit.ts";
+import type {
+  ExploreRateLimitIdentity,
+  ExploreRateLimitTicket,
+} from "#src/explore/rate-limit.ts";
 import {
   ExploreInvalidTurnError,
   resolveRegenerateTarget,
@@ -85,6 +90,42 @@ export function createDeferred(): {
 } {
   const deferred = Promise.withResolvers<null>();
   return { promise: deferred.promise, resolve: deferred.resolve };
+}
+
+/**
+ * One place that decides what a fresh in-memory run starts out holding.
+ *
+ * Both the ordinary start path and Temporal rehydration build an `ActiveRun`,
+ * and they had drifted into two copies of the same literal — so every field
+ * added to the live-run state had to be remembered twice, and forgetting one
+ * would leave rehydrated runs silently missing it.
+ */
+export function createActiveExploreRun(input: {
+  summary: ExploreActiveRun;
+  identity: ExploreRateLimitIdentity;
+  guildIds: string[];
+  ticket: ExploreRateLimitTicket;
+  started: StartedTurn;
+  history: ExploreMessage[];
+}): ActiveRun {
+  const deferred = createDeferred();
+  return {
+    summary: input.summary,
+    identity: input.identity,
+    guildIds: input.guildIds,
+    ticket: input.ticket,
+    started: input.started,
+    history: input.history,
+    abortController: new AbortController(),
+    subscribers: new Set(),
+    answer: "",
+    activity: "Thinking…",
+    trace: [],
+    preview: null,
+    termination: null,
+    settled: deferred.promise,
+    resolveSettled: deferred.resolve,
+  };
 }
 
 export async function executeActiveExploreRun(input: {

--- a/packages/scout-for-lol/packages/backend/src/explore/run-manager-helpers.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-manager-helpers.ts
@@ -1,4 +1,8 @@
 import * as Sentry from "@sentry/bun";
+import {
+  ExploreRunPreviewEventSchema,
+  ExploreRunSnapshotEventSchema,
+} from "@scout-for-lol/data";
 import type {
   ExploreActiveRun,
   ExploreMessage,
@@ -126,6 +130,36 @@ export function createActiveExploreRun(input: {
     settled: deferred.promise,
     resolveSettled: deferred.resolve,
   };
+}
+
+/**
+ * Everything an attaching observer is sent, in order.
+ *
+ * The result travels as its own `run_preview` event rather than as a field on
+ * the snapshot, and that is a compatibility requirement rather than a
+ * preference: every bundle already open in a browser parses the snapshot
+ * strictly, so an added key makes the snapshot itself unparseable there. The
+ * reader calls that a corrupted stream, reconnects, and receives the same
+ * rejected snapshot for the rest of the turn.
+ */
+export function attachEvents(run: ActiveRun): ExploreStreamEvent[] {
+  const snapshot = ExploreRunSnapshotEventSchema.parse({
+    type: "snapshot",
+    ...run.summary,
+    answer: run.answer.length === 0 ? null : run.answer,
+    activity: run.activity,
+    trace: run.trace,
+  });
+  if (run.preview === null) {
+    return [snapshot];
+  }
+  return [
+    snapshot,
+    ExploreRunPreviewEventSchema.parse({
+      type: "run_preview",
+      preview: run.preview,
+    }),
+  ];
 }
 
 export async function executeActiveExploreRun(input: {

--- a/packages/scout-for-lol/packages/backend/src/explore/run-manager-start.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-manager-start.ts
@@ -17,8 +17,8 @@ import {
 import { rollbackUnstartedExploreTurn } from "#src/explore/rollback.ts";
 import { reserveAndStartDurableExploreRun } from "#src/explore/durable-runs.ts";
 import {
+  createActiveExploreRun,
   resolveTurnTarget,
-  createDeferred,
 } from "#src/explore/run-manager-helpers.ts";
 import type { ActiveRun, StartedTurn } from "#src/explore/run-manager-types.ts";
 
@@ -73,23 +73,14 @@ export async function startExploreRun(input: {
       versionCountAtStart,
       startedAt: new Date().toISOString(),
     });
-    const deferred = createDeferred();
-    const run: ActiveRun = {
+    const run = createActiveExploreRun({
       summary,
       identity,
       guildIds,
       ticket,
       started,
       history: transcript.messages,
-      abortController: new AbortController(),
-      subscribers: new Set(),
-      answer: "",
-      activity: "Thinking…",
-      trace: [],
-      termination: null,
-      settled: deferred.promise,
-      resolveSettled: deferred.resolve,
-    };
+    });
     input.registerRun(run);
     if (input.inlineExecutionForTests) {
       input.executeInline(run);

--- a/packages/scout-for-lol/packages/backend/src/explore/run-manager-types.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-manager-types.ts
@@ -4,6 +4,7 @@ import type {
   ExploreMessage,
   ExploreStreamEvent,
   ExploreTraceEntry,
+  ReportAiPreviewSummary,
 } from "@scout-for-lol/data";
 import type {
   ExploreAgentParams,
@@ -43,6 +44,13 @@ export type ActiveRun = {
   answer: string;
   activity: string | null;
   trace: ExploreTraceEntry[];
+  /**
+   * The latest query result this turn produced, retained purely so a
+   * reconnect snapshot can carry it. Last write wins, matching the agent's
+   * own `lastPreview`, so a reconnecting reader never sees an earlier
+   * query's table beside a later query's answer.
+   */
+  preview: ReportAiPreviewSummary | null;
   termination: RunTermination;
   settled: Promise<null>;
   resolveSettled: (value: null) => void;

--- a/packages/scout-for-lol/packages/backend/src/explore/run-manager.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-manager.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   DiscordAccountIdSchema,
   EXPLORE_ANSWER_MAX_LENGTH,
+  ReportAiPreviewSummarySchema,
   type ExploreActiveRun,
   type ExploreStreamEvent,
 } from "@scout-for-lol/data";
@@ -192,6 +193,10 @@ describe("ExploreRunManager", () => {
       answer: "Jinx wins.",
       activity: "Thinking…",
       trace: [],
+      // Named explicitly: `toMatchObject` ignores fields it is not told
+      // about, so a new snapshot field added without a line here would go
+      // unpinned rather than failing.
+      preview: null,
     });
     expect(manager.list(owner)).toHaveLength(1);
 
@@ -201,6 +206,44 @@ describe("ExploreRunManager", () => {
     expect(manager.list(owner)).toEqual([]);
     expect(manager.outcome(summary.runId, owner)).toBe("succeeded");
     expect(manager.outcome(summary.runId, stranger)).toBeNull();
+  });
+
+  test("a reconnect keeps the query result but not its chart", async () => {
+    // The table is what the reader is looking at, and the run row can serve
+    // it cheaply. The chart deliberately does not survive: a snapshot is
+    // re-sent on every durable poll tick that sees a change, and a
+    // visualization permits eight series totalling two thousand points.
+    const preview = ReportAiPreviewSummarySchema.parse({
+      columns: [{ key: "label", label: "Champion", format: "text" }],
+      rows: [{ label: "Jinx", values: [] }],
+      rowsReturned: 1,
+      rowsScanned: 1284,
+      renderKind: "TABLE",
+    });
+    const agent = controlledAgent();
+    const manager = createManager(agent);
+    const summary = await startNew(manager, "Who wins most?");
+    const unsubscribe = manager.subscribe(summary.runId, owner, () => null);
+    if (unsubscribe === null) throw new Error("Expected an observer.");
+
+    await requiredRun(agent, 0).params.emit({
+      type: "preview",
+      preview,
+      visualization: null,
+    });
+    unsubscribe();
+
+    const reconnected: ExploreStreamEvent[] = [];
+    const finished = observeUntilDone(manager, summary, reconnected);
+    const snapshot = reconnected[0];
+    if (snapshot?.type !== "snapshot") {
+      throw new Error("Expected a snapshot first.");
+    }
+    expect(snapshot.preview?.rowsScanned).toBe(1284);
+    expect(snapshot).not.toHaveProperty("visualization");
+
+    requiredRun(agent, 0).resolve(successfulResult("Jinx wins."));
+    expect(await finished).toBe("succeeded");
   });
 
   test("reconnect snapshots remain valid after overlong partial output", async () => {

--- a/packages/scout-for-lol/packages/backend/src/explore/run-manager.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-manager.test.ts
@@ -193,11 +193,12 @@ describe("ExploreRunManager", () => {
       answer: "Jinx wins.",
       activity: "Thinking…",
       trace: [],
-      // Named explicitly: `toMatchObject` ignores fields it is not told
-      // about, so a new snapshot field added without a line here would go
-      // unpinned rather than failing.
-      preview: null,
     });
+    // The snapshot itself gains no fields — every bundle already in a browser
+    // parses it strictly — so the result travels as its own ignorable event.
+    expect(reconnected.some((event) => event.type === "run_preview")).toBe(
+      false,
+    );
     expect(manager.list(owner)).toHaveLength(1);
 
     requiredRun(agent, 0).resolve(successfulResult("Jinx wins."));
@@ -235,12 +236,16 @@ describe("ExploreRunManager", () => {
 
     const reconnected: ExploreStreamEvent[] = [];
     const finished = observeUntilDone(manager, summary, reconnected);
-    const snapshot = reconnected[0];
-    if (snapshot?.type !== "snapshot") {
-      throw new Error("Expected a snapshot first.");
+    expect(reconnected[0]?.type).toBe("snapshot");
+    const restored = reconnected[1];
+    if (restored?.type !== "run_preview") {
+      throw new Error("Expected the preview to follow the snapshot.");
     }
-    expect(snapshot.preview?.rowsScanned).toBe(1284);
-    expect(snapshot).not.toHaveProperty("visualization");
+    expect(restored.preview?.rowsScanned).toBe(1284);
+    // Ignorable, so a bundle that predates this member skips it and renders
+    // the table a beat later rather than failing the stream.
+    expect(restored.ignorable).toBe(true);
+    expect(restored).not.toHaveProperty("visualization");
 
     requiredRun(agent, 0).resolve(successfulResult("Jinx wins."));
     expect(await finished).toBe("succeeded");

--- a/packages/scout-for-lol/packages/backend/src/explore/run-manager.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-manager.ts
@@ -32,6 +32,7 @@ import {
   waitForDurableExploreRun,
 } from "#src/explore/durable-runs.ts";
 import {
+  createActiveExploreRun,
   createDeferred,
   executeActiveExploreRun,
 } from "#src/explore/run-manager-helpers.ts";
@@ -212,6 +213,7 @@ export class ExploreRunManager {
         answer: run.answer.length === 0 ? null : run.answer,
         activity: run.activity,
         trace: run.trace,
+        preview: run.preview,
       }),
     );
     run.subscribers.add(subscriber);
@@ -294,23 +296,14 @@ export class ExploreRunManager {
         // Rehydrated runs do not own a new quota reservation.
       },
     };
-    const deferred = createDeferred();
-    const run: ActiveRun = {
+    const run = createActiveExploreRun({
       summary: input.summary,
       identity: input.identity,
       guildIds: input.guildIds,
       ticket,
       started: input.started,
       history: transcript.messages,
-      abortController: new AbortController(),
-      subscribers: new Set(),
-      answer: "",
-      activity: "Thinking…",
-      trace: [],
-      termination: null,
-      settled: deferred.promise,
-      resolveSettled: deferred.resolve,
-    };
+    });
     this.#runs.set(run.summary.runId, run);
     this.#conversationRuns.set(run.summary.conversationId, run.summary.runId);
   }

--- a/packages/scout-for-lol/packages/backend/src/explore/run-manager.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-manager.ts
@@ -1,6 +1,5 @@
 import {
   EXPLORE_TIMEOUT_MS,
-  ExploreRunSnapshotEventSchema,
   type DiscordAccountId,
   type ExploreActiveRun,
   type ExploreRunOutcome,
@@ -32,6 +31,7 @@ import {
   waitForDurableExploreRun,
 } from "#src/explore/durable-runs.ts";
 import {
+  attachEvents,
   createActiveExploreRun,
   createDeferred,
   executeActiveExploreRun,
@@ -206,16 +206,7 @@ export class ExploreRunManager {
     if (run?.identity.userId !== userId) {
       return null;
     }
-    subscriber(
-      ExploreRunSnapshotEventSchema.parse({
-        type: "snapshot",
-        ...run.summary,
-        answer: run.answer.length === 0 ? null : run.answer,
-        activity: run.activity,
-        trace: run.trace,
-        preview: run.preview,
-      }),
-    );
+    for (const event of attachEvents(run)) subscriber(event);
     run.subscribers.add(subscriber);
     return () => {
       run.subscribers.delete(subscriber);

--- a/packages/scout-for-lol/packages/data/src/model/explore.ts
+++ b/packages/scout-for-lol/packages/data/src/model/explore.ts
@@ -466,6 +466,21 @@ export const ExploreRunSnapshotEventSchema = z
     answer: z.string().max(EXPLORE_ANSWER_MAX_LENGTH).nullable(),
     activity: z.string().trim().min(1).max(500).nullable(),
     trace: z.array(ExploreTraceEntrySchema),
+    /**
+     * The most recent query result, so a reconnecting reader keeps the table
+     * a `preview` event already put on screen instead of watching it vanish
+     * until the turn finishes.
+     *
+     * Deliberately without the visualization that rides alongside it on the
+     * live `preview` event. A `VisualizationSnapshot` permits eight series
+     * totalling two thousand points, and the durable observer re-emits this
+     * whole snapshot on every poll tick that sees a change — roughly once a
+     * second for the rest of the turn. This summary is hard-bounded at 20
+     * columns by 22 rows, so it is a few KB either way. A reconnecting reader
+     * therefore gets the table back immediately and the chart at the next
+     * query or at `final`, whichever comes first.
+     */
+    preview: ReportAiPreviewSummarySchema.nullable().default(null),
   })
   .strict();
 

--- a/packages/scout-for-lol/packages/data/src/model/explore.ts
+++ b/packages/scout-for-lol/packages/data/src/model/explore.ts
@@ -466,26 +466,40 @@ export const ExploreRunSnapshotEventSchema = z
     answer: z.string().max(EXPLORE_ANSWER_MAX_LENGTH).nullable(),
     activity: z.string().trim().min(1).max(500).nullable(),
     trace: z.array(ExploreTraceEntrySchema),
-    /**
-     * The most recent query result, so a reconnecting reader keeps the table
-     * a `preview` event already put on screen instead of watching it vanish
-     * until the turn finishes.
-     *
-     * Deliberately without the visualization that rides alongside it on the
-     * live `preview` event. A `VisualizationSnapshot` permits eight series
-     * totalling two thousand points, and the durable observer re-emits this
-     * whole snapshot on every poll tick that sees a change — roughly once a
-     * second for the rest of the turn. This summary is hard-bounded at 20
-     * columns by 22 rows, so it is a few KB either way. A reconnecting reader
-     * therefore gets the table back immediately and the chart at the next
-     * query or at `final`, whichever comes first.
-     */
-    preview: ReportAiPreviewSummarySchema.nullable().default(null),
+  })
+  .strict();
+
+/**
+ * The newest query result, sent straight after a snapshot on reconnect.
+ *
+ * A separate member rather than a field on the snapshot, and this is a
+ * compatibility requirement rather than a preference. A browser keeps its
+ * bundle for as long as the tab stays open, and every bundle already shipped
+ * parses `ExploreRunSnapshotEventSchema` as `.strict()` — so an added key
+ * makes the snapshot itself unparseable there. The reader treats that as a
+ * corrupted stream and reconnects, receives the same rejected snapshot, and
+ * the turn stops updating for the rest of its life.
+ *
+ * Marked ignorable because it is: a client that skips it renders the table a
+ * beat later, when the next `preview` or `final` arrives, rather than
+ * rendering something wrong.
+ *
+ * Carries no visualization, matching the snapshot's own economy: a
+ * `VisualizationSnapshot` permits eight series totalling two thousand points
+ * and the durable observer re-sends this roughly once a second, while this
+ * summary is hard-bounded at 20 columns by 22 rows.
+ */
+export const ExploreRunPreviewEventSchema = z
+  .object({
+    type: z.literal("run_preview"),
+    preview: ReportAiPreviewSummarySchema.nullable(),
+    ignorable: z.literal(true).default(true),
   })
   .strict();
 
 export const ExploreStreamEventSchema = z.discriminatedUnion("type", [
   ExploreRunSnapshotEventSchema,
+  ExploreRunPreviewEventSchema,
   z
     .object({
       type: z.literal("started"),


### PR DESCRIPTION
## Why

The backend emits a `preview` event carrying the result table and chart the instant a query returns (`agent.ts`), and the client threw it away — `applyStreamEvent` folded `preview` into the same no-op branch as `done`. The reader watched a blank turn for seconds while the data sat in the browser already, and the table appeared only once the whole turn landed.

## What

- `ExplorePendingTurn` gains `preview` and `visualization`; the `preview` event folds into them and `final` hands over to the persisted message, so there is never a frame rendering the table twice.
- `ActiveRun` retains the newest preview, and an attaching observer receives it as a **separate `run_preview` event** sent straight after the snapshot — see below.
- **The streaming turn renders `ExploreVisualResult`** — the same component the persisted turn uses — so the two views cannot diverge.
- Both `ActiveRun` construction sites now go through `createActiveExploreRun`. They had already drifted into two copies of one literal, so adding a field meant remembering it twice, and rehydrated Temporal runs are exactly the path where forgetting is invisible.

## Integration with #2702

#2702 landed on `main` while this was open, replacing the assistant turn's result rendering with `ExploreVisualResult` (chart/table tabs, sortable columns, CSV export, follow-up chips).

That supersedes the small shared renderer this branch had extracted, so the extraction is gone. Instead `ExploreVisualResult` is **widened** to take `preview` and `visualization` rather than a whole `ExploreMessage` — it only ever read those two fields, so the change is narrow, and it is what lets the streaming turn use it.

That equivalence is the point: a turn shows its result twice, once mid-stream and once from the persisted message, and separate renderers would visibly reflow the table at the hand-off while leaving the streaming view without the tabs and export the finished view has.

## Why the result is beside the snapshot, not inside it

`ExploreRunSnapshotEventSchema` is `.strict()`, and every SPA bundle already open in a browser parses it that way. Adding a key makes the snapshot unparseable there: the reader calls that a corrupted stream, reconnects, receives the same rejected snapshot, and **the turn stops updating for the rest of its life.**

The tolerant parser in #2709 does not cover this — it forgives an unknown *member*, not a known member with an unexpected key. So no field can ever be added to that snapshot. `run_preview` is marked ignorable because it genuinely is: a client that skips it renders the table a beat later rather than rendering anything wrong.

Caught in review as a P1; it would have broken running turns on deploy.

## The chart deliberately does not survive a reconnect

A `VisualizationSnapshot` permits 8 series totalling 2000 points and the durable observer re-sends roughly once a second; the preview summary is bounded at 20 columns × 22 rows. So a snapshot clears **both** fields and the companion restores only the table — which also removes the last way an earlier query's chart could sit above newer numbers, since a chart takes precedence over a table.

## Verification

- `bunx turbo run typecheck test lint --filter='@scout-for-lol/*'` — 57/57.
- app 439 tests pass, including #2702's own `explore-visual-result.test.tsx` updated to the widened props.
- `run-manager.test.ts` asserts the snapshot is followed by a `run_preview` carrying `ignorable: true`, and that a run with no preview sends none.
- The backend reconnect test was confirmed to fail with the `run.preview` retention removed.
- **Not yet exercised against a live model.**
