### PR TITLE
fix(ci): restore main verification after Playwright config loads

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
+  // Each workspace has an isolated @playwright/test installation. Knip loads
+  // all Playwright configs in one process, while Playwright deliberately throws
+  // when its package is initialized more than once. Keep configs as explicit
+  // entries below and let the browser lanes own their config validation.
+  "playwright": false,
   "workspaces": {
     ".": {
       "entry": [".buildkite/scripts/**/*.ts"],
@@ -14,6 +19,7 @@
     },
     "packages/alert-dashboard": {
       "entry": [
+        "playwright.config.ts",
         "src/**/*.test.ts",
         "integration/**/*.ts",
         "e2e/**/*.ts",
@@ -59,11 +65,11 @@
       "vite": false
     },
     "packages/sjer.red": {
-      "entry": ["src/**/*.astro"],
+      "entry": ["playwright.config.ts", "src/**/*.astro"],
       "project": ["src/**/*.{ts,tsx,astro,css,mdx,sass,scss}"]
     },
     "packages/docs/wiki": {
-      "entry": ["public/posthog.js"]
+      "entry": ["playwright.config.ts", "public/posthog.js"]
     },
     "packages/glitter": {
       "entry": ["public/posthog.js"]
@@ -155,6 +161,9 @@
       "entry": ["src/**/*.test.ts", "scripts/**/*.ts"],
       "project": ["src/**/*.ts", "scripts/**/*.ts", "prisma/**/*.prisma"]
     },
+    "packages/scout-for-lol/packages/activity": {
+      "entry": ["playwright.config.ts"]
+    },
     "packages/scout-for-lol/packages/data": {
       "entry": ["scripts/**/*.ts"],
       "project": ["src/**/*.ts", "scripts/**/*.ts"]
@@ -180,8 +189,19 @@
       "project": ["src/**/*.{ts,tsx,css}", "*.ts"]
     },
     "packages/scout-for-lol/packages/evals": {
-      "entry": ["src/scripts/**/*.ts", "src/**/*.test.ts", "e2e/**/*.ts"],
+      "entry": [
+        "playwright.config.ts",
+        "src/scripts/**/*.ts",
+        "src/**/*.test.ts",
+        "e2e/**/*.ts"
+      ],
       "project": ["src/**/*.{ts,tsx,css}", "e2e/**/*.ts", "*.ts"]
+    },
+    "packages/scout-for-lol/packages/design-audit": {
+      "entry": ["playwright.config.ts"]
+    },
+    "packages/scout-for-lol/packages/design-system": {
+      "entry": ["playwright.config.ts"]
     },
     "packages/scout-for-lol/packages/desktop": {
       "entry": ["src/main.tsx"],

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -24,7 +24,7 @@ import { scoutImageGcActivities } from "./scout-image-gc.ts";
 import { homelabCrdImportsRefreshActivities } from "./homelab-crd-imports-refresh.ts";
 import { pokeemeraldDataRefreshActivities } from "./dpp-pokeemerald-data-refresh.ts";
 import { scoutShowcaseRefreshActivities } from "./scout-showcase-refresh.ts";
-import { scheduleRehearsalActivities } from "./schedule-rehearsal.ts";
+import { scheduleRehearsalActivities } from "./scout/schedule-rehearsal.ts";
 import { scoutQueueWindowsActivities } from "./scout-queue-windows.ts";
 import { glitterCorpusActivities } from "./glitter-corpus.ts";
 import { glitterContextRefreshActivities } from "./glitter-context-refresh.ts";

--- a/packages/temporal/src/activities/scout/schedule-rehearsal.ts
+++ b/packages/temporal/src/activities/scout/schedule-rehearsal.ts
@@ -1,6 +1,6 @@
 import { Context } from "@temporalio/activity";
 import { simpleGit } from "simple-git";
-import { runCommand } from "./data-dragon-shell.ts";
+import { runCommand } from "#activities/data-dragon-shell.ts";
 
 const REPO_URL = "https://github.com/shepherdjerred/monorepo.git";
 const MAIN_BRANCH = "main";

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -110,7 +110,7 @@ import type {
 import { runMainVulnScanWorkflow as runMainVulnScanWorkflowImplementation } from "./main-vuln-scan.ts";
 import { runLinkRotScanWorkflow as runLinkRotScanWorkflowImplementation } from "./link-rot-scan.ts";
 import { runScheduleRehearsalWorkflow as runScheduleRehearsalWorkflowImplementation } from "./schedule-rehearsal.ts";
-import type { ScheduleRehearsalResult } from "#activities/schedule-rehearsal.ts";
+import type { ScheduleRehearsalResult } from "#activities/scout/schedule-rehearsal.ts";
 import {
   runKometaWorkflow as runKometaWorkflowImplementation,
   runBunCacheGcWorkflow as runBunCacheGcWorkflowImplementation,

--- a/packages/temporal/src/workflows/schedule-rehearsal.ts
+++ b/packages/temporal/src/workflows/schedule-rehearsal.ts
@@ -2,7 +2,7 @@ import { proxyActivities } from "@temporalio/workflow";
 import type {
   ScheduleRehearsalActivities,
   ScheduleRehearsalResult,
-} from "#activities/schedule-rehearsal.ts";
+} from "#activities/scout/schedule-rehearsal.ts";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
 
 // The rehearsal runs on the SCOUT queue, not maintenance: the jobs it


### PR DESCRIPTION
Why

Buildkite main #14437 failed the hard verify gate because Knip loaded six isolated @playwright/test installations in one process, and the newly scheduled Temporal rehearsal pushed the activities directory one file above its ratcheted ceiling.

What

Disable Knip's incompatible Playwright config plugin and register each browser config as an explicit workspace entry. Move the rehearsal activity into the Scout activity subdomain and update its package imports without changing runtime behavior.

Verification

- bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal
- bun run check-directory-file-counts
- bunx --no-install knip --treat-config-hints-as-errors --exclude files,exports,unresolved
- bun run jscpd
- bunx lefthook run pre-commit

Hosted follow-up: require the exact-head Buildkite PR gate and then rebuild current main after merge. No live services or deployment checks are required for this CI-only repair.