### PR TITLE
docs(scout-for-lol): document creating things from an Explore conversation

### DIFF
--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -11,6 +11,12 @@ reference. Load `scout-development` for its working procedure.
   conversational query authoring and continuation.
 - Bryan Bucks owns Dare viewing and management. Preserve origin conversation
   links without moving management into Explore.
+- Explore may prepare report, subscription, and competition creations, never
+  perform them. A tool mints a guild- and actor-bound confirmation intent; the
+  human confirm re-runs access, permissions, channel, and limits and calls the
+  same services the web forms call. Confirmation intents are one shared table
+  and protocol with Dares: single-use, expiring, claimed by a guarded write
+  before any effect.
 - Version stored betting and Dare semantics. Existing records keep their
   original cross-game or same-game interpretation.
 - Challenger stake, pile-ons, pot total, settlement, and Discord presentation

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/tutorials/first-explore-conversation.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/tutorials/first-explore-conversation.md
@@ -84,6 +84,26 @@ unknown rather than as a failed condition. Save the revision only when the diff
 matches the intended dare, then prepare and confirm funding. The confirmation
 is single-use and expires after ten minutes.
 
+## Set something up from the conversation
+
+Where your server has this enabled, Explore can also prepare a scheduled report,
+a tracked player, or a competition from the conversation you are already having,
+instead of sending you to a form.
+
+Ask for it in ordinary language—for example, “save this as a weekly report in
+the #general channel.” Scout confirms the details it is missing, then shows a
+confirmation card summarising exactly what it would create.
+
+Nothing exists until you press **Confirm**. Scout re-checks your permissions in
+that server at that moment, so a card prepared before your access changed still
+cannot create anything you are no longer allowed to create. Like a Dare funding
+confirmation, the card is single-use and expires after ten minutes; when it
+expires, ask again to prepare a fresh one.
+
+The card appears only for you, in your own conversation. Sharing or publishing
+the conversation shows the question and answer without it, so nobody else is
+offered a confirmation they cannot complete.
+
 ## Next steps
 
 - [Find and interpret a player profile](/docs/how-to/find-player-profile/)


### PR DESCRIPTION
## Why

Explore can now prepare a report, a subscription or a competition and hand the person
a confirmation card (#2716, #2719, #2720). Nothing said so.

The behaviour most worth stating is the part that is easy to assume wrongly: **the card
is a proposal, and pressing Confirm is what creates anything.**

## What

- **Tutorial section** in `first-explore-conversation.md`: the flow, the ten-minute
  single-use card, that permissions are re-checked *at confirm* rather than at prepare
  (so a card prepared before your access changed still cannot create anything), and that
  the card is absent from a shared or published conversation.
- **The invariant** recorded in the Scout constraints file: Explore prepares, never
  performs; the intent binds a guild and an actor; confirm re-runs access, permissions,
  channel and limits and calls the same services the web forms call; confirmation intents
  share one table and protocol with Dares — single-use, expiring, claimed by a guarded
  write before any effect.

The permissions reference needs no change: creation reuses the existing
`reports:create` / `subscriptions:create` / `competitions:create` permissions, and that
page is generated from the catalog rather than hand-written.

Wording is conditional ("where your server has this enabled") because the feature ships
behind `explore_creation_enabled`, which is declared with no rollouts.

## Verification

```
bunx markdownlint-cli2 <changed files>          -> 0 issues
bunx turbo run build --filter=@scout-for-lol/docs-site  -> success
```

No new URLs, so nothing to liveness-check. **Not run:** any live or deployed check.