### PR TITLE
fix(ci): treat an if_changed-excluded macOS job as settled, not pending

### DIFF
--- a/.buildkite/scripts/macos-native-dispatch-watch.test.ts
+++ b/.buildkite/scripts/macos-native-dispatch-watch.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   dispatchDecision,
+  MAX_IDLE_DISPATCH_MS,
   parseNativeJobs,
   parseOtherRunningNativeJobs,
   type NativeJob,
@@ -103,6 +104,33 @@ describe("native macOS dispatch watch", () => {
         { idleSinceMs: null, nowMs: 10_000 },
       ),
     ).toEqual({ kind: "complete" });
+  });
+
+  /**
+   * `broken` is what Buildkite calls a job its `if_changed` excluded. It will
+   * never be scheduled, so it cannot be waited for. Treating it as pending made
+   * the watchdog burn its whole idle budget and then fail the build telling
+   * someone to go wake a Mac that had no work to do.
+   */
+  test("treats a job excluded by if_changed as settled, not pending", () => {
+    expect(
+      dispatchDecision(
+        [
+          job("tasknotes-native-pr", "passed", "2026-08-24T00:00:00Z"),
+          job("quotabar-macos-pr", "broken", null),
+          job("hkctl-native-pr", "broken", null),
+        ],
+        { idleSinceMs: null, nowMs: 10_000 },
+      ),
+    ).toEqual({ kind: "complete" });
+  });
+
+  test("still times out when a genuinely undispatched job is pending", () => {
+    const decision = dispatchDecision(
+      [job("quotabar-macos-pr", "scheduled", "2026-08-24T00:00:00Z")],
+      { idleSinceMs: 0, nowMs: MAX_IDLE_DISPATCH_MS + 1 },
+    );
+    expect(decision.kind).toBe("timed-out");
   });
 
   test("pauses the idle clock while the serial Mac is running another job", () => {

--- a/.buildkite/scripts/macos-native-dispatch-watch.ts
+++ b/.buildkite/scripts/macos-native-dispatch-watch.ts
@@ -15,7 +15,17 @@ const ALL_NATIVE_STEP_KEYS = new Set([
   "tasknotes-native-main",
 ]);
 const ACTIVE_STATES = new Set(["running"]);
-const SUCCESS_STATES = new Set(["passed", "skipped"]);
+/**
+ * States that mean a job needs no dispatch.
+ *
+ * `broken` is the state Buildkite gives a job its `if_changed` excluded — it
+ * will never be scheduled, so it is settled, not pending. Counting it as
+ * pending makes the watchdog wait out its idle budget and then fail the build
+ * claiming the macOS host is asleep, on a pull request whose macOS lanes were
+ * simply not selected. That is exactly backwards: the message sends someone to
+ * wake a machine that had no work to do.
+ */
+const SETTLED_STATES = new Set(["passed", "skipped", "broken"]);
 
 export const MAX_IDLE_DISPATCH_MS = 5 * 60 * 1000;
 const POLL_INTERVAL_MS = 15_000;
@@ -179,7 +189,7 @@ export function dispatchDecision(
   const maxIdleMs = context.maxIdleMs ?? MAX_IDLE_DISPATCH_MS;
   const { attempts, awaitingRetry } = currentAttempts(jobs);
   const pending = [
-    ...attempts.filter((job) => !SUCCESS_STATES.has(job.state)),
+    ...attempts.filter((job) => !SETTLED_STATES.has(job.state)),
     ...awaitingRetry,
   ];
   if (pending.length === 0) return { kind: "complete" };


### PR DESCRIPTION
## Why

`broken` is the state Buildkite gives a job whose `if_changed` excluded it. It will never be scheduled, so it is **settled**, not pending.

The dispatch watchdog counted it as pending, burned its full five-minute idle budget, then failed the build with:

> `No macOS job dispatched for 5 minutes; pending: QuotaBar macOS (PR) (broken), hkctl Swift tests (PR) (broken). Wake and log in to the macOS Buildkite host, then retry the jobs.`

That message sends someone to wake a machine **that had no work to do**, and the build fails for a reason that does not exist.

It bites whenever lane selection is mixed. [Build 14282](https://buildkite.com/sjerred/monorepo/builds/14282) had `tasknotes-native-pr` selected and **passing**, while `quotabar-macos-pr` and `hkctl-native-pr` were excluded — and the watchdog failed the whole build after the passing job finished.

## What

`SUCCESS_STATES` becomes `SETTLED_STATES` — the set is about needing no dispatch, not about succeeding — and gains `broken`.

The existing test only covered `skipped`, a **different** state the API does not return for this case. That is why the gap survived.

## Verification

- `vitest run macos-native-dispatch-watch.test.ts` — **12 passed**, including a new case reproducing the mixed selection above
- **reverting the one-line set change makes that new test fail**, so it pins the behaviour rather than restating it
- a second new case asserts a genuinely undispatched job *still* times out, so this does not disable the watchdog

## Note

This sits at the bottom of a 10-PR stack that was blocked by it. It stands alone and can merge independently.