### PR TITLE
feat(scout-for-lol): offer a way back to the latest Explore answer

### DIFF
--- a/packages/scout-for-lol/packages/app/src/hooks/use-pinned-scroll.ts
+++ b/packages/scout-for-lol/packages/app/src/hooks/use-pinned-scroll.ts
@@ -48,8 +48,16 @@ export function usePinnedScroll(): {
     // middle of a conversation both land here already scrolled away.
     measure();
     window.addEventListener("scroll", measure, { passive: true });
+    // Explore changes the document's height without necessarily scrolling it:
+    // switching from a long conversation to a short one reuses this component
+    // and leaves `scrollY` where it was, so no scroll event fires even though
+    // the whole page may now fit. Without this the pill would linger on a page
+    // that is already at its bottom.
+    const observer = new ResizeObserver(measure);
+    observer.observe(document.documentElement);
     return () => {
       window.removeEventListener("scroll", measure);
+      observer.disconnect();
     };
   }, []);
 
@@ -62,10 +70,19 @@ export function usePinnedScroll(): {
   }, []);
 
   const scrollToBottom = useCallback((): void => {
-    // Smooth here, unlike `scrollIfPinned`: this is one deliberate jump the
-    // reader asked for, not a per-token correction whose animation would
-    // restart on every delta.
-    bottomRef.current?.scrollIntoView({ block: "end", behavior: "smooth" });
+    // The document, not `bottomRef`. That anchor sits *above* the sticky
+    // composer, which is still in normal flow and carries the pill, the box
+    // and the page padding — so aligning it with the viewport can leave more
+    // than the 120px slack below, finishing the scroll still un-pinned with
+    // the pill still showing.
+    //
+    // Smooth here, unlike `scrollIfPinned`: one deliberate jump the reader
+    // asked for, not a per-token correction whose animation would restart on
+    // every delta.
+    window.scrollTo({
+      top: document.documentElement.scrollHeight,
+      behavior: "smooth",
+    });
   }, []);
 
   return { bottomRef, scrollIfPinned, pinned, scrollToBottom };

--- a/packages/scout-for-lol/packages/app/src/hooks/use-pinned-scroll.ts
+++ b/packages/scout-for-lol/packages/app/src/hooks/use-pinned-scroll.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, type RefObject } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
 import { isScrolledToBottom } from "#src/lib/pinned-scroll.ts";
 
 /**
@@ -8,15 +14,25 @@ import { isScrolledToBottom } from "#src/lib/pinned-scroll.ts";
  * columns with no overflow of their own — so pinning is measured against the
  * window. A reader who scrolls up to re-read is never yanked back down by the
  * next streamed token; scrolling back to the bottom re-pins.
+ *
+ * `pinned` is that same measurement as state, for the one thing not following
+ * the bottom needs: an offer to go back. Without it a reader who scrolled up
+ * mid-turn gets no signal that the answer moved on and no way back but the
+ * scrollbar. It is kept alongside the ref rather than replacing it because
+ * `scrollIfPinned` runs on every streamed token and must not wait on a
+ * re-render to know where the reader is.
  */
 export function usePinnedScroll(): {
   bottomRef: RefObject<HTMLDivElement | null>;
   scrollIfPinned: () => void;
+  pinned: boolean;
+  scrollToBottom: () => void;
 } {
   const bottomRef = useRef<HTMLDivElement | null>(null);
   // Optimistic only until the effect below measures; a reader who mounted
   // part-way up is un-pinned before anything can scroll them.
   const pinnedRef = useRef(true);
+  const [pinned, setPinned] = useState(true);
 
   useEffect(() => {
     const measure = (): void => {
@@ -25,6 +41,7 @@ export function usePinnedScroll(): {
         scrollY: window.scrollY,
         scrollHeight: document.documentElement.scrollHeight,
       });
+      setPinned(pinnedRef.current);
     };
     // Measure once on mount: the ref's initial value is a guess, and a scroll
     // event may never come. Browser scroll restoration and links into the
@@ -44,5 +61,12 @@ export function usePinnedScroll(): {
     }
   }, []);
 
-  return { bottomRef, scrollIfPinned };
+  const scrollToBottom = useCallback((): void => {
+    // Smooth here, unlike `scrollIfPinned`: this is one deliberate jump the
+    // reader asked for, not a per-token correction whose animation would
+    // restart on every delta.
+    bottomRef.current?.scrollIntoView({ block: "end", behavior: "smooth" });
+  }, []);
+
+  return { bottomRef, scrollIfPinned, pinned, scrollToBottom };
 }

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
@@ -90,6 +90,11 @@ export function createPendingTurn(input: {
 /**
  * Fold one stream event into the turn.
  *
+ * Status and timeline are separate concerns here: `activity` moves the status
+ * line and tool events build the step list. They used to be updated on
+ * adjacent lines of one branch, which is exactly where the generic trace
+ * string leaked onto the live status line.
+ *
  * `final` replaces the streamed prose with the persisted message's content —
  * the two can differ by whatever the last delta had not delivered yet, and
  * the persisted text is what the refetch will show. `error` is deliberately
@@ -130,12 +135,11 @@ export function applyStreamEvent(
         questionMessageId: event.questionMessageId,
       };
     }
+    case "activity": {
+      return { ...turn, activity: event.text };
+    }
     case "tool_call": {
-      return {
-        ...turn,
-        activity: event.message,
-        trace: applyTraceEvent(turn.trace, event),
-      };
+      return { ...turn, trace: applyTraceEvent(turn.trace, event) };
     }
     case "answer_delta": {
       return { ...turn, answer: (turn.answer ?? "") + event.text };
@@ -170,11 +174,7 @@ export function applyStreamEvent(
       return turn;
     }
     case "tool_result": {
-      return {
-        ...turn,
-        activity: event.message,
-        trace: applyTraceEvent(turn.trace, event),
-      };
+      return { ...turn, trace: applyTraceEvent(turn.trace, event) };
     }
   }
 }

--- a/packages/scout-for-lol/packages/app/src/routes/explore.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/explore.tsx
@@ -2,7 +2,7 @@ import { Loaded } from "@shepherdjerred/loaded";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useLocation, useNavigate } from "react-router";
-import { ChevronDown } from "lucide-react";
+import { ArrowDown, ChevronDown } from "lucide-react";
 import { Button } from "@scout-for-lol/design-system/components/button";
 import {
   Collapsible,
@@ -193,7 +193,8 @@ export function Explore() {
     visualization: pendingVisualization,
   } = visiblePending(pendingTurn, conversationId, messages);
 
-  const { bottomRef, scrollIfPinned } = usePinnedScroll();
+  const { bottomRef, scrollIfPinned, pinned, scrollToBottom } =
+    usePinnedScroll();
   useEffect(() => {
     scrollIfPinned();
   }, [
@@ -366,6 +367,22 @@ export function Explore() {
       {/* Pinned to the bottom of the viewport with a translucent gradient fade:
           allows chat text to remain visible below the composer through the fade effect. */}
       <div className="sticky bottom-0 w-full pointer-events-none pt-8 pb-4 bg-gradient-to-t from-scout-canvas/80 via-scout-canvas/30 via-40% to-transparent dark:from-black/75 dark:via-black/30 dark:via-40% dark:to-transparent">
+        {/* Only while the reader is away from the bottom, so the idle page is
+            unchanged and nothing overlaps the composer at rest. */}
+        {!pinned && (
+          <div className="pointer-events-auto mb-2 flex justify-center">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="rounded-full shadow-sm"
+              onClick={scrollToBottom}
+            >
+              <ArrowDown className="size-3.5" aria-hidden="true" />
+              Jump to latest
+            </Button>
+          </div>
+        )}
         <div className="pointer-events-auto">
           <ExploreComposer
             active={pendingTurn !== null}

--- a/packages/scout-for-lol/packages/app/src/routes/explore.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/explore.tsx
@@ -367,22 +367,7 @@ export function Explore() {
       {/* Pinned to the bottom of the viewport with a translucent gradient fade:
           allows chat text to remain visible below the composer through the fade effect. */}
       <div className="sticky bottom-0 w-full pointer-events-none pt-8 pb-4 bg-gradient-to-t from-scout-canvas/80 via-scout-canvas/30 via-40% to-transparent dark:from-black/75 dark:via-black/30 dark:via-40% dark:to-transparent">
-        {/* Only while the reader is away from the bottom, so the idle page is
-            unchanged and nothing overlaps the composer at rest. */}
-        {!pinned && (
-          <div className="pointer-events-auto mb-2 flex justify-center">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="rounded-full shadow-sm"
-              onClick={scrollToBottom}
-            >
-              <ArrowDown className="size-3.5" aria-hidden="true" />
-              Jump to latest
-            </Button>
-          </div>
-        )}
+        <ExploreJumpToLatest pinned={pinned} onClick={scrollToBottom} />
         <div className="pointer-events-auto">
           <ExploreComposer
             active={pendingTurn !== null}
@@ -402,6 +387,28 @@ export function Explore() {
 
 function errorText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Only while the reader is away from the bottom, so the idle page is
+ * unchanged and nothing overlaps the composer at rest.
+ */
+function ExploreJumpToLatest(props: { pinned: boolean; onClick: () => void }) {
+  if (props.pinned) return null;
+  return (
+    <div className="pointer-events-auto mb-2 flex justify-center">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="rounded-full shadow-sm"
+        onClick={props.onClick}
+      >
+        <ArrowDown className="size-3.5" aria-hidden="true" />
+        Jump to latest
+      </Button>
+    </div>
+  );
 }
 
 /**

--- a/packages/scout-for-lol/packages/backend/prisma/migrations/20260904000000_interactive_run_progress/migration.sql
+++ b/packages/scout-for-lol/packages/backend/prisma/migrations/20260904000000_interactive_run_progress/migration.sql
@@ -1,0 +1,12 @@
+-- The durable observer polls this row to reconstruct a run's progress for a
+-- client whose SSE request did not land on the process that owns the run.
+-- Without somewhere to mirror them, it had to fabricate the status line
+-- ("Thinking…") and could not restore the result table at all — so the same
+-- run showed different progress depending on which subscribe path won.
+--
+-- Both are nullable with no default, which is a metadata-only change in
+-- PostgreSQL 16: rows written before this migration simply fall back to the
+-- old fabricated values.
+ALTER TABLE "ScoutInteractiveRun"
+  ADD COLUMN "activity" TEXT,
+  ADD COLUMN "preview" TEXT;

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -2112,6 +2112,11 @@ model ScoutInteractiveRun {
   stopRequestedAt   DateTime?
   partialOutput     String?
   trace             String?
+  /// Mirrored live-run progress, so a durable observer that did not land on
+  /// the process owning the run shows the same status line and result table
+  /// as one that did. `preview` is JSON, matching `trace`.
+  activity          String?
+  preview           String?
   resultMessageId   String?
   outcome           String?
   lastError         String?

--- a/packages/scout-for-lol/packages/backend/src/explore/durable-runs.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/durable-runs.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+import { ReportAiPreviewSummarySchema } from "@scout-for-lol/data";
+import { exploreAttachEventsFromRow } from "#src/explore/durable-runs.ts";
+
+const SUMMARY = {
+  runId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  conversationId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+  questionMessageId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+  leafIdAtStart: null,
+  versionCountAtStart: 0,
+  startedAt: "2026-09-04T12:00:00.000Z",
+};
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    state: "RUNNING",
+    payload: JSON.stringify({ summary: SUMMARY }),
+    partialOutput: "Jinx",
+    trace: null,
+    activity: null,
+    preview: null,
+    ...overrides,
+  };
+}
+
+/**
+ * A client's SSE request does not necessarily reach the process that owns its
+ * run, so this path has to reconstruct progress from the row the Activity's
+ * heartbeat mirrors onto. Every field it cannot read is one it has to invent,
+ * and inventing them is what made the same run narrate itself differently
+ * depending on which subscribe path a request happened to land on.
+ */
+describe("explore durable snapshot", () => {
+  test("uses the mirrored status rather than a fabricated one", () => {
+    const [snapshot] = exploreAttachEventsFromRow(
+      row({ activity: "Scanned 1.3M rows, kept 84" }),
+    );
+    if (snapshot?.type !== "snapshot") throw new Error("expected a snapshot");
+    expect(snapshot.activity).toBe("Scanned 1.3M rows, kept 84");
+  });
+
+  test("restores a mirrored query result", () => {
+    const preview = ReportAiPreviewSummarySchema.parse({
+      columns: [{ key: "label", label: "Champion", format: "text" }],
+      rows: [{ label: "Jinx", values: [] }],
+      rowsReturned: 1,
+      rowsScanned: 1284,
+      renderKind: "TABLE",
+    });
+    const [snapshot, restored] = exploreAttachEventsFromRow(
+      row({ preview: JSON.stringify(preview) }),
+    );
+    // Beside the snapshot, never inside it — a bundle that predates the
+    // companion skips it instead of failing on an unparseable snapshot.
+    expect(snapshot?.type).toBe("snapshot");
+    if (restored?.type !== "run_preview") {
+      throw new Error("expected the preview to follow");
+    }
+    expect(restored.preview?.rowsScanned).toBe(1284);
+    expect(restored.ignorable).toBe(true);
+  });
+
+  test("falls back for a run that has not heartbeated yet", () => {
+    // Not the old behaviour returning: this covers the window before the
+    // first heartbeat, and rows written before these columns existed.
+    const [pending] = exploreAttachEventsFromRow(
+      row({ state: "PENDING", partialOutput: null }),
+    );
+    if (pending?.type !== "snapshot") throw new Error("expected a snapshot");
+    expect(pending.activity).toBe("Waiting to start…");
+    expect(pending.answer).toBeNull();
+
+    const running = exploreAttachEventsFromRow(row());
+    expect(running).toHaveLength(1);
+    if (running[0]?.type !== "snapshot") {
+      throw new Error("expected a snapshot");
+    }
+    expect(running[0].activity).toBe("Thinking…");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/durable-runs.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/durable-runs.ts
@@ -208,19 +208,9 @@ export async function subscribeDurableExploreRun(
     }
     lastPartial = row.partialOutput ?? "";
     lastTrace = row.trace ?? "[]";
-    subscriber(
-      ExploreRunSnapshotEventSchema.parse({
-        type: "snapshot",
-        ...parsed.summary,
-        answer: lastPartial.length === 0 ? null : lastPartial,
-        activity: row.state === "PENDING" ? "Waiting to start…" : "Thinking…",
-        trace,
-      }),
-    );
-    // No companion `run_preview` here: the run row has no column for it, so
-    // an observer that reached this path instead of the in-process one gets
-    // no table back until the next query or `final`. Stated rather than left
-    // implicit, so the gap is visible to whoever reads this next.
+    lastActivity = row.activity;
+    lastPreview = row.preview;
+    for (const event of exploreAttachEventsFromRow(row)) subscriber(event);
     return false;
   };
   if (emitRow(initial)) {

--- a/packages/scout-for-lol/packages/backend/src/explore/durable-runs.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/durable-runs.ts
@@ -2,8 +2,10 @@ import * as Sentry from "@sentry/bun";
 import { z } from "zod";
 import {
   ExploreActiveRunSchema,
+  ExploreRunPreviewEventSchema,
   ExploreRunSnapshotEventSchema,
   ExploreTraceEntrySchema,
+  ReportAiPreviewSummarySchema,
   type DiscordAccountId,
   type ExploreActiveRun,
   type ExploreRunOutcome,
@@ -132,6 +134,56 @@ function outcomeForStatus(status: string): ExploreRunOutcome {
   return "failed";
 }
 
+/**
+ * Rebuild a run's snapshot from the row a durable observer polls.
+ *
+ * Exported because this mapping is the whole of the durable path's fidelity:
+ * every field it cannot read is one it has to invent, and inventing
+ * `"Thinking…"` is exactly what made the same run narrate itself differently
+ * depending on which subscribe path a request happened to land on.
+ *
+ * The two fallbacks are not the old behaviour returning — they cover a run
+ * that has not heartbeated yet, and rows written before these columns
+ * existed.
+ */
+export function exploreAttachEventsFromRow(row: {
+  state: string;
+  payload: string;
+  partialOutput: string | null;
+  trace: string | null;
+  activity: string | null;
+  preview: string | null;
+}): ExploreStreamEvent[] {
+  const parsed = z
+    .object({ summary: ExploreActiveRunSchema })
+    .parse(JSON.parse(row.payload));
+  const answer = row.partialOutput ?? "";
+  const snapshot = ExploreRunSnapshotEventSchema.parse({
+    type: "snapshot",
+    ...parsed.summary,
+    answer: answer.length === 0 ? null : answer,
+    activity:
+      row.activity ??
+      (row.state === "PENDING" ? "Waiting to start…" : "Thinking…"),
+    trace: z
+      .array(ExploreTraceEntrySchema)
+      .parse(row.trace === null ? [] : JSON.parse(row.trace)),
+  });
+  if (row.preview === null) {
+    return [snapshot];
+  }
+  // Beside the snapshot, never inside it: every bundle already open in a
+  // browser parses the snapshot strictly, so an added key there makes the
+  // snapshot itself unparseable and the turn stops updating for that tab.
+  return [
+    snapshot,
+    ExploreRunPreviewEventSchema.parse({
+      type: "run_preview",
+      preview: ReportAiPreviewSummarySchema.parse(JSON.parse(row.preview)),
+    }),
+  ];
+}
+
 export async function subscribeDurableExploreRun(
   database: ExtendedPrismaClient,
   runId: string,
@@ -147,17 +199,13 @@ export async function subscribeDurableExploreRun(
   let reading = false;
   let lastPartial = "";
   let lastTrace = "[]";
+  let lastActivity: string | null = null;
+  let lastPreview: string | null = null;
   const emitRow = (row: typeof initial): boolean => {
     if (row.state !== "PENDING" && row.state !== "RUNNING") {
       subscriber({ type: "done", outcome: outcomeForStatus(row.state) });
       return true;
     }
-    const parsed = z
-      .object({ summary: ExploreActiveRunSchema })
-      .parse(JSON.parse(row.payload));
-    const trace = z
-      .array(ExploreTraceEntrySchema)
-      .parse(row.trace === null ? [] : JSON.parse(row.trace));
     lastPartial = row.partialOutput ?? "";
     lastTrace = row.trace ?? "[]";
     subscriber(
@@ -193,7 +241,12 @@ export async function subscribeDurableExploreRun(
         subscriber({ type: "done", outcome: outcomeForStatus(row.state) });
       } else if (
         (row.partialOutput ?? "") !== lastPartial ||
-        (row.trace ?? "[]") !== lastTrace
+        (row.trace ?? "[]") !== lastTrace ||
+        // Without these two the status line would freeze at whatever it said
+        // when the answer last grew — which, during a long query, is exactly
+        // when the reader is watching it.
+        row.activity !== lastActivity ||
+        row.preview !== lastPreview
       ) {
         emitRow(row);
       }

--- a/packages/scout-for-lol/packages/backend/src/explore/run-events.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-events.ts
@@ -36,8 +36,16 @@ export function recordExploreEvent(
     broadcastExploreEvent(run, { type: "answer_delta", text });
     return;
   }
-  if (event.type === "tool_call" || event.type === "tool_result") {
-    run.activity = event.message;
+  if (event.type === "activity") {
+    // The one thing that moves the status line. Tool events deliberately no
+    // longer set it: their `message` is the generic, share-safe string, and
+    // routing it here is what kept the live status as vague as the anonymous
+    // audience requires. An activity event is never folded into the trace —
+    // `recordExploreTraceEvent` matches only tool members — so the specific
+    // text it carries cannot reach a persisted message.
+    run.activity = event.text;
+    broadcastExploreEvent(run, event);
+    return;
   }
   if (event.type === "preview") {
     // Retained without its visualization: see the snapshot schema's comment

--- a/packages/scout-for-lol/packages/backend/src/explore/run-manager-types.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-manager-types.ts
@@ -32,6 +32,22 @@ export type StartedTurn = {
   createdQuestion: boolean;
 };
 
+/**
+ * The live progress a durable observer needs to reconstruct a run.
+ *
+ * Mirrored onto the run row by the Temporal Activity's heartbeat, because a
+ * client's SSE request does not necessarily reach the process that owns the
+ * run. Anything missing from this shape is something that observer has to
+ * invent — which is what used to make the same run show a real status line on
+ * one path and a fabricated "Thinking…" on the other.
+ */
+export type ExploreRunProgress = {
+  answer: string;
+  trace: ExploreTraceEntry[];
+  activity: string | null;
+  preview: ReportAiPreviewSummary | null;
+};
+
 export type ActiveRun = {
   summary: ExploreActiveRun;
   identity: ExploreRateLimitIdentity;

--- a/packages/scout-for-lol/packages/backend/src/explore/run-manager.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-manager.ts
@@ -3,7 +3,6 @@ import {
   type DiscordAccountId,
   type ExploreActiveRun,
   type ExploreRunOutcome,
-  type ExploreTraceEntry,
   type ExploreTurnRequest,
 } from "@scout-for-lol/data";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
@@ -40,6 +39,7 @@ import { startExploreRun } from "#src/explore/run-manager-start.ts";
 import type {
   ActiveRun,
   ExploreAgentRunner,
+  ExploreRunProgress,
   RunTermination,
   Subscriber,
   StartedTurn,
@@ -238,13 +238,16 @@ export class ExploreRunManager {
     return await requestDurableExploreStop(this.#client, runId, userId);
   }
 
-  snapshot(
-    runId: string,
-  ): { answer: string; trace: ExploreTraceEntry[] } | undefined {
+  snapshot(runId: string): ExploreRunProgress | undefined {
     const run = this.#runs.get(runId);
     return run === undefined
       ? undefined
-      : { answer: run.answer, trace: run.trace };
+      : {
+          answer: run.answer,
+          trace: run.trace,
+          activity: run.activity,
+          preview: run.preview,
+        };
   }
 
   cancelTemporal(runId: string, message: string): void {

--- a/packages/scout-for-lol/packages/backend/src/explore/stream.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/stream.test.ts
@@ -654,7 +654,12 @@ describe("explore live status versus persisted trace", () => {
     // Status text is decoration: it degrades to the generic phrase rather
     // than escalating, and it is emitted before the strict parse that throws.
     expect(events).toEqual([
-      { type: "activity", text: "Querying match data.", toolCallId: "call-1" },
+      {
+        type: "activity",
+        text: "Querying match data.",
+        toolCallId: "call-1",
+        ignorable: true,
+      },
     ]);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/explore/stream.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/stream.test.ts
@@ -663,3 +663,51 @@ describe("explore live status versus persisted trace", () => {
     ]);
   });
 });
+
+describe("explore status with overlapping tool calls", () => {
+  test("a finished tool does not claim the turn is done while another runs", async () => {
+    // A step can issue several tool calls at once. Announcing "Got results."
+    // as soon as the first one lands claims the turn finished work it had
+    // not, and overwrites the status describing the call still executing.
+    const { events } = await collect([
+      {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "run_report_query",
+        input: { queryText: "FROM match_participants SELECT games" },
+      },
+      {
+        type: "tool-call",
+        toolCallId: "call-2",
+        toolName: "run_report_query",
+        input: { queryText: "FROM player_groups SELECT games" },
+      },
+      {
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "run_report_query",
+        input: { queryText: "FROM match_participants SELECT games" },
+        output: {
+          ok: true,
+          message: "Returned 1 row.",
+          formattedQueryText: "FROM match_participants SELECT games",
+          preview: null,
+        },
+      },
+    ]);
+
+    // Two call narrations, and no result narration while call-2 is in flight.
+    const narrated = events.flatMap((event) =>
+      event.type === "activity" ? [event.text] : [],
+    );
+    expect(narrated).toEqual([
+      "Querying match participants",
+      "Querying player groups",
+    ]);
+
+    // The step itself still completes in the panel — only the status line waits.
+    expect(events.filter((event) => event.type === "tool_result")).toHaveLength(
+      1,
+    );
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/stream.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/stream.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { z } from "zod";
 import {
+  EXPLORE_ACTIVITY_MAX_LENGTH,
   EXPLORE_ANSWER_MAX_LENGTH,
   EXPLORE_TITLE_MAX_LENGTH,
   ExploreAnswerSchema,
@@ -159,7 +160,15 @@ describe("explore stream mapping", () => {
       { type: "text-delta", text: '{"answer":"Across' },
       { type: "text-delta", text: ' the bottom lane"' },
     ]);
-    expect(events).toHaveLength(0);
+    expect(events.filter((event) => event.type === "answer_delta")).toEqual([]);
+    // Their arrival is still information — with no tool in flight the first
+    // one is the moment the model started composing — but it is announced
+    // once per turn, not once per fragment.
+    expect(events.filter((event) => event.type === "activity")).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "activity",
+      text: "Writing the answer…",
+    });
   });
 
   test("tool activity still surfaces alongside the answer", async () => {
@@ -185,9 +194,15 @@ describe("explore stream mapping", () => {
       objectChunk("Jinx leads."),
     ]);
 
+    // This is the test that pins the bracket ordering: the call is narrated
+    // before the step appears, and the outcome only after the step has
+    // flipped to its final status, so the status line and the step panel can
+    // never disagree about what is happening.
     expect(events.map((event) => event.type)).toEqual([
+      "activity",
       "tool_call",
       "tool_result",
+      "activity",
       "answer_delta",
     ]);
   });
@@ -363,8 +378,7 @@ describe("explore raw tool payload inspection", () => {
       },
     ]);
 
-    expect(events).toHaveLength(1);
-    const [event] = events;
+    const [event, narration] = events;
     if (event?.type !== "tool_result") {
       throw new Error("expected a tool_result event");
     }
@@ -374,6 +388,19 @@ describe("explore raw tool payload inspection", () => {
     expect(event.message).not.toContain("xxxx");
     // The schema is what would have thrown, so parsing is the real assertion.
     expect(ExploreStreamEventSchema.parse(event)).toEqual(event);
+
+    // The status line is a second place the exception could have escaped to,
+    // and it has a tighter cap than the trace message, so it would fail the
+    // schema sooner rather than later.
+    if (narration?.type !== "activity") {
+      throw new Error("expected the failure to be narrated");
+    }
+    expect(narration.text.length).toBeLessThanOrEqual(
+      EXPLORE_ACTIVITY_MAX_LENGTH,
+    );
+    expect(narration.text).not.toContain("someInternalFrame");
+    expect(narration.text).not.toContain("xxxx");
+    expect(ExploreStreamEventSchema.parse(narration)).toEqual(narration);
   });
 
   test("drains both agent streams concurrently to completion", async () => {
@@ -442,5 +469,192 @@ describe("explore raw tool payload inspection", () => {
         createExploreStreamState(),
       ),
     ).rejects.toThrow(/upstream exploded/);
+  });
+});
+
+/**
+ * The live status line and the persisted trace are two channels with two
+ * audiences. A trace `message` is stored on the message and served
+ * unauthenticated to anyone holding a share link; an `activity` string is
+ * never stored and never shared. That asymmetry is what lets the status line
+ * be specific, and these tests are what keep the two from swapping places.
+ */
+function narrations(events: ExploreStreamEvent[]): string[] {
+  return events.flatMap((event) =>
+    event.type === "activity" ? [event.text] : [],
+  );
+}
+
+function traceMessages(events: ExploreStreamEvent[]): string[] {
+  return events.flatMap((event) =>
+    event.type === "tool_call" || event.type === "tool_result"
+      ? [event.message]
+      : [],
+  );
+}
+
+describe("explore live status versus persisted trace", () => {
+  test("the status line names the player while the trace stays anonymous", async () => {
+    const { events } = await collect([
+      {
+        type: "tool-input-start",
+        id: "call-1",
+        toolName: "resolve_player",
+      },
+      {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "resolve_player",
+        input: { query: "Jerred#NA1" },
+      },
+      {
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "resolve_player",
+        input: { query: "Jerred#NA1" },
+        output: { candidates: [{ displayName: "Jerred" }], message: "One." },
+      },
+    ]);
+
+    expect(narrations(events).join(" ")).toContain("Jerred#NA1");
+    // The pair of assertions below is the entire design in one place.
+    for (const message of traceMessages(events)) {
+      expect(message).not.toContain("Jerred");
+    }
+    expect(traceMessages(events)).toEqual([
+      "Looking up who that is.",
+      "Identified the player.",
+    ]);
+  });
+
+  test("no part of a query reaches the status line", async () => {
+    // The source name is looked up in the closed catalog and the catalog's own
+    // id is what gets emitted, so a query cannot smuggle text onto the wire
+    // through the table it names.
+    const queryText =
+      "FROM match_participants SELECT games WHERE player('secret-alias')";
+    const { events } = await collect([
+      {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "run_report_query",
+        input: { queryText },
+      },
+      {
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "run_report_query",
+        input: { queryText },
+        output: {
+          ok: true,
+          message: "Returned 84 rows.",
+          formattedQueryText: queryText,
+          preview: {
+            columns: [{ key: "label", label: "Player", format: "text" }],
+            rows: [{ label: "Jinx", values: [] }],
+            rowsReturned: 84,
+            rowsScanned: 1_284_000,
+            renderKind: "TABLE",
+          },
+        },
+      },
+    ]);
+
+    const text = narrations(events).join(" ");
+    expect(text).not.toContain("secret-alias");
+    expect(text).not.toContain("SELECT");
+    expect(text).not.toContain("WHERE");
+    // The high-information half comes from numbers the engine computed.
+    expect(text).toContain("Querying match participants");
+    expect(text).toContain("Scanned 1.3M rows, kept 84");
+  });
+
+  test("an unknown source falls back to the generic phrase", async () => {
+    const { events } = await collect([
+      {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "run_report_query",
+        input: { queryText: "FROM notasource SELECT x" },
+      },
+    ]);
+    const text = narrations(events).join(" ");
+    expect(text).not.toContain("notasource");
+    expect(text).toBe("Querying match data.");
+  });
+
+  test("tool-input-start narrates early without starting the duration clock", async () => {
+    let now = 1000;
+    const state = createExploreStreamState(() => now);
+    const events: ExploreStreamEvent[] = [];
+    const push = (event: ExploreStreamEvent) => {
+      events.push(event);
+    };
+    await emitExploreStreamChunk(
+      { type: "tool-input-start", id: "call-1", toolName: "run_report_query" },
+      push,
+      state,
+    );
+    // Only a status line so far — no step exists until its arguments do.
+    expect(events.map((event) => event.type)).toEqual(["activity"]);
+
+    now = 2000;
+    await emitExploreStreamChunk(
+      {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "run_report_query",
+        input: { queryText: "FROM match_participants SELECT games" },
+      },
+      push,
+      state,
+    );
+    now = 2275;
+    await emitExploreStreamChunk(
+      {
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "run_report_query",
+        input: { queryText: "FROM match_participants SELECT games" },
+        output: {
+          ok: true,
+          message: "Returned 1 row.",
+          formattedQueryText: "FROM match_participants SELECT games",
+          preview: null,
+        },
+      },
+      push,
+      state,
+    );
+
+    // 275ms, not 1275: the clock starts when the tool runs, not when the
+    // model began writing its arguments. Timing it from input-start would
+    // silently redefine what the trace's `durationMs` means.
+    const result = events.find((event) => event.type === "tool_result");
+    expect(result?.durationMs).toBe(275);
+  });
+
+  test("a malformed tool input still narrates before the inspection throws", async () => {
+    const state = createExploreStreamState();
+    const events: ExploreStreamEvent[] = [];
+    await expect(
+      emitExploreStreamChunk(
+        {
+          type: "tool-call",
+          toolCallId: "call-1",
+          toolName: "run_report_query",
+          input: { queryText: 42 },
+        },
+        (event) => {
+          events.push(event);
+        },
+        state,
+      ),
+    ).rejects.toThrow();
+    // Status text is decoration: it degrades to the generic phrase rather
+    // than escalating, and it is emitted before the strict parse that throws.
+    expect(events).toEqual([
+      { type: "activity", text: "Querying match data.", toolCallId: "call-1" },
+    ]);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/explore/stream.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/stream.ts
@@ -12,6 +12,11 @@ import {
   inspectExploreToolCall,
   inspectExploreToolResult,
 } from "#src/explore/tool-inspection.ts";
+import {
+  toolCallActivity,
+  toolResultActivity,
+  toolStartActivity,
+} from "#src/explore/tool-activity.ts";
 
 const logger = createLogger("explore-stream");
 type JsonValue = z.infer<ReturnType<typeof z.json>>;
@@ -27,6 +32,8 @@ export type ExploreStreamState = {
   sentAnswerLength: number;
   rawTraceBytes: number;
   toolStartedAt: Map<string, number>;
+  /** "Writing the answer…" is announced once per turn, not once per chunk. */
+  answerNarrated: boolean;
   now: () => number;
 };
 
@@ -37,6 +44,7 @@ export function createExploreStreamState(
     sentAnswerLength: 0,
     rawTraceBytes: 0,
     toolStartedAt: new Map(),
+    answerNarrated: false,
     now,
   };
 }
@@ -117,15 +125,56 @@ export async function emitExploreStreamChunk(
       // "started a step" line adds noise to a chat transcript.
       break;
     }
+    case "tool-input-start": {
+      // The provider has named a tool but not finished its arguments. Only
+      // the generic phrase is knowable here; the argument-derived one
+      // replaces it a beat later at `tool-call`. Deliberately does not touch
+      // `state.toolStartedAt` — starting the clock here would redefine the
+      // trace's `durationMs` from execution time to argument generation plus
+      // execution.
+      await emit({
+        type: "activity",
+        text: toolStartActivity(toolCallMessage(chunk.toolName)),
+        toolCallId: chunk.toolCallId,
+      });
+      break;
+    }
     case "text-delta": {
-      // Deliberately ignored. This agent runs with structured output, so a
-      // text delta is a fragment of the raw JSON the model is emitting —
-      // relaying it would stream `{"answer":"Across the botto…` into the
-      // page. The prose arrives as snapshots on the AI SDK's separate
-      // `partialOutputStream`, handled by emitExploreAnswerSnapshot.
+      // The text itself is deliberately ignored. This agent runs with
+      // structured output, so a text delta is a fragment of the raw JSON the
+      // model is emitting — relaying it would stream `{"answer":"Across the
+      // botto…` into the page. The prose arrives as snapshots on the AI SDK's
+      // separate `partialOutputStream`, handled by emitExploreAnswerSnapshot.
+      //
+      // Its *arrival* is still information: by construction the first one is
+      // the moment the model stopped calling tools and started composing, so
+      // it is what turns the status line over to "Writing the answer…". The
+      // in-flight guard covers a provider that interleaves a JSON token
+      // before its first tool result, which would otherwise flash the wrong
+      // status over a tool that is still running.
+      if (!state.answerNarrated && state.toolStartedAt.size === 0) {
+        state.answerNarrated = true;
+        await emit({
+          type: "activity",
+          text: "Writing the answer…",
+          toolCallId: null,
+        });
+      }
       break;
     }
     case "tool-call": {
+      // Emitted before `inspectExploreToolCall`, which parses strictly and can
+      // throw: a malformed input should still have narrated, and the throw
+      // behaviour is unchanged.
+      await emit({
+        type: "activity",
+        text: toolCallActivity(
+          chunk.toolName,
+          chunk.input,
+          toolCallMessage(chunk.toolName),
+        ),
+        toolCallId: chunk.toolCallId,
+      });
       const inspection = inspectExploreToolCall(chunk.toolName, chunk.input);
       state.toolStartedAt.set(chunk.toolCallId, state.now());
       await emit({
@@ -154,6 +203,18 @@ export async function emitExploreStreamChunk(
         details: inspection.details,
         rawOutput: boundedRawValue(inspection.rawOutput, state),
       });
+      // After the tool_result, so the step in the panel has already flipped to
+      // its final status by the time the status line describes the outcome.
+      await emit({
+        type: "activity",
+        text: toolResultActivity(
+          chunk.toolName,
+          chunk.input,
+          inspection,
+          toolResultMessage(chunk.toolName, inspection.succeeded),
+        ),
+        toolCallId: chunk.toolCallId,
+      });
       break;
     }
     case "tool-error": {
@@ -175,6 +236,11 @@ export async function emitExploreStreamChunk(
         durationMs: finishToolDuration(chunk.toolCallId, state),
         details: inspectExploreToolCall(chunk.toolName, chunk.input).details,
         rawOutput: null,
+      });
+      await emit({
+        type: "activity",
+        text: toolResultMessage(chunk.toolName, false),
+        toolCallId: chunk.toolCallId,
       });
       break;
     }

--- a/packages/scout-for-lol/packages/backend/src/explore/stream.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/stream.ts
@@ -217,18 +217,24 @@ export async function emitExploreStreamChunk(
         rawOutput: boundedRawValue(inspection.rawOutput, state),
       });
       // After the tool_result, so the step in the panel has already flipped to
-      // its final status by the time the status line describes the outcome.
-      await emit(
-        activityEvent(
-          toolResultActivity(
-            chunk.toolName,
-            chunk.input,
-            inspection,
-            toolResultMessage(chunk.toolName, inspection.succeeded),
+      // its final status by the time the status line describes the outcome —
+      // and only when nothing else is still running. A step can issue several
+      // tool calls at once, and announcing "Got results." while a second query
+      // is still executing would claim the turn had finished work it had not.
+      // The still-running call keeps the line until it too completes.
+      if (state.toolStartedAt.size === 0) {
+        await emit(
+          activityEvent(
+            toolResultActivity(
+              chunk.toolName,
+              chunk.input,
+              inspection,
+              toolResultMessage(chunk.toolName, inspection.succeeded),
+            ),
+            chunk.toolCallId,
           ),
-          chunk.toolCallId,
-        ),
-      );
+        );
+      }
       break;
     }
     case "tool-error": {
@@ -251,12 +257,14 @@ export async function emitExploreStreamChunk(
         details: inspectExploreToolCall(chunk.toolName, chunk.input).details,
         rawOutput: null,
       });
-      await emit(
-        activityEvent(
-          toolResultMessage(chunk.toolName, false),
-          chunk.toolCallId,
-        ),
-      );
+      if (state.toolStartedAt.size === 0) {
+        await emit(
+          activityEvent(
+            toolResultMessage(chunk.toolName, false),
+            chunk.toolCallId,
+          ),
+        );
+      }
       break;
     }
   }

--- a/packages/scout-for-lol/packages/backend/src/explore/stream.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/stream.ts
@@ -37,6 +37,21 @@ export type ExploreStreamState = {
   now: () => number;
 };
 
+/**
+ * Build the ephemeral status event.
+ *
+ * Exists so `ignorable` is set in one place: the marker is what lets a client
+ * too old to know this member drop it instead of treating the stream as
+ * corrupt, and an emit site that forgot it would fail that client at runtime
+ * rather than here.
+ */
+function activityEvent(
+  text: string,
+  toolCallId: string | null,
+): ExploreStreamEvent {
+  return { type: "activity", text, toolCallId, ignorable: true };
+}
+
 export function createExploreStreamState(
   now: () => number = Date.now,
 ): ExploreStreamState {
@@ -132,11 +147,12 @@ export async function emitExploreStreamChunk(
       // `state.toolStartedAt` — starting the clock here would redefine the
       // trace's `durationMs` from execution time to argument generation plus
       // execution.
-      await emit({
-        type: "activity",
-        text: toolStartActivity(toolCallMessage(chunk.toolName)),
-        toolCallId: chunk.toolCallId,
-      });
+      await emit(
+        activityEvent(
+          toolStartActivity(toolCallMessage(chunk.toolName)),
+          chunk.toolCallId,
+        ),
+      );
       break;
     }
     case "text-delta": {
@@ -154,11 +170,7 @@ export async function emitExploreStreamChunk(
       // status over a tool that is still running.
       if (!state.answerNarrated && state.toolStartedAt.size === 0) {
         state.answerNarrated = true;
-        await emit({
-          type: "activity",
-          text: "Writing the answer…",
-          toolCallId: null,
-        });
+        await emit(activityEvent("Writing the answer…", null));
       }
       break;
     }
@@ -166,15 +178,16 @@ export async function emitExploreStreamChunk(
       // Emitted before `inspectExploreToolCall`, which parses strictly and can
       // throw: a malformed input should still have narrated, and the throw
       // behaviour is unchanged.
-      await emit({
-        type: "activity",
-        text: toolCallActivity(
-          chunk.toolName,
-          chunk.input,
-          toolCallMessage(chunk.toolName),
+      await emit(
+        activityEvent(
+          toolCallActivity(
+            chunk.toolName,
+            chunk.input,
+            toolCallMessage(chunk.toolName),
+          ),
+          chunk.toolCallId,
         ),
-        toolCallId: chunk.toolCallId,
-      });
+      );
       const inspection = inspectExploreToolCall(chunk.toolName, chunk.input);
       state.toolStartedAt.set(chunk.toolCallId, state.now());
       await emit({
@@ -205,16 +218,17 @@ export async function emitExploreStreamChunk(
       });
       // After the tool_result, so the step in the panel has already flipped to
       // its final status by the time the status line describes the outcome.
-      await emit({
-        type: "activity",
-        text: toolResultActivity(
-          chunk.toolName,
-          chunk.input,
-          inspection,
-          toolResultMessage(chunk.toolName, inspection.succeeded),
+      await emit(
+        activityEvent(
+          toolResultActivity(
+            chunk.toolName,
+            chunk.input,
+            inspection,
+            toolResultMessage(chunk.toolName, inspection.succeeded),
+          ),
+          chunk.toolCallId,
         ),
-        toolCallId: chunk.toolCallId,
-      });
+      );
       break;
     }
     case "tool-error": {
@@ -237,11 +251,12 @@ export async function emitExploreStreamChunk(
         details: inspectExploreToolCall(chunk.toolName, chunk.input).details,
         rawOutput: null,
       });
-      await emit({
-        type: "activity",
-        text: toolResultMessage(chunk.toolName, false),
-        toolCallId: chunk.toolCallId,
-      });
+      await emit(
+        activityEvent(
+          toolResultMessage(chunk.toolName, false),
+          chunk.toolCallId,
+        ),
+      );
       break;
     }
   }

--- a/packages/scout-for-lol/packages/backend/src/explore/tool-activity.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/tool-activity.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "vitest";
+import { EXPLORE_ACTIVITY_MAX_LENGTH } from "@scout-for-lol/data";
+import {
+  toolCallActivity,
+  toolResultActivity,
+  toolStartActivity,
+} from "#src/explore/tool-activity.ts";
+import type { ExploreToolResultInspection } from "#src/explore/tool-inspection.ts";
+
+/**
+ * Every tool whose calls can reach the status line. The generic phrase each
+ * one falls back to is supplied by `stream.ts`; what matters here is that no
+ * input shape can make these functions throw, return nothing, or overrun the
+ * cap — all three of which fail at the SSE boundary by silently detaching the
+ * reader's browser rather than by raising anything visible.
+ */
+const TOOL_NAMES = [
+  "get_report_language",
+  "validate_report_query",
+  "format_report_query",
+  "run_report_query",
+  "resolve_player",
+  "get_bucks_dataset",
+  "query_bucks_accounts",
+  "query_bucks_ledger",
+  "query_bucks_bets",
+  "get_dare_language",
+  "validate_dare_contract",
+  "validate_dare_scoutql",
+  "preview_dare_contract",
+  "create_dare_draft",
+  "revise_dare_draft",
+  "list_dares",
+  "inspect_dare",
+  "prepare_dare_action",
+  "delete_dare_draft",
+  "a_tool_that_does_not_exist",
+];
+
+const HOSTILE_INPUTS: unknown[] = [
+  undefined,
+  null,
+  {},
+  [],
+  42,
+  "a string",
+  { queryText: 42 },
+  { query: { nested: true } },
+  { queryText: "" },
+  { query: "x".repeat(500) },
+];
+
+function inspection(
+  overrides: Partial<ExploreToolResultInspection> = {},
+): ExploreToolResultInspection {
+  return { succeeded: true, details: null, rawOutput: null, ...overrides };
+}
+
+describe("explore tool activity", () => {
+  test("never throws and never returns an unusable string", () => {
+    for (const toolName of TOOL_NAMES) {
+      for (const input of HOSTILE_INPUTS) {
+        const call = toolCallActivity(toolName, input, "Working.");
+        const result = toolResultActivity(
+          toolName,
+          input,
+          inspection({ rawOutput: null }),
+          "Done.",
+        );
+        for (const text of [call, result, toolStartActivity("Working.")]) {
+          expect(text.length).toBeGreaterThan(0);
+          expect(text.length).toBeLessThanOrEqual(EXPLORE_ACTIVITY_MAX_LENGTH);
+          expect(text.trim()).toBe(text);
+        }
+      }
+    }
+  });
+
+  test("clamps a long player query rather than overrunning the cap", () => {
+    // The only user-influenced substring anywhere on this channel. Its own
+    // input schema caps it at 100, but the cap here must hold regardless.
+    const text = toolCallActivity(
+      "resolve_player",
+      { query: "y".repeat(400) },
+      "Looking up who that is.",
+    );
+    expect(text.length).toBeLessThanOrEqual(EXPLORE_ACTIVITY_MAX_LENGTH);
+    expect(text.endsWith("…")).toBe(true);
+  });
+
+  test("falls back rather than echoing an unknown source name", () => {
+    const text = toolCallActivity(
+      "run_report_query",
+      { queryText: "FROM notasource SELECT x" },
+      "Querying match data.",
+    );
+    expect(text).toBe("Querying match data.");
+    expect(text).not.toContain("notasource");
+  });
+
+  test("reports row counts compactly", () => {
+    const text = toolResultActivity(
+      "run_report_query",
+      { queryText: "FROM match_participants SELECT games" },
+      inspection({
+        details: {
+          kind: "execution",
+          queryText: "FROM match_participants SELECT games",
+          ok: true,
+          rowsReturned: 84,
+          rowsScanned: 1_284_000,
+          renderKind: "TABLE",
+        },
+      }),
+      "Got results.",
+    );
+    expect(text).toBe("Scanned 1.3M rows, kept 84");
+  });
+
+  test("says so when a query matched nothing", () => {
+    const text = toolResultActivity(
+      "run_report_query",
+      { queryText: "FROM match_participants SELECT games" },
+      inspection({
+        details: {
+          kind: "execution",
+          queryText: "FROM match_participants SELECT games",
+          ok: true,
+          rowsReturned: 0,
+          rowsScanned: 4207,
+          renderKind: "TABLE",
+        },
+      }),
+      "Got results.",
+    );
+    expect(text).toBe("Scanned 4,207 rows, none matched");
+  });
+
+  test("keeps the generic phrase for a failed tool", () => {
+    const text = toolResultActivity(
+      "run_report_query",
+      { queryText: "FROM match_participants SELECT games" },
+      inspection({ succeeded: false }),
+      "run_report_query returned an error.",
+    );
+    expect(text).toBe("run_report_query returned an error.");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/tool-activity.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/tool-activity.test.ts
@@ -146,3 +146,46 @@ describe("explore tool activity", () => {
     expect(text).toBe("run_report_query returned an error.");
   });
 });
+
+describe("naming a query's source", () => {
+  test("ignores a FROM inside a comment or a string literal", () => {
+    // The status line would otherwise name a table the query never reads.
+    // Blanking comments and literals first is cheap; the real parser is the
+    // full grammar on a hot stream path and its diagnostics carry the query's
+    // own text, which is what must not reach this channel.
+    expect(
+      toolCallActivity(
+        "run_report_query",
+        {
+          queryText:
+            "-- from match_participants\nFROM player_groups SELECT games",
+        },
+        "Querying match data.",
+      ),
+    ).toBe("Querying player groups");
+
+    expect(
+      toolCallActivity(
+        "run_report_query",
+        {
+          queryText:
+            "FROM player_groups SELECT games WHERE alias = 'from match_participants'",
+        },
+        "Querying match data.",
+      ),
+    ).toBe("Querying player groups");
+  });
+
+  test("a block comment before the source does not win", () => {
+    expect(
+      toolCallActivity(
+        "run_report_query",
+        {
+          queryText:
+            "/* from rank_current */ FROM match_participants SELECT games",
+        },
+        "Querying match data.",
+      ),
+    ).toBe("Querying match participants");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/tool-activity.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/tool-activity.ts
@@ -57,6 +57,26 @@ function compactCount(value: number): string {
 }
 
 /**
+ * Blank out comments and string literals so a `FROM` inside one cannot be
+ * mistaken for the query's actual source clause.
+ *
+ * `-- from match_participants` above `SELECT … FROM player_groups` would
+ * otherwise narrate the wrong table. Characters are replaced with spaces
+ * rather than removed so nothing downstream depends on offsets shifting.
+ *
+ * Deliberately not the real parser: `parseScoutQl` is the full grammar on a
+ * hot stream path, its diagnostics carry the query's own text, and a
+ * summariser built on the AST would drift with every grammar change. This
+ * needs to find one identifier, and being wrong costs a generic phrase.
+ */
+function withoutCommentsAndStrings(queryText: string): string {
+  return queryText.replaceAll(
+    /--[^\n]*|\/\*[\s\S]*?(?:\*\/|$)|'(?:[^']|'')*'?|"(?:[^"]|"")*"?/gu,
+    (match) => " ".repeat(match.length),
+  );
+}
+
+/**
  * Name the table a query reads without echoing any of the query.
  *
  * The token found after `FROM` is used only to *look up* an entry in the
@@ -66,7 +86,7 @@ function compactCount(value: number): string {
  * unrecognised token simply yields the generic phrase.
  */
 function querySourceLabel(queryText: string): string | null {
-  const match = /\bfrom\s+(\w+)/iu.exec(queryText);
+  const match = /\bfrom\s+(\w+)/iu.exec(withoutCommentsAndStrings(queryText));
   const token = match?.[1];
   if (token === undefined) {
     return null;

--- a/packages/scout-for-lol/packages/backend/src/explore/tool-activity.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/tool-activity.ts
@@ -1,0 +1,195 @@
+import { z } from "zod";
+import { EXPLORE_ACTIVITY_MAX_LENGTH } from "@scout-for-lol/data";
+import { scoutQlSourceCatalog } from "@scout-for-lol/data/model/scoutql/catalog-columns.ts";
+import type { ExploreToolResultInspection } from "#src/explore/tool-inspection.ts";
+
+/**
+ * The owner-only live status strings.
+ *
+ * **Nothing in this file may be returned from `toolCallMessage` /
+ * `toolResultMessage` in `stream.ts`, or assigned to any `ExploreTraceEntry`
+ * field.** Those strings are persisted into a message's trace and served
+ * unauthenticated to anyone holding a share link, which is why they are as
+ * vague as they are. The strings here travel only on the ephemeral `activity`
+ * event, which is never stored and never shared, so they may name the player
+ * being looked up or the number of rows a query scanned.
+ *
+ * That separation is the whole point of this module existing rather than these
+ * functions living next to their generic counterparts, where a copy-paste
+ * between the two would look unremarkable in review.
+ *
+ * Three invariants, each with a test:
+ *
+ * - **Never throws.** Every read of tool input or output is a `safeParse` with
+ *   a fallback to the generic phrase. `inspectExploreToolCall` uses `.parse`
+ *   and a throw there ends the turn; status text is decoration and must
+ *   degrade, never escalate.
+ * - **Never returns an empty string.** The wire schema requires `min(1)`, and
+ *   the SSE writer validates each frame inside the subscriber callback that
+ *   broadcast wraps in a `try`/`catch` which drops the subscriber — so an
+ *   empty string does not error visibly, it silently detaches that browser.
+ * - **Always clamped** to `EXPLORE_ACTIVITY_MAX_LENGTH`, for the same reason.
+ */
+
+/** Collapse whitespace and bound the length, always returning something. */
+function clampActivity(text: string, fallback: string): string {
+  const collapsed = text.replaceAll(/\s+/gu, " ").trim();
+  if (collapsed.length === 0) {
+    return fallback;
+  }
+  return collapsed.length <= EXPLORE_ACTIVITY_MAX_LENGTH
+    ? collapsed
+    : `${collapsed.slice(0, EXPLORE_ACTIVITY_MAX_LENGTH - 1)}…`;
+}
+
+/** Readable at a glance: exact below ten thousand, compact above. */
+function compactCount(value: number): string {
+  if (!Number.isFinite(value) || value < 0) {
+    return "0";
+  }
+  const whole = Math.floor(value);
+  return whole < 10_000
+    ? whole.toLocaleString("en-US")
+    : new Intl.NumberFormat("en-US", {
+        notation: "compact",
+        maximumFractionDigits: 1,
+      }).format(whole);
+}
+
+/**
+ * Name the table a query reads without echoing any of the query.
+ *
+ * The token found after `FROM` is used only to *look up* an entry in the
+ * closed source catalog, and it is the catalog's own id that gets emitted —
+ * never the text from the query. So no substring the model authored can reach
+ * the status line, and there is nothing here that could need truncating. An
+ * unrecognised token simply yields the generic phrase.
+ */
+function querySourceLabel(queryText: string): string | null {
+  const match = /\bfrom\s+(\w+)/iu.exec(queryText);
+  const token = match?.[1];
+  if (token === undefined) {
+    return null;
+  }
+  const catalog = scoutQlSourceCatalog(token.toLowerCase());
+  return catalog === undefined ? null : catalog.id.replaceAll("_", " ");
+}
+
+const QueryInputSchema = z.looseObject({ queryText: z.string() });
+const PlayerQueryInputSchema = z.looseObject({ query: z.string() });
+const PlayerResultSchema = z.looseObject({
+  candidates: z.array(z.unknown()),
+});
+const ExecutionResultSchema = z.looseObject({
+  rowsReturned: z.number().nullable(),
+  rowsScanned: z.number().nullable(),
+});
+
+/**
+ * The moment the model names a tool, before its arguments have arrived.
+ *
+ * Nothing but the tool name is known yet, so this is exactly the generic
+ * phrase — it simply lands a beat earlier than it used to. The
+ * argument-derived phrase replaces it at `tool-call`.
+ */
+export function toolStartActivity(genericMessage: string): string {
+  return clampActivity(genericMessage, "Working…");
+}
+
+/** What the turn is about to do, given the arguments it will do it with. */
+export function toolCallActivity(
+  toolName: string,
+  input: unknown,
+  genericMessage: string,
+): string {
+  const fallback = clampActivity(genericMessage, "Working…");
+  if (toolName === "resolve_player") {
+    const parsed = PlayerQueryInputSchema.safeParse(input);
+    return parsed.success
+      ? clampActivity(`Finding “${parsed.data.query}”`, fallback)
+      : fallback;
+  }
+  if (toolName === "run_report_query" || toolName === "validate_report_query") {
+    const parsed = QueryInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return fallback;
+    }
+    const source = querySourceLabel(parsed.data.queryText);
+    if (source === null) {
+      return fallback;
+    }
+    return clampActivity(
+      toolName === "run_report_query"
+        ? `Querying ${source}`
+        : `Checking a query over ${source}`,
+      fallback,
+    );
+  }
+  return fallback;
+}
+
+function playerResultActivity(
+  input: unknown,
+  inspection: ExploreToolResultInspection,
+  fallback: string,
+): string {
+  // `inspectExploreToolResult` has no branch for this tool, so its output is
+  // read here rather than taken from the inspection.
+  const query = PlayerQueryInputSchema.safeParse(input);
+  const result = PlayerResultSchema.safeParse(inspection.rawOutput);
+  if (!query.success || !result.success) {
+    return fallback;
+  }
+  const count = result.data.candidates.length;
+  const plural = count === 1 ? "" : "es";
+  return clampActivity(
+    count === 0
+      ? `No player matches “${query.data.query}”`
+      : `Found ${compactCount(count)} match${plural} for “${query.data.query}”`,
+    fallback,
+  );
+}
+
+function queryResultActivity(
+  inspection: ExploreToolResultInspection,
+  fallback: string,
+): string {
+  // Numbers and nothing else: `rowsScanned` and `rowsReturned` are computed by
+  // the query engine, so this is the high-information half of the status line
+  // with none of the risk of echoing query text.
+  const details = inspection.details;
+  if (details?.kind !== "execution") {
+    return fallback;
+  }
+  const parsed = ExecutionResultSchema.safeParse(details);
+  if (!parsed.success || parsed.data.rowsScanned === null) {
+    return fallback;
+  }
+  const { rowsScanned, rowsReturned } = parsed.data;
+  return clampActivity(
+    rowsReturned === null || rowsReturned === 0
+      ? `Scanned ${compactCount(rowsScanned)} rows, none matched`
+      : `Scanned ${compactCount(rowsScanned)} rows, kept ${compactCount(rowsReturned)}`,
+    fallback,
+  );
+}
+
+/** What the turn just learned, in numbers the engine already computed. */
+export function toolResultActivity(
+  toolName: string,
+  input: unknown,
+  inspection: ExploreToolResultInspection,
+  genericMessage: string,
+): string {
+  const fallback = clampActivity(genericMessage, "Done.");
+  if (!inspection.succeeded) {
+    return fallback;
+  }
+  if (toolName === "resolve_player") {
+    return playerResultActivity(input, inspection, fallback);
+  }
+  if (toolName === "run_report_query") {
+    return queryResultActivity(inspection, fallback);
+  }
+  return fallback;
+}

--- a/packages/scout-for-lol/packages/backend/src/explore/trace.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/trace.test.ts
@@ -160,3 +160,81 @@ describe("Explore trace recording", () => {
     expect(encoded).toContain("Created the draft.");
   });
 });
+
+describe("the activity channel cannot reach a persisted trace", () => {
+  test("an activity event is not recorded as a step", () => {
+    // Structural, not editorial: `recordExploreTraceEvent` matches only tool
+    // members and `ExploreTraceEntrySchema` is `.strict()` with no such
+    // field, so the specific text on this channel could not enter the trace
+    // even if a caller tried to put it there.
+    const trace: ExploreTraceEntry[] = [];
+    recordExploreTraceEvent(trace, {
+      type: "activity",
+      text: "Finding “Jerred#NA1”",
+      toolCallId: "call-1",
+    });
+    expect(trace).toEqual([]);
+  });
+
+  test("a shared transcript carries no trace of the specific status text", () => {
+    const trace: ExploreTraceEntry[] = [];
+    for (const event of [
+      {
+        type: "activity" as const,
+        text: "Finding “Jerred#NA1”",
+        toolCallId: "call-1",
+      },
+      {
+        type: "tool_call" as const,
+        toolCallId: "call-1",
+        toolName: "resolve_player",
+        message: "Looking up who that is.",
+        details: null,
+        rawInput: null,
+      },
+      {
+        type: "activity" as const,
+        text: "Found 1 match for “Jerred#NA1”",
+        toolCallId: "call-1",
+      },
+      {
+        type: "tool_result" as const,
+        toolCallId: "call-1",
+        toolName: "resolve_player",
+        status: "succeeded" as const,
+        message: "Identified the player.",
+        durationMs: 12,
+        details: null,
+        rawOutput: null,
+      },
+    ]) {
+      recordExploreTraceEvent(trace, event);
+    }
+
+    const encoded = JSON.stringify(
+      redactSharedExploreTranscript(
+        ExploreTranscriptSchema.parse({
+          conversation: {
+            id: "11111111-1111-4111-8111-111111111111",
+            title: "Who is that",
+            shareToken: "a".repeat(32),
+            sharedLeafId: "22222222-2222-4222-8222-222222222222",
+            createdAt: "2026-08-18T12:00:00.000Z",
+            updatedAt: "2026-08-18T12:00:00.000Z",
+          },
+          messages: [
+            {
+              id: "22222222-2222-4222-8222-222222222222",
+              role: "assistant",
+              content: "Answer",
+              trace,
+              createdAt: "2026-08-18T12:00:00.000Z",
+            },
+          ],
+        }),
+      ),
+    );
+    expect(encoded).not.toContain("Jerred#NA1");
+    expect(encoded).toContain("Identified the player.");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/trace.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/trace.test.ts
@@ -172,6 +172,7 @@ describe("the activity channel cannot reach a persisted trace", () => {
       type: "activity",
       text: "Finding “Jerred#NA1”",
       toolCallId: "call-1",
+      ignorable: true,
     });
     expect(trace).toEqual([]);
   });
@@ -183,6 +184,7 @@ describe("the activity channel cannot reach a persisted trace", () => {
         type: "activity" as const,
         text: "Finding “Jerred#NA1”",
         toolCallId: "call-1",
+        ignorable: true as const,
       },
       {
         type: "tool_call" as const,
@@ -196,6 +198,7 @@ describe("the activity channel cannot reach a persisted trace", () => {
         type: "activity" as const,
         text: "Found 1 match for “Jerred#NA1”",
         toolCallId: "call-1",
+        ignorable: true as const,
       },
       {
         type: "tool_result" as const,

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-agent-stream.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-agent-stream.ts
@@ -11,6 +11,12 @@ export async function emitReportAgentStreamChunk(
     return;
   }
   switch (chunk.kind) {
+    case "tool-input-start": {
+      // The report editor already announces every step and streams the
+      // model's own text, so it has no quiet stretch for an early tool name
+      // to fill. Explore does, which is why the parser reads this chunk.
+      break;
+    }
     case "step-start": {
       await emit({
         type: "step_started",

--- a/packages/scout-for-lol/packages/backend/src/temporal/durability.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/durability.integration.test.ts
@@ -214,6 +214,47 @@ describe("durable interactive recovery", () => {
     ).toMatchObject({ state: "INTERRUPTED" });
   });
 
+  test("a settled run keeps no owner-only progress on its row", async () => {
+    // `activity` may name the person a turn looked up — that channel is the
+    // one place such text is allowed, precisely because it is never stored.
+    // These columns exist only so a durable observer can follow a *running*
+    // turn, and nothing deletes these rows, so a terminal state has to clear
+    // them or "never persisted" quietly becomes "persisted forever".
+    const runId = globalThis.crypto.randomUUID();
+    await prisma.scoutInteractiveRun.create({
+      data: {
+        id: runId,
+        kind: "explore",
+        ownerId: DiscordAccountIdSchema.parse("900000000000000201"),
+        payload: "{}",
+        state: "RUNNING",
+        partialOutput: "Jinx wins.",
+        activity: "Finding “Jerred#NA1”",
+        preview: JSON.stringify({ rows: [] }),
+      },
+    });
+
+    await persistScoutInteractiveOutcome(
+      {
+        stage: "dev",
+        kind: "explore",
+        databaseRunId: runId,
+        outcome: { status: "completed", partialOutputAvailable: true },
+      },
+      prisma,
+    );
+
+    const row = await prisma.scoutInteractiveRun.findUniqueOrThrow({
+      where: { id: runId },
+      select: { state: true, activity: true, preview: true },
+    });
+    expect(row).toEqual({
+      state: "COMPLETED",
+      activity: null,
+      preview: null,
+    });
+  });
+
   test("rebuilds a pending report-AI execution from its durable payload", async () => {
     const runId = globalThis.crypto.randomUUID();
     const guildId = DiscordGuildIdSchema.parse("900000000000000212");

--- a/packages/scout-for-lol/packages/backend/src/temporal/interactive-activities.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/interactive-activities.ts
@@ -252,12 +252,41 @@ export async function executeRecoveredExplore(
       // Durable cleanup releases quota when this Activity records its outcome.
     },
   };
+  let activity: string | null = null;
+  let preview: string | null = null;
   const emit = async (event: ExploreStreamEvent): Promise<void> => {
-    if (event.type === "answer_delta") {
-      const available = EXPLORE_ANSWER_MAX_LENGTH - partial.length;
-      if (available > 0) partial += event.text.slice(0, available);
-    } else if (event.type === "final") {
-      partial = event.message.content;
+    switch (event.type) {
+      case "answer_delta": {
+        const available = EXPLORE_ANSWER_MAX_LENGTH - partial.length;
+        if (available > 0) partial += event.text.slice(0, available);
+        break;
+      }
+      case "final": {
+        partial = event.message.content;
+        break;
+      }
+      case "activity": {
+        activity = event.text;
+        break;
+      }
+      case "preview": {
+        // The chart is deliberately not mirrored, matching the reconnect
+        // snapshot: it is far larger and the observer re-reads this row about
+        // once a second.
+        preview = JSON.stringify(event.preview);
+        break;
+      }
+      case "snapshot":
+      case "run_preview":
+      case "started":
+      case "tool_call":
+      case "tool_result":
+      case "error":
+      case "done": {
+        // Nothing mirrored: the trace is folded below, and the rest is either
+        // reconstructed by the observer or terminal.
+        break;
+      }
     }
     recordExploreTraceEvent(trace, event);
     await database.scoutInteractiveRun.update({
@@ -265,6 +294,8 @@ export async function executeRecoveredExplore(
       data: {
         partialOutput: partial.length === 0 ? null : partial,
         trace: JSON.stringify(trace),
+        activity,
+        preview,
         ...(event.type === "final"
           ? { resultMessageId: event.message.id }
           : {}),
@@ -300,6 +331,8 @@ async function runExploreActivity(
   const cancellationSignal = Context.current().cancellationSignal;
   const recoveredAbortController = new AbortController();
   const localRuntime = exploreRunManager.snapshot(run.id) !== undefined;
+  /** Last preview written to the row, so an unchanged one is not rewritten. */
+  let lastMirroredPreview: string | null = null;
   const cancel = (): void => {
     if (localRuntime) {
       exploreRunManager.cancelTemporal(
@@ -332,13 +365,21 @@ async function runExploreActivity(
         });
         if (control.stopRequestedAt !== null) cancel();
         if (snapshot !== undefined) {
+          // `preview` is written only when it actually changed. It is small
+          // by design but not trivial, and this runs once a second for the
+          // life of the turn.
+          const preview =
+            snapshot.preview === null ? null : JSON.stringify(snapshot.preview);
           await database.scoutInteractiveRun.update({
             where: { id: run.id },
             data: {
               partialOutput: snapshot.answer,
               trace: JSON.stringify(snapshot.trace),
+              activity: snapshot.activity,
+              ...(preview === lastMirroredPreview ? {} : { preview }),
             },
           });
+          lastMirroredPreview = preview;
         }
         Context.current().heartbeat({
           runId: run.id,

--- a/packages/scout-for-lol/packages/backend/src/temporal/interactive-activities.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/interactive-activities.ts
@@ -79,6 +79,11 @@ async function salvageAmbiguousExploreRun(input: {
       state: "INTERRUPTED",
       outcome: "interrupted",
       completedAt: new Date(),
+      // Same reason as the outcome path below: these mirror a running turn's
+      // progress and may name the person it looked up, so a terminal state
+      // clears them rather than leaving them in an undeleted row.
+      activity: null,
+      preview: null,
       lastError:
         "Provider attempt state was ambiguous after restart; Scout did not issue a second model request.",
     },
@@ -473,6 +478,14 @@ export async function persistScoutInteractiveOutcome(
               : "FAILED",
       outcome: input.outcome.status,
       completedAt: new Date(),
+      // Both are mirrored purely so a durable observer can follow a *running*
+      // turn, and both may name the person the turn looked up — the activity
+      // channel is the one place that text is allowed, precisely because it is
+      // never stored. Rows here are not deleted, so leaving them behind would
+      // turn "never persisted" into "persisted forever". A finished run has
+      // nothing to observe, so this costs nothing.
+      activity: null,
+      preview: null,
     },
     select: { partialOutput: true },
   });

--- a/packages/scout-for-lol/packages/backend/src/utils/agent-stream-chunk.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/utils/agent-stream-chunk.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import { parseAgentStreamChunk } from "#src/utils/agent-stream-chunk.ts";
+
+describe("parseAgentStreamChunk", () => {
+  test("renames tool-input-start's `id` to a call id", () => {
+    // The AI SDK carries two dialects of this part. `agent.stream().stream`
+    // yields `TextStreamPart`, where the field is `id`; the `toolCallId`
+    // spelling belongs to the UI-message chunk union, which Explore does not
+    // consume. Matching on the wrong one produces a member that silently
+    // never fires, because unparsed chunks are dropped by design — so this
+    // test is the only thing standing between that and an invisible bug.
+    expect(
+      parseAgentStreamChunk({
+        type: "tool-input-start",
+        id: "call-1",
+        toolName: "run_report_query",
+      }),
+    ).toEqual({
+      kind: "tool-input-start",
+      toolCallId: "call-1",
+      toolName: "run_report_query",
+    });
+  });
+
+  test("ignores the chunk kinds this parser deliberately does not read", () => {
+    // Each of these is an omission with a reason, documented on the parser:
+    // argument deltas would mean buffering model-authored query text, and
+    // reasoning is free text that is the likeliest place for a raw query to
+    // appear verbatim. A future change that starts parsing one of these
+    // should have to delete a line here and say why.
+    for (const chunk of [
+      { type: "tool-input-delta", id: "call-1", delta: '{"queryText":"FROM' },
+      { type: "tool-input-end", id: "call-1" },
+      { type: "reasoning-start", id: "reason-1" },
+      { type: "reasoning-delta", id: "reason-1", text: "Let me think" },
+      { type: "finish-step" },
+      { type: "raw", rawValue: {} },
+    ]) {
+      expect(parseAgentStreamChunk(chunk)).toBeNull();
+    }
+  });
+
+  test("drops an unrecognised chunk rather than failing the turn", () => {
+    expect(parseAgentStreamChunk({ type: "something-new" })).toBeNull();
+    expect(parseAgentStreamChunk("not a chunk")).toBeNull();
+  });
+
+  test("throws only on a chunk that reports a stream error", () => {
+    expect(() =>
+      parseAgentStreamChunk({ type: "error", error: new Error("upstream") }),
+    ).toThrow("upstream");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/utils/agent-stream-chunk.ts
+++ b/packages/scout-for-lol/packages/backend/src/utils/agent-stream-chunk.ts
@@ -14,6 +14,17 @@ import { z } from "zod";
 
 const AgentStreamChunkSchema = z.discriminatedUnion("type", [
   z.looseObject({ type: z.literal("start-step") }),
+  // The provider names the tool before it has finished emitting arguments.
+  // Note the field is `id`, not `toolCallId`: on `TextStreamPart` — the union
+  // `agent.stream().stream` actually yields — this part spells it `id`, while
+  // the `toolCallId` spelling belongs to the UI-message chunk union, which
+  // Explore does not consume. Getting that wrong yields a member that silently
+  // never matches, because unparsed chunks are dropped by design.
+  z.looseObject({
+    type: z.literal("tool-input-start"),
+    id: z.string().min(1),
+    toolName: z.string(),
+  }),
   z.looseObject({
     type: z.literal("text-delta"),
     text: z.string(),
@@ -51,6 +62,7 @@ type JsonValue = z.infer<ReturnType<typeof z.json>>;
 
 export type AgentStreamChunk =
   | { kind: "step-start" }
+  | { kind: "tool-input-start"; toolCallId: string; toolName: string }
   | { kind: "text-delta"; text: string }
   | {
       kind: "tool-call";
@@ -87,6 +99,18 @@ export type AgentStreamChunk =
 /**
  * Returns null for chunks that carry nothing an agent needs to act on.
  * Throws when the chunk reports a stream error.
+ *
+ * Two omissions are deliberate rather than pending.
+ *
+ * `tool-input-delta` is not parsed: deriving anything from it means buffering
+ * and partially parsing argument JSON, and the arguments are complete by
+ * `tool-call` anyway. For Explore that buffer would hold model-authored query
+ * text, which is precisely what must not reach a status line.
+ *
+ * `reasoning-*` is not parsed: reasoning is model-authored free text and is
+ * the most likely place for a raw query — or anything else the model happens
+ * to be thinking about — to appear verbatim. It is the worst available source
+ * for a status line, even one that is never persisted.
  */
 export function parseAgentStreamChunk(
   rawChunk: unknown,
@@ -99,6 +123,13 @@ export function parseAgentStreamChunk(
   switch (chunk.type) {
     case "start-step": {
       return { kind: "step-start" };
+    }
+    case "tool-input-start": {
+      return {
+        kind: "tool-input-start",
+        toolCallId: chunk.id,
+        toolName: chunk.toolName,
+      };
     }
     case "text-delta": {
       return chunk.text.length > 0

--- a/packages/scout-for-lol/packages/data/src/model/explore.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/explore.test.ts
@@ -39,6 +39,11 @@ describe("parseExploreStreamEvent", () => {
     // deploy that adds a stream event reaches parsers that predate it. The
     // SSE reader treats a throw as a corrupted stream, so without this an
     // open tab would die mid-turn on a turn the server answered correctly.
+    //
+    // The discriminator here is deliberately one that will never be added.
+    // An earlier version of this test used a type that was genuinely planned,
+    // and it started failing the moment that type shipped — the fixture has
+    // to stand for "from a newer server", not "not written yet".
     expect(
       parseExploreStreamEvent({
         type: "a-member-from-a-newer-server",

--- a/packages/scout-for-lol/packages/data/src/model/explore.ts
+++ b/packages/scout-for-lol/packages/data/src/model/explore.ts
@@ -29,6 +29,16 @@ export const EXPLORE_TIMEOUT_MS = 180_000;
  */
 export const EXPLORE_MAX_HISTORY_TURNS = 8;
 export const EXPLORE_TITLE_MAX_LENGTH = 120;
+/**
+ * How long an owner-only live status line may be.
+ *
+ * Deliberately smaller than the 500-character cap on a persisted trace
+ * `message`. The two are different channels with different audiences — a trace
+ * message is served publicly on a share link, an activity string never is —
+ * and the asymmetry is a tripwire: a 500-character trace message cannot be
+ * routed onto the activity channel without visibly truncating.
+ */
+export const EXPLORE_ACTIVITY_MAX_LENGTH = 200;
 
 export const ExploreConversationTitleSchema = z
   .string()
@@ -512,6 +522,31 @@ export const ExploreStreamEventSchema = z.discriminatedUnion("type", [
        * id, and recognise a salvaged partial answer after a stop.
        */
       questionMessageId: z.uuid(),
+    })
+    .strict(),
+  /**
+   * Owner-only narration of what the turn is doing right now.
+   *
+   * A separate member rather than a field on `tool_call`/`tool_result`, for
+   * three reasons. It has to narrate moments where no tool call exists yet —
+   * the model has named a tool but not finished its arguments — and moments
+   * with no tool at all, such as writing the answer. It keeps the specific
+   * text structurally out of the trace: `recordExploreTraceEvent` matches only
+   * tool members, and `ExploreTraceEntrySchema` is `.strict()` with no such
+   * field, so this cannot reach a trace entry even by accident. And it keeps
+   * the concern separate in the client reducer, where status and timeline used
+   * to be updated on adjacent lines of the same branch.
+   *
+   * Nothing here is persisted, and nothing here reaches a share link. That is
+   * what lets it name a player or a row count while the trace message stays as
+   * generic as the anonymous audience requires.
+   */
+  z
+    .object({
+      type: z.literal("activity"),
+      text: z.string().trim().min(1).max(EXPLORE_ACTIVITY_MAX_LENGTH),
+      /** The provider call this narrates, when there is one. */
+      toolCallId: z.string().trim().min(1).max(200).nullable().default(null),
     })
     .strict(),
   z

--- a/packages/scout-for-lol/packages/data/src/model/explore.ts
+++ b/packages/scout-for-lol/packages/data/src/model/explore.ts
@@ -547,6 +547,17 @@ export const ExploreStreamEventSchema = z.discriminatedUnion("type", [
       text: z.string().trim().min(1).max(EXPLORE_ACTIVITY_MAX_LENGTH),
       /** The provider call this narrates, when there is one. */
       toolCallId: z.string().trim().min(1).max(200).nullable().default(null),
+      /**
+       * Says a client too old to know this member may drop it and still
+       * render a correct transcript — which is true here, because a status
+       * line narrates the turn without ever changing what it produced. A
+       * client without this member simply keeps the last status it did
+       * understand until the answer arrives.
+       *
+       * Literal rather than boolean: this event is always safe to skip, and a
+       * field that could say otherwise would invite a caller to claim so.
+       */
+      ignorable: z.literal(true).default(true),
     })
     .strict(),
   z


### PR DESCRIPTION
## Why

`usePinnedScroll` already did the hard half — a reader who scrolls up to re-read is never yanked back down by the next streamed token. But once un-pinned there was nothing telling them the answer had moved on, and no way back except the scrollbar.

## What

- The hook exposes `pinned` and `scrollToBottom` alongside the existing ref. The boolean is kept beside the ref rather than replacing it: `scrollIfPinned` runs on every streamed token and must not wait on a re-render to know where the reader is.
- A "Jump to latest" pill above the composer, rendered only while un-pinned. `scrollToBottom` animates, unlike `scrollIfPinned`, because it is one deliberate jump the reader asked for rather than a per-token correction whose animation would restart on every delta.

Built from `Button` rather than a new design-system primitive: a DS component would need a workbench catalog entry and brings 24 more visual goldens with it, for one rounded button.

## Verification

- `bunx turbo run typecheck test lint --filter=@scout-for-lol/app` — 17/17, 412 tests.
- The pill's condition is `isScrolledToBottom`, already covered by `pinned-scroll.test.ts` including the mounted-part-way-up regression.
- Keeping it conditional on `!pinned` leaves the idle `/app/explore` page unchanged, so the Playwright goldens should not move; the design audit's axe, contrast and keyboard-focus checks still cover the new control.

## Deliberately not included

Anchoring a newly asked question to the top of the viewport — so the answer grows into empty space instead of the view creeping — is not in this change. It needs a viewport-sized spacer interacting with the sticky composer, and that is a layout judgement I could not confirm visually. It ships as its own change once it can be seen running.