### PR TITLE
fix(scout-for-lol): accept Riot PUUIDs starting with underscore or dash

### DIFF
--- a/packages/scout-for-lol/packages/temporal/src/contracts.test.ts
+++ b/packages/scout-for-lol/packages/temporal/src/contracts.test.ts
@@ -1,6 +1,28 @@
 import { describe, expect, test } from "vitest";
 import { PostMatchDiscoveryResultSchema } from "./contracts.ts";
 
+describe("post-match discovery result puuid validation", () => {
+  test("accepts a Riot PUUID that starts with an underscore", () => {
+    // Real incident: base64url-derived PUUIDs may start with `_` or `-`.
+    // A schema that assumes an alphanumeric first character throws on every
+    // replay of the workflow that parses this, wedging it forever.
+    const sourcePuuid =
+      "_UiFP1VZrFut5_6UFe-ksTFBQnBO-tj3YZuwfdcg59Qm2kq-8FW1uD7eAuH-muhhBaNppwZcknUv4A";
+    expect(
+      PostMatchDiscoveryResultSchema.parse({
+        matches: [
+          {
+            matchId: "NA1_5635515108",
+            sourcePuuid,
+            region: "AMERICA_NORTH",
+            delivery: "live",
+          },
+        ],
+      }).matches[0]?.sourcePuuid,
+    ).toBe(sourcePuuid);
+  });
+});
+
 describe("post-match discovery result compatibility", () => {
   test("treats pre-field activity completions as complete evidence", () => {
     expect(

--- a/packages/scout-for-lol/packages/temporal/src/contracts.ts
+++ b/packages/scout-for-lol/packages/temporal/src/contracts.ts
@@ -14,6 +14,16 @@ const OpaqueIdentifierSchema = z
   .max(180)
   .regex(/^[A-Z0-9][\w.:-]*$/i);
 
+// Riot PUUIDs are base64url-derived and may legitimately start with `_` or
+// `-` (e.g. "_UiFP1VZrFut5_6UFe-ks..."), unlike our own generated identifiers.
+// Reusing OpaqueIdentifierSchema's leading-alnum assumption here throws on
+// every replay of an affected workflow, wedging it forever.
+const RiotPuuidSchema = z
+  .string()
+  .min(1)
+  .max(180)
+  .regex(/^[\w.:-]+$/);
+
 const IsoInstantSchema = z.iso.datetime({ offset: true });
 
 export const ScoutWorkflowStatusSchema = z.enum([
@@ -41,7 +51,7 @@ export type ScoutRealtimePollInput = z.infer<
 export const ScoutMatchIngestionInputSchema = z.object({
   stage: ScoutStageSchema,
   matchId: OpaqueIdentifierSchema,
-  sourcePuuid: OpaqueIdentifierSchema,
+  sourcePuuid: RiotPuuidSchema,
   region: z.enum([
     "BRAZIL",
     "EU_EAST",
@@ -75,7 +85,7 @@ export type ScoutPostMatchDiscoveryInput = z.infer<
 
 export const ScoutInitialHistoryInputSchema = z.object({
   stage: ScoutStageSchema,
-  puuid: OpaqueIdentifierSchema,
+  puuid: RiotPuuidSchema,
   cursor: z.string().min(1).max(512).optional(),
   runOnStart: z.boolean().optional(),
   pagesProcessed: z.number().int().nonnegative().default(0),
@@ -212,7 +222,7 @@ export const ScoutChallengeRunRecomputeInputSchema = z.strictObject({
     .strictObject({
       gameEndMs: z.number().int().nonnegative(),
       matchId: OpaqueIdentifierSchema,
-      puuid: OpaqueIdentifierSchema,
+      puuid: RiotPuuidSchema,
     })
     .optional(),
   pagesProcessed: z.number().int().nonnegative().default(0),
@@ -263,7 +273,7 @@ export type InitialHistoryPageResult = z.infer<
 >;
 
 export const IngestionReconciliationResultSchema = z.object({
-  initialHistoryPuuids: z.array(OpaqueIdentifierSchema),
+  initialHistoryPuuids: z.array(RiotPuuidSchema),
   detachedWorks: z.array(
     ScoutDetachedWorkInputSchema.pick({ kind: true, workId: true }),
   ),


### PR DESCRIPTION
## Why
Scout beta's post-match discovery workflow has been permanently wedged
since 2026-09-05T03:24 UTC, blocking every post-match Discord report and
Bryan Bucks/Dare settlement for that stage. A discovered match's
`sourcePuuid` (`_UiFP1VZrFut5_6UFe-ks...`) failed `OpaqueIdentifierSchema`'s
leading-alphanumeric regex — base64url PUUIDs can legitimately start with
`_` or `-`. The parse throws inside `scoutPostMatchDiscoveryWorkflow`
itself (not an activity), so Temporal retries the same workflow task
forever, and the schedule's `Skip` overlap policy discards every
subsequent 1-minute tick (1276 skipped as of writing).

This is not a recent regression: the vulnerable schema shipped 2026-08-25
when the post-match pipeline moved onto Temporal; it simply hadn't hit a
PUUID starting with `_`/`-` until now.

## What
- Add `RiotPuuidSchema` (same character class as `OpaqueIdentifierSchema`,
  no leading-alnum anchor) in `packages/scout-for-lol/packages/temporal/src/contracts.ts`.
- Use it for `sourcePuuid`, `puuid` (both occurrences), and
  `initialHistoryPuuids` — the fields that hold raw Riot PUUIDs.
- Leave `OpaqueIdentifierSchema` unchanged for our own generated
  identifiers (`matchId`, `workId`, `reportId`, `guildId`, etc.), where the
  leading-alnum assumption still holds.

## Verification
- `bunx turbo run build typecheck test lint --filter=@scout-for-lol/temporal`
  — all pass, including a new regression test in `contracts.test.ts` that
  parses the exact PUUID that broke production.
- **Not yet verified**: live beta deployment, and clearing the wedged
  `scout-beta-postmatch-discovery-workflow-2026-09-05T03:24:00Z` execution
  in the live `beta` Temporal namespace — that workflow can't recover on
  its own even after this ships and needs an explicit terminate once the
  fix is live, so the schedule can start a fresh run.