### PR TITLE
feat(scout-for-lol): let Explore prepare entity creations for confirmation

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-dare-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-dare-v2.ts
@@ -265,6 +265,10 @@ export async function replyBbDareV2(
       ticket,
       identity,
       guildIds: [input.serverId],
+      // `/bb dare` is a Discord command, and the user upserted above carries no
+      // OAuth token — so no creation tools, for the same reason `/scout ask`
+      // gets none.
+      surface: "discord",
       originChannelId: input.channelId,
       started: { ...created, question },
       history: transcript.messages,

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/scout.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/scout.ts
@@ -137,6 +137,9 @@ export async function executeScout(
       // Discord asks always carry a guild context (global in production,
       // guild-scoped in beta), so the invoking server is the whole alias scope.
       guildIds: [interaction.guildId],
+      // `/scout ask` is one-shot with no confirmation UI, and the user upserted
+      // above deliberately has no OAuth token, so creation tools stay absent.
+      surface: "discord",
       started,
       history: transcript.messages,
       emit: () => Promise.resolve(),

--- a/packages/scout-for-lol/packages/backend/src/explore/agent.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/agent.ts
@@ -32,7 +32,13 @@ import {
   challengeExploreEnabled,
   createChallengeExploreTools,
 } from "#src/explore/challenge-tools.ts";
+import {
+  resolveCreationCapability,
+  type CreationCapability,
+} from "#src/explore/creation/capability.ts";
+import { createCreationExploreTools } from "#src/explore/creation/tools.ts";
 import { exploreAgentInstructions } from "#src/explore/prompt.ts";
+import type { ExploreSurface } from "#src/explore/surface.ts";
 import { getOpenRouterRuntime } from "#src/league/review/ai-clients.ts";
 import { createLogger } from "#src/logger.ts";
 import { drainExploreStreams } from "#src/explore/stream.ts";
@@ -88,6 +94,12 @@ export type ExploreAgentParams = {
   requesterId: DiscordAccountId;
   /** Discord-originated dare drafts keep the invoking channel as metadata. */
   originChannelId: DiscordChannelId | null;
+  /**
+   * Which product surface this turn is answered on. Creation tools are
+   * web-only; see `explore/surface.ts` for why that is structural rather than
+   * a policy choice.
+   */
+  surface: ExploreSurface;
   abortSignal: AbortSignal;
   emit: (event: ExploreStreamEvent) => void | Promise<void>;
 };
@@ -140,6 +152,13 @@ async function streamExploreAgentInternal(
   const bucksCapability = await resolveBucksCapability(params.guildIds);
   const daresEnabled = await dareExploreEnabled(bucksCapability);
   const challengesEnabled = await challengeExploreEnabled(params.guildIds);
+  // Tier 1 only: a surface comparison and one flag read per guild. The
+  // permission work this gates is deferred into the first creation tool call,
+  // so an analytics turn never pays for an OAuth refresh it will not use.
+  const creationCapability = await resolveCreationCapability({
+    surface: params.surface,
+    guildIds: params.guildIds,
+  });
 
   const agent = new ToolLoopAgent({
     id: "scout-explore-agent",
@@ -150,6 +169,7 @@ async function streamExploreAgentInternal(
           : { currentTime: new Date().toISOString() },
       dares: daresEnabled,
       challenges: challengesEnabled,
+      creation: creationCapability !== null,
     }),
     model: runtime.languageModel(model, ["tools"]),
     tools: createExploreTools({
@@ -158,6 +178,7 @@ async function streamExploreAgentInternal(
       bucksCapability,
       daresEnabled,
       challengesEnabled,
+      creationCapability,
     }),
     stopWhen: stepCountIs(EXPLORE_MAX_STEPS),
     // Most current models (every GPT-5.x, most Claude) declare
@@ -250,11 +271,18 @@ type ExploreToolsOptions = {
   bucksCapability: Awaited<ReturnType<typeof resolveBucksCapability>>;
   daresEnabled: boolean;
   challengesEnabled: boolean;
+  creationCapability: CreationCapability | null;
 };
 
 function createExploreTools(options: ExploreToolsOptions) {
-  const { params, state, bucksCapability, daresEnabled, challengesEnabled } =
-    options;
+  const {
+    params,
+    state,
+    bucksCapability,
+    daresEnabled,
+    challengesEnabled,
+    creationCapability,
+  } = options;
   const track: ToolTracker = async (toolName, work) => {
     state.toolCalls++;
     if (state.toolCalls > EXPLORE_MAX_TOOL_CALLS) {
@@ -410,5 +438,10 @@ function createExploreTools(options: ExploreToolsOptions) {
           track,
         })
       : {}),
+    ...createCreationExploreTools({
+      capability: creationCapability,
+      requesterId: params.requesterId,
+      track,
+    }),
   };
 }

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/capability.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/capability.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { TRPCError } from "@trpc/server";
+import {
+  createPermissionSet,
+  P,
+  rootPermissions,
+  type DiscordGuildId,
+  type PermissionSet,
+} from "@scout-for-lol/data";
+import type { User } from "#generated/prisma/client/index.js";
+import {
+  addFlagOverride,
+  clearFlagOverrides,
+  resetFlagOverrides,
+} from "#src/configuration/flags.ts";
+import {
+  resolveCreationAccess,
+  resolveCreationCapability,
+  type CreationAccess,
+  type CreationCapability,
+} from "#src/explore/creation/capability.ts";
+import {
+  createCreationExploreTools,
+  createCreationToolExecutors,
+} from "#src/explore/creation/tools.ts";
+import { testAccountId, testGuildId } from "#src/testing/test-ids.ts";
+import type { ToolTracker } from "#src/reports/ai/scoutql-tools.ts";
+
+const ENABLED_GUILD = testGuildId("510001");
+const OTHER_GUILD = testGuildId("510002");
+const REQUESTER = testAccountId("910000101");
+
+const passthroughTracker: ToolTracker = async (_toolName, work) => await work();
+
+afterEach(() => {
+  resetFlagOverrides("explore_creation_enabled");
+});
+
+function testUser(): User {
+  return {
+    discordId: REQUESTER,
+    discordUsername: "creation-test",
+    discordAvatar: null,
+    discordAccessToken: null,
+    discordRefreshToken: null,
+    tokenExpiresAt: null,
+    analyticsUserId: `analytics-${REQUESTER}`,
+    lastSeenAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+type AccessCounters = { oauth: number; permission: number };
+
+/**
+ * The real Tier-2 resolver with its two expensive seams counted, so a test can
+ * assert not only what came back but that nothing was paid for.
+ */
+function countedAccess(
+  counters: AccessCounters,
+  permissions: (guildId: DiscordGuildId) => Promise<PermissionSet>,
+  onFetch: () => Promise<void> = () => Promise.resolve(),
+) {
+  return (input: {
+    capability: CreationCapability;
+    requesterId: typeof REQUESTER;
+  }): Promise<CreationAccess> =>
+    resolveCreationAccess(input, {
+      loadUser: () => Promise.resolve(testUser()),
+      fetchUserGuilds: async () => {
+        counters.oauth += 1;
+        await onFetch();
+        return [];
+      },
+      resolvePermissions: async (_user, guildId) => {
+        counters.permission += 1;
+        return await permissions(guildId);
+      },
+      guildName: (guildId) => `Guild ${guildId}`,
+    });
+}
+
+describe("resolveCreationCapability", () => {
+  test("returns null when no guild in scope has creation enabled", async () => {
+    clearFlagOverrides("explore_creation_enabled");
+    await expect(
+      resolveCreationCapability({
+        surface: "web",
+        guildIds: [ENABLED_GUILD, OTHER_GUILD],
+      }),
+    ).resolves.toBeNull();
+  });
+
+  test("keeps only the guilds the flag is on for", async () => {
+    clearFlagOverrides("explore_creation_enabled");
+    addFlagOverride("explore_creation_enabled", true, {
+      server: ENABLED_GUILD,
+    });
+    await expect(
+      resolveCreationCapability({
+        surface: "web",
+        guildIds: [OTHER_GUILD, ENABLED_GUILD],
+      }),
+    ).resolves.toEqual({ guildIds: [ENABLED_GUILD] });
+  });
+
+  test("Discord is never a creation surface, however the flag is set", async () => {
+    clearFlagOverrides("explore_creation_enabled");
+    addFlagOverride("explore_creation_enabled", true, {
+      server: ENABLED_GUILD,
+    });
+    await expect(
+      resolveCreationCapability({
+        surface: "discord",
+        guildIds: [ENABLED_GUILD],
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("creation tool registration", () => {
+  test("the flag off means no tools AND no permission I/O at all", async () => {
+    // The regression guard for the laziness requirement: an OAuth refresh on
+    // the setup path of every Explore turn would let a Discord outage degrade
+    // ordinary analytics questions that never touch creation.
+    clearFlagOverrides("explore_creation_enabled");
+    const counters: AccessCounters = { oauth: 0, permission: 0 };
+    const capability = await resolveCreationCapability({
+      surface: "web",
+      guildIds: [ENABLED_GUILD],
+    });
+    expect(capability).toBeNull();
+
+    const tools = createCreationExploreTools({
+      capability,
+      requesterId: REQUESTER,
+      track: passthroughTracker,
+      dependencies: {
+        resolveAccess: countedAccess(counters, () =>
+          Promise.resolve(rootPermissions()),
+        ),
+        listChannels: () => [],
+      },
+    });
+
+    expect(Object.keys(tools)).toEqual([]);
+    expect(counters).toEqual({ oauth: 0, permission: 0 });
+  });
+
+  test("registering the tools pays nothing; the first call pays once", async () => {
+    clearFlagOverrides("explore_creation_enabled");
+    addFlagOverride("explore_creation_enabled", true, {
+      server: ENABLED_GUILD,
+    });
+    const counters: AccessCounters = { oauth: 0, permission: 0 };
+    const capability = await resolveCreationCapability({
+      surface: "web",
+      guildIds: [ENABLED_GUILD],
+    });
+    expect(capability).not.toBeNull();
+
+    const tools = createCreationExploreTools({
+      capability,
+      requesterId: REQUESTER,
+      track: passthroughTracker,
+      dependencies: {
+        // No permissions, so the limit previews never reach the database.
+        resolveAccess: countedAccess(counters, () =>
+          Promise.resolve(createPermissionSet([])),
+        ),
+        listChannels: () => [],
+      },
+    });
+    expect(Object.keys(tools).toSorted()).toEqual([
+      "list_creation_targets",
+      "list_guild_channels",
+      "prepare_competition_creation",
+      "prepare_report_creation",
+      "prepare_subscription_creation",
+    ]);
+    // Building the toolset is Tier 1 only.
+    expect(counters).toEqual({ oauth: 0, permission: 0 });
+  });
+
+  test("the first creation call resolves permissions once for the turn", async () => {
+    const counters: AccessCounters = { oauth: 0, permission: 0 };
+    // The executors behind the tool wrappers, so the assertion is about the
+    // memoization rather than about the AI SDK's call plumbing.
+    const executors = createCreationToolExecutors({
+      capability: { guildIds: [ENABLED_GUILD] },
+      requesterId: REQUESTER,
+      track: passthroughTracker,
+      dependencies: {
+        // No permissions, so the limit previews never reach the database.
+        resolveAccess: countedAccess(counters, () =>
+          Promise.resolve(createPermissionSet([])),
+        ),
+        listChannels: () => [],
+      },
+    });
+    expect(counters).toEqual({ oauth: 0, permission: 0 });
+
+    const first = await executors.listTargets();
+    expect(first).toMatchObject({ kind: "targets" });
+    expect(counters).toEqual({ oauth: 1, permission: 1 });
+
+    // Memoized for the turn: a second creation tool reuses the resolution.
+    await executors.listTargets();
+    expect(counters).toEqual({ oauth: 1, permission: 1 });
+  });
+});
+
+describe("resolveCreationAccess", () => {
+  const capability: CreationCapability = {
+    guildIds: [ENABLED_GUILD, OTHER_GUILD],
+  };
+
+  test("drops a guild the user has no permission in, keeps the rest", async () => {
+    const counters: AccessCounters = { oauth: 0, permission: 0 };
+    const access = await countedAccess(counters, (guildId) =>
+      guildId === ENABLED_GUILD
+        ? Promise.resolve(createPermissionSet([P("reports", "create")]))
+        : Promise.reject(
+            new TRPCError({
+              code: "FORBIDDEN",
+              message: "You are not a member of that guild",
+            }),
+          ),
+    )({ capability, requesterId: REQUESTER });
+
+    expect(access.kind).toBe("resolved");
+    if (access.kind !== "resolved") return;
+    expect(access.guilds.map((guild) => guild.guildId)).toEqual([
+      ENABLED_GUILD,
+    ]);
+    expect(access.guilds[0]?.permissions.can("reports", "create")).toBe(true);
+  });
+
+  test("a guild without Scout installed is excluded, not an error", async () => {
+    const counters: AccessCounters = { oauth: 0, permission: 0 };
+    const access = await countedAccess(counters, () =>
+      Promise.reject(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "Scout is not installed in that guild",
+        }),
+      ),
+    )({ capability, requesterId: REQUESTER });
+
+    expect(access).toEqual({ kind: "resolved", guilds: [] });
+  });
+
+  /** Resolve access against a membership probe that fails with `code`. */
+  async function accessUnderOutage(
+    code: "SERVICE_UNAVAILABLE" | "UNAUTHORIZED",
+    counters: AccessCounters,
+  ): Promise<CreationAccess> {
+    return await countedAccess(
+      counters,
+      () => Promise.resolve(rootPermissions()),
+      () => Promise.reject(new TRPCError({ code, message: "Discord said no" })),
+    )({ capability, requesterId: REQUESTER });
+  }
+
+  test("a Discord outage says 'couldn't verify', never a denial", async () => {
+    // The failure this whole design forbids: reporting an outage as "you have
+    // no permission" tells the user to stop trying rather than to retry.
+    const counters: AccessCounters = { oauth: 0, permission: 0 };
+    const access = await accessUnderOutage("SERVICE_UNAVAILABLE", counters);
+
+    expect(access.kind).toBe("verification_unavailable");
+    if (access.kind !== "verification_unavailable") return;
+    expect(access.message).toContain("could not reach Discord");
+    // The message must steer the model away from a permission answer rather
+    // than merely avoid the word.
+    expect(access.message).toContain("Do not tell them they lack permission");
+    // No guild was ever attributed a decision.
+    expect(counters.permission).toBe(0);
+  });
+
+  test("an expired Discord grant is also 'couldn't verify'", async () => {
+    const counters: AccessCounters = { oauth: 0, permission: 0 };
+    const access = await accessUnderOutage("UNAUTHORIZED", counters);
+
+    expect(access.kind).toBe("verification_unavailable");
+  });
+
+  test("an unexpected error propagates rather than reading as a denial", async () => {
+    const counters: AccessCounters = { oauth: 0, permission: 0 };
+    await expect(
+      countedAccess(counters, () =>
+        Promise.reject(new Error("prisma exploded")),
+      )({ capability, requesterId: REQUESTER }),
+    ).rejects.toThrow("prisma exploded");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/capability.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/capability.ts
@@ -1,0 +1,193 @@
+/**
+ * Whether — and where — an Explore turn may prepare a creation.
+ *
+ * The resolution is deliberately split into two tiers, and the split is the
+ * most load-bearing decision in this feature:
+ *
+ * **Tier 1 (`resolveCreationCapability`)** runs at turn setup, on every turn.
+ * It reads the surface and one feature flag per guild in scope. It performs no
+ * Discord I/O and no database I/O, so an ordinary analytics question costs
+ * nothing extra.
+ *
+ * **Tier 2 (`resolveCreationAccess`)** runs inside the first creation tool call
+ * and is memoized for the rest of the turn by the tool factory. It resolves the
+ * asker's real permissions, which means a Discord OAuth round trip
+ * (`getFreshUserAccessToken` inside `fetchUserGuildsForRequest`) plus a
+ * `ServerPermission` read per guild. Doing that at setup would put an OAuth
+ * refresh on the critical path of every Explore turn, and a refresh failure
+ * would then degrade turns that never intended to create anything.
+ *
+ * The other rule here: **an outage is never a denial.** `fetchUserGuildsForRequest`
+ * is called once up front precisely so "Discord could not be reached" stays
+ * distinguishable from "you have no eligible servers". A blanket per-guild
+ * catch would collapse the two and tell someone they lack permission when the
+ * truth is that Scout could not ask.
+ */
+
+import { TRPCError } from "@trpc/server";
+import {
+  DiscordGuildIdSchema,
+  type DiscordAccountId,
+  type DiscordGuildId,
+  type PermissionSet,
+} from "@scout-for-lol/data";
+import type { User } from "#generated/prisma/client/index.js";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
+import { prisma } from "#src/database/index.ts";
+import { client as discordClient } from "#src/discord/client.ts";
+import type { ExploreSurface } from "#src/explore/surface.ts";
+import type { PartialGuild } from "#src/lib/discord-rest.ts";
+import { fetchUserGuildsForRequest } from "#src/trpc/discord-upstream.ts";
+import { resolveGuildPermissions } from "#src/trpc/guild-permission.ts";
+
+/** Tier 1: the guilds in scope whose operator has switched creation on. */
+export type CreationCapability = {
+  guildIds: readonly DiscordGuildId[];
+};
+
+/**
+ * Tier 1. Cheap by construction: a surface comparison and one flag evaluation
+ * per guild, with no Discord or database access.
+ */
+export async function resolveCreationCapability(input: {
+  surface: ExploreSurface;
+  guildIds: readonly string[];
+}): Promise<CreationCapability | null> {
+  if (input.surface !== "web") return null;
+  const enabled: DiscordGuildId[] = [];
+  for (const raw of input.guildIds) {
+    const guildId = DiscordGuildIdSchema.parse(raw);
+    if (
+      await isPolicyEnabled("explore_creation_enabled", { server: guildId })
+    ) {
+      enabled.push(guildId);
+    }
+  }
+  return enabled.length === 0 ? null : { guildIds: enabled };
+}
+
+/** One guild the asker may actually act in, with the permissions they hold. */
+export type CreationGuildAccess = {
+  guildId: DiscordGuildId;
+  /** Display name from the bot's guild cache, for the model to name servers. */
+  name: string;
+  permissions: PermissionSet;
+};
+
+export type CreationAccess =
+  | { kind: "resolved"; guilds: CreationGuildAccess[] }
+  /**
+   * Scout could not ask Discord who this person is. Distinct from an empty
+   * `resolved` list on purpose: the tools must say "couldn't verify your
+   * servers", never "you don't have permission".
+   */
+  | { kind: "verification_unavailable"; message: string };
+
+const CREATION_VERIFICATION_UNAVAILABLE_MESSAGE =
+  "Scout could not reach Discord to verify which servers you belong to. Tell the user Scout could not check their servers right now and to try again shortly. Do not tell them they lack permission.";
+
+type CreationAccessDependencies = {
+  loadUser: (discordId: DiscordAccountId) => Promise<User>;
+  fetchUserGuilds: (user: User) => Promise<readonly PartialGuild[]>;
+  resolvePermissions: (
+    user: User,
+    guildId: DiscordGuildId,
+  ) => Promise<PermissionSet>;
+  guildName: (guildId: DiscordGuildId) => string;
+};
+
+/**
+ * The bot's cached display name for a guild.
+ *
+ * `resolveGuildPermissions` has already proved Scout is installed by the time
+ * this is read, so a miss only happens for a dev guild override, where the id
+ * is the most honest label available.
+ */
+function cachedGuildName(guildId: DiscordGuildId): string {
+  return discordClient.guilds.cache.get(guildId)?.name ?? guildId;
+}
+
+const defaultCreationAccessDependencies: CreationAccessDependencies = {
+  // `resolveGuildPermissions` takes a Prisma `User` row and the agent only
+  // carries the Discord id, so the row is loaded here. A missing row is a
+  // broken caller contract — the turn is being answered for a signed-in web
+  // session — so it throws rather than degrading into "no permission".
+  loadUser: (discordId) =>
+    prisma.user.findUniqueOrThrow({ where: { discordId } }),
+  fetchUserGuilds: fetchUserGuildsForRequest,
+  resolvePermissions: resolveGuildPermissions,
+  guildName: cachedGuildName,
+};
+
+/**
+ * `UNAUTHORIZED` (their Discord grant is gone) and `SERVICE_UNAVAILABLE`
+ * (Discord is down) are the two codes `discord-upstream.ts` raises when it
+ * could not get an answer. Neither is a permission decision.
+ */
+function isVerificationOutage(error: unknown): boolean {
+  return (
+    error instanceof TRPCError &&
+    (error.code === "UNAUTHORIZED" || error.code === "SERVICE_UNAVAILABLE")
+  );
+}
+
+/**
+ * `FORBIDDEN` (not a member) and `NOT_FOUND` (Scout is not installed there) are
+ * real answers about one guild: it simply is not a creation target for this
+ * person. Every other error is a bug and propagates.
+ */
+function isGuildExclusion(error: unknown): boolean {
+  return (
+    error instanceof TRPCError &&
+    (error.code === "FORBIDDEN" || error.code === "NOT_FOUND")
+  );
+}
+
+function verificationUnavailable(): CreationAccess {
+  return {
+    kind: "verification_unavailable",
+    message: CREATION_VERIFICATION_UNAVAILABLE_MESSAGE,
+  };
+}
+
+/**
+ * Tier 2. Expensive, so call it lazily — see the module docblock.
+ *
+ * Guilds the asker cannot act in are dropped from the result; only a failure to
+ * reach Discord produces `verification_unavailable`.
+ */
+export async function resolveCreationAccess(
+  input: {
+    capability: CreationCapability;
+    requesterId: DiscordAccountId;
+  },
+  dependencies: CreationAccessDependencies = defaultCreationAccessDependencies,
+): Promise<CreationAccess> {
+  const user = await dependencies.loadUser(input.requesterId);
+  try {
+    // Once, up front. An outage is only distinguishable from "no eligible
+    // guilds" while nothing has been attributed to a specific guild yet.
+    await dependencies.fetchUserGuilds(user);
+  } catch (error) {
+    if (isVerificationOutage(error)) return verificationUnavailable();
+    throw error;
+  }
+
+  const guilds: CreationGuildAccess[] = [];
+  for (const guildId of input.capability.guildIds) {
+    try {
+      const permissions = await dependencies.resolvePermissions(user, guildId);
+      guilds.push({
+        guildId,
+        name: dependencies.guildName(guildId),
+        permissions,
+      });
+    } catch (error) {
+      // The membership cache can expire between the probe above and this call,
+      // so an outage is still possible here and still must not read as denial.
+      if (isVerificationOutage(error)) return verificationUnavailable();
+      if (!isGuildExclusion(error)) throw error;
+    }
+  }
+  return { kind: "resolved", guilds };
+}

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/context.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/context.ts
@@ -1,0 +1,182 @@
+/**
+ * What every creation tool executor is handed, and the refusals they share.
+ *
+ * The context carries the Tier-2 permission resolution as a *function*, not a
+ * value: `access()` is memoized by the tool factory, so the OAuth round trip
+ * and per-guild grant reads happen at most once, inside whichever creation tool
+ * the model calls first, and never at all on a turn that calls none.
+ */
+
+import type {
+  DiscordAccountId,
+  DiscordGuildId,
+  CreationIntentPayload,
+} from "@scout-for-lol/data";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import type {
+  CreationAccess,
+  CreationCapability,
+  CreationGuildAccess,
+} from "#src/explore/creation/capability.ts";
+import {
+  CreationPrepareResultSchema,
+  CREATION_MAX_SUMMARY_LENGTH,
+  type CreationPrepareResult,
+} from "#src/explore/creation/schemas.ts";
+import { createConfirmationIntent } from "#src/lib/confirmation-intent/create.ts";
+import type { PostableChannel } from "#src/lib/discord/postable-channels.ts";
+import type { resolveSubscriptionPuuid } from "#src/lib/subscription/add.ts";
+import type { ToolTracker } from "#src/reports/ai/scoutql-tools.ts";
+
+/**
+ * How long a prepared creation waits for a human. Ten minutes, the same window
+ * a prepared dare action gets, so Explore has one confirmation lifetime rather
+ * than one per feature.
+ */
+export const CREATION_INTENT_TTL_MS = 10 * 60 * 1000;
+
+export type CreationToolContext = {
+  capability: CreationCapability;
+  requesterId: DiscordAccountId;
+  track: ToolTracker;
+  db: ExtendedPrismaClient;
+  /** Memoized for the turn; see the module docblock. */
+  access: () => Promise<CreationAccess>;
+  listChannels: (guildId: DiscordGuildId) => PostableChannel[];
+  resolvePuuid: typeof resolveSubscriptionPuuid;
+  now: () => Date;
+  /**
+   * A fresh key per call. Deriving it from the payload would make "create the
+   * same weekly report again" silently return the first intent, and asking for
+   * two identical entities is a legitimate request.
+   */
+  newIdempotencyKey: () => string;
+};
+
+/** A prepare tool's refusal: never a claim that anything was created. */
+export function creationRefusal(
+  kind: Exclude<
+    CreationPrepareResult["kind"],
+    "creation_confirmation_required"
+  >,
+  message: string,
+): CreationPrepareResult {
+  return CreationPrepareResultSchema.parse({ kind, message, intent: null });
+}
+
+type GuildAccessLookup =
+  | { kind: "ok"; guild: CreationGuildAccess }
+  | { kind: "refused"; result: CreationPrepareResult };
+
+/**
+ * The guild the model named, if the asker may act in it.
+ *
+ * An unverifiable answer and an ineligible guild are different refusals: the
+ * first says Scout could not check, the second says this server is not one of
+ * the asker's creation targets.
+ */
+export async function lookupGuildAccess(
+  context: CreationToolContext,
+  guildId: DiscordGuildId,
+): Promise<GuildAccessLookup> {
+  const access = await context.access();
+  if (access.kind === "verification_unavailable") {
+    return {
+      kind: "refused",
+      result: creationRefusal("verification_unavailable", access.message),
+    };
+  }
+  const guild = access.guilds.find((entry) => entry.guildId === guildId);
+  if (guild === undefined) {
+    return {
+      kind: "refused",
+      result: creationRefusal(
+        "forbidden_target",
+        "That server is not one this user can create things in. Call list_creation_targets and ask them to choose one of the servers it returns.",
+      ),
+    };
+  }
+  return { kind: "ok", guild };
+}
+
+/** The channel must be one Scout can actually post the entity's output into. */
+export function requirePostableChannel(
+  context: CreationToolContext,
+  input: { guildId: DiscordGuildId; channelId: string },
+): CreationPrepareResult | null {
+  const channels = context.listChannels(input.guildId);
+  if (channels.some((channel) => channel.id === input.channelId)) return null;
+  return creationRefusal(
+    "invalid",
+    "Scout cannot post in that channel. Call list_guild_channels and ask the user to pick one of the channels it returns.",
+  );
+}
+
+/**
+ * The channel's display name, for a summary a person will read.
+ *
+ * Every caller has already proved the channel is postable, so a miss is
+ * unreachable; the id is the honest label if it ever happens.
+ */
+export function postableChannelName(
+  context: CreationToolContext,
+  guildId: DiscordGuildId,
+  channelId: string,
+): string {
+  const channel = context
+    .listChannels(guildId)
+    .find((candidate) => candidate.id === channelId);
+  return channel?.name ?? channelId;
+}
+
+function boundedSummary(summary: string): string {
+  return summary.length <= CREATION_MAX_SUMMARY_LENGTH
+    ? summary
+    : `${summary.slice(0, CREATION_MAX_SUMMARY_LENGTH - 1).trimEnd()}…`;
+}
+
+/**
+ * Mint the confirmation intent a human will later approve.
+ *
+ * The guild is taken from the payload the executor built from a verified
+ * target, and `createConfirmationIntent` stores it as the row's own column —
+ * the confirm procedure reads it from there and re-resolves every permission,
+ * so nothing minted here is trusted as authorization.
+ */
+export async function mintCreationIntent(
+  context: CreationToolContext,
+  input: {
+    payload: CreationIntentPayload;
+    guildId: DiscordGuildId;
+    summary: string;
+  },
+): Promise<CreationPrepareResult> {
+  const now = context.now();
+  const created = await createConfirmationIntent(context.db, {
+    serverId: input.guildId,
+    actorDiscordId: context.requesterId,
+    payload: input.payload,
+    idempotencyKey: context.newIdempotencyKey(),
+    expiresAt: new Date(now.getTime() + CREATION_INTENT_TTL_MS),
+  });
+  if (created.kind === "idempotency_conflict") {
+    // A fresh UUID per call makes this unreachable short of a collision; say so
+    // rather than presenting a stranger's intent as this request's confirmation.
+    return creationRefusal(
+      "invalid",
+      "Scout could not prepare that confirmation. Ask the user to try again.",
+    );
+  }
+  return CreationPrepareResultSchema.parse({
+    kind: "creation_confirmation_required",
+    message:
+      "Nothing has been created yet. Tell the user this is waiting for their confirmation and that the card expires in ten minutes.",
+    intent: {
+      intentId: created.intent.id,
+      kind: input.payload.kind,
+      guildId: input.guildId,
+      expiresAt: created.intent.expiresAt.toISOString(),
+      summary: boundedSummary(input.summary),
+    },
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/limits.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/limits.ts
@@ -1,0 +1,111 @@
+/**
+ * Limit previews for the creation tools.
+ *
+ * These call the same limit functions the create pipelines call, but they are
+ * advisory only: the authoritative check runs again inside the confirm
+ * transaction, where it sees the same snapshot as the insert it guards. Their
+ * job is to stop the agent walking a user through a form it already knows will
+ * be rejected — not to decide anything.
+ */
+
+import type { DiscordAccountId, DiscordGuildId } from "@scout-for-lol/data";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import {
+  validateOwnerLimit,
+  validateServerLimit,
+} from "#src/database/competition/validation.ts";
+import { canCreateAnotherUserReport } from "#src/lib/reports/authorization.ts";
+import { creationRefusal } from "#src/explore/creation/context.ts";
+import type { CreationPrepareResult } from "#src/explore/creation/schemas.ts";
+import { checkSubscriptionAndAccountLimits } from "#src/lib/subscription/limits.ts";
+
+export type CreationLimitPreview = {
+  atLimit: boolean;
+  limitMessage: string | null;
+};
+
+const WITHIN_LIMIT: CreationLimitPreview = {
+  atLimit: false,
+  limitMessage: null,
+};
+
+export async function previewReportLimit(
+  db: ExtendedPrismaClient,
+  input: { guildId: DiscordGuildId; ownerId: DiscordAccountId },
+): Promise<CreationLimitPreview> {
+  const limit = await canCreateAnotherUserReport({
+    prisma: db,
+    serverId: input.guildId,
+    ownerId: input.ownerId,
+  });
+  return limit.allowed
+    ? WITHIN_LIMIT
+    : { atLimit: true, limitMessage: limit.reason };
+}
+
+/**
+ * `isAddingToExistingPlayer` decides whether the per-server *player* limit
+ * applies, so a preview without a chosen alias has to assume the stricter
+ * branch — a new player — which is what "can this server track someone else"
+ * actually asks.
+ */
+export async function previewSubscriptionLimit(
+  db: ExtendedPrismaClient,
+  input: { guildId: DiscordGuildId; alias?: string | undefined },
+): Promise<CreationLimitPreview> {
+  const existingPlayer =
+    input.alias === undefined
+      ? null
+      : await db.player.findUnique({
+          where: {
+            serverId_alias: { serverId: input.guildId, alias: input.alias },
+          },
+        });
+  const limit = await checkSubscriptionAndAccountLimits({
+    guildId: input.guildId,
+    isAddingToExistingPlayer: existingPlayer !== null,
+    db,
+  });
+  if (limit.kind === "ok") return WITHIN_LIMIT;
+  const subject =
+    limit.kind === "subscription-limit-reached"
+      ? "tracked players"
+      : "tracked accounts";
+  return {
+    atLimit: true,
+    limitMessage: `This server is at its limit of ${subject} (${limit.current.toString()}/${limit.max.toString()}). Remove one before adding another.`,
+  };
+}
+
+/**
+ * The competition limits throw rather than returning a result, so this reads
+ * their messages back out. Both the server-wide and the per-owner ceiling
+ * matter, and either one blocks.
+ */
+export async function previewCompetitionLimit(
+  db: ExtendedPrismaClient,
+  input: { guildId: DiscordGuildId; ownerId: DiscordAccountId },
+): Promise<CreationLimitPreview> {
+  try {
+    await validateServerLimit(db, input.guildId, input.ownerId);
+    await validateOwnerLimit(db, input.guildId, input.ownerId);
+  } catch (error) {
+    return {
+      atLimit: true,
+      limitMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+  return WITHIN_LIMIT;
+}
+
+/**
+ * A preview turned into the prepare tools' refusal, or `null` when there is
+ * room. Shared so the three prepare tools state the rule once.
+ */
+export function limitRefusal(
+  preview: CreationLimitPreview,
+): CreationPrepareResult | null {
+  return preview.atLimit && preview.limitMessage !== null
+    ? creationRefusal("limit_reached", preview.limitMessage)
+    : null;
+}

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/prepare-competition.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/prepare-competition.ts
@@ -1,0 +1,140 @@
+import {
+  P,
+  WebCompetitionDatesSchema,
+  type CompetitionWrite,
+  type CreationIntentPayload,
+  type PermissionSet,
+} from "@scout-for-lol/data";
+import {
+  DEFAULT_COMPETITION_CRON,
+  DEFAULT_SCHEDULE_TIMEZONE,
+} from "@scout-for-lol/data/model/competition-cron.ts";
+import { CompetitionDatesSchema } from "#src/database/competition/competition-dates.ts";
+import { validateCompetitionConfiguration } from "#src/database/competition/configuration-validation.ts";
+import {
+  creationRefusal,
+  lookupGuildAccess,
+  mintCreationIntent,
+  postableChannelName,
+  requirePostableChannel,
+  type CreationToolContext,
+} from "#src/explore/creation/context.ts";
+import {
+  limitRefusal,
+  previewCompetitionLimit,
+} from "#src/explore/creation/limits.ts";
+import {
+  PrepareCompetitionToolInputSchema,
+  type CreationPrepareResult,
+} from "#src/explore/creation/schemas.ts";
+
+function failureMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * The two sub-permissions `createCompetitionForActor` enforces beyond
+ * `competitions:create`, checked here in the same order and on the same
+ * conditions so the agent can advise instead of minting a card that the
+ * confirm path will refuse.
+ */
+function subPermissionRefusal(
+  permissions: PermissionSet,
+  input: CompetitionWrite,
+): string | null {
+  const enrollsSomeone =
+    input.visibility === "SERVER_WIDE" || input.initialPlayerIds.length > 0;
+  if (enrollsSomeone && !permissions.can("competitions", "invite")) {
+    return input.visibility === "SERVER_WIDE"
+      ? "A server-wide competition enrolls every tracked player, which needs the competitions:invite permission this user does not have. Offer an invite-only competition instead."
+      : "Choosing initial entrants needs the competitions:invite permission this user does not have. Offer to create the competition with an empty roster.";
+  }
+  const customizesSchedule =
+    input.scheduledUpdates.enabled ||
+    input.scheduledUpdates.cronExpression !== DEFAULT_COMPETITION_CRON ||
+    input.scheduledUpdates.timezone !== DEFAULT_SCHEDULE_TIMEZONE;
+  if (customizesSchedule && !permissions.can("competitions", "schedule")) {
+    return "Configuring leaderboard updates needs the competitions:schedule permission this user does not have. Offer to create the competition with the default schedule.";
+  }
+  return null;
+}
+
+/**
+ * Prepare a competition for a human to confirm.
+ *
+ * Dates arrive as ISO strings and are run through the web schema and then
+ * `CompetitionDatesSchema`, which is where ordering and the 90-day duration cap
+ * live. That check throws at confirm time — after the intent has been claimed —
+ * so catching it here is what keeps a bad window a conversation rather than a
+ * failed confirmation.
+ */
+export async function prepareCompetitionCreation(
+  context: CreationToolContext,
+  raw: unknown,
+): Promise<CreationPrepareResult> {
+  const parsed = PrepareCompetitionToolInputSchema.parse(raw);
+  const lookup = await lookupGuildAccess(context, parsed.guildId);
+  if (lookup.kind === "refused") return lookup.result;
+  if (!lookup.guild.permissions.canAny(P("competitions", "create"))) {
+    return creationRefusal(
+      "forbidden_target",
+      `This user cannot create competitions in ${lookup.guild.name}. Tell them they need the competitions:create permission there.`,
+    );
+  }
+
+  const channelRefusal = requirePostableChannel(context, {
+    guildId: parsed.guildId,
+    channelId: parsed.channelId,
+  });
+  if (channelRefusal !== null) return channelRefusal;
+
+  const dates = WebCompetitionDatesSchema.parse(parsed.dates);
+  const write: CompetitionWrite = { ...parsed, dates };
+  try {
+    CompetitionDatesSchema.parse(dates);
+  } catch (error) {
+    return creationRefusal(
+      "invalid",
+      `Those competition dates are not usable: ${failureMessage(error)}. Ask the user for a window that starts before it ends and runs at most 90 days.`,
+    );
+  }
+  try {
+    validateCompetitionConfiguration(write.criteria, write.gameVariant);
+  } catch (error) {
+    return creationRefusal(
+      "invalid",
+      `That criteria and game variant do not go together: ${failureMessage(error)}.`,
+    );
+  }
+
+  const subPermission = subPermissionRefusal(lookup.guild.permissions, write);
+  if (subPermission !== null) {
+    return creationRefusal("forbidden_target", subPermission);
+  }
+
+  const limit = await previewCompetitionLimit(context.db, {
+    guildId: parsed.guildId,
+    ownerId: context.requesterId,
+  });
+  const atLimit = limitRefusal(limit);
+  if (atLimit !== null) return atLimit;
+
+  const payload: CreationIntentPayload = {
+    kind: "competition",
+    guildId: parsed.guildId,
+    ...write,
+  };
+  return await mintCreationIntent(context, {
+    payload,
+    guildId: parsed.guildId,
+    summary: `${write.visibility === "SERVER_WIDE" ? "Server-wide" : "Invite-only"} competition "${write.title}" in ${lookup.guild.name}, scored by ${write.criteria.type}, posting to #${postableChannelName(context, parsed.guildId, parsed.channelId)}, ${describeWindow(dates)}.`,
+  });
+}
+
+function describeWindow(
+  dates: ReturnType<typeof WebCompetitionDatesSchema.parse>,
+): string {
+  return dates.type === "SEASON"
+    ? `following season ${dates.seasonId}`
+    : `running ${dates.startDate.toISOString()} to ${dates.endDate.toISOString()}`;
+}

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/prepare-report.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/prepare-report.ts
@@ -1,0 +1,70 @@
+import { P, type CreationIntentPayload } from "@scout-for-lol/data";
+import { compileScoutQl } from "@scout-for-lol/data/model/scoutql/compile.ts";
+import {
+  creationRefusal,
+  lookupGuildAccess,
+  mintCreationIntent,
+  postableChannelName,
+  requirePostableChannel,
+  type CreationToolContext,
+} from "#src/explore/creation/context.ts";
+import {
+  limitRefusal,
+  previewReportLimit,
+} from "#src/explore/creation/limits.ts";
+import {
+  PrepareReportToolInputSchema,
+  type CreationPrepareResult,
+} from "#src/explore/creation/schemas.ts";
+
+/**
+ * Prepare a scheduled report for a human to confirm.
+ *
+ * The ScoutQL is compiled here rather than at confirm time so a query the
+ * engine cannot read is a conversation the agent can still fix, instead of a
+ * card that fails after the user has already approved it. The confirm path
+ * compiles it again anyway — this is a preview, not the gate.
+ */
+export async function prepareReportCreation(
+  context: CreationToolContext,
+  raw: unknown,
+): Promise<CreationPrepareResult> {
+  const parsed = PrepareReportToolInputSchema.parse(raw);
+  const lookup = await lookupGuildAccess(context, parsed.guildId);
+  if (lookup.kind === "refused") return lookup.result;
+  if (!lookup.guild.permissions.canAny(P("reports", "create"))) {
+    return creationRefusal(
+      "forbidden_target",
+      `This user cannot create reports in ${lookup.guild.name}. Tell them they need the reports:create permission there.`,
+    );
+  }
+
+  const channelRefusal = requirePostableChannel(context, {
+    guildId: parsed.guildId,
+    channelId: parsed.channelId,
+  });
+  if (channelRefusal !== null) return channelRefusal;
+
+  try {
+    compileScoutQl(parsed.queryText);
+  } catch (error) {
+    return creationRefusal(
+      "invalid",
+      `That ScoutQL does not compile: ${error instanceof Error ? error.message : String(error)}. Fix the query with validate_report_query before preparing the report again.`,
+    );
+  }
+
+  const limit = await previewReportLimit(context.db, {
+    guildId: parsed.guildId,
+    ownerId: context.requesterId,
+  });
+  const atLimit = limitRefusal(limit);
+  if (atLimit !== null) return atLimit;
+
+  const payload: CreationIntentPayload = { kind: "report", ...parsed };
+  return await mintCreationIntent(context, {
+    payload,
+    guildId: parsed.guildId,
+    summary: `Report "${parsed.title}" in ${lookup.guild.name}, posting to #${postableChannelName(context, parsed.guildId, parsed.channelId)} on cron ${parsed.cronExpression} (${parsed.scheduleTimezone}), ${parsed.isEnabled ? "enabled" : "disabled"}.`,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/prepare-subscription.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/prepare-subscription.ts
@@ -1,0 +1,147 @@
+import {
+  P,
+  type CreationIntentPayload,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import {
+  creationRefusal,
+  lookupGuildAccess,
+  mintCreationIntent,
+  postableChannelName,
+  requirePostableChannel,
+  type CreationToolContext,
+} from "#src/explore/creation/context.ts";
+import {
+  limitRefusal,
+  previewSubscriptionLimit,
+} from "#src/explore/creation/limits.ts";
+import {
+  PrepareSubscriptionToolInputSchema,
+  type CreationPrepareResult,
+} from "#src/explore/creation/schemas.ts";
+import type { resolveSubscriptionPuuid } from "#src/lib/subscription/add.ts";
+
+type SubscriptionInput = ReturnType<
+  typeof PrepareSubscriptionToolInputSchema.parse
+>;
+
+/** The success arm of the Riot lookup, carrying the PUUID and canonical casing. */
+type ResolvedRiotAccount = Extract<
+  Awaited<ReturnType<typeof resolveSubscriptionPuuid>>,
+  { kind: "ok" }
+>;
+
+/**
+ * Anything already tracking this account, or this player in this channel.
+ *
+ * Both are refusals the confirm path would produce anyway; catching them here
+ * means the agent can say "already tracked as X" in the conversation rather
+ * than after a user has approved a card that then does nothing.
+ */
+async function existingSubscription(
+  context: CreationToolContext,
+  input: {
+    guildId: DiscordGuildId;
+    puuid: string;
+    alias: string;
+    channelId: string;
+  },
+): Promise<string | null> {
+  const account = await context.db.account.findUnique({
+    where: { serverId_puuid: { serverId: input.guildId, puuid: input.puuid } },
+    include: { player: true },
+  });
+  if (account !== null) {
+    return `That Riot account is already tracked in this server as ${account.player.alias}.`;
+  }
+  const player = await context.db.player.findUnique({
+    where: { serverId_alias: { serverId: input.guildId, alias: input.alias } },
+    include: { subscriptions: { select: { channelId: true } } },
+  });
+  if (
+    player?.subscriptions.some((row) => row.channelId === input.channelId) ===
+    true
+  ) {
+    return `${input.alias} is already subscribed in that channel. Adding this account would only attach it to the existing player.`;
+  }
+  return null;
+}
+
+/**
+ * Prepare a tracked-player subscription for a human to confirm.
+ *
+ * The PUUID and Riot's canonical Riot ID casing are resolved here and frozen
+ * into the payload. Two reasons, and both matter: the model must never author
+ * the identity a confirmation acts on, and Riot's account lookup routinely
+ * takes seconds while confirm runs inside a Prisma transaction whose 5s timeout
+ * would trip `P2028`.
+ */
+export async function prepareSubscriptionCreation(
+  context: CreationToolContext,
+  raw: unknown,
+): Promise<CreationPrepareResult> {
+  const parsed = PrepareSubscriptionToolInputSchema.parse(raw);
+  const lookup = await lookupGuildAccess(context, parsed.guildId);
+  if (lookup.kind === "refused") return lookup.result;
+  if (!lookup.guild.permissions.canAny(P("subscriptions", "create"))) {
+    return creationRefusal(
+      "forbidden_target",
+      `This user cannot track players in ${lookup.guild.name}. Tell them they need the subscriptions:create permission there.`,
+    );
+  }
+
+  const channelRefusal = requirePostableChannel(context, {
+    guildId: parsed.guildId,
+    channelId: parsed.channelId,
+  });
+  if (channelRefusal !== null) return channelRefusal;
+
+  const resolved = await context.resolvePuuid(parsed.riotId, parsed.region);
+  if (resolved.kind !== "ok") {
+    return creationRefusal(
+      "invalid",
+      `Riot does not recognise ${parsed.riotId.game_name}#${parsed.riotId.tag_line} in that region: ${resolved.message}. Ask the user to check the Riot ID and region.`,
+    );
+  }
+
+  const duplicate = await existingSubscription(context, {
+    guildId: parsed.guildId,
+    puuid: resolved.puuid,
+    alias: parsed.alias,
+    channelId: parsed.channelId,
+  });
+  if (duplicate !== null) return creationRefusal("invalid", duplicate);
+
+  const limit = await previewSubscriptionLimit(context.db, {
+    guildId: parsed.guildId,
+    alias: parsed.alias,
+  });
+  const atLimit = limitRefusal(limit);
+  if (atLimit !== null) return atLimit;
+
+  return await mintCreationIntent(context, {
+    payload: subscriptionPayload(parsed, resolved),
+    guildId: parsed.guildId,
+    summary: `Track ${resolved.gameName}#${resolved.tagLine} (${parsed.region}) as "${parsed.alias}" in ${lookup.guild.name}, posting to #${postableChannelName(context, parsed.guildId, parsed.channelId)}.`,
+  });
+}
+
+function subscriptionPayload(
+  parsed: SubscriptionInput,
+  resolved: ResolvedRiotAccount,
+): CreationIntentPayload {
+  return {
+    kind: "subscription",
+    guildId: parsed.guildId,
+    channelId: parsed.channelId,
+    region: parsed.region,
+    alias: parsed.alias,
+    ...(parsed.discordUserId === undefined
+      ? {}
+      : { discordUserId: parsed.discordUserId }),
+    // Frozen from Riot, never from the model: the stored Riot ID is seeded
+    // from Riot's own casing exactly as `subscription.add` seeds it.
+    puuid: resolved.puuid,
+    riotId: { game_name: resolved.gameName, tag_line: resolved.tagLine },
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/schemas.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/schemas.ts
@@ -1,0 +1,168 @@
+/**
+ * The creation tools' validated input and output shapes.
+ *
+ * Inputs reuse the same schemas the web forms post (`ReportCreateInputSchema`,
+ * `CompetitionWriteSchema`) so a prepared entity and a hand-filled form cannot
+ * describe different things. Two fields are deliberately re-declared rather
+ * than reused:
+ *
+ *  - competition `dates` arrive as ISO strings. The web schema coerces a
+ *    `Date`, which has no honest JSON Schema rendering for a tool call, so the
+ *    tool takes strings and the executor runs them through the web schema.
+ *  - subscription `puuid` and `riotId` are NOT tool inputs at all. They are
+ *    resolved from Riot at prepare time and frozen into the payload, so the
+ *    model cannot author the identity a confirmation will act on.
+ *
+ * Outputs are bounded on purpose: every one of them is persisted into the
+ * conversation trace.
+ */
+
+import { z } from "zod";
+import {
+  CompetitionWriteSchema,
+  CreationIntentKindSchema,
+  DiscordAccountIdSchema,
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+  PlayerAliasSchema,
+  RegionSchema,
+  ReportCreateInputSchema,
+  RiotIdPartsSchema,
+  SeasonIdSchema,
+} from "@scout-for-lol/data";
+
+/** A guild picker never needs more rows than a person will read. */
+export const CREATION_MAX_TARGETS = 25;
+/** Matches the dashboard channel picker's practical ceiling. */
+export const CREATION_MAX_CHANNELS = 100;
+/** The confirmation card's one-line recap, persisted into the trace. */
+export const CREATION_MAX_SUMMARY_LENGTH = 400;
+
+const MessageSchema = z.string().min(1).max(1000);
+
+const CreationChannelSchema = z.strictObject({
+  id: DiscordChannelIdSchema,
+  name: z.string(),
+});
+
+/** What one entity kind looks like in one guild: may they, and is there room. */
+const CreationTargetEntitySchema = z.strictObject({
+  /** RBAC now: they hold the `<entity>:create` permission in this guild. */
+  permitted: z.boolean(),
+  /**
+   * A limit preview. Advisory only — the authoritative check runs again inside
+   * the confirm transaction, where it sees the same snapshot as the insert.
+   */
+  atLimit: z.boolean(),
+  limitMessage: z.string().max(500).nullable(),
+});
+
+const CreationTargetSchema = z.strictObject({
+  guildId: DiscordGuildIdSchema,
+  name: z.string(),
+  report: CreationTargetEntitySchema,
+  subscription: CreationTargetEntitySchema,
+  competition: CreationTargetEntitySchema,
+  /**
+   * Inlined only when exactly one guild is eligible. The binding budget is
+   * `EXPLORE_MAX_STEPS` (12), not the tool-call ceiling, so saving the
+   * `list_guild_channels` round trip in the common case is worth the bytes.
+   */
+  channels: z
+    .array(CreationChannelSchema)
+    .max(CREATION_MAX_CHANNELS)
+    .nullable(),
+});
+
+export const CreationTargetsResultSchema = z.strictObject({
+  kind: z.enum(["targets", "verification_unavailable"]),
+  message: MessageSchema,
+  targets: z.array(CreationTargetSchema).max(CREATION_MAX_TARGETS),
+});
+export type CreationTargetsResult = z.infer<typeof CreationTargetsResultSchema>;
+
+export const CreationChannelsResultSchema = z.strictObject({
+  kind: z.enum(["channels", "forbidden_target", "verification_unavailable"]),
+  message: MessageSchema,
+  channels: z.array(CreationChannelSchema).max(CREATION_MAX_CHANNELS),
+});
+export type CreationChannelsResult = z.infer<
+  typeof CreationChannelsResultSchema
+>;
+
+/**
+ * The three prepare tools share one result shape.
+ *
+ * `creation_confirmation_required` is the only kind that carries an intent, and
+ * no kind means anything was created — a tool here can mint a proposal and
+ * nothing else.
+ */
+export const CreationPrepareResultSchema = z.strictObject({
+  kind: z.enum([
+    "creation_confirmation_required",
+    "invalid",
+    "limit_reached",
+    "forbidden_target",
+    "verification_unavailable",
+  ]),
+  message: MessageSchema,
+  intent: z
+    .strictObject({
+      intentId: z.uuid(),
+      kind: CreationIntentKindSchema,
+      guildId: DiscordGuildIdSchema,
+      expiresAt: z.iso.datetime(),
+      summary: z.string().min(1).max(CREATION_MAX_SUMMARY_LENGTH),
+    })
+    .nullable(),
+});
+export type CreationPrepareResult = z.infer<typeof CreationPrepareResultSchema>;
+
+/**
+ * Every creation tool result carries a `kind`. The trace reads only that, so
+ * one loose shape covers all three result schemas without restating their
+ * enums.
+ */
+export const CreationToolKindSchema = z.looseObject({ kind: z.string() });
+
+export const ListCreationTargetsToolInputSchema = z.strictObject({});
+
+export const ListGuildChannelsToolInputSchema = z.strictObject({
+  guildId: DiscordGuildIdSchema,
+});
+
+export const PrepareReportToolInputSchema = z.strictObject({
+  guildId: DiscordGuildIdSchema,
+  ...ReportCreateInputSchema.shape,
+});
+
+/**
+ * Subscription filters are omitted deliberately: the filter spec is a
+ * dashboard concern with its own editor, and a model-authored queue allow-list
+ * would silently narrow which matches a server hears about. A prepared
+ * subscription notifies on everything, exactly as the add form's default does,
+ * and filters are set afterwards in the dashboard.
+ */
+export const PrepareSubscriptionToolInputSchema = z.strictObject({
+  guildId: DiscordGuildIdSchema,
+  channelId: DiscordChannelIdSchema,
+  region: RegionSchema,
+  riotId: RiotIdPartsSchema,
+  alias: PlayerAliasSchema,
+  discordUserId: DiscordAccountIdSchema.optional(),
+});
+
+const CompetitionDatesToolInputSchema = z.discriminatedUnion("type", [
+  z.strictObject({
+    type: z.literal("FIXED_DATES"),
+    startDate: z.iso.datetime(),
+    endDate: z.iso.datetime(),
+  }),
+  z.strictObject({ type: z.literal("SEASON"), seasonId: SeasonIdSchema }),
+]);
+
+export const PrepareCompetitionToolInputSchema = z.strictObject({
+  ...CompetitionWriteSchema.shape,
+  guildId: DiscordGuildIdSchema,
+  dates: CompetitionDatesToolInputSchema,
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/targets.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/targets.ts
@@ -1,0 +1,179 @@
+/**
+ * The two discovery tools: which servers can this person create in, and which
+ * channels can Scout post to there.
+ *
+ * Both read the memoized Tier-2 resolution, so the first of them to run pays
+ * for the OAuth round trip and the rest of the turn does not.
+ */
+
+import {
+  P,
+  type CreationIntentKind,
+  type DiscordGuildId,
+  type Permission,
+} from "@scout-for-lol/data";
+import type { CreationGuildAccess } from "#src/explore/creation/capability.ts";
+import type { CreationToolContext } from "#src/explore/creation/context.ts";
+import {
+  previewCompetitionLimit,
+  previewReportLimit,
+  previewSubscriptionLimit,
+  type CreationLimitPreview,
+} from "#src/explore/creation/limits.ts";
+import {
+  CreationChannelsResultSchema,
+  CreationTargetsResultSchema,
+  CREATION_MAX_CHANNELS,
+  CREATION_MAX_TARGETS,
+  type CreationChannelsResult,
+  type CreationTargetsResult,
+} from "#src/explore/creation/schemas.ts";
+
+/** The permission each kind needs, matching the confirm procedure's table. */
+const CREATE_PERMISSION: Record<CreationIntentKind, Permission> = {
+  report: P("reports", "create"),
+  subscription: P("subscriptions", "create"),
+  competition: P("competitions", "create"),
+};
+
+const DENIED: CreationLimitPreview = { atLimit: false, limitMessage: null };
+
+function permitted(
+  guild: CreationGuildAccess,
+  kind: CreationIntentKind,
+): boolean {
+  return guild.permissions.canAny(CREATE_PERMISSION[kind]);
+}
+
+/**
+ * A limit is only worth reading for an entity the asker may create at all —
+ * three count queries per guild is not free, and a denied entity's headroom
+ * changes nothing the model would do.
+ */
+async function limitFor(
+  context: CreationToolContext,
+  guild: CreationGuildAccess,
+  kind: CreationIntentKind,
+): Promise<CreationLimitPreview> {
+  if (!permitted(guild, kind)) return DENIED;
+  if (kind === "report") {
+    return await previewReportLimit(context.db, {
+      guildId: guild.guildId,
+      ownerId: context.requesterId,
+    });
+  }
+  if (kind === "subscription") {
+    return await previewSubscriptionLimit(context.db, {
+      guildId: guild.guildId,
+    });
+  }
+  return await previewCompetitionLimit(context.db, {
+    guildId: guild.guildId,
+    ownerId: context.requesterId,
+  });
+}
+
+function boundedChannels(
+  context: CreationToolContext,
+  guildId: DiscordGuildId,
+): { id: string; name: string }[] {
+  return context
+    .listChannels(guildId)
+    .slice(0, CREATION_MAX_CHANNELS)
+    .map((channel) => ({ id: channel.id, name: channel.name }));
+}
+
+async function describeTarget(
+  context: CreationToolContext,
+  guild: CreationGuildAccess,
+  inlineChannels: boolean,
+): Promise<unknown> {
+  const [report, subscription, competition] = await Promise.all([
+    limitFor(context, guild, "report"),
+    limitFor(context, guild, "subscription"),
+    limitFor(context, guild, "competition"),
+  ]);
+  return {
+    guildId: guild.guildId,
+    name: guild.name,
+    report: { permitted: permitted(guild, "report"), ...report },
+    subscription: {
+      permitted: permitted(guild, "subscription"),
+      ...subscription,
+    },
+    competition: { permitted: permitted(guild, "competition"), ...competition },
+    channels: inlineChannels ? boundedChannels(context, guild.guildId) : null,
+  };
+}
+
+export async function listCreationTargets(
+  context: CreationToolContext,
+): Promise<CreationTargetsResult> {
+  const access = await context.access();
+  if (access.kind === "verification_unavailable") {
+    return CreationTargetsResultSchema.parse({
+      kind: "verification_unavailable",
+      message: access.message,
+      targets: [],
+    });
+  }
+  const eligible = access.guilds.slice(0, CREATION_MAX_TARGETS);
+  // One eligible server is the common case, and inlining its channels saves a
+  // whole agent step — the binding budget is EXPLORE_MAX_STEPS (12), not the
+  // tool-call ceiling.
+  const inlineChannels = eligible.length === 1;
+  const targets = await Promise.all(
+    eligible.map((guild) => describeTarget(context, guild, inlineChannels)),
+  );
+  return CreationTargetsResultSchema.parse({
+    kind: "targets",
+    message: targetsMessage(eligible.length, access.guilds.length),
+    targets,
+  });
+}
+
+function targetsMessage(shown: number, total: number): string {
+  if (total === 0) {
+    return "This user cannot create anything from Explore right now: no server they belong to has it enabled, or they lack the permission there. Say so plainly and do not prepare anything.";
+  }
+  if (total === 1) {
+    return "One eligible server, with its postable channels included. Confirm every required field with the user before preparing anything.";
+  }
+  const suffix =
+    shown < total
+      ? ` Only the first ${shown.toString()} of ${total.toString()} are listed.`
+      : "";
+  return `${total.toString()} eligible servers. Ask the user which one they mean before preparing anything.${suffix}`;
+}
+
+export async function listGuildChannels(
+  context: CreationToolContext,
+  guildId: DiscordGuildId,
+): Promise<CreationChannelsResult> {
+  const access = await context.access();
+  if (access.kind === "verification_unavailable") {
+    return CreationChannelsResultSchema.parse({
+      kind: "verification_unavailable",
+      message: access.message,
+      channels: [],
+    });
+  }
+  const guild = access.guilds.find((entry) => entry.guildId === guildId);
+  if (guild === undefined) {
+    return CreationChannelsResultSchema.parse({
+      kind: "forbidden_target",
+      message:
+        "That server is not one this user can create things in. Call list_creation_targets first.",
+      channels: [],
+    });
+  }
+  const channels = boundedChannels(context, guildId);
+  return CreationChannelsResultSchema.parse({
+    kind: "channels",
+    message:
+      channels.length === 0
+        ? "Scout cannot post in any channel of that server. Tell the user Scout needs View Channel and Send Messages somewhere before anything can be created."
+        : `${channels.length.toString()} channels Scout can post in, sorted by name.`,
+    channels,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/tools.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/tools.integration.test.ts
@@ -1,0 +1,389 @@
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import {
+  ConfirmationIntentPayloadSchema,
+  rootPermissions,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import type { CreationAccess } from "#src/explore/creation/capability.ts";
+import { CREATION_INTENT_TTL_MS } from "#src/explore/creation/context.ts";
+import { createCreationToolExecutors } from "#src/explore/creation/tools.ts";
+import type { PostableChannel } from "#src/lib/discord/postable-channels.ts";
+import type { ToolTracker } from "#src/reports/ai/scoutql-tools.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+  testPuuid,
+} from "#src/testing/test-ids.ts";
+
+/**
+ * The prepare side of Explore-driven creation. Every executor here may only
+ * mint a proposal, so what these tests pin is that a valid request produces an
+ * intent row a human still has to confirm, and that every refusal is a domain
+ * result rather than a claim that something was created.
+ */
+const { prisma } = createTestDatabase("explore-creation-tools-test");
+
+const GUILD = testGuildId("520001");
+const OTHER_GUILD = testGuildId("520002");
+const CHANNEL = testChannelId("520003");
+const FOREIGN_CHANNEL = testChannelId("520004");
+const REQUESTER = testAccountId("910000201");
+
+const QUERY_TEXT =
+  "SELECT player, COUNT(*) AS games FROM match_participants GROUP BY player RENDER table";
+
+const CHANNELS: PostableChannel[] = [
+  { id: CHANNEL, name: "scout-reports", parentId: null },
+];
+
+const passthroughTracker: ToolTracker = async (_toolName, work) => await work();
+
+const resolvedAccess: CreationAccess = {
+  kind: "resolved",
+  guilds: [
+    { guildId: GUILD, name: "Test Server", permissions: rootPermissions() },
+  ],
+};
+
+function executors(overrides?: { access?: CreationAccess }) {
+  return createCreationToolExecutors({
+    capability: { guildIds: [GUILD] },
+    requesterId: REQUESTER,
+    track: passthroughTracker,
+    dependencies: {
+      db: prisma,
+      resolveAccess: () => Promise.resolve(overrides?.access ?? resolvedAccess),
+      listChannels: (guildId: DiscordGuildId) =>
+        guildId === GUILD ? CHANNELS : [],
+      resolvePuuid: () =>
+        Promise.resolve({
+          kind: "ok",
+          puuid: testPuuid("prepared"),
+          // Riot's canonical casing differs from what the model typed.
+          gameName: "Prepared",
+          tagLine: "NA1",
+        }),
+      now: () => new Date("2026-09-05T00:00:00.000Z"),
+    },
+  });
+}
+
+function reportInput(overrides?: Record<string, unknown>) {
+  return {
+    guildId: GUILD,
+    channelId: CHANNEL,
+    title: "Weekly games",
+    queryText: QUERY_TEXT,
+    ...overrides,
+  };
+}
+
+function subscriptionInput(overrides?: Record<string, unknown>) {
+  return {
+    guildId: GUILD,
+    channelId: CHANNEL,
+    region: "AMERICA_NORTH",
+    // Deliberately mis-cased: the payload must carry Riot's answer, not this.
+    riotId: { game_name: "prepared", tag_line: "na1" },
+    alias: "Prepared",
+    ...overrides,
+  };
+}
+
+function competitionInput(overrides?: Record<string, unknown>) {
+  return {
+    guildId: GUILD,
+    channelId: CHANNEL,
+    title: "September ladder",
+    description: "Most games played this month.",
+    visibility: "INVITE_ONLY",
+    dates: {
+      type: "FIXED_DATES",
+      startDate: "2026-09-01T00:00:00.000Z",
+      endDate: "2026-09-30T00:00:00.000Z",
+    },
+    criteria: { type: "MOST_GAMES_PLAYED", queues: ["flex"] },
+    ...overrides,
+  };
+}
+
+async function seedEnabledReport(title: string): Promise<void> {
+  const now = new Date();
+  await prisma.report.create({
+    data: {
+      serverId: GUILD,
+      ownerId: REQUESTER,
+      channelId: CHANNEL,
+      title,
+      queryText: QUERY_TEXT,
+      isEnabled: true,
+      isSystemManaged: false,
+      cronExpression: "0 12 * * 1",
+      scheduleTimezone: "UTC",
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+}
+
+beforeEach(async () => {
+  await prisma.confirmationIntent.deleteMany();
+  await prisma.reportScheduleOutbox.deleteMany();
+  await prisma.report.deleteMany();
+  await prisma.competitionParticipant.deleteMany();
+  await prisma.competition.deleteMany();
+  await prisma.subscription.deleteMany();
+  await prisma.account.deleteMany();
+  await prisma.player.deleteMany();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("prepare_report_creation", () => {
+  test("a valid request mints an intent and creates nothing", async () => {
+    const result = await executors().prepareReport(reportInput());
+
+    expect(result.kind).toBe("creation_confirmation_required");
+    expect(result.intent?.kind).toBe("report");
+    expect(result.intent?.guildId).toBe(GUILD);
+    expect(result.intent?.summary).toContain("scout-reports");
+    expect(result.message).toContain("Nothing has been created yet");
+
+    const rows = await prisma.confirmationIntent.findMany();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.kind).toBe("report");
+    expect(rows[0]?.serverId).toBe(GUILD);
+    expect(rows[0]?.actorDiscordId).toBe(REQUESTER);
+    expect(rows[0]?.expiresAt.toISOString()).toBe(
+      new Date(
+        new Date("2026-09-05T00:00:00.000Z").getTime() + CREATION_INTENT_TTL_MS,
+      ).toISOString(),
+    );
+    // The proposal is a proposal: no report exists yet.
+    await expect(prisma.report.count()).resolves.toBe(0);
+  });
+
+  test("two identical requests mint two intents", async () => {
+    // The key is a fresh UUID per call, not a hash of the payload: asking for a
+    // second identical report is a legitimate request.
+    const tools = executors();
+    const first = await tools.prepareReport(reportInput());
+    const second = await tools.prepareReport(reportInput());
+
+    expect(first.intent?.intentId).not.toBe(second.intent?.intentId);
+    await expect(prisma.confirmationIntent.count()).resolves.toBe(2);
+  });
+
+  test("uncompilable ScoutQL is refused before anything is minted", async () => {
+    const result = await executors().prepareReport(
+      reportInput({ queryText: "SELECT nonsense FROM nowhere" }),
+    );
+
+    expect(result.kind).toBe("invalid");
+    expect(result.intent).toBeNull();
+    await expect(prisma.confirmationIntent.count()).resolves.toBe(0);
+  });
+
+  test("a channel Scout cannot post in is refused", async () => {
+    const result = await executors().prepareReport(
+      reportInput({ channelId: FOREIGN_CHANNEL }),
+    );
+
+    expect(result.kind).toBe("invalid");
+    expect(result.message).toContain("list_guild_channels");
+    await expect(prisma.confirmationIntent.count()).resolves.toBe(0);
+  });
+
+  test("the per-owner report limit is previewed rather than minted into", async () => {
+    // reports_per_owner_per_server defaults to 2.
+    await seedEnabledReport("First");
+    await seedEnabledReport("Second");
+
+    const result = await executors().prepareReport(reportInput());
+
+    expect(result.kind).toBe("limit_reached");
+    expect(result.message).toContain("2/2");
+    await expect(prisma.confirmationIntent.count()).resolves.toBe(0);
+  });
+
+  test("a guild outside the resolved access is a forbidden target", async () => {
+    const result = await executors().prepareReport(
+      reportInput({ guildId: OTHER_GUILD }),
+    );
+
+    expect(result.kind).toBe("forbidden_target");
+    await expect(prisma.confirmationIntent.count()).resolves.toBe(0);
+  });
+
+  test("an unverifiable turn says so instead of denying", async () => {
+    const result = await executors({
+      access: {
+        kind: "verification_unavailable",
+        message: "Scout could not reach Discord to verify …",
+      },
+    }).prepareReport(reportInput());
+
+    expect(result.kind).toBe("verification_unavailable");
+    await expect(prisma.confirmationIntent.count()).resolves.toBe(0);
+  });
+});
+
+describe("prepare_subscription_creation", () => {
+  test("Riot's canonical Riot ID and PUUID are frozen into the payload", async () => {
+    const result = await executors().prepareSubscription(subscriptionInput());
+
+    expect(result.kind).toBe("creation_confirmation_required");
+    const row = await prisma.confirmationIntent.findFirstOrThrow();
+    const payload = ConfirmationIntentPayloadSchema.parse(
+      JSON.parse(row.payload),
+    );
+    expect(payload.kind).toBe("subscription");
+    if (payload.kind !== "subscription") return;
+    // Not the "prepared"/"na1" the caller typed.
+    expect(payload.riotId).toEqual({ game_name: "Prepared", tag_line: "NA1" });
+    expect(payload.puuid).toBe(testPuuid("prepared"));
+  });
+
+  test("an unknown Riot ID is refused with Riot's own reason", async () => {
+    const tools = createCreationToolExecutors({
+      capability: { guildIds: [GUILD] },
+      requesterId: REQUESTER,
+      track: passthroughTracker,
+      dependencies: {
+        db: prisma,
+        resolveAccess: () => Promise.resolve(resolvedAccess),
+        listChannels: () => CHANNELS,
+        resolvePuuid: () =>
+          Promise.resolve({
+            kind: "riot-id-not-found",
+            message: "No Riot account named prepared#na1 in AMERICA_NORTH.",
+          }),
+      },
+    });
+
+    const result = await tools.prepareSubscription(subscriptionInput());
+
+    expect(result.kind).toBe("invalid");
+    expect(result.message).toContain("No Riot account named");
+    await expect(prisma.confirmationIntent.count()).resolves.toBe(0);
+  });
+
+  test("an already-tracked account is refused rather than prepared", async () => {
+    const now = new Date();
+    await prisma.account.create({
+      data: {
+        alias: "Existing",
+        puuid: testPuuid("prepared"),
+        region: "AMERICA_NORTH",
+        riotGameName: "Prepared",
+        riotTagLine: "NA1",
+        serverId: GUILD,
+        creatorDiscordId: REQUESTER,
+        createdTime: now,
+        updatedTime: now,
+        player: {
+          create: {
+            alias: "Existing",
+            serverId: GUILD,
+            creatorDiscordId: REQUESTER,
+            createdTime: now,
+            updatedTime: now,
+          },
+        },
+      },
+    });
+
+    const result = await executors().prepareSubscription(subscriptionInput());
+
+    expect(result.kind).toBe("invalid");
+    expect(result.message).toContain("already tracked");
+    await expect(prisma.confirmationIntent.count()).resolves.toBe(0);
+  });
+});
+
+describe("prepare_competition_creation", () => {
+  test("a valid request mints a competition intent", async () => {
+    const result = await executors().prepareCompetition(competitionInput());
+
+    expect(result.kind).toBe("creation_confirmation_required");
+    expect(result.intent?.kind).toBe("competition");
+    const row = await prisma.confirmationIntent.findFirstOrThrow();
+    expect(row.kind).toBe("competition");
+    await expect(prisma.competition.count()).resolves.toBe(0);
+  });
+
+  test("a window longer than the 90-day cap is refused here, not at confirm", async () => {
+    const result = await executors().prepareCompetition(
+      competitionInput({
+        dates: {
+          type: "FIXED_DATES",
+          startDate: "2026-01-01T00:00:00.000Z",
+          endDate: "2026-12-01T00:00:00.000Z",
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("invalid");
+    expect(result.message).toContain("90 days");
+    await expect(prisma.confirmationIntent.count()).resolves.toBe(0);
+  });
+});
+
+describe("list_creation_targets", () => {
+  test("inlines the channels of the single eligible server", async () => {
+    const result = await executors().listTargets();
+
+    expect(result.kind).toBe("targets");
+    expect(result.targets).toHaveLength(1);
+    expect(result.targets[0]?.name).toBe("Test Server");
+    expect(result.targets[0]?.report.permitted).toBe(true);
+    expect(result.targets[0]?.report.atLimit).toBe(false);
+    expect(result.targets[0]?.channels).toEqual([
+      { id: CHANNEL, name: "scout-reports" },
+    ]);
+  });
+
+  test("reports a reached limit alongside the permission", async () => {
+    await seedEnabledReport("First");
+    await seedEnabledReport("Second");
+
+    const result = await executors().listTargets();
+
+    expect(result.targets[0]?.report).toMatchObject({
+      permitted: true,
+      atLimit: true,
+    });
+  });
+
+  test("an unverifiable turn returns no targets and says why", async () => {
+    const result = await executors({
+      access: {
+        kind: "verification_unavailable",
+        message: "Scout could not reach Discord to verify …",
+      },
+    }).listTargets();
+
+    expect(result.kind).toBe("verification_unavailable");
+    expect(result.targets).toEqual([]);
+  });
+});
+
+describe("list_guild_channels", () => {
+  test("returns the postable channels of an eligible server", async () => {
+    const result = await executors().listChannels({ guildId: GUILD });
+
+    expect(result.kind).toBe("channels");
+    expect(result.channels).toEqual([{ id: CHANNEL, name: "scout-reports" }]);
+  });
+
+  test("refuses a server outside the resolved access", async () => {
+    const result = await executors().listChannels({ guildId: OTHER_GUILD });
+
+    expect(result.kind).toBe("forbidden_target");
+    expect(result.channels).toEqual([]);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/tools.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/tools.ts
@@ -1,0 +1,196 @@
+/**
+ * The five Explore creation tools.
+ *
+ * The security model in one line: **the model never writes domain state.** A
+ * prepare tool mints a confirmation intent describing a report, subscription or
+ * competition; a human then confirms it through `explore.confirmCreationIntent`,
+ * which re-runs the entire authorization decision from scratch. Nothing decided
+ * here is trusted there.
+ *
+ * Everything routes through the shared `ToolTracker`, so creation calls consume
+ * the same tool budget and emit the same metrics as every other Explore tool —
+ * no limit is raised to make room for them.
+ */
+
+import { tool } from "ai";
+import type { DiscordAccountId, DiscordGuildId } from "@scout-for-lol/data";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import {
+  resolveCreationAccess,
+  type CreationAccess,
+  type CreationCapability,
+} from "#src/explore/creation/capability.ts";
+import type { CreationToolContext } from "#src/explore/creation/context.ts";
+import { prepareCompetitionCreation } from "#src/explore/creation/prepare-competition.ts";
+import { prepareReportCreation } from "#src/explore/creation/prepare-report.ts";
+import { prepareSubscriptionCreation } from "#src/explore/creation/prepare-subscription.ts";
+import {
+  CreationChannelsResultSchema,
+  CreationPrepareResultSchema,
+  CreationTargetsResultSchema,
+  ListCreationTargetsToolInputSchema,
+  ListGuildChannelsToolInputSchema,
+  PrepareCompetitionToolInputSchema,
+  PrepareReportToolInputSchema,
+  PrepareSubscriptionToolInputSchema,
+} from "#src/explore/creation/schemas.ts";
+import {
+  listCreationTargets,
+  listGuildChannels,
+} from "#src/explore/creation/targets.ts";
+import {
+  listPostableChannels,
+  type PostableChannel,
+} from "#src/lib/discord/postable-channels.ts";
+import { resolveSubscriptionPuuid } from "#src/lib/subscription/add.ts";
+import type { ToolTracker } from "#src/reports/ai/scoutql-tools.ts";
+
+type CreationToolDependencies = {
+  db: ExtendedPrismaClient;
+  resolveAccess: (input: {
+    capability: CreationCapability;
+    requesterId: DiscordAccountId;
+  }) => Promise<CreationAccess>;
+  listChannels: (guildId: DiscordGuildId) => PostableChannel[];
+  resolvePuuid: typeof resolveSubscriptionPuuid;
+  now: () => Date;
+  newIdempotencyKey: () => string;
+};
+
+const defaultDependencies: CreationToolDependencies = {
+  db: prisma,
+  resolveAccess: (input) => resolveCreationAccess(input),
+  listChannels: listPostableChannels,
+  resolvePuuid: resolveSubscriptionPuuid,
+  now: () => new Date(),
+  // Fresh per call, matching both existing dare mint sites: creating two
+  // identical reports is a legitimate request, so the key must not be derived
+  // from the payload.
+  newIdempotencyKey: () => globalThis.crypto.randomUUID(),
+};
+
+export type CreationExploreToolsInput = {
+  /** Tier 1's answer. `null` means no creation tools at all for this turn. */
+  capability: CreationCapability | null;
+  requesterId: DiscordAccountId;
+  track: ToolTracker;
+  /** Test seams; production uses the real implementations. */
+  dependencies?: Partial<CreationToolDependencies> | undefined;
+};
+
+/**
+ * The executors, separate from the AI-SDK `tool()` wrappers so tests can drive
+ * them without constructing a `ToolExecutionOptions`.
+ *
+ * Tier-2 permission resolution is memoized here as a promise: the first
+ * creation tool the model calls pays for the OAuth round trip and the per-guild
+ * grant reads, every later one reuses them, and a turn that calls none never
+ * touches Discord at all.
+ */
+export function createCreationToolExecutors(input: {
+  capability: CreationCapability;
+  requesterId: DiscordAccountId;
+  track: ToolTracker;
+  dependencies?: Partial<CreationToolDependencies> | undefined;
+}) {
+  const resolved: CreationToolDependencies = {
+    ...defaultDependencies,
+    ...input.dependencies,
+  };
+  let accessPromise: Promise<CreationAccess> | null = null;
+  const context: CreationToolContext = {
+    capability: input.capability,
+    requesterId: input.requesterId,
+    track: input.track,
+    db: resolved.db,
+    access: () => {
+      accessPromise ??= resolved.resolveAccess({
+        capability: input.capability,
+        requesterId: input.requesterId,
+      });
+      return accessPromise;
+    },
+    listChannels: resolved.listChannels,
+    resolvePuuid: resolved.resolvePuuid,
+    now: resolved.now,
+    newIdempotencyKey: resolved.newIdempotencyKey,
+  };
+
+  return {
+    listTargets: () =>
+      input.track("list_creation_targets", () => listCreationTargets(context)),
+    listChannels: (raw: unknown) =>
+      input.track("list_guild_channels", () =>
+        listGuildChannels(
+          context,
+          ListGuildChannelsToolInputSchema.parse(raw).guildId,
+        ),
+      ),
+    prepareReport: (raw: unknown) =>
+      input.track("prepare_report_creation", () =>
+        prepareReportCreation(context, raw),
+      ),
+    prepareSubscription: (raw: unknown) =>
+      input.track("prepare_subscription_creation", () =>
+        prepareSubscriptionCreation(context, raw),
+      ),
+    prepareCompetition: (raw: unknown) =>
+      input.track("prepare_competition_creation", () =>
+        prepareCompetitionCreation(context, raw),
+      ),
+  };
+}
+
+const PREPARE_DESCRIPTION_SUFFIX =
+  "This creates nothing. It returns a confirmation the user must accept in the Explore page within ten minutes; say plainly that nothing has been created yet.";
+
+/**
+ * The tools, or nothing at all.
+ *
+ * Returning `{}` for a null capability is what makes Tier 1 a real gate: with
+ * the flag off, or on Discord, the tools are absent from the model's schema and
+ * no permission work is ever scheduled.
+ */
+export function createCreationExploreTools(input: CreationExploreToolsInput) {
+  if (input.capability === null) return {};
+  const executors = createCreationToolExecutors({
+    capability: input.capability,
+    requesterId: input.requesterId,
+    track: input.track,
+    dependencies: input.dependencies,
+  });
+  return {
+    list_creation_targets: tool({
+      description:
+        "List the servers this user can create a report, tracked player or competition in, with what they are allowed to create in each and whether any limit is already reached. When exactly one server is eligible its postable channels are included. Call this before proposing any creation.",
+      inputSchema: ListCreationTargetsToolInputSchema,
+      outputSchema: CreationTargetsResultSchema,
+      execute: () => executors.listTargets(),
+    }),
+    list_guild_channels: tool({
+      description:
+        "List the text channels Scout can post in for one server, sorted by name. Use it to let the user choose where a report, tracked player or competition posts.",
+      inputSchema: ListGuildChannelsToolInputSchema,
+      outputSchema: CreationChannelsResultSchema,
+      execute: (raw) => executors.listChannels(raw),
+    }),
+    prepare_report_creation: tool({
+      description: `Prepare a scheduled ScoutQL report for the user to confirm. Validate the query with validate_report_query first and confirm the title, channel, schedule and timezone with the user. ${PREPARE_DESCRIPTION_SUFFIX}`,
+      inputSchema: PrepareReportToolInputSchema,
+      outputSchema: CreationPrepareResultSchema,
+      execute: (raw) => executors.prepareReport(raw),
+    }),
+    prepare_subscription_creation: tool({
+      description: `Prepare a tracked player for the user to confirm. Scout resolves the Riot ID against Riot itself and freezes the account it found, so confirm the exact Riot ID, region, display name and channel with the user first. ${PREPARE_DESCRIPTION_SUFFIX}`,
+      inputSchema: PrepareSubscriptionToolInputSchema,
+      outputSchema: CreationPrepareResultSchema,
+      execute: (raw) => executors.prepareSubscription(raw),
+    }),
+    prepare_competition_creation: tool({
+      description: `Prepare a competition for the user to confirm. Confirm the title, description, visibility, scoring criteria, channel and the exact date window with the user first; dates are ISO-8601 timestamps and a fixed window may not exceed 90 days. ${PREPARE_DESCRIPTION_SUFFIX}`,
+      inputSchema: PrepareCompetitionToolInputSchema,
+      outputSchema: CreationPrepareResultSchema,
+      execute: (raw) => executors.prepareCompetition(raw),
+    }),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/explore/durable-payload.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/durable-payload.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import { ExploreDurablePayloadSchema } from "#src/explore/durable-payload.ts";
+
+const started = {
+  conversationId: "11111111-1111-4111-8111-111111111111",
+  title: "Weekly games",
+  messageId: "22222222-2222-4222-8222-222222222222",
+  question: "Who played the most games?",
+  expectedCurrentLeafId: null,
+  previousCurrentLeafId: null,
+  createdConversation: true,
+  createdQuestion: true,
+};
+
+const legacyRow = {
+  summary: { runId: "33333333-3333-4333-8333-333333333333" },
+  started,
+  guildIds: ["1337623164146155593"],
+};
+
+describe("ExploreDurablePayloadSchema", () => {
+  test("a row written before `surface` existed parses as web", () => {
+    // Durable Explore runs are enqueued only from the web run manager, so this
+    // restores what those rows already meant rather than guessing.
+    const parsed = ExploreDurablePayloadSchema.parse(legacyRow);
+
+    expect(parsed.surface).toBe("web");
+  });
+
+  test("a stored surface is read back rather than defaulted", () => {
+    const parsed = ExploreDurablePayloadSchema.parse({
+      ...legacyRow,
+      surface: "discord",
+    });
+
+    expect(parsed.surface).toBe("discord");
+  });
+
+  test("an unknown surface is rejected instead of falling back", () => {
+    expect(() =>
+      ExploreDurablePayloadSchema.parse({ ...legacyRow, surface: "sms" }),
+    ).toThrow();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/durable-payload.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/durable-payload.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import { ExploreSurfaceSchema } from "#src/explore/surface.ts";
+
+/**
+ * The `ScoutInteractiveRun.payload` of a durable `kind: "explore"` run.
+ *
+ * Shared by the writer (`explore/durable-runs.ts`) and the reader
+ * (`temporal/interactive-activities.ts`) so a field cannot be added on one side
+ * and silently dropped on the other. It is serialized into the database, which
+ * is why every addition has to say what a row written before it means.
+ */
+export const ExploreDurablePayloadSchema = z.strictObject({
+  summary: z.looseObject({ runId: z.uuid() }),
+  started: z.strictObject({
+    conversationId: z.uuid(),
+    title: z.string(),
+    messageId: z.uuid(),
+    question: z.string(),
+    expectedCurrentLeafId: z.uuid().nullable(),
+    previousCurrentLeafId: z.uuid().nullable(),
+    createdConversation: z.boolean(),
+    createdQuestion: z.boolean(),
+  }),
+  guildIds: z.array(z.string()),
+  /**
+   * Rows written before this field existed carry no surface. Durable Explore
+   * runs are enqueued from exactly one place — `run-manager-start.ts`, the web
+   * run manager — so `"web"` restores what those rows already meant rather than
+   * guessing at it. A Discord ask never becomes a durable run: it runs the turn
+   * inline inside the interaction.
+   */
+  surface: ExploreSurfaceSchema.default("web"),
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/durable-runs.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/durable-runs.ts
@@ -13,6 +13,7 @@ import { scoutInteractiveWorkflowId } from "@scout-for-lol/temporal";
 import { requestStopSignal } from "@scout-for-lol/temporal/signals";
 import configuration from "#src/configuration.ts";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import type { ExploreSurface } from "#src/explore/surface.ts";
 import { reserveDurableExploreRun } from "#src/temporal/durable-quota.ts";
 import { currentScoutTemporalSupervisor } from "#src/temporal/runtime.ts";
 import { startScoutInteractiveRun } from "#src/temporal/starts.ts";
@@ -46,6 +47,11 @@ export async function reserveAndStartDurableExploreRun(input: {
   ownerId: DiscordAccountId;
   started: StartedTurn;
   guildIds: string[];
+  /**
+   * Serialized into the run row, so the activity answers the resumed turn on
+   * the surface that started it rather than on a default.
+   */
+  surface: ExploreSurface;
 }): Promise<DurableExploreRejection | null> {
   const rejection = await reserveDurableExploreRun({
     id: input.summary.runId,
@@ -55,6 +61,7 @@ export async function reserveAndStartDurableExploreRun(input: {
       summary: input.summary,
       started: input.started,
       guildIds: input.guildIds,
+      surface: input.surface,
     }),
     database: input.database,
   });

--- a/packages/scout-for-lol/packages/backend/src/explore/prompt.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/prompt.test.ts
@@ -40,6 +40,36 @@ describe("exploreAgentInstructions", () => {
     expect(withBucks).toContain("## ScoutQL reference");
   });
 
+  test("appends the creation section only when the creation tools exist", () => {
+    const plain = exploreAgentInstructions({ bucks: null });
+    const withCreation = exploreAgentInstructions({
+      bucks: null,
+      creation: true,
+    });
+
+    expect(plain).not.toContain("## Creating reports");
+    expect(plain).not.toContain("list_creation_targets");
+    expect(withCreation).toContain(
+      "## Creating reports, tracked players and competitions",
+    );
+    // The load-bearing rules: discover before proposing, ask which server,
+    // confirm the fields, and never claim an entity exists.
+    expect(withCreation).toContain(
+      "Call list_creation_targets before proposing any creation",
+    );
+    expect(withCreation).toContain("ask which one they mean");
+    expect(withCreation).toContain(
+      "Confirm every required field with the user",
+    );
+    expect(withCreation).toContain("NOTHING HAS BEEN CREATED YET");
+    expect(withCreation).toContain("expires in ten minutes");
+    expect(withCreation).toContain(
+      "NEVER say that a report, tracked player or competition exists",
+    );
+    // An outage is never reported as a denial — the same rule the tools enforce.
+    expect(withCreation).toContain("Do NOT say they lack permission");
+  });
+
   test("carries no v1 clause the language no longer has", () => {
     const instructions = exploreAgentInstructions({ bucks: null });
 

--- a/packages/scout-for-lol/packages/backend/src/explore/prompt.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/prompt.ts
@@ -34,6 +34,8 @@ export function exploreAgentInstructions(options: {
   bucks: { currentTime: string } | null;
   dares?: boolean | undefined;
   challenges?: boolean | undefined;
+  /** True only when the creation tools are registered for this turn. */
+  creation?: boolean | undefined;
 }): string {
   return [
     "You answer questions about League of Legends match data by querying Scout's report lake with ScoutQL.",
@@ -102,6 +104,7 @@ export function exploreAgentInstructions(options: {
     ...(options.challenges === true
       ? ["", challengeExplorePromptSection()]
       : []),
+    ...(options.creation === true ? ["", creationExplorePromptSection()] : []),
     "",
     scoutQlFieldGuideSection(),
     "",
@@ -119,6 +122,29 @@ export function challengeExplorePromptSection(): string {
     "Call list_challenge_accounts before preview_challenge_draft. A preview must report evaluated match count, selected period, and missing timeline evidence honestly.",
     "Never publish a challenge from Explore. After a successful preview, link the user to the returned confirmationPath; publication requires their explicit web confirmation.",
     "For challenge-only answers, set queryText to null. The challenge contract belongs in the answer prose or tool card, not in an Explore report query.",
+  ].join("\n");
+}
+
+/**
+ * The creation section, included only when the creation tools are registered.
+ *
+ * Its last rule is the same class of rule as "never state a statistic you did
+ * not read from a query result": a preparation is a proposal, and an answer
+ * that says a report exists when only a confirmation card does is a lie the
+ * reader has no way to detect.
+ */
+export function creationExplorePromptSection(): string {
+  return [
+    "## Creating reports, tracked players and competitions",
+    "You can PREPARE a scheduled report, a tracked player, or a competition for this user. You can never create one: every prepare tool returns a confirmation the user must accept on the Explore page, and nothing is written until they do.",
+    "Call list_creation_targets before proposing any creation. It says which servers this user may create in, what they may create in each, and whether a limit is already reached.",
+    "If more than one server is eligible, ask which one they mean. Never pick for them.",
+    "Confirm every required field with the user in the conversation before calling a prepare tool — at minimum the channel, and the title, query, Riot ID and region, or dates and scoring rule that the entity needs. Do not invent a value they did not give you and do not guess a channel.",
+    "Use list_guild_channels to offer channels. Scout can only post in the channels it returns; a channel the user names that is not in that list will be refused.",
+    "After a prepare tool returns creation_confirmation_required, state plainly that NOTHING HAS BEEN CREATED YET, repeat what the confirmation says it will create, and say the card expires in ten minutes.",
+    "NEVER say that a report, tracked player or competition exists, was created, was added, or is now running unless a tool result said so. A prepared confirmation is a proposal, not an entity.",
+    "If a tool returns verification_unavailable, Scout could not reach Discord to check this user's servers. Say exactly that and suggest trying again shortly. Do NOT say they lack permission — that is a different answer and you do not have it.",
+    "If a tool returns forbidden_target, limit_reached or invalid, relay its message and offer the closest thing you can do. Do not retry the same call unchanged.",
   ].join("\n");
 }
 

--- a/packages/scout-for-lol/packages/backend/src/explore/run-manager-helpers.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-manager-helpers.ts
@@ -100,6 +100,8 @@ export async function executeActiveExploreRun(input: {
         ticket: input.run.ticket,
         identity: input.run.identity,
         guildIds: input.run.guildIds,
+        // The web run manager only ever answers the Explore page.
+        surface: "web",
         started: input.run.started,
         history: input.run.history,
         abortSignal: input.run.abortController.signal,

--- a/packages/scout-for-lol/packages/backend/src/explore/run-manager-start.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-manager-start.ts
@@ -123,6 +123,8 @@ async function startDurableRun(
       ownerId: input.identity.userId,
       started,
       guildIds: input.guildIds,
+      // Durable Explore runs are only ever enqueued from the Explore page.
+      surface: "web",
     });
     if (durableRejection !== null) {
       throw input.createRateLimitedError({

--- a/packages/scout-for-lol/packages/backend/src/explore/run-turn.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-turn.integration.test.ts
@@ -123,6 +123,7 @@ describe("shared persisted Explore turn", () => {
         ...prepared,
         identity: { userId },
         guildIds: [],
+        surface: "web",
         emit: () => Promise.resolve(),
       },
       {
@@ -166,6 +167,7 @@ describe("shared persisted Explore turn", () => {
         ...prepared,
         identity: { userId },
         guildIds: [],
+        surface: "web",
         emit: () => Promise.resolve(),
       },
       {
@@ -199,6 +201,7 @@ describe("shared persisted Explore turn", () => {
         ...prepared,
         identity: { userId },
         guildIds: [],
+        surface: "web",
         emit: () => Promise.resolve(),
       },
       {
@@ -242,6 +245,7 @@ describe("shared persisted Explore turn", () => {
         ...prepared,
         identity: { userId },
         guildIds: [],
+        surface: "web",
         abortSignal: caller.signal,
         abortOutcome: () => "stopped",
         emit: () => Promise.resolve(),
@@ -286,6 +290,7 @@ describe("shared persisted Explore turn", () => {
         ...prepared,
         identity: { userId },
         guildIds: [],
+        surface: "web",
         abortSignal: caller.signal,
         abortOutcome: () => "stopped",
         emit: () => Promise.resolve(),

--- a/packages/scout-for-lol/packages/backend/src/explore/run-turn.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-turn.ts
@@ -16,6 +16,7 @@ import {
   type ExploreRateLimitTicket,
 } from "#src/explore/rate-limit.ts";
 import { appendExploreAnswer } from "#src/explore/store.ts";
+import type { ExploreSurface } from "#src/explore/surface.ts";
 import {
   applyGeneratedTitle,
   rollbackGeneratedTitle,
@@ -85,6 +86,12 @@ export async function runPersistedExploreTurn(
     history: ExploreMessage[];
     /** The asker's servers; scopes `player('…')` alias resolution. */
     guildIds: string[];
+    /**
+     * Which surface is asking. Required rather than defaulted: it decides
+     * whether creation tools exist at all, and a silent default would make a
+     * forgotten call site quietly grant them.
+     */
+    surface: ExploreSurface;
     abortSignal?: AbortSignal;
     originChannelId?: DiscordChannelId | undefined;
     abortOutcome?: () => Extract<ExploreTurnOutcome, "stopped" | "interrupted">;
@@ -167,6 +174,7 @@ export async function runPersistedExploreTurn(
       guildIds: input.guildIds,
       requesterId: input.identity.userId,
       originChannelId: input.originChannelId ?? null,
+      surface: input.surface,
       abortSignal: abortController.signal,
       emit: record,
     });

--- a/packages/scout-for-lol/packages/backend/src/explore/surface.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/surface.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+/**
+ * Which product surface an Explore turn is being answered on.
+ *
+ * It exists because creating entities from Explore is web-only in v1:
+ *
+ *  - `/scout ask` is one-shot. It renders a frozen answer and never continues
+ *    the conversation, so there is nowhere to put a confirmation card and no
+ *    way for the asker to accept one.
+ *  - A Discord-upserted user deliberately carries no OAuth token
+ *    (`discord/commands/scout.ts` omits the credential fields on purpose), so
+ *    their guild permissions cannot be resolved at all.
+ *
+ * Carried explicitly rather than inferred from `originChannelId`: that field is
+ * an optional input no production caller passes, so it is always null and could
+ * not distinguish the two surfaces even if it were read that way.
+ */
+export const ExploreSurfaceSchema = z.enum(["web", "discord"]);
+export type ExploreSurface = z.infer<typeof ExploreSurfaceSchema>;

--- a/packages/scout-for-lol/packages/backend/src/explore/tool-inspection.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/tool-inspection.ts
@@ -28,6 +28,17 @@ import {
   DareToolResultSchema,
   ReviseDareToolInputSchema,
 } from "#src/explore/dare-tool-schemas.ts";
+import {
+  CreationChannelsResultSchema,
+  CreationToolKindSchema,
+  CreationPrepareResultSchema,
+  CreationTargetsResultSchema,
+  ListCreationTargetsToolInputSchema,
+  ListGuildChannelsToolInputSchema,
+  PrepareCompetitionToolInputSchema,
+  PrepareReportToolInputSchema,
+  PrepareSubscriptionToolInputSchema,
+} from "#src/explore/creation/schemas.ts";
 
 /**
  * The Bryan Bucks tools' validated shapes, keyed by tool name. They carry no
@@ -100,6 +111,54 @@ const DARE_TOOL_SCHEMAS = new Map<
   [
     "delete_dare_draft",
     { input: DareDeleteToolInputSchema, output: DareToolResultSchema },
+  ],
+]);
+
+/**
+ * The Explore creation tools' validated shapes, keyed by tool name.
+ *
+ * Like the Bucks and Dare maps they carry no curated `details`: the closed
+ * `ExploreTraceDetails` union is persisted data, and these results are already
+ * bounded by their own schemas.
+ */
+const CREATION_TOOL_SCHEMAS = new Map<
+  string,
+  { input: z.ZodType; output: z.ZodType }
+>([
+  [
+    "list_creation_targets",
+    {
+      input: ListCreationTargetsToolInputSchema,
+      output: CreationTargetsResultSchema,
+    },
+  ],
+  [
+    "list_guild_channels",
+    {
+      input: ListGuildChannelsToolInputSchema,
+      output: CreationChannelsResultSchema,
+    },
+  ],
+  [
+    "prepare_report_creation",
+    {
+      input: PrepareReportToolInputSchema,
+      output: CreationPrepareResultSchema,
+    },
+  ],
+  [
+    "prepare_subscription_creation",
+    {
+      input: PrepareSubscriptionToolInputSchema,
+      output: CreationPrepareResultSchema,
+    },
+  ],
+  [
+    "prepare_competition_creation",
+    {
+      input: PrepareCompetitionToolInputSchema,
+      output: CreationPrepareResultSchema,
+    },
   ],
 ]);
 
@@ -178,6 +237,13 @@ export function inspectExploreToolCall(
   if (dare !== undefined) {
     return {
       rawInput: JsonValueSchema.parse(dare.input.parse(input)),
+      details: null,
+    };
+  }
+  const creation = CREATION_TOOL_SCHEMAS.get(toolName);
+  if (creation !== undefined) {
+    return {
+      rawInput: JsonValueSchema.parse(creation.input.parse(input)),
       details: null,
     };
   }
@@ -267,6 +333,23 @@ export function inspectExploreToolResult(
         "stale_revision",
         "contract_invalid",
       ].includes(parsed.kind),
+      rawOutput: JsonValueSchema.parse(parsed),
+      details: null,
+    };
+  }
+  const creation = CREATION_TOOL_SCHEMAS.get(toolName);
+  if (creation !== undefined) {
+    creation.input.parse(input);
+    const parsed = creation.output.parse(output);
+    // A creation tool never throws for a domain refusal: it answers with one.
+    // Only the outcomes that produced nothing count as failures here.
+    return {
+      succeeded: ![
+        "invalid",
+        "limit_reached",
+        "forbidden_target",
+        "verification_unavailable",
+      ].includes(CreationToolKindSchema.parse(parsed).kind),
       rawOutput: JsonValueSchema.parse(parsed),
       details: null,
     };

--- a/packages/scout-for-lol/packages/backend/src/temporal/interactive-activities.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/interactive-activities.ts
@@ -23,6 +23,7 @@ import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { exploreRunManager } from "#src/explore/run-manager.ts";
 import { persistPartialAnswer } from "#src/explore/partial-answer.ts";
 import { loadExploreTranscript } from "#src/explore/store.ts";
+import { ExploreDurablePayloadSchema } from "#src/explore/durable-payload.ts";
 import { runPersistedExploreTurn } from "#src/explore/run-turn.ts";
 import { streamExploreAgent } from "#src/explore/agent.ts";
 import type { ExploreRateLimitTicket } from "#src/explore/rate-limit.ts";
@@ -31,21 +32,6 @@ import { streamReportQueryAgent } from "#src/reports/ai/report-query-agent.ts";
 import { getReportAiQuotaStatus } from "#src/reports/ai/rate-limit.ts";
 import { scoutTemporalInterruptedProviderAttempts } from "#src/metrics/temporal.ts";
 import type { ScoutInteractiveRun } from "#generated/prisma/client/index.js";
-
-const ExplorePayloadSchema = z.strictObject({
-  summary: z.looseObject({ runId: z.uuid() }),
-  started: z.strictObject({
-    conversationId: z.uuid(),
-    title: z.string(),
-    messageId: z.uuid(),
-    question: z.string(),
-    expectedCurrentLeafId: z.uuid().nullable(),
-    previousCurrentLeafId: z.uuid().nullable(),
-    createdConversation: z.boolean(),
-    createdQuestion: z.boolean(),
-  }),
-  guildIds: z.array(z.string()),
-});
 
 const ReportAiPayloadSchema = z.strictObject({
   edit: ReportAiEditRequestSchema,
@@ -72,7 +58,7 @@ async function salvageAmbiguousExploreRun(input: {
   database: ExtendedPrismaClient;
   run: ScoutInteractiveRun;
 }): Promise<InteractiveOutcome> {
-  const parsedPayload = ExplorePayloadSchema.parse(
+  const parsedPayload = ExploreDurablePayloadSchema.parse(
     JSON.parse(input.run.payload),
   );
   const trace = z
@@ -240,7 +226,7 @@ export async function executeRecoveredExplore(
   abortSignal: AbortSignal,
   database: ExtendedPrismaClient,
 ): Promise<ExploreRunOutcome> {
-  const payload = ExplorePayloadSchema.parse(JSON.parse(run.payload));
+  const payload = ExploreDurablePayloadSchema.parse(JSON.parse(run.payload));
   const transcript = await loadExploreTranscript(
     database,
     payload.started.conversationId,
@@ -290,6 +276,7 @@ export async function executeRecoveredExplore(
       ticket,
       identity: { userId: run.ownerId },
       guildIds: payload.guildIds,
+      surface: payload.surface,
       started: payload.started,
       history: transcript.messages,
       abortSignal,


### PR DESCRIPTION
Stacked on #2716.

## Why

The confirm half of Explore-driven creation already exists (#2716) but nothing can
reach it — no surface mints a creation intent. This adds the prepare half, so a
person can ask Explore to save a report, track a player, or start a competition and
get a confirmation card back.

**The model still never writes domain state.** A tool only mints an intent; the
confirm procedure re-runs every authorization check and does the write.

## What

- **An explicit `surface` on the turn.** Creation is web-only for now: Discord's
  `/scout ask` is one-shot with nowhere to render a confirmation, and a
  Discord-upserted user may have no OAuth token to resolve permissions with. Durable
  runs carry it in their stored payload; rows written before the field existed read as
  `web`, which is what that path has always been by construction. (`originChannelId`
  was not reused for this — no production caller passes it, so it is always null.)
- **Two-tier capability, and the second tier is lazy.** Turn setup only asks whether
  the flag is on for a guild in scope; if none qualifies, **no tools are registered and
  no permission work happens at all**. Resolving permissions costs a Discord OAuth
  round trip plus a query per guild, so it waits until the first creation tool is
  actually called, then memoizes for the turn. Paying it at setup would tax *every*
  Explore turn — and a token refresh failure would degrade ordinary analytics questions
  that never touch creation.
- **An outage is never a denial.** Guild membership is fetched once up front, so a
  Discord outage answers *"couldn't verify your servers"* rather than telling someone
  they lack permission. `resolveGuildPermissions` throws FORBIDDEN for an ordinary
  non-member too, so a blanket per-guild catch would have silently conflated the two.
- **Five tools**: list eligible servers, list a server's postable channels, and prepare
  each of the three creations. Listing targets inlines the channels when exactly one
  server is eligible, saving a step in the common case — the binding budget is
  `EXPLORE_MAX_STEPS` (12), not the 30 tool calls, and **neither limit moves**.
  Channels come from the helper #2703 extracted from `guild.router.ts`, so the tool and
  the router cannot drift.
- **Frozen Riot identity.** Preparing a subscription resolves the puuid and Riot's
  canonical casing and freezes both into the payload, so neither is ever
  model-authored.
- **Prompt.** Confirm the fields first; then say plainly that nothing has been created
  yet and that the card expires in ten minutes. Same class of rule as the existing one
  forbidding a statistic not read from a query result in that turn.

Idempotency keys are a fresh UUID per prepare call, matching both existing dare call
sites — deliberately *not* derived from the payload, since creating two identical
reports is a legitimate request.

## Verification

```
bunx turbo run typecheck test lint \
  --filter=@scout-for-lol/backend --filter=@scout-for-lol/data --filter=@scout-for-lol/app
```

24/24 tasks successful — backend 3155 tests / 350 files, data 1371 / 67, app 406 / 60.

**28 new tests.** The laziness is pinned directly rather than assumed: with the flag
off there are no tools *and no permission I/O at all*; registering the tools costs
nothing; the first call pays once; a second call reuses it. A Discord outage, an
expired grant, and an unexpected error are each distinguished from a denial. Discord
surface yields no creation tools, and a legacy durable payload with no `surface` parses
as web.

**Not run:** any live or deployed check. No UI in this PR, so the cards these intents
produce are not renderable yet — the confirmation card and its screenshots come with
the next branch.