### PR TITLE
feat(scout-for-lol): confirm Explore-prepared entity creation

### DIFF
--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -661,6 +661,18 @@
       "thresholdRollouts": []
     },
     {
+      "key": "explore_creation_enabled",
+      "owner": "scout",
+      "namespace": "scout",
+      "source": "scout-policy",
+      "purpose": "Let Explore prepare report, subscription and competition creations for confirmation.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
+    },
+    {
       "key": "llm-daily-token-budget",
       "owner": "scout",
       "namespace": "scout",

--- a/packages/scout-for-lol/packages/backend/src/betting/dares/lifecycle/dare-intent-consume-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dares/lifecycle/dare-intent-consume-v2.ts
@@ -2,6 +2,7 @@ import {
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
   type ConfirmationIntentPayload,
+  type DareIntentPayload,
   type DiscordAccountId,
   type DiscordGuildId,
 } from "@scout-for-lol/data";
@@ -31,7 +32,33 @@ type IntentAccount = { id: number } | undefined;
 /** The dare an intent acts on, together with the revision it was minted for. */
 type DareIntentTarget = { dareId: number; revision: number };
 
-function needsFeature(payload: ConfirmationIntentPayload): boolean {
+/**
+ * Narrow a stored payload to a dare payload, or `null` for a creation intent.
+ *
+ * Creation intents live on the same table and have their own confirm procedure
+ * with its own gate and its own RBAC; this one must refuse them rather than
+ * fall through to the contribute branch.
+ */
+function asDarePayload(
+  payload: ConfirmationIntentPayload,
+): DareIntentPayload | null {
+  switch (payload.kind) {
+    case "dare_fund":
+    case "dare_accept":
+    case "dare_decline":
+    case "dare_contribute":
+    case "dare_cancel": {
+      return payload;
+    }
+    case "report":
+    case "subscription":
+    case "competition": {
+      return null;
+    }
+  }
+}
+
+function needsFeature(payload: DareIntentPayload): boolean {
   return (
     payload.kind === "dare_fund" ||
     payload.kind === "dare_accept" ||
@@ -39,7 +66,7 @@ function needsFeature(payload: ConfirmationIntentPayload): boolean {
   );
 }
 
-function needsAccount(payload: ConfirmationIntentPayload): boolean {
+function needsAccount(payload: DareIntentPayload): boolean {
   return (
     payload.kind === "dare_fund" ||
     payload.kind === "dare_accept" ||
@@ -67,7 +94,7 @@ async function executeAction(
   input: {
     target: DareIntentTarget;
     actorDiscordId: DiscordAccountId;
-    payload: ConfirmationIntentPayload;
+    payload: DareIntentPayload;
     account: IntentAccount;
     now: Date;
   },
@@ -130,7 +157,7 @@ async function insufficientOutcome(
   input: {
     error: unknown;
     account: IntentAccount;
-    payload: ConfirmationIntentPayload;
+    payload: DareIntentPayload;
     target: DareIntentTarget;
   },
   dependencies: DareV2Dependencies,
@@ -175,7 +202,10 @@ export async function consumeDareV2ConfirmationIntent(
   if (intent.actorDiscordId !== input.actorDiscordId) {
     return { kind: "forbidden" } as const;
   }
-  const payload = readConfirmationIntentPayload(intent);
+  const payload = asDarePayload(readConfirmationIntentPayload(intent));
+  if (payload === null) {
+    return { kind: "not_found" } as const;
+  }
   if (intent.consumedAt !== null) {
     return {
       kind: "already_consumed",

--- a/packages/scout-for-lol/packages/backend/src/betting/dares/lifecycle/dare-intent-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dares/lifecycle/dare-intent-v2.ts
@@ -1,8 +1,8 @@
 import {
-  ConfirmationIntentPayloadSchema,
+  DareIntentPayloadSchema,
   DiscordGuildIdSchema,
-  type ConfirmationIntentKind,
-  type ConfirmationIntentPayload,
+  type DareIntentKind,
+  type DareIntentPayload,
   type DiscordAccountId,
   type DiscordGuildId,
 } from "@scout-for-lol/data";
@@ -28,13 +28,11 @@ const DARE_ACTION_BY_KIND = {
   dare_decline: "decline",
   dare_contribute: "contribute",
   dare_cancel: "cancel",
-} as const satisfies Record<ConfirmationIntentKind, string>;
+} as const satisfies Record<DareIntentKind, string>;
 
-type DareV2IntentAction = (typeof DARE_ACTION_BY_KIND)[ConfirmationIntentKind];
+type DareV2IntentAction = (typeof DARE_ACTION_BY_KIND)[DareIntentKind];
 
-export function dareV2IntentAction(
-  kind: ConfirmationIntentKind,
-): DareV2IntentAction {
+export function dareV2IntentAction(kind: DareIntentKind): DareV2IntentAction {
   return DARE_ACTION_BY_KIND[kind];
 }
 
@@ -64,13 +62,13 @@ export async function createDareV2ConfirmationIntent(
     serverId: DiscordGuildId;
     actorDiscordId: DiscordAccountId;
     expectedRevision: number;
-    payload: ConfirmationIntentPayload;
+    payload: DareIntentPayload;
     idempotencyKey: string;
   },
   dependencies: DareV2Dependencies = defaultDareV2Dependencies,
   now: Date = new Date(),
 ) {
-  const payload = ConfirmationIntentPayloadSchema.parse(input.payload);
+  const payload = DareIntentPayloadSchema.parse(input.payload);
   const action = dareV2IntentAction(payload.kind);
   const dare = await dependencies.prismaClient.bucksDareV2.findUnique({
     where: { id: input.dareId },

--- a/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
@@ -156,6 +156,7 @@ export type FlagName =
   | "custom_nights_enabled"
   | "debug"
   | "duels_enabled"
+  | "explore_creation_enabled"
   | "hall_of_fame_enabled"
   | "initial_match_history_import_enabled"
   | "scoutql_relational_enabled"
@@ -344,6 +345,20 @@ const FLAG_REGISTRY: Record<FlagName, FlagConfig> = {
         attributes: { user: ME },
       },
     ],
+  },
+  /**
+   * Confirming an Explore-prepared report, subscription or competition.
+   *
+   * One flag covers all three kinds: which entities a given person may create
+   * is already decided by per-entity RBAC at confirm time, so a per-kind flag
+   * would only duplicate that. Deliberately absent from
+   * `PRODUCTION_HARD_DISABLED_FLAGS` — this is meant to ramp through Flipt
+   * rather than stay beta-only. It is re-read at confirm time, so revoking it
+   * blocks intents that were already prepared.
+   */
+  explore_creation_enabled: {
+    default: false,
+    overrides: [],
   },
   initial_match_history_import_enabled: {
     default: false,

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-tool-schemas.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-tool-schemas.ts
@@ -8,7 +8,7 @@ import {
   DareDeadlineSpecV2Schema,
   DareSqlV3CompetitionSchema,
   DareActivationV3Schema,
-  ConfirmationIntentPayloadSchema,
+  DareIntentPayloadSchema,
 } from "@scout-for-lol/data";
 
 export const DareToolResultSchema = z.strictObject({
@@ -96,10 +96,12 @@ export const DareInspectToolInputSchema = z.strictObject({
   dareId: z.number().int().positive(),
 });
 
+// The dare-only payload union, so the Explore dare tool cannot mint a
+// creation intent — those have their own gate, RBAC and confirm procedure.
 export const DareActionToolInputSchema = z.strictObject({
   dareId: z.number().int().positive(),
   expectedRevision: z.number().int().positive(),
-  payload: ConfirmationIntentPayloadSchema,
+  payload: DareIntentPayloadSchema,
 });
 
 export const DareDeleteToolInputSchema = z.strictObject({

--- a/packages/scout-for-lol/packages/backend/src/lib/audit/audited-mutation.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/audit/audited-mutation.ts
@@ -25,6 +25,37 @@ export type AuditDetail = Pick<
 >;
 
 /**
+ * Insert a mutation's audit row inside a transaction the caller already owns.
+ *
+ * Split out of {@link runAuditedMutation} because not every audited mutation
+ * gets to open its own transaction: confirming a prepared confirmation intent
+ * has to make the single-use claim the *first* statement of the transaction
+ * (that guarded write is the entire double-spend guard), so the claim helper
+ * owns the transaction and this records the audit row into it. Both callers
+ * share one mapping from ctx to audit row rather than restating it.
+ *
+ * A `null` detail records nothing, e.g. when the mutation was a no-op.
+ */
+export async function recordMutationAudit(params: {
+  ctx: AuditedMutationCtx;
+  guildId: string;
+  tx: Db;
+  detail: AuditDetail | null;
+}): Promise<void> {
+  if (params.detail === null) return;
+  await recordAudit(
+    {
+      ...params.detail,
+      actorDiscordId: params.ctx.user.discordId,
+      serverId: params.guildId,
+      ipAddress: params.ctx.webSession.ipAddress,
+      userAgent: params.ctx.webSession.userAgent,
+    },
+    params.tx,
+  );
+}
+
+/**
  * Run a state-changing domain mutation and its audit-row insert inside a
  * single Prisma transaction so they commit atomically — either both land or
  * neither does.
@@ -43,19 +74,7 @@ export async function runAuditedMutation<TResult>(
 ): Promise<TResult> {
   return prisma.$transaction(async (tx) => {
     const result = await run(tx);
-    const detail = audit(result);
-    if (detail !== null) {
-      await recordAudit(
-        {
-          ...detail,
-          actorDiscordId: ctx.user.discordId,
-          serverId: guildId,
-          ipAddress: ctx.webSession.ipAddress,
-          userAgent: ctx.webSession.userAgent,
-        },
-        tx,
-      );
-    }
+    await recordMutationAudit({ ctx, guildId, tx, detail: audit(result) });
     return result;
   });
 }

--- a/packages/scout-for-lol/packages/backend/src/lib/confirmation-intent/creation.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/confirmation-intent/creation.ts
@@ -1,0 +1,350 @@
+/**
+ * Executing a confirmed creation intent.
+ *
+ * Everything here runs inside the transaction that claimed the intent, so the
+ * claim, the domain write and the audit row commit together or not at all.
+ * Each arm calls the *same* service the corresponding web form calls —
+ * `createReportInTransaction`, `addSubscription`, `createCompetitionForActor` —
+ * so a prepared entity and a hand-filled form produce identical rows and run
+ * identical policy. Nothing here re-derives authorization: the caller has
+ * already resolved the actor's permissions against the guild on the intent row
+ * and passes them in.
+ *
+ * Policy rejections come back as a discriminated outcome, which the claim
+ * helper stores on the intent and replays on a second confirmation. Failures
+ * that must not leave a partial entity behind stay exceptions instead, so the
+ * caller's transaction rolls back and the intent is left unconsumed.
+ */
+
+import type {
+  CreationIntentKind,
+  CreationIntentPayload,
+  DiscordAccountId,
+  DiscordGuildId,
+  LeaguePuuid,
+  PermissionSet,
+  Region,
+} from "@scout-for-lol/data";
+import type { Db } from "#src/database/index.ts";
+import type { AuditDetail } from "#src/lib/audit/audited-mutation.ts";
+import { createCompetitionForActor } from "#src/lib/competitions/create.ts";
+import { createReportInTransaction } from "#src/lib/reports/create.ts";
+import { addSubscription } from "#src/lib/subscription/add.ts";
+import type { AddSubscriptionResult } from "#src/lib/subscription/types.ts";
+
+export type CreationIntentOutcome =
+  /**
+   * The entity exists. `guildId` travels with the id so the confirming client
+   * can deep-link without re-reading the intent.
+   */
+  | {
+      kind: "created";
+      entity: CreationIntentKind;
+      entityId: number;
+      guildId: DiscordGuildId;
+    }
+  /** A per-server or per-owner active-entity limit rejected the request. */
+  | { kind: "limit_reached"; message: string }
+  /** The report's `queryText` is not compilable ScoutQL. */
+  | { kind: "invalid_query"; message: string }
+  /** The criteria/game-variant combination is not a valid competition. */
+  | { kind: "invalid_configuration"; message: string }
+  /** The per-(guild, owner) competition creation rate limit rejected this. */
+  | { kind: "rate_limited"; message: string }
+  /** `competitions:invite` or `competitions:schedule` is missing. */
+  | { kind: "missing_permission"; message: string }
+  /** The PUUID is already tracked in this guild under another player. */
+  | { kind: "account_already_subscribed"; message: string }
+  /** That player is already subscribed in the requested channel. */
+  | { kind: "subscription_already_exists"; message: string }
+  /** Riot no longer recognises the frozen Riot ID. */
+  | { kind: "riot_id_not_found"; message: string };
+
+/**
+ * Work that must happen after the transaction commits, described rather than
+ * done: a schedule nudge, a rate-limit stamp, and a best-effort Riot backfill
+ * all become wrong if the transaction that produced them rolls back.
+ */
+export type CreationPostCommit =
+  | { kind: "report" }
+  | { kind: "competition" }
+  | {
+      kind: "subscription";
+      alias: string;
+      puuid: LeaguePuuid;
+      region: Region;
+      discordUserId: DiscordAccountId | undefined;
+      /** Whether this is the guild's first subscription (analytics milestone). */
+      firstSubscription: boolean;
+    };
+
+export type CreationExecution = {
+  outcome: CreationIntentOutcome;
+  audit: AuditDetail | null;
+  postCommit: CreationPostCommit | null;
+};
+
+export type ExecuteCreationIntentParams = {
+  payload: CreationIntentPayload;
+  /** Read off the intent row, never out of the payload. */
+  guildId: DiscordGuildId;
+  actorDiscordId: DiscordAccountId;
+  /** The actor's effective permissions, resolved at confirm time. */
+  permissions: PermissionSet;
+  /** Operator control, read at confirm time rather than frozen at prepare. */
+  initialHistoryImportEnabled: boolean;
+};
+
+async function executeReport(
+  tx: Db,
+  params: ExecuteCreationIntentParams & { payload: { kind: "report" } },
+): Promise<CreationExecution> {
+  const { payload, guildId, actorDiscordId } = params;
+  const result = await createReportInTransaction(tx, {
+    serverId: guildId,
+    ownerId: actorDiscordId,
+    input: payload,
+  });
+  if (result.kind === "limit_reached") {
+    return {
+      outcome: { kind: "limit_reached", message: result.reason },
+      audit: null,
+      postCommit: null,
+    };
+  }
+  if (result.kind === "invalid_query") {
+    return {
+      outcome: { kind: "invalid_query", message: result.message },
+      audit: null,
+      postCommit: null,
+    };
+  }
+  return {
+    outcome: {
+      kind: "created",
+      entity: "report",
+      entityId: result.report.id,
+      guildId,
+    },
+    audit: {
+      action: "REPORT_CREATE",
+      targetChannelId: payload.channelId,
+      payload: {
+        reportId: result.report.id,
+        title: payload.title,
+        queryText: payload.queryText,
+        cronExpression: payload.cronExpression,
+        scheduleTimezone: payload.scheduleTimezone,
+        isEnabled: payload.isEnabled,
+        via: "explore",
+      },
+    },
+    postCommit: { kind: "report" },
+  };
+}
+
+async function executeCompetition(
+  tx: Db,
+  params: ExecuteCreationIntentParams & { payload: { kind: "competition" } },
+): Promise<CreationExecution> {
+  const { payload, guildId, actorDiscordId, permissions } = params;
+  const result = await createCompetitionForActor({
+    db: tx,
+    permissions,
+    guildId,
+    ownerId: actorDiscordId,
+    input: payload,
+  });
+  if (result.kind !== "created") {
+    const outcome: CreationIntentOutcome =
+      result.kind === "invalid_configuration"
+        ? { kind: "invalid_configuration", message: result.message }
+        : result.kind === "rate_limited"
+          ? { kind: "rate_limited", message: result.message }
+          : result.kind === "limit_reached"
+            ? { kind: "limit_reached", message: result.message }
+            : { kind: "missing_permission", message: result.message };
+    return { outcome, audit: null, postCommit: null };
+  }
+  return {
+    outcome: {
+      kind: "created",
+      entity: "competition",
+      entityId: result.competition.id,
+      guildId,
+    },
+    audit: {
+      action: "COMPETITION_CREATE",
+      targetChannelId: payload.channelId,
+      payload: {
+        competitionId: result.competition.id,
+        title: payload.title,
+        visibility: payload.visibility,
+        gameVariant: payload.gameVariant,
+        maxParticipants: payload.maxParticipants,
+        initialPlayerIds: payload.initialPlayerIds,
+        via: "explore",
+      },
+    },
+    postCommit: { kind: "competition" },
+  };
+}
+
+/**
+ * The non-`created` half of a subscription result.
+ *
+ * `subscription-already-exists` still commits a new Account row, exactly as it
+ * does through the web form, so it audits `ACCOUNT_ADD` rather than nothing —
+ * a state change without an audit trail is the thing this whole path exists to
+ * prevent.
+ */
+function subscriptionRefusal(
+  result: Exclude<
+    AddSubscriptionResult,
+    { kind: "created" } | { kind: "internal-error" }
+  >,
+  payload: CreationIntentPayload & { kind: "subscription" },
+): CreationExecution {
+  if (result.kind === "account-already-subscribed") {
+    return {
+      outcome: {
+        kind: "account_already_subscribed",
+        message: `That account is already tracked as ${result.existingPlayerAlias}.`,
+      },
+      audit: null,
+      postCommit: null,
+    };
+  }
+  if (result.kind === "subscription-already-exists") {
+    return {
+      outcome: {
+        kind: "subscription_already_exists",
+        message: `${result.playerAlias} is already subscribed in that channel.`,
+      },
+      audit: {
+        action: "ACCOUNT_ADD",
+        targetChannelId: payload.channelId,
+        targetPlayerId: result.playerId,
+        targetAccountId: result.accountId,
+        payload: {
+          riotId: payload.riotId,
+          region: payload.region,
+          alias: payload.alias,
+          via: "explore",
+        },
+      },
+      // An account row still committed, so it gets the same best-effort
+      // match-history backfill `subscription.add` gives this outcome. It is not
+      // the guild's first subscription by construction — one already exists in
+      // that channel.
+      postCommit: {
+        kind: "subscription",
+        alias: payload.alias,
+        puuid: payload.puuid,
+        region: payload.region,
+        discordUserId: payload.discordUserId,
+        firstSubscription: false,
+      },
+    };
+  }
+  if (result.kind === "riot-id-not-found") {
+    return {
+      outcome: { kind: "riot_id_not_found", message: result.message },
+      audit: null,
+      postCommit: null,
+    };
+  }
+  return {
+    outcome: {
+      kind: "limit_reached",
+      message: `Limit reached: ${result.current.toString()} of ${result.max.toString()}.`,
+    },
+    audit: null,
+    postCommit: null,
+  };
+}
+
+async function executeSubscription(
+  tx: Db,
+  params: ExecuteCreationIntentParams & { payload: { kind: "subscription" } },
+): Promise<CreationExecution> {
+  const { payload, guildId, actorDiscordId, initialHistoryImportEnabled } =
+    params;
+  const result = await addSubscription(
+    {
+      guildId,
+      channelId: payload.channelId,
+      region: payload.region,
+      riotId: payload.riotId,
+      alias: payload.alias,
+      discordUserId: payload.discordUserId,
+      creatorDiscordId: actorDiscordId,
+      filters: payload.filters ?? null,
+    },
+    payload.puuid,
+    tx,
+    initialHistoryImportEnabled,
+  );
+  // `addSubscription` preserves its public result contract by turning database
+  // failures into `internal-error`. Rethrow inside this transaction, exactly as
+  // `subscription.add` does, or a rolled-back write would report success.
+  if (result.kind === "internal-error") {
+    throw new Error(
+      `Subscription creation failed for ${payload.alias}: ${result.message}`,
+    );
+  }
+  if (result.kind !== "created") {
+    return subscriptionRefusal(result, payload);
+  }
+  return {
+    outcome: {
+      kind: "created",
+      entity: "subscription",
+      entityId: result.subscription.id,
+      guildId,
+    },
+    audit: {
+      action: "SUBSCRIPTION_ADD",
+      targetChannelId: payload.channelId,
+      targetPlayerId: result.player.id,
+      targetAccountId: result.account.id,
+      payload: {
+        riotId: payload.riotId,
+        region: payload.region,
+        alias: payload.alias,
+        isAddingToExistingPlayer: result.isAddingToExistingPlayer,
+        via: "explore",
+      },
+    },
+    postCommit: {
+      kind: "subscription",
+      alias: payload.alias,
+      puuid: payload.puuid,
+      region: payload.region,
+      discordUserId: payload.discordUserId,
+      firstSubscription: result.isFirstSubscription,
+    },
+  };
+}
+
+/**
+ * Create the entity a confirmed intent describes, inside `tx`.
+ *
+ * @throws when the competition payload's dates fail `CompetitionDatesSchema`,
+ * when its initial roster is invalid, or when the subscription write fails —
+ * all cases where the caller's transaction must abort rather than commit a
+ * partial entity and a claimed intent.
+ */
+export async function executeCreationIntent(
+  tx: Db,
+  params: ExecuteCreationIntentParams,
+): Promise<CreationExecution> {
+  const { payload } = params;
+  if (payload.kind === "report") {
+    return await executeReport(tx, { ...params, payload });
+  }
+  if (payload.kind === "competition") {
+    return await executeCompetition(tx, { ...params, payload });
+  }
+  return await executeSubscription(tx, { ...params, payload });
+}

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/bucks-dare-action-procedures.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/bucks-dare-action-procedures.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import {
   BucksStakeSchema,
-  ConfirmationIntentPayloadSchema,
+  DareIntentPayloadSchema,
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
 } from "@scout-for-lol/data";
@@ -55,9 +55,12 @@ const LegacyDarePayloadSchema = z
       : { kind: LEGACY_ACTION_KINDS[legacy.action] },
   );
 
+// Deliberately the dare-only union, not the full confirmation-intent one: a
+// creation payload accepted here would mint a creation intent through the dare
+// prepare procedure and skip the creation gate entirely.
 export const DarePayloadInputSchema = z.union([
-  ConfirmationIntentPayloadSchema,
-  LegacyDarePayloadSchema.pipe(ConfirmationIntentPayloadSchema),
+  DareIntentPayloadSchema,
+  LegacyDarePayloadSchema.pipe(DareIntentPayloadSchema),
 ]);
 
 const GuildInput = z.object({ guildId: DiscordGuildIdSchema });

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/explore-creation-procedures.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/explore-creation-procedures.ts
@@ -1,0 +1,294 @@
+/**
+ * Confirming an entity an Explore agent prepared.
+ *
+ * The security model in one line: **the model never writes domain state.** It
+ * may mint an intent describing a report, subscription or competition; a human
+ * then confirms it through a CSRF-protected mutation, and this path re-runs the
+ * whole authorization decision from scratch. Nothing the model produced is
+ * trusted — not the guild (read off the intent row), not the permissions
+ * (re-resolved against Discord and the grant table now), not the channel
+ * (re-checked against the guild), and not the feature gate (re-read, so
+ * revoking it blocks intents that were already prepared).
+ *
+ * These procedures deliberately do **not** use `guildMutationProcedure`. That
+ * builder reads `guildId` from the procedure *input*; here the guild comes from
+ * the intent row, and binding the permission check to an input field would let
+ * a caller pair someone's intent with a guild they happen to administer.
+ *
+ * Its own module rather than more of `explore.router.ts` because that file is
+ * already close to the 500-line cap.
+ */
+
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import {
+  DiscordGuildIdSchema,
+  P,
+  type ConfirmationIntentPayload,
+  type CreationIntentKind,
+  type CreationIntentPayload,
+  type DiscordAccountId,
+  type DiscordGuildId,
+  type Permission,
+  type PermissionDeniedCause,
+  type PermissionSet,
+} from "@scout-for-lol/data";
+import type {
+  ConfirmationIntent,
+  User,
+} from "#generated/prisma/client/index.js";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
+import { prisma } from "#src/database/index.ts";
+import { captureFirstSubscriptionCreated } from "#src/analytics/guild-lifecycle.ts";
+import { recordMutationAudit } from "#src/lib/audit/audited-mutation.ts";
+import { claimAndExecute } from "#src/lib/confirmation-intent/claim.ts";
+import {
+  executeCreationIntent,
+  type CreationPostCommit,
+} from "#src/lib/confirmation-intent/creation.ts";
+import { readConfirmationIntentPayload } from "#src/lib/confirmation-intent/payload.ts";
+import { recordCompetitionCreation } from "#src/lib/competitions/create.ts";
+import { runBackfillAfterCommit } from "#src/lib/subscription/add.ts";
+import { notifyReportScheduleReconciler } from "#src/reports/temporal-schedules.ts";
+import { assertChannelInGuild } from "#src/trpc/guild-guard.ts";
+import { resolveGuildPermissions } from "#src/trpc/guild-permission.ts";
+import {
+  requireActorIntent,
+  requireExploreUserAndGuilds,
+} from "#src/trpc/router/explore-intent-access.ts";
+import { protectedProcedure, webMutationProcedure } from "#src/trpc/trpc.ts";
+
+const intentInput = z.strictObject({ intentId: z.uuid() });
+
+/** The permission each creation kind requires, in the guild on the intent. */
+const CREATE_PERMISSION: Record<CreationIntentKind, Permission> = {
+  report: P("reports", "create"),
+  subscription: P("subscriptions", "create"),
+  competition: P("competitions", "create"),
+};
+
+type LoadedCreationIntent = {
+  intent: ConfirmationIntent;
+  payload: CreationIntentPayload;
+  /** The guild on the intent row — authoritative for every later check. */
+  guildId: DiscordGuildId;
+  userId: DiscordAccountId;
+};
+
+/**
+ * Narrow a stored payload to a creation payload, or `null`.
+ *
+ * Switching on the discriminant rather than validating the string separately is
+ * what lets TypeScript narrow the union without an assertion.
+ */
+function asCreationPayload(
+  payload: ConfirmationIntentPayload,
+): CreationIntentPayload | null {
+  switch (payload.kind) {
+    case "report":
+    case "subscription":
+    case "competition": {
+      return payload;
+    }
+    case "dare_fund":
+    case "dare_accept":
+    case "dare_decline":
+    case "dare_contribute":
+    case "dare_cancel": {
+      return null;
+    }
+  }
+}
+
+/**
+ * Everything both procedures do before they diverge: prove the caller may see
+ * this intent at all, that the feature is still enabled for its guild, and that
+ * it really is a creation intent.
+ */
+async function loadCreationIntent(
+  user: User,
+  intentId: string,
+): Promise<LoadedCreationIntent> {
+  const { userId, guildIds } = await requireExploreUserAndGuilds(user);
+  const intent = await requireActorIntent({ intentId, guildIds, userId });
+  const guildId = DiscordGuildIdSchema.parse(intent.serverId);
+
+  if (
+    !(await isPolicyEnabled("explore_creation_enabled", { server: guildId }))
+  ) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Creating things from Explore is not enabled for this server.",
+    });
+  }
+
+  const payload = asCreationPayload(readConfirmationIntentPayload(intent));
+  if (payload === null) {
+    // A dare intent has its own confirm procedure with its own rules; it must
+    // not be executable through this one.
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "That confirmation does not create anything.",
+    });
+  }
+  if (payload.guildId !== guildId) {
+    // The mint path derives the column from the payload, so a disagreement is
+    // a broken writer rather than user input — fail loudly instead of picking
+    // a side.
+    throw new Error(
+      `Confirmation intent ${intent.id} stores guild ${intent.serverId} but its payload declares ${payload.guildId}.`,
+    );
+  }
+  return { intent, payload, guildId, userId };
+}
+
+/**
+ * The authoritative RBAC decision, re-run now.
+ *
+ * `resolveGuildPermissions` throws by itself for a non-member (FORBIDDEN), an
+ * uninstalled guild (NOT_FOUND), and a Discord outage (UNAUTHORIZED /
+ * SERVICE_UNAVAILABLE). Those propagate untouched: an outage is not a
+ * permission answer and must never be reported as one.
+ */
+async function authorizeCreation(
+  user: User,
+  loaded: LoadedCreationIntent,
+): Promise<PermissionSet> {
+  const permissions = await resolveGuildPermissions(user, loaded.guildId);
+  const required = CREATE_PERMISSION[loaded.payload.kind];
+  if (!permissions.canAny(required)) {
+    const cause: PermissionDeniedCause = { missingPermission: required };
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: `Missing permission ${required.resource}:${required.action}`,
+      cause,
+    });
+  }
+  // The competition sub-gates (competitions:invite / competitions:schedule) and
+  // the creation rate limit live inside `createCompetitionForActor`, which
+  // receives this same PermissionSet — re-checking them here would be a second
+  // copy of a reviewed policy.
+  assertChannelInGuild({
+    guildId: loaded.guildId,
+    channelId: loaded.payload.channelId,
+  });
+  return permissions;
+}
+
+async function runPostCommit(params: {
+  postCommit: CreationPostCommit | null;
+  permissions: PermissionSet;
+  guildId: DiscordGuildId;
+  ownerId: DiscordAccountId;
+  initialHistoryImportEnabled: boolean;
+}): Promise<void> {
+  const { postCommit } = params;
+  if (postCommit === null) return;
+  if (postCommit.kind === "report") {
+    await notifyReportScheduleReconciler();
+    return;
+  }
+  if (postCommit.kind === "competition") {
+    recordCompetitionCreation({
+      permissions: params.permissions,
+      guildId: params.guildId,
+      ownerId: params.ownerId,
+    });
+    return;
+  }
+  if (postCommit.firstSubscription) {
+    await captureFirstSubscriptionCreated(params.guildId, "web");
+  }
+  if (!params.initialHistoryImportEnabled) {
+    void runBackfillAfterCommit({
+      alias: postCommit.alias,
+      puuid: postCommit.puuid,
+      region: postCommit.region,
+      discordUserId: postCommit.discordUserId,
+    });
+  }
+}
+
+const confirmCreationIntent = webMutationProcedure
+  .input(intentInput)
+  .mutation(async ({ ctx, input }) => {
+    const loaded = await loadCreationIntent(ctx.user, input.intentId);
+    const permissions = await authorizeCreation(ctx.user, loaded);
+    // An operator control, so it is read now rather than frozen when the intent
+    // was prepared.
+    const initialHistoryImportEnabled = await isPolicyEnabled(
+      "initial_match_history_import_enabled",
+      { server: loaded.guildId },
+    );
+
+    // Captured out of the transaction callback rather than returned, so the
+    // stored replay result stays the outcome the client sees and a replayed
+    // confirmation repeats no side effects.
+    const captured: { postCommit: CreationPostCommit | null } = {
+      postCommit: null,
+    };
+    const outcome = await claimAndExecute(
+      prisma,
+      {
+        intentId: loaded.intent.id,
+        actorDiscordId: loaded.userId,
+        now: new Date(),
+      },
+      async (tx) => {
+        const executed = await executeCreationIntent(tx, {
+          payload: loaded.payload,
+          guildId: loaded.guildId,
+          actorDiscordId: loaded.userId,
+          permissions,
+          initialHistoryImportEnabled,
+        });
+        captured.postCommit = executed.postCommit;
+        await recordMutationAudit({
+          ctx,
+          guildId: loaded.guildId,
+          tx,
+          detail: executed.audit,
+        });
+        return executed.outcome;
+      },
+    );
+
+    await runPostCommit({
+      postCommit: captured.postCommit,
+      permissions,
+      guildId: loaded.guildId,
+      ownerId: loaded.userId,
+      initialHistoryImportEnabled,
+    });
+    return outcome;
+  });
+
+const creationIntentStatus = protectedProcedure
+  .input(intentInput)
+  .query(async ({ ctx, input }) => {
+    const loaded = await loadCreationIntent(ctx.user, input.intentId);
+    const { intent } = loaded;
+    return {
+      state:
+        intent.consumedAt === null
+          ? intent.expiresAt.getTime() <= Date.now()
+            ? ("expired" as const)
+            : ("pending" as const)
+          : ("consumed" as const),
+      // Taken from the payload, which `readConfirmationIntentPayload` has
+      // already proved agrees with the row's `kind` column.
+      kind: loaded.payload.kind,
+      guildId: loaded.guildId,
+      expiresAt: intent.expiresAt.toISOString(),
+      result:
+        intent.resultJson === null
+          ? null
+          : z.json().parse(JSON.parse(intent.resultJson)),
+    };
+  });
+
+/** Spread into `exploreRouter`; see the module docblock for why they live here. */
+export const exploreCreationProcedures = {
+  confirmCreationIntent,
+  creationIntentStatus,
+};

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/explore-creation-procedures.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/explore-creation-procedures.ts
@@ -38,10 +38,15 @@ import type {
   User,
 } from "#generated/prisma/client/index.js";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
-import { prisma } from "#src/database/index.ts";
+import { prisma, type Db } from "#src/database/index.ts";
 import { captureFirstSubscriptionCreated } from "#src/analytics/guild-lifecycle.ts";
 import { recordMutationAudit } from "#src/lib/audit/audited-mutation.ts";
-import { claimAndExecute } from "#src/lib/confirmation-intent/claim.ts";
+import {
+  claimAndExecute,
+  type ClaimRefusal,
+} from "#src/lib/confirmation-intent/claim.ts";
+import { InitialEntrantsValidationError } from "#src/database/competition/participants.ts";
+import { asCompetitionBadRequest } from "#src/trpc/router/competition-router-helpers.ts";
 import {
   executeCreationIntent,
   type CreationPostCommit,
@@ -209,6 +214,46 @@ async function runPostCommit(params: {
   }
 }
 
+/**
+ * Run the claim, turning a prepared payload's own invalidity into an answer.
+ *
+ * A competition intent carries model-authored dates and entrant ids, so a
+ * reversed range, or an entrant removed between preparing and confirming, is
+ * expected input at this boundary rather than a broken caller.
+ * `createCompetitionForActor` deliberately lets both throw so the transaction
+ * rolls back instead of committing a half-enrolled competition — and that
+ * rollback takes the claim with it, so without this the person would get a 500
+ * and the same 500 on every retry until the intent expired.
+ *
+ * Rolling the claim back is the right half of that behaviour and is kept: the
+ * intent is left to expire rather than burned by a failure, and the refusal
+ * carries the same message the web form would have given.
+ */
+async function claimCreation<Result>(
+  run: (tx: Db) => Promise<Result>,
+  input: { intentId: string; actorDiscordId: DiscordAccountId },
+): Promise<Result | ClaimRefusal> {
+  try {
+    return await claimAndExecute(
+      prisma,
+      {
+        intentId: input.intentId,
+        actorDiscordId: input.actorDiscordId,
+        now: new Date(),
+      },
+      run,
+    );
+  } catch (error) {
+    if (
+      error instanceof InitialEntrantsValidationError ||
+      error instanceof z.ZodError
+    ) {
+      asCompetitionBadRequest(error);
+    }
+    throw error;
+  }
+}
+
 const confirmCreationIntent = webMutationProcedure
   .input(intentInput)
   .mutation(async ({ ctx, input }) => {
@@ -227,13 +272,7 @@ const confirmCreationIntent = webMutationProcedure
     const captured: { postCommit: CreationPostCommit | null } = {
       postCommit: null,
     };
-    const outcome = await claimAndExecute(
-      prisma,
-      {
-        intentId: loaded.intent.id,
-        actorDiscordId: loaded.userId,
-        now: new Date(),
-      },
+    const outcome = await claimCreation(
       async (tx) => {
         const executed = await executeCreationIntent(tx, {
           payload: loaded.payload,
@@ -250,6 +289,10 @@ const confirmCreationIntent = webMutationProcedure
           detail: executed.audit,
         });
         return executed.outcome;
+      },
+      {
+        intentId: loaded.intent.id,
+        actorDiscordId: loaded.userId,
       },
     );
 

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/explore-creation.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/explore-creation.router.test.ts
@@ -331,6 +331,28 @@ describe("explore.confirmCreationIntent — subscriptions", () => {
 });
 
 describe("explore.confirmCreationIntent — competitions", () => {
+  test("an entrant that no longer exists is a refusal, not a server error", async () => {
+    // The payload's entrant ids were written by the model when the intent was
+    // prepared, so a player deleted since then is expected input at this
+    // boundary rather than a broken caller. createCompetitionForActor lets the
+    // enrollment throw so the half-built competition rolls back; that must
+    // surface as an actionable refusal instead of an internal error the person
+    // would hit again on every retry.
+    await grant({ resource: "competitions", action: "create" });
+    await grant({ resource: "competitions", action: "invite" });
+    const payload = ConfirmationIntentPayloadSchema.parse({
+      ...competitionPayload(),
+      initialPlayerIds: [987_654_321],
+    });
+    const intentId = await mintIntent(payload);
+
+    await expect(
+      caller().explore.confirmCreationIntent({ intentId }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(await db.competition.count({ where: { serverId: GUILD } })).toBe(0);
+  });
+
   test("creates the competition with a COMPETITION_CREATE audit row", async () => {
     await grant({ resource: "competitions", action: "create" });
     const intentId = await mintIntent(competitionPayload());

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/explore-creation.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/explore-creation.router.test.ts
@@ -1,0 +1,539 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+import {
+  ConfirmationIntentPayloadSchema,
+  permissionKey,
+  type ConfirmationIntentPayload,
+  type DiscordAccountId,
+  type DiscordGuildId,
+  type Permission,
+} from "@scout-for-lol/data";
+import {
+  initFeatureFlags,
+  shutdownFeatureFlags,
+} from "@shepherdjerred/feature-flags";
+import { resetConfigurationForTests } from "#src/configuration.ts";
+import {
+  addFlagOverride,
+  resetFlagOverrides,
+} from "#src/configuration/flags.ts";
+import { clearAllRateLimits } from "#src/database/competition/rate-limit.ts";
+import { createOfflineTrpcHarness } from "#src/testing/test-trpc-caller.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+  testPuuid,
+} from "#src/testing/test-ids.ts";
+
+/**
+ * The confirm path is the security surface of Explore-driven creation: an AI
+ * agent prepares the intent, so every check that decides whether the write is
+ * allowed has to happen here, at confirm time, against live state.
+ *
+ * The harness installs module mocks, so it must run before anything imports the
+ * router (see its docblock).
+ */
+const GUILD = testGuildId("410001");
+const OTHER_GUILD = testGuildId("410002");
+const CHANNEL = testChannelId("410003");
+const ACTOR = testAccountId("910000001");
+const STRANGER = testAccountId("910000002");
+
+const trpc = await createOfflineTrpcHarness("explore-creation-test");
+const db = trpc.prisma;
+
+const QUERY_TEXT =
+  "SELECT player, COUNT(*) AS games FROM match_participants GROUP BY player RENDER table";
+
+function setAllowlist(value: string | undefined): void {
+  if (value === undefined) {
+    delete Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+  } else {
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = value;
+  }
+  resetConfigurationForTests();
+}
+
+function reportPayload(
+  guildId: DiscordGuildId = GUILD,
+): ConfirmationIntentPayload {
+  return ConfirmationIntentPayloadSchema.parse({
+    kind: "report",
+    guildId,
+    channelId: CHANNEL,
+    title: "Weekly games",
+    description: null,
+    queryText: QUERY_TEXT,
+  });
+}
+
+function subscriptionPayload(
+  account = "explore-creation",
+): ConfirmationIntentPayload {
+  return ConfirmationIntentPayloadSchema.parse({
+    kind: "subscription",
+    guildId: GUILD,
+    channelId: CHANNEL,
+    region: "AMERICA_NORTH",
+    alias: "Prepared",
+    puuid: testPuuid(account),
+    riotId: { game_name: "Prepared", tag_line: "NA1" },
+  });
+}
+
+function competitionPayload(): ConfirmationIntentPayload {
+  return ConfirmationIntentPayloadSchema.parse({
+    kind: "competition",
+    guildId: GUILD,
+    channelId: CHANNEL,
+    title: "Prepared competition",
+    description: "Prepared from Explore",
+    visibility: "INVITE_ONLY",
+    dates: {
+      type: "FIXED_DATES",
+      startDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      endDate: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000),
+    },
+    criteria: { type: "MOST_GAMES_PLAYED", queues: ["flex"] },
+  });
+}
+
+let intentCounter = 0;
+async function mintIntent(
+  payload: ConfirmationIntentPayload,
+  overrides?: {
+    serverId?: DiscordGuildId;
+    actorDiscordId?: DiscordAccountId;
+    expiresAt?: Date;
+  },
+): Promise<string> {
+  intentCounter += 1;
+  const intent = await db.confirmationIntent.create({
+    data: {
+      kind: payload.kind,
+      serverId: overrides?.serverId ?? GUILD,
+      actorDiscordId: overrides?.actorDiscordId ?? ACTOR,
+      payload: JSON.stringify(payload),
+      idempotencyKey: `explore-creation-${intentCounter.toString()}`,
+      expiresAt: overrides?.expiresAt ?? new Date(Date.now() + 60_000),
+    },
+  });
+  return intent.id;
+}
+
+async function grant(...permissions: Permission[]): Promise<void> {
+  await db.serverPermission.createMany({
+    data: permissions.map((permission) => ({
+      serverId: GUILD,
+      discordUserId: ACTOR,
+      permission: permissionKey(permission),
+      grantedBy: ACTOR,
+      grantedAt: new Date(),
+    })),
+  });
+}
+
+async function seedEnabledReport(title: string): Promise<void> {
+  const now = new Date();
+  await db.report.create({
+    data: {
+      serverId: GUILD,
+      ownerId: ACTOR,
+      channelId: CHANNEL,
+      title,
+      queryText: QUERY_TEXT,
+      isEnabled: true,
+      isSystemManaged: false,
+      cronExpression: "0 12 * * 1",
+      scheduleTimezone: "UTC",
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+}
+
+function caller(discordId: string = ACTOR) {
+  return trpc.authedCaller(discordId);
+}
+
+beforeAll(async () => {
+  await initFeatureFlags({
+    environment: { FEATURE_FLAGS_MODE: "disabled" },
+  });
+});
+
+beforeEach(async () => {
+  await db.confirmationIntent.deleteMany();
+  await db.auditLog.deleteMany();
+  await db.reportScheduleOutbox.deleteMany();
+  await db.report.deleteMany();
+  await db.competitionParticipant.deleteMany();
+  await db.competition.deleteMany();
+  await db.subscription.deleteMany();
+  await db.account.deleteMany();
+  await db.player.deleteMany();
+  await db.serverPermission.deleteMany();
+  clearAllRateLimits();
+
+  resetFlagOverrides("explore_creation_enabled");
+  resetFlagOverrides("initial_match_history_import_enabled");
+  addFlagOverride("explore_creation_enabled", true, { server: GUILD });
+  trpc.setMembership([
+    { guildId: GUILD, asAdmin: false },
+    { guildId: OTHER_GUILD, asAdmin: false },
+  ]);
+  setAllowlist(`${GUILD},${OTHER_GUILD}`);
+});
+
+afterAll(async () => {
+  resetFlagOverrides("explore_creation_enabled");
+  resetFlagOverrides("initial_match_history_import_enabled");
+  setAllowlist(undefined);
+  await shutdownFeatureFlags();
+  await db.$disconnect();
+});
+
+describe("explore.confirmCreationIntent — reports", () => {
+  test("creates the same rows the web form creates, plus the audit row", async () => {
+    await grant({ resource: "reports", action: "create" });
+    const intentId = await mintIntent(reportPayload());
+
+    const result = await caller().explore.confirmCreationIntent({ intentId });
+
+    expect(result).toMatchObject({
+      kind: "created",
+      entity: "report",
+      guildId: GUILD,
+    });
+    const reports = await db.report.findMany({ where: { serverId: GUILD } });
+    expect(reports).toHaveLength(1);
+    const [report] = reports;
+    expect(report).toBeDefined();
+    if (report === undefined) return;
+    expect(report.ownerId).toBe(ACTOR);
+    expect(report.queryText).toBe(QUERY_TEXT);
+    expect(report.channelId).toBe(CHANNEL);
+
+    const audits = await db.auditLog.findMany({ where: { serverId: GUILD } });
+    expect(audits).toHaveLength(1);
+    const [audit] = audits;
+    expect(audit).toBeDefined();
+    if (audit === undefined) return;
+    expect(audit.action).toBe("REPORT_CREATE");
+    expect(audit.actorDiscordId).toBe(ACTOR);
+    expect(audit.targetChannelId).toBe(CHANNEL);
+    expect(JSON.parse(audit.payload)).toMatchObject({
+      reportId: report.id,
+      via: "explore",
+    });
+  });
+
+  test("enqueues the schedule-outbox row so the reconciler picks it up", async () => {
+    await grant({ resource: "reports", action: "create" });
+    const intentId = await mintIntent(reportPayload());
+
+    await caller().explore.confirmCreationIntent({ intentId });
+
+    const outbox = await db.reportScheduleOutbox.findMany();
+    expect(outbox).toHaveLength(1);
+  });
+
+  test("re-checks the report limit inside the transaction", async () => {
+    await grant({ resource: "reports", action: "create" });
+    // reports_per_owner_per_server defaults to 2.
+    await seedEnabledReport("Existing one");
+    await seedEnabledReport("Existing two");
+    const intentId = await mintIntent(reportPayload());
+
+    const result = await caller().explore.confirmCreationIntent({ intentId });
+
+    expect(result).toMatchObject({ kind: "limit_reached" });
+    expect(await db.report.count({ where: { serverId: GUILD } })).toBe(2);
+    expect(await db.auditLog.count({ where: { serverId: GUILD } })).toBe(0);
+  });
+});
+
+describe("explore.confirmCreationIntent — subscriptions", () => {
+  test("creates the player, account and subscription with an audit row", async () => {
+    await grant({ resource: "subscriptions", action: "create" });
+    const intentId = await mintIntent(subscriptionPayload());
+
+    const result = await caller().explore.confirmCreationIntent({ intentId });
+
+    expect(result).toMatchObject({
+      kind: "created",
+      entity: "subscription",
+      guildId: GUILD,
+    });
+    expect(await db.player.count({ where: { serverId: GUILD } })).toBe(1);
+    expect(await db.subscription.count({ where: { serverId: GUILD } })).toBe(1);
+
+    const account = await db.account.findFirst({ where: { serverId: GUILD } });
+    expect(account).not.toBeNull();
+    // The stored Riot ID comes from the frozen Riot-canonical value, not from
+    // whatever the agent typed.
+    expect(account?.riotGameName).toBe("Prepared");
+    expect(account?.riotTagLine).toBe("NA1");
+    expect(account?.puuid).toBe(testPuuid("explore-creation"));
+
+    const audit = await db.auditLog.findFirst({
+      where: { serverId: GUILD, action: "SUBSCRIPTION_ADD" },
+    });
+    expect(audit).not.toBeNull();
+    expect(JSON.parse(audit?.payload ?? "{}")).toMatchObject({
+      via: "explore",
+    });
+  });
+
+  test("reports an already-tracked account instead of creating a duplicate", async () => {
+    await grant({ resource: "subscriptions", action: "create" });
+    const first = await mintIntent(subscriptionPayload());
+    await caller().explore.confirmCreationIntent({ intentId: first });
+    const second = await mintIntent(subscriptionPayload());
+
+    const result = await caller().explore.confirmCreationIntent({
+      intentId: second,
+    });
+
+    expect(result).toMatchObject({ kind: "account_already_subscribed" });
+    expect(await db.account.count({ where: { serverId: GUILD } })).toBe(1);
+  });
+
+  test("a second account on an already-subscribed player audits ACCOUNT_ADD, as the web form does", async () => {
+    await grant({ resource: "subscriptions", action: "create" });
+    const first = await mintIntent(subscriptionPayload());
+    await caller().explore.confirmCreationIntent({ intentId: first });
+    const smurf = await mintIntent(subscriptionPayload("explore-smurf"));
+
+    const result = await caller().explore.confirmCreationIntent({
+      intentId: smurf,
+    });
+
+    expect(result).toMatchObject({ kind: "subscription_already_exists" });
+    // The account row still commits, so it still has to be audited.
+    expect(await db.account.count({ where: { serverId: GUILD } })).toBe(2);
+    expect(await db.subscription.count({ where: { serverId: GUILD } })).toBe(1);
+    const audit = await db.auditLog.findFirst({
+      where: { serverId: GUILD, action: "ACCOUNT_ADD" },
+    });
+    expect(audit).not.toBeNull();
+    expect(JSON.parse(audit?.payload ?? "{}")).toMatchObject({
+      via: "explore",
+    });
+  });
+});
+
+describe("explore.confirmCreationIntent — competitions", () => {
+  test("creates the competition with a COMPETITION_CREATE audit row", async () => {
+    await grant({ resource: "competitions", action: "create" });
+    const intentId = await mintIntent(competitionPayload());
+
+    const result = await caller().explore.confirmCreationIntent({ intentId });
+
+    expect(result).toMatchObject({
+      kind: "created",
+      entity: "competition",
+      guildId: GUILD,
+    });
+    expect(await db.competition.count({ where: { serverId: GUILD } })).toBe(1);
+    const audit = await db.auditLog.findFirst({
+      where: { serverId: GUILD, action: "COMPETITION_CREATE" },
+    });
+    expect(audit).not.toBeNull();
+    expect(JSON.parse(audit?.payload ?? "{}")).toMatchObject({
+      via: "explore",
+    });
+  });
+});
+
+describe("explore.confirmCreationIntent — authorization", () => {
+  test("a permission revoked between minting and confirming is FORBIDDEN", async () => {
+    // No grant seeded: the intent was minted while the actor could create, and
+    // the grant has since been withdrawn.
+    const intentId = await mintIntent(reportPayload());
+
+    await expect(
+      caller().explore.confirmCreationIntent({ intentId }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(await db.report.count()).toBe(0);
+    expect(
+      await db.confirmationIntent.count({ where: { consumedAt: null } }),
+    ).toBe(1);
+  });
+
+  test("the wrong permission does not authorize another kind", async () => {
+    await grant({ resource: "reports", action: "create" });
+    const intentId = await mintIntent(competitionPayload());
+
+    await expect(
+      caller().explore.confirmCreationIntent({ intentId }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(await db.competition.count()).toBe(0);
+  });
+
+  test("an intent in another guild is NOT_FOUND, not FORBIDDEN", async () => {
+    await grant({ resource: "reports", action: "create" });
+    // The caller belongs to OTHER_GUILD too, so this is specifically about the
+    // intent's guild, not about membership.
+    const intentId = await mintIntent(reportPayload(OTHER_GUILD), {
+      serverId: OTHER_GUILD,
+    });
+    trpc.setMembership([{ guildId: GUILD, asAdmin: false }]);
+
+    await expect(
+      caller().explore.confirmCreationIntent({ intentId }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  test("another person's intent is NOT_FOUND, not FORBIDDEN", async () => {
+    await grant({ resource: "reports", action: "create" });
+    const intentId = await mintIntent(reportPayload(), {
+      actorDiscordId: STRANGER,
+    });
+
+    await expect(
+      caller().explore.confirmCreationIntent({ intentId }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(await db.report.count()).toBe(0);
+  });
+
+  test("a dare intent cannot be confirmed through the creation procedure", async () => {
+    await grant({ resource: "reports", action: "create" });
+    const dare = await db.bucksDareV2.create({
+      data: {
+        serverId: GUILD,
+        channelId: CHANNEL,
+        challengerDiscordId: ACTOR,
+        openingStake: 20,
+      },
+    });
+    const intent = await db.confirmationIntent.create({
+      data: {
+        kind: "dare_fund",
+        serverId: GUILD,
+        dareId: dare.id,
+        expectedRevision: 1,
+        actorDiscordId: ACTOR,
+        payload: JSON.stringify({ kind: "dare_fund" }),
+        idempotencyKey: "explore-creation-dare",
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    });
+
+    await expect(
+      caller().explore.confirmCreationIntent({ intentId: intent.id }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    const stored = await db.confirmationIntent.findUniqueOrThrow({
+      where: { id: intent.id },
+    });
+    expect(stored.consumedAt).toBeNull();
+    await db.bucksDareV2.deleteMany();
+  });
+
+  test("revoking the feature flag blocks an already-pending intent", async () => {
+    await grant({ resource: "reports", action: "create" });
+    const intentId = await mintIntent(reportPayload());
+    resetFlagOverrides("explore_creation_enabled");
+
+    await expect(
+      caller().explore.confirmCreationIntent({ intentId }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(await db.report.count()).toBe(0);
+  });
+
+  test("an unauthenticated caller is rejected", async () => {
+    const intentId = await mintIntent(reportPayload());
+
+    await expect(
+      trpc.anonCaller().explore.confirmCreationIntent({ intentId }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("explore.confirmCreationIntent — single use", () => {
+  test("an expired intent creates nothing", async () => {
+    await grant({ resource: "reports", action: "create" });
+    const intentId = await mintIntent(reportPayload(), {
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    const result = await caller().explore.confirmCreationIntent({ intentId });
+
+    expect(result).toEqual({ kind: "intent_expired" });
+    expect(await db.report.count()).toBe(0);
+  });
+
+  test("a second confirmation replays the outcome and creates nothing", async () => {
+    await grant({ resource: "reports", action: "create" });
+    const intentId = await mintIntent(reportPayload());
+
+    const first = await caller().explore.confirmCreationIntent({ intentId });
+    const second = await caller().explore.confirmCreationIntent({ intentId });
+
+    expect(first).toMatchObject({ kind: "created" });
+    expect(second).toMatchObject({ kind: "already_consumed" });
+    expect(await db.report.count({ where: { serverId: GUILD } })).toBe(1);
+    expect(await db.auditLog.count({ where: { serverId: GUILD } })).toBe(1);
+  });
+
+  test("two concurrent confirmations create exactly one entity", async () => {
+    await grant({ resource: "reports", action: "create" });
+    const intentId = await mintIntent(reportPayload());
+
+    const results = await Promise.all([
+      caller().explore.confirmCreationIntent({ intentId }),
+      caller().explore.confirmCreationIntent({ intentId }),
+    ]);
+
+    expect(results.filter((r) => r.kind === "created")).toHaveLength(1);
+    expect(await db.report.count({ where: { serverId: GUILD } })).toBe(1);
+    expect(await db.auditLog.count({ where: { serverId: GUILD } })).toBe(1);
+  });
+});
+
+describe("explore.creationIntentStatus", () => {
+  test("reports pending, then consumed with the stored outcome", async () => {
+    await grant({ resource: "reports", action: "create" });
+    const intentId = await mintIntent(reportPayload());
+
+    const pending = await caller().explore.creationIntentStatus({ intentId });
+    expect(pending).toMatchObject({
+      state: "pending",
+      kind: "report",
+      guildId: GUILD,
+      result: null,
+    });
+
+    await caller().explore.confirmCreationIntent({ intentId });
+    const consumed = await caller().explore.creationIntentStatus({ intentId });
+    expect(consumed.state).toBe("consumed");
+    expect(consumed.result).toMatchObject({ kind: "created" });
+  });
+
+  test("hides another person's intent", async () => {
+    const intentId = await mintIntent(reportPayload(), {
+      actorDiscordId: STRANGER,
+    });
+
+    await expect(
+      caller().explore.creationIntentStatus({ intentId }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  test("is blocked when the feature flag is off", async () => {
+    const intentId = await mintIntent(reportPayload());
+    resetFlagOverrides("explore_creation_enabled");
+
+    await expect(
+      caller().explore.creationIntentStatus({ intentId }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/explore-intent-access.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/explore-intent-access.ts
@@ -1,0 +1,91 @@
+/**
+ * Who may see an Explore confirmation intent.
+ *
+ * Its own module rather than a helper inside `explore.router.ts` because the
+ * creation-confirm procedures are spread *into* that router: importing the
+ * helpers from there would close an eager import cycle, which
+ * `check-architecture` rejects for good reason — module initialisation order
+ * would start to matter for an authorization check.
+ */
+
+import { TRPCError } from "@trpc/server";
+import {
+  DiscordAccountIdSchema,
+  type DiscordAccountId,
+} from "@scout-for-lol/data";
+import type {
+  ConfirmationIntent,
+  User,
+} from "#generated/prisma/client/index.js";
+import { prisma } from "#src/database/index.ts";
+import { assertExploreAccess } from "#src/explore/access.ts";
+
+/**
+ * The one refusal every visibility check answers with.
+ *
+ * Probing another guild's or another person's intent has to be
+ * indistinguishable from the intent not existing, so "you may not see this"
+ * and "there is nothing here" must produce the same error and the same text.
+ */
+export function confirmationNotFound(): TRPCError {
+  return new TRPCError({
+    code: "NOT_FOUND",
+    message: "Confirmation not found.",
+  });
+}
+
+/**
+ * The caller's id together with the servers they belong to.
+ *
+ * `assertExploreAccess` already fetches those servers to make its allowlist
+ * decision, so returning them costs nothing extra — and starting a turn needs
+ * them, because a `player('…')` alias may only resolve against servers the
+ * asker is actually in.
+ */
+export async function requireExploreUserAndGuilds(
+  user: User,
+): Promise<{ userId: DiscordAccountId; guildIds: string[] }> {
+  const guildIds = await assertExploreAccess(user);
+  return {
+    userId: DiscordAccountIdSchema.parse(user.discordId),
+    guildIds,
+  };
+}
+
+/**
+ * Loads a confirmation intent the caller's servers can see.
+ *
+ * The guild is stored on the intent, so this is a direct column comparison
+ * rather than a join through the dare it targets.
+ */
+export async function requireGuildIntent(
+  intentId: string,
+  guildIds: string[],
+): Promise<ConfirmationIntent> {
+  const intent = await prisma.confirmationIntent.findUnique({
+    where: { id: intentId },
+  });
+  if (!guildIds.includes(intent?.serverId ?? "")) {
+    throw confirmationNotFound();
+  }
+  if (intent === null) {
+    throw new Error("A visible confirmation unexpectedly disappeared.");
+  }
+  return intent;
+}
+
+/**
+ * {@link requireGuildIntent} plus the actor check: an intent is only visible
+ * to the person it was minted for.
+ */
+export async function requireActorIntent(params: {
+  intentId: string;
+  guildIds: string[];
+  userId: DiscordAccountId;
+}): Promise<ConfirmationIntent> {
+  const intent = await requireGuildIntent(params.intentId, params.guildIds);
+  if (intent.actorDiscordId !== params.userId) {
+    throw confirmationNotFound();
+  }
+  return intent;
+}

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.ts
@@ -40,6 +40,13 @@ import {
   shareExploreConversation,
 } from "#src/explore/store.ts";
 import { scoutExploreSharesTotal } from "#src/metrics/explore.ts";
+import { exploreCreationProcedures } from "#src/trpc/router/explore-creation-procedures.ts";
+import {
+  confirmationNotFound,
+  requireActorIntent,
+  requireExploreUserAndGuilds,
+  requireGuildIntent,
+} from "#src/trpc/router/explore-intent-access.ts";
 import {
   protectedProcedure,
   router,
@@ -67,48 +74,6 @@ async function requireExploreUser(user: User): Promise<DiscordAccountId> {
   return DiscordAccountIdSchema.parse(user.discordId);
 }
 
-/**
- * The caller's id together with the servers they belong to.
- *
- * `assertExploreAccess` already fetches those servers to make its allowlist
- * decision, so returning them costs nothing extra — and starting a turn needs
- * them, because a `player('…')` alias may only resolve against servers the
- * asker is actually in.
- */
-async function requireExploreUserAndGuilds(
-  user: User,
-): Promise<{ userId: DiscordAccountId; guildIds: string[] }> {
-  const guildIds = await assertExploreAccess(user);
-  return {
-    userId: DiscordAccountIdSchema.parse(user.discordId),
-    guildIds,
-  };
-}
-
-/**
- * Loads a confirmation intent the caller's servers can see.
- *
- * The guild is stored on the intent, so this is a direct column comparison
- * rather than a join through the dare it targets. Probing an intent in another
- * server has to stay indistinguishable from it not existing, hence NOT_FOUND
- * for both.
- */
-async function requireGuildIntent(intentId: string, guildIds: string[]) {
-  const intent = await prisma.confirmationIntent.findUnique({
-    where: { id: intentId },
-  });
-  if (!guildIds.includes(intent?.serverId ?? "")) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: "Confirmation not found.",
-    });
-  }
-  if (intent === null) {
-    throw new Error("A visible confirmation unexpectedly disappeared.");
-  }
-  return intent;
-}
-
 const exploreProcedure = protectedProcedure;
 
 /**
@@ -126,13 +91,11 @@ const intentStatusProcedure = exploreProcedure
   .input(z.strictObject({ intentId: z.uuid() }))
   .query(async ({ ctx, input }) => {
     const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
-    const intent = await requireGuildIntent(input.intentId, guildIds);
-    if (intent.actorDiscordId !== userId) {
-      throw new TRPCError({
-        code: "NOT_FOUND",
-        message: "Confirmation not found.",
-      });
-    }
+    const intent = await requireActorIntent({
+      intentId: input.intentId,
+      guildIds,
+      userId,
+    });
     return {
       state:
         intent.consumedAt === null
@@ -183,16 +146,17 @@ export const exploreRouter = router({
   /** @deprecated Pre-rename alias; see {@link intentStatusProcedure}. */
   dareIntentStatus: intentStatusProcedure,
 
+  // Confirming an entity an Explore agent prepared. Nothing mints these yet;
+  // see explore-creation-procedures.ts.
+  ...exploreCreationProcedures,
+
   confirmDareIntent: webMutationProcedure
     .input(z.strictObject({ intentId: z.uuid() }))
     .mutation(async ({ ctx, input }) => {
       const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
       const intent = await requireGuildIntent(input.intentId, guildIds);
       if (intent.dareId === null) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Confirmation not found.",
-        });
+        throw confirmationNotFound();
       }
       const outcome = await consumeDareV2ConfirmationIntent({
         intentId: input.intentId,

--- a/packages/scout-for-lol/packages/data/src/model/confirmation-intent.ts
+++ b/packages/scout-for-lol/packages/data/src/model/confirmation-intent.ts
@@ -1,5 +1,85 @@
 import { z } from "zod";
 import { BucksStakeSchema } from "./bryan-bucks.ts";
+import { CompetitionWriteSchema } from "./competition-write.ts";
+import {
+  DiscordAccountIdSchema,
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+} from "./discord.ts";
+import { PlayerAliasSchema } from "./form-inputs.ts";
+import {
+  LeaguePuuidSchema,
+  RegionSchema,
+  RiotIdPartsSchema,
+} from "./league-account.ts";
+import { ReportCreateInputSchema } from "./report.ts";
+import { SubscriptionFilterSpecSchema } from "./subscription-filter.ts";
+
+/**
+ * The arms that act on an existing dare.
+ *
+ * Split out of the full union rather than filtered back out of it, because
+ * `dare.prepareAction` takes a payload straight off the wire: a union that
+ * admitted a creation arm would let a client mint a creation intent through
+ * the dare prepare procedure, bypassing the creation gate entirely.
+ */
+const dareIntentPayloadArms = [
+  z.strictObject({ kind: z.literal("dare_fund") }),
+  z.strictObject({ kind: z.literal("dare_accept") }),
+  z.strictObject({ kind: z.literal("dare_decline") }),
+  z.strictObject({
+    kind: z.literal("dare_contribute"),
+    amount: BucksStakeSchema,
+  }),
+  z.strictObject({ kind: z.literal("dare_cancel") }),
+] as const;
+
+/**
+ * The arms that create a domain entity an Explore agent prepared.
+ *
+ * They reuse the same schemas the web forms post (`ReportCreateInputSchema`,
+ * `CompetitionWriteSchema`) rather than restating field shapes, so a prepared
+ * entity and a hand-filled form cannot describe different things. Nothing in
+ * the payload is trusted as authorization: the confirm path re-resolves the
+ * caller's permissions from scratch and reads the guild off the intent row,
+ * not out of here.
+ */
+const creationIntentPayloadArms = [
+  z.strictObject({
+    kind: z.literal("report"),
+    guildId: DiscordGuildIdSchema,
+    ...ReportCreateInputSchema.shape,
+  }),
+  z.strictObject({
+    kind: z.literal("subscription"),
+    guildId: DiscordGuildIdSchema,
+    channelId: DiscordChannelIdSchema,
+    region: RegionSchema,
+    alias: PlayerAliasSchema,
+    discordUserId: DiscordAccountIdSchema.optional(),
+    filters: SubscriptionFilterSpecSchema.nullable().optional(),
+    /**
+     * The PUUID and Riot-canonical Riot ID are frozen when the intent is
+     * prepared, never re-resolved at confirm time. Riot's account lookup
+     * routinely takes seconds and confirm runs inside a Prisma transaction
+     * whose 5s timeout would trip `P2028` — the same reason
+     * `subscription.add` resolves them before opening its transaction.
+     */
+    puuid: LeaguePuuidSchema,
+    riotId: RiotIdPartsSchema,
+  }),
+  z.strictObject({
+    kind: z.literal("competition"),
+    guildId: DiscordGuildIdSchema,
+    ...CompetitionWriteSchema.shape,
+  }),
+] as const;
+
+export const DareIntentPayloadSchema = z.discriminatedUnion(
+  "kind",
+  dareIntentPayloadArms,
+);
+export type DareIntentPayload = z.infer<typeof DareIntentPayloadSchema>;
 
 /**
  * The payload of a confirmation intent: an actor-bound, single-use, expiring
@@ -11,26 +91,44 @@ import { BucksStakeSchema } from "./bryan-bucks.ts";
  * makes that state unrepresentable instead.
  */
 export const ConfirmationIntentPayloadSchema = z.discriminatedUnion("kind", [
-  z.strictObject({ kind: z.literal("dare_fund") }),
-  z.strictObject({ kind: z.literal("dare_accept") }),
-  z.strictObject({ kind: z.literal("dare_decline") }),
-  z.strictObject({
-    kind: z.literal("dare_contribute"),
-    amount: BucksStakeSchema,
-  }),
-  z.strictObject({ kind: z.literal("dare_cancel") }),
+  ...dareIntentPayloadArms,
+  ...creationIntentPayloadArms,
 ]);
 export type ConfirmationIntentPayload = z.infer<
   typeof ConfirmationIntentPayloadSchema
 >;
 
-/** Every kind a stored confirmation intent may carry. */
-export const ConfirmationIntentKindSchema = z.enum([
+/** The kinds that act on an existing dare. */
+export const DareIntentKindSchema = z.enum([
   "dare_fund",
   "dare_accept",
   "dare_decline",
   "dare_contribute",
   "dare_cancel",
+]);
+export type DareIntentKind = z.infer<typeof DareIntentKindSchema>;
+
+/**
+ * The kinds that create a domain entity rather than acting on an existing
+ * dare. They are gated, authorized and executed by their own procedure, so the
+ * split is a real boundary and not merely a naming convention.
+ */
+export const CreationIntentKindSchema = z.enum([
+  "report",
+  "subscription",
+  "competition",
+]);
+export type CreationIntentKind = z.infer<typeof CreationIntentKindSchema>;
+
+export type CreationIntentPayload = Extract<
+  ConfirmationIntentPayload,
+  { kind: CreationIntentKind }
+>;
+
+/** Every kind a stored confirmation intent may carry. */
+export const ConfirmationIntentKindSchema = z.enum([
+  ...DareIntentKindSchema.options,
+  ...CreationIntentKindSchema.options,
 ]);
 export type ConfirmationIntentKind = z.infer<
   typeof ConfirmationIntentKindSchema

--- a/packages/scout-for-lol/packages/data/src/model/league-account.ts
+++ b/packages/scout-for-lol/packages/data/src/model/league-account.ts
@@ -59,6 +59,19 @@ export const LeaguePuuidSchema = z
 
 // https://developer.riotgames.com/docs/summoner-name-to-riot-id-faq
 // a riot ID looks like this: game_name#tag_line
+/**
+ * A Riot ID already split into its two parts.
+ *
+ * Named separately from {@link RiotIdSchema} because that schema's *input* is
+ * the `game_name#tag_line` string; anything that stores or transports the
+ * already-parsed value (a confirmation intent payload, for example) needs the
+ * object shape and would fail to re-parse the string form.
+ */
+export const RiotIdPartsSchema = z.object({
+  game_name: z.string().min(3).max(16),
+  tag_line: z.string().min(3).max(5),
+});
+
 export type RiotId = z.infer<typeof RiotIdSchema>;
 export const RiotIdSchema = z
   .string()
@@ -70,12 +83,7 @@ export const RiotIdSchema = z
     const [gameName, tagLine] = val.split("#");
     return { game_name: gameName, tag_line: tagLine };
   })
-  .pipe(
-    z.object({
-      game_name: z.string().min(3).max(16),
-      tag_line: z.string().min(3).max(5),
-    }),
-  );
+  .pipe(RiotIdPartsSchema);
 
 export type LeagueAccount = z.infer<typeof LeagueAccountSchema>;
 export const LeagueAccountSchema = z.strictObject({


### PR DESCRIPTION
Stacked on #2706.

## Why

Reports, competitions and subscriptions can only be created through the guild-scoped
web forms. A follow-up lets the Explore agent prepare one conversationally — but
**the model must never write domain state itself**: it prepares an *intent*, and a
human confirms it.

This PR adds the confirm half. It is **inert on its own** — nothing mints creation
intents until the agent tools land (next PR), and no UI renders them yet — which is
deliberate: it keeps the authorization surface reviewable by itself.

## What

- **Payload contracts.** Extend the confirmation-intent union with `report`,
  `subscription` and `competition` arms, reusing the existing create schemas rather
  than restating them. The union is **split** so dare code takes `DareIntentPayload`
  and creation code takes `CreationIntentPayload`: each stays exhaustive over its own
  kinds, and neither can be handed the other's payload.
- **Frozen Riot identity.** The subscription payload carries the resolved `puuid` and
  Riot-canonical `riotId`. Confirm must not re-resolve them — the web form
  deliberately calls Riot *outside* its transaction, because Prisma's 5s transaction
  timeout against Riot's latency trips P2028.
- **`explore.confirmCreationIntent` / `explore.creationIntentStatus`.** Confirm
  re-runs everything from scratch and trusts nothing from prepare time: Explore
  access, intent ownership, the feature flag, the payload, guild permissions, the
  channel, and the domain limits. It then calls **the same services the web forms
  call** (`createReportInTransaction`, `addSubscription`, `createCompetitionForActor`),
  so the two surfaces cannot diverge.
- **Audit inside the claim's transaction.** `recordMutationAudit` is split out of
  `runAuditedMutation` because the single-use claim has to be the *first* statement of
  its transaction — that guarded write is the double-spend guard — so the confirm path
  cannot open its own transaction around it. Both callers still share one ctx→audit-row
  mapping.
- **`explore_creation_enabled`**, defaulted off and free to ramp. One flag covers all
  three kinds; *which* entities a person may create is already decided by per-entity
  permissions.

### Authorization notes for review

- An intent belonging to another guild or another person answers **NOT_FOUND**, not
  FORBIDDEN, so an intent id cannot be probed. One helper produces that refusal so the
  code and the message cannot drift apart.
- `resolveGuildPermissions` throws by itself for a non-member (FORBIDDEN), an
  uninstalled guild (NOT_FOUND) and a Discord outage (UNAUTHORIZED /
  SERVICE_UNAVAILABLE). Those propagate untouched — **an outage is not a permission
  answer** and must never be reported as one.
- The competition sub-gates (`competitions:invite`, `competitions:schedule`) and the
  creation rate limit live inside `createCompetitionForActor`, which receives this same
  `PermissionSet`. Re-checking them here would be a second copy of a reviewed policy.
- These procedures deliberately do **not** use `guildMutationProcedure`: it reads
  `guildId` from the procedure *input*, and here the guild comes from the intent —
  binding it to an input field would let a caller pair an intent with a different guild.
- Where a column and its payload disagree — on `kind` or on `guildId` — the request
  fails loudly rather than picking a side.

## Verification

```
bunx turbo run typecheck test lint \
  --filter=@scout-for-lol/backend --filter=@scout-for-lol/data --filter=@scout-for-lol/app
```

24/24 tasks successful — backend 3123 tests / 347 files, data 1371 / 67, app 406 / 60.

**20 new tests** cover each kind creating the same rows and audit rows as its web form;
a permission revoked between minting and confirming; cross-guild and wrong-actor
probing answering NOT_FOUND; a dare intent refused by this procedure; flag revocation
blocking an already-pending intent; expiry; a replayed confirmation creating nothing;
two concurrent confirmations creating exactly one entity; and limits re-checked inside
the transaction.

**Not run:** any live or deployed check. No UI in this PR, so there is nothing to show
visually — the confirmation card and its screenshots come with the UI PR.