### PR TITLE
feat(streambot): parameterize wake-phrase tooling for hey-scout

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/streambot-voice.md
+++ b/packages/docs/wiki/src/content/docs/explanation/streambot-voice.md
@@ -171,6 +171,13 @@ Packaging requires the minimum training counts, the complete ACAV100M general-sp
 a generated positive smoke WAV. Both local runtimes must accept that checksum-pinned smoke sample;
 successfully loading an ONNX graph is insufficient.
 
+The corpus, keywords, packaging, and evaluation tooling stays in streambot but is
+phrase-parameterized: each wake phrase is a profile (corpus spec, per-corpus manifest format
+literal, asset manifest, fragment-tail table) selected with `--phrase`/`--phrase-slug`, defaulting
+to `hey-streambot` with byte-identical behavior. Scout's "hey scout" verifier trains through the
+same tools; its recipe and handoff live in
+`packages/scout-for-lol/packages/backend/voice-training/`.
+
 The production image requires both sherpa runtimes and the in-process phrase-verifier graph to
 complete inference as the deployment user; merely opening model files is not a successful smoke.
 Corpus evaluation is deliberately not a build step: it is a multi-hour acceptance measurement an

--- a/packages/docs/wiki/src/content/docs/explanation/streambot-voice.md
+++ b/packages/docs/wiki/src/content/docs/explanation/streambot-voice.md
@@ -171,12 +171,10 @@ Packaging requires the minimum training counts, the complete ACAV100M general-sp
 a generated positive smoke WAV. Both local runtimes must accept that checksum-pinned smoke sample;
 successfully loading an ONNX graph is insufficient.
 
-The corpus, keywords, packaging, and evaluation tooling stays in streambot but is
-phrase-parameterized: each wake phrase is a profile (corpus spec, per-corpus manifest format
-literal, asset manifest, fragment-tail table) selected with `--phrase`/`--phrase-slug`, defaulting
-to `hey-streambot` with byte-identical behavior. Scout's "hey scout" verifier trains through the
-same tools; its recipe and handoff live in
-`packages/scout-for-lol/packages/backend/voice-training/`.
+The corpus, keywords, packaging, and evaluation tooling stays in streambot but serves every
+trained wake phrase: each phrase is a self-contained profile, and the hey-streambot defaults are
+unchanged. Scout's "hey scout" verifier trains through the same tools; its recipe and operator
+procedure live in `packages/scout-for-lol/packages/backend/voice-training/`.
 
 The production image requires both sherpa runtimes and the in-process phrase-verifier graph to
 complete inference as the deployment user; merely opening model files is not a successful smoke.

--- a/packages/docs/wiki/src/content/docs/explanation/streambot-voice.md
+++ b/packages/docs/wiki/src/content/docs/explanation/streambot-voice.md
@@ -172,9 +172,12 @@ a generated positive smoke WAV. Both local runtimes must accept that checksum-pi
 successfully loading an ONNX graph is insufficient.
 
 The corpus, keywords, packaging, and evaluation tooling stays in streambot but serves every
-trained wake phrase: each phrase is a self-contained profile, and the hey-streambot defaults are
-unchanged. Scout's "hey scout" verifier trains through the same tools; its recipe and operator
-procedure live in `packages/scout-for-lol/packages/backend/voice-training/`.
+trained wake phrase: each phrase is a self-contained
+[profile](https://github.com/shepherdjerred/monorepo/blob/8cf8056934b7fa7d9238f5d43ae88c63afeacd8e/packages/streambot/src/voice/corpus-phrases.ts),
+and the [hey-streambot defaults](https://github.com/shepherdjerred/monorepo/blob/8cf8056934b7fa7d9238f5d43ae88c63afeacd8e/packages/streambot/src/voice/corpus-recipes.ts)
+are unchanged. Scout's "hey scout" verifier trains through the same tools; its recipe and operator
+procedure live in
+[`packages/scout-for-lol/packages/backend/voice-training/`](https://github.com/shepherdjerred/monorepo/tree/8cf8056934b7fa7d9238f5d43ae88c63afeacd8e/packages/scout-for-lol/packages/backend/voice-training).
 
 The production image requires both sherpa runtimes and the in-process phrase-verifier graph to
 complete inference as the deployment user; merely opening model files is not a successful smoke.

--- a/packages/scout-for-lol/packages/backend/assets/voice/fragment-tails.json
+++ b/packages/scout-for-lol/packages/backend/assets/voice/fragment-tails.json
@@ -1,5 +1,5 @@
 {
-  "note": "Milliseconds of wake-phrase audio still to come after each matched sherpa fragment ends; consumed by the voice lifecycle's fragmentTailMs option. Measurement method: packages/streambot/src/voice/constants.ts (VOICE_FRAGMENT_TAIL_MS). HEY's 500 ms is provisional pending re-measurement against the trained hey-scout assets; HEY_SCOUT and SCOUT end with the phrase and take no tail.",
+  "note": "Milliseconds of wake-phrase audio still to come after each matched sherpa fragment ends; consumed by the voice lifecycle's fragmentTailMs option. Measurement method: packages/streambot/src/voice/constants.ts (VOICE_FRAGMENT_TAIL_MS). HEY_SCOUT and SCOUT end with the phrase and take no tail; HEY carries over streambot's hey-streambot value, not independently measured against hey-scout audio.",
   "tails": {
     "HEY_SCOUT": 0,
     "SCOUT": 0,

--- a/packages/scout-for-lol/packages/backend/assets/voice/fragment-tails.json
+++ b/packages/scout-for-lol/packages/backend/assets/voice/fragment-tails.json
@@ -1,0 +1,8 @@
+{
+  "note": "Milliseconds of wake-phrase audio still to come after each matched sherpa fragment ends; consumed by the voice lifecycle's fragmentTailMs option. Measurement method: packages/streambot/src/voice/constants.ts (VOICE_FRAGMENT_TAIL_MS). HEY's 500 ms is provisional pending re-measurement against the trained hey-scout assets; HEY_SCOUT and SCOUT end with the phrase and take no tail.",
+  "tails": {
+    "HEY_SCOUT": 0,
+    "SCOUT": 0,
+    "HEY": 500
+  }
+}

--- a/packages/scout-for-lol/packages/backend/assets/voice/hey-scout.txt
+++ b/packages/scout-for-lol/packages/backend/assets/voice/hey-scout.txt
@@ -1,0 +1,3 @@
+▁HE Y ▁S CO U T :2.0 #0.05 @HEY_SCOUT
+▁S CO U T :2.0 #0.15 @SCOUT
+▁HE Y :2.0 #0.05 @HEY

--- a/packages/scout-for-lol/packages/backend/voice-training/README.md
+++ b/packages/scout-for-lol/packages/backend/voice-training/README.md
@@ -1,0 +1,107 @@
+# Scout "hey scout" phrase-verifier training
+
+The Scout wake verifier is trained with LiveKit's openWakeWord-compatible
+`livekit-wakeword` pipeline at commit `95448a7559c453fcd87645bd67b247ffb45f85b0` — the same
+pinned checkout, base model, and procedure as streambot's
+(`packages/streambot/voice-training/README.md`). The checked-in `scout-cascade.yaml` is the
+canonical recipe. All corpus/training/packaging tooling lives in `packages/streambot` and is
+phrase-parameterized; Scout work selects it with `--phrase hey-scout` / `--phrase-slug hey-scout`.
+
+## Already committed (no GPU needed)
+
+- `../assets/voice/hey-scout.txt` — sherpa KWS keywords. Generated from the pinned base model's
+  own `bpe.model`/`tokens.txt` (byte-for-byte reproducible via
+  `bun run voice:keywords:generate --phrase-slug hey-scout`; `--check` verifies it) and
+  validated by loading both sherpa runtimes with it. `@SCOUT` starts at a raised per-line
+  threshold (`#0.15`) because "scout" is common speech; tune that line further upward if the
+  evaluation candidate rate is high — never the global `keywordsThreshold`.
+- `../assets/voice/fragment-tails.json` — fragment tail table (`HEY_SCOUT: 0`, `SCOUT: 0`,
+  `HEY: 500`). The 500 ms `HEY` tail is provisional pending measurement against trained assets
+  using the method documented at `packages/streambot/src/voice/constants.ts`.
+
+## Machine split
+
+- **Linux GPU worker** (single 24 GB-class GPU, 50–100 GB free disk): dataset setup and the
+  100,000-step training run. Expect roughly **1–2 days wall-clock** end to end; no paid
+  credentials are involved.
+- **macOS operator machine**: corpus generation (`say` + ffmpeg + `OPENAI_API_KEY`), feedback
+  clips, keyword/harness tooling, evaluation, and packaging from the monorepo.
+
+## GPU run (Linux worker)
+
+On the pinned `livekit-wakeword` checkout, with `/data` and `/output` as persistent mounts and
+this file's `scout-cascade.yaml` visible at `/workspace/scout-cascade.yaml`:
+
+```bash
+uv sync --all-extras
+uv run livekit-wakeword setup --config /workspace/scout-cascade.yaml
+uv run livekit-wakeword run /workspace/scout-cascade.yaml
+```
+
+The setup must include the complete ACAV100M 2,000-hour feature artifact. **Do not use
+`--skip-acav`** — packaging rejects a checkout without the full ~13 GB feature file. The recipe
+generates 40,000 training positives, 40,000 adversarial negatives (heavy on bare-"scout" and
+homophones), 45,000 standalone backgrounds, validation splits, and two noisy augmentation
+rounds. Never mount the formal synthetic or human holdouts into the worker. Select a threshold
+using only the generated tuning split.
+
+## Packaging (monorepo, macOS)
+
+```bash
+cd packages/streambot
+bun run voice:verifier:package \
+  --phrase-slug hey-scout \
+  --livekit-dir ../../.context/livekit-wakeword \
+  --model-dir <persistent-output>/hey_scout_cascade \
+  --threshold <reviewed-threshold>
+```
+
+This writes `hey_scout.onnx`, `melspectrogram.onnx`, `embedding_model.onnx`,
+`hey-scout-smoke.wav`, and `wake-verifier.json` into
+`packages/scout-for-lol/packages/backend/assets/voice/` (override with `--dest`), verifying the
+training corpus provenance counts and the full ACAV artifact first.
+
+## Post-training acceptance (macOS)
+
+1. Assemble an assets dir at `.context/scout-voice-models/`: the pinned sherpa base model +
+   `silero_vad.onnx` + `test_wavs/` (copy from the `bun run voice:harness:prepare` export,
+   dropping streambot's wake files) plus everything in `../assets/voice/`.
+2. Generate and verify the 400-clip Scout corpus (~$1–5 of OpenAI TTS):
+
+   ```bash
+   bun run voice:corpus:generate --phrase hey-scout
+   bun run voice:corpus:verify --phrase hey-scout
+   ```
+
+3. Evaluate **with the 2-hour negative soak** (a skipped soak records as failed):
+
+   ```bash
+   bun run voice:corpus:evaluate --phrase hey-scout --assets-dir ../../.context/scout-voice-models
+   ```
+
+   Commit the dated report to `reports/` in this directory and review it. Re-measure the `HEY`
+   fragment tail and update `fragment-tails.json` if endpoint numbers demand it.
+
+4. Human holdout — 3 speakers x 10 clips (5 positive / 3 near-match / 2 background), recordings
+   kept under `.context/` and deleted by the tool after the aggregate report:
+
+   ```bash
+   bun run voice:human:evaluate --phrase hey-scout --input-dir ../../.context/<holdout-dir>
+   ```
+
+5. Regenerate Scout's spoken feedback clips when shipping — prefer OpenAI TTS output over the
+   `say`-based `bun run scripts/voice-feedback-generate.ts --phrase hey-scout`.
+
+## Acceptance criteria
+
+Measured and operator-reviewed (streambot precedent: review inputs, not CI gates), on both the
+native and WASM runtimes:
+
+- clean-positive recall = 100%; stress recall at ≥ 10 dB SNR ≥ 95%
+- zero negative-corpus activations and zero 2-hour soak activations
+  (bare-"scout" false accepts are the number to scrutinize)
+- zero endpoint violations (650–1500 ms after speech end)
+- human holdout: 15/15 positives, 15/15 negatives, identical native/WASM classification
+
+Packaging is not acceptance: the committed corpus report, untouched human holdout, and Scout's
+own integration gates must still pass before the assets ship.

--- a/packages/scout-for-lol/packages/backend/voice-training/README.md
+++ b/packages/scout-for-lol/packages/backend/voice-training/README.md
@@ -16,8 +16,9 @@ phrase-parameterized; Scout work selects it with `--phrase hey-scout` / `--phras
   threshold (`#0.15`) because "scout" is common speech; tune that line further upward if the
   evaluation candidate rate is high — never the global `keywordsThreshold`.
 - `../assets/voice/fragment-tails.json` — fragment tail table (`HEY_SCOUT: 0`, `SCOUT: 0`,
-  `HEY: 500`). The 500 ms `HEY` tail is provisional pending measurement against trained assets
-  using the method documented at `packages/streambot/src/voice/constants.ts`.
+  `HEY: 500`). `HEY`'s value carries over streambot's hey-streambot tail; step 3 below
+  re-measures it against the trained hey-scout assets using the method documented at
+  `packages/streambot/src/voice/constants.ts`.
 
 ## Machine split
 

--- a/packages/scout-for-lol/packages/backend/voice-training/reports/README.md
+++ b/packages/scout-for-lol/packages/backend/voice-training/reports/README.md
@@ -1,0 +1,6 @@
+# Voice acceptance reports
+
+Date-stamped `voice:corpus:evaluate --phrase hey-scout` reports produced by the
+operator-run acceptance procedure documented one directory up. Each report is
+committed evidence for an enablement or tuning decision; no build or CI step
+runs this evaluation.

--- a/packages/scout-for-lol/packages/backend/voice-training/scout-cascade.yaml
+++ b/packages/scout-for-lol/packages/backend/voice-training/scout-cascade.yaml
@@ -1,0 +1,69 @@
+# LiveKit livekit-wakeword training input for the Scout "hey scout" phrase verifier.
+# Pinned upstream commit: 95448a7559c453fcd87645bd67b247ffb45f85b0
+# Run against a pinned checkout with the full ACAV100M feature setup; do not use
+# the formal synthetic or human holdouts as training inputs.
+# "scout" is an ordinary English word, so the adversarial negatives lean heavily on
+# bare and conversational "scout" usage plus homophones.
+model_name: hey_scout_cascade
+target_phrases: ["hey scout"]
+
+n_samples: 40000
+n_samples_val: 4000
+n_background_samples: 45000
+n_background_samples_val: 2000
+tts_batch_size: 80
+
+custom_negative_phrases:
+  - "scout"
+  - "a scout"
+  - "the scout"
+  - "boy scout"
+  - "girl scout"
+  - "talent scout"
+  - "scout the jungle"
+  - "scout ahead"
+  - "scout it out"
+  - "send a scout"
+  - "scouting report"
+  - "scouts honor"
+  - "ask scout about the match"
+  - "hey scott"
+  - "hey scoot"
+  - "hey shout"
+  - "hey sprout"
+  - "we need to scout them"
+  - "the scout rushed mid"
+  - "watch the map"
+  - "check the scoreboard"
+
+noise_scales: [0.667, 0.8, 0.98]
+noise_scale_ws: [0.667, 0.8, 0.98]
+length_scales: [0.65, 0.8, 1.0, 1.2, 1.4]
+slerp_weights: [0.15, 0.3, 0.5, 0.7, 0.85]
+
+data_dir: /data
+output_dir: /output
+
+augmentation:
+  clip_duration: 2.0
+  batch_size: 32
+  rounds: 2
+  background_paths: [/data/backgrounds]
+  rir_paths: [/data/rirs]
+
+model:
+  model_type: conv_attention
+  model_size: medium
+
+steps: 100000
+learning_rate: 0.0001
+weight_decay: 0.01
+label_smoothing: 0.05
+max_negative_weight: 5000
+target_fp_per_hour: 0.02
+
+batch_n_per_class:
+  positive: 64
+  adversarial_negative: 128
+  ACAV100M_sample: 512
+  background_noise: 128

--- a/packages/streambot/package.json
+++ b/packages/streambot/package.json
@@ -30,6 +30,7 @@
     "voice:harness:evaluate": "bun run scripts/voice-harness-evaluate.ts",
     "voice:cloud-probe": "bun run scripts/voice-cloud-probe.ts",
     "voice:verifier:package": "bun run scripts/voice-verifier-package.ts",
+    "voice:keywords:generate": "bun run scripts/voice-keywords-generate.ts",
     "e2e:local": "bun run e2e/local.ts",
     "typecheck": "PATH=node_modules/@typescript/native/bin:$PATH tsc --noEmit",
     "lint": "eslint . && check-architecture",

--- a/packages/streambot/scripts/voice-corpus-evaluate.ts
+++ b/packages/streambot/scripts/voice-corpus-evaluate.ts
@@ -1,27 +1,54 @@
 import path from "node:path";
+import { parseArgs } from "node:util";
 import { z } from "zod";
 import { atomicWrite } from "@shepherdjerred/streambot/voice/corpus-io.ts";
 import { evaluateVoiceCorpus } from "@shepherdjerred/streambot/voice/corpus-evaluator.ts";
+import { resolveVoiceWakePhrase } from "@shepherdjerred/streambot/voice/corpus-phrases.ts";
 
-function option(name: string): string | undefined {
-  const index = Bun.argv.indexOf(name);
-  return index === -1 ? undefined : Bun.argv[index + 1];
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    phrase: { type: "string" },
+    "assets-dir": { type: "string" },
+    report: { type: "string" },
+    "skip-soak": { type: "boolean", default: false },
+    help: { type: "boolean", short: "h", default: false },
+  },
+  strict: true,
+  allowPositionals: false,
+});
+
+if (values.help) {
+  process.stdout
+    .write(`Evaluate a wake-phrase corpus against prepared model assets.
+
+Usage:
+  bun run voice:corpus:evaluate [--phrase hey-streambot|hey-scout]
+    [--assets-dir <dir>] [--report <file>] [--skip-soak]
+
+The assets directory must hold the pinned base model plus the phrase's packaged wake-verifier
+assets. Acceptance runs include the 2-hour negative soak; --skip-soak is for iteration only and
+records the soak as skipped (which fails the pass gate).
+`);
+  process.exit(0);
 }
 
+const phrase = resolveVoiceWakePhrase(values.phrase);
 const assetsDir = z
   .string()
   .min(1)
   .parse(
-    option("--assets-dir") ??
+    values["assets-dir"] ??
       Bun.env["VOICE_ASSETS_DIR"] ??
-      "/opt/streambot/voice",
+      phrase.defaultAssetsDir,
   );
 const reportPath = path.resolve(
-  option("--report") ?? "/tmp/streambot-voice-corpus-report.json",
+  values.report ?? phrase.defaultCorpusReportPath,
 );
 const report = await evaluateVoiceCorpus({
   assetsDir,
-  runSoak: !Bun.argv.includes("--skip-soak"),
+  phrase,
+  runSoak: !values["skip-soak"],
 });
 await atomicWrite(reportPath, `${JSON.stringify(report, null, 2)}\n`);
 process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);

--- a/packages/streambot/scripts/voice-corpus-generate.ts
+++ b/packages/streambot/scripts/voice-corpus-generate.ts
@@ -1,22 +1,47 @@
+import { parseArgs } from "node:util";
 import { z } from "zod";
 import {
   AppleSyntheticTtsClient,
   generateVoiceCorpus,
   OpenAiSyntheticTtsClient,
 } from "@shepherdjerred/streambot/voice/corpus-generator.ts";
+import { resolveVoiceWakePhrase } from "@shepherdjerred/streambot/voice/corpus-phrases.ts";
 
-const ArgsSchema = z.strictObject({ refresh: z.boolean() });
-const args = ArgsSchema.parse({
-  refresh: Bun.argv.slice(2).includes("--refresh"),
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    refresh: { type: "boolean", default: false },
+    phrase: { type: "string" },
+    help: { type: "boolean", short: "h", default: false },
+  },
+  strict: true,
+  allowPositionals: false,
 });
+
+if (values.help) {
+  process.stdout.write(`Generate a wake-phrase acceptance corpus.
+
+Usage:
+  bun run voice:corpus:generate [--phrase hey-streambot|hey-scout] [--refresh]
+
+The default phrase is hey-streambot, writing streambot's canonical fixtures. Each phrase writes
+into its own committed corpus directory. Requires OPENAI_API_KEY and, on macOS, the built-in
+say voice plus ffmpeg.
+`);
+  process.exit(0);
+}
+
+const phrase = resolveVoiceWakePhrase(values.phrase);
 const apiKey = z.string().min(1).parse(Bun.env["OPENAI_API_KEY"]);
 const manifest = await generateVoiceCorpus({
-  refresh: args.refresh,
+  refresh: values.refresh,
+  spec: phrase.spec,
+  corpusDir: phrase.corpusDir,
   clients: {
     openai: new OpenAiSyntheticTtsClient(apiKey),
     apple: new AppleSyntheticTtsClient(Bun.env["FFMPEG_PATH"] ?? "ffmpeg"),
   },
 });
 process.stdout.write(
-  `generated ${String(manifest.entries.length)} canonical voice clips\n`,
+  `generated ${String(manifest.entries.length)} canonical ${phrase.slug} voice clips\n`,
 );

--- a/packages/streambot/scripts/voice-corpus-verify.ts
+++ b/packages/streambot/scripts/voice-corpus-verify.ts
@@ -1,26 +1,15 @@
-import { parseArgs } from "node:util";
 import { verifyVoiceCorpus } from "@shepherdjerred/streambot/voice/corpus-io.ts";
-import { resolveVoiceWakePhrase } from "@shepherdjerred/streambot/voice/corpus-phrases.ts";
+import {
+  parsePhraseCliArgs,
+  resolveVoiceWakePhrase,
+} from "@shepherdjerred/streambot/voice/corpus-phrases.ts";
 
-const { values } = parseArgs({
-  args: Bun.argv.slice(2),
-  options: {
-    phrase: { type: "string" },
-    help: { type: "boolean", short: "h", default: false },
-  },
-  strict: true,
-  allowPositionals: false,
-});
-
-if (values.help) {
-  process.stdout
-    .write(`Verify a committed wake-phrase corpus against its manifest.
+const values =
+  parsePhraseCliArgs(`Verify a committed wake-phrase corpus against its manifest.
 
 Usage:
   bun run voice:corpus:verify [--phrase hey-streambot|hey-scout]
 `);
-  process.exit(0);
-}
 
 const phrase = resolveVoiceWakePhrase(values.phrase);
 const result = await verifyVoiceCorpus(phrase.corpusDir, true, phrase.spec);

--- a/packages/streambot/scripts/voice-corpus-verify.ts
+++ b/packages/streambot/scripts/voice-corpus-verify.ts
@@ -1,6 +1,29 @@
+import { parseArgs } from "node:util";
 import { verifyVoiceCorpus } from "@shepherdjerred/streambot/voice/corpus-io.ts";
+import { resolveVoiceWakePhrase } from "@shepherdjerred/streambot/voice/corpus-phrases.ts";
 
-const result = await verifyVoiceCorpus();
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    phrase: { type: "string" },
+    help: { type: "boolean", short: "h", default: false },
+  },
+  strict: true,
+  allowPositionals: false,
+});
+
+if (values.help) {
+  process.stdout
+    .write(`Verify a committed wake-phrase corpus against its manifest.
+
+Usage:
+  bun run voice:corpus:verify [--phrase hey-streambot|hey-scout]
+`);
+  process.exit(0);
+}
+
+const phrase = resolveVoiceWakePhrase(values.phrase);
+const result = await verifyVoiceCorpus(phrase.corpusDir, true, phrase.spec);
 process.stdout.write(
-  `verified ${String(result.clipCount)} voice clips (${String(result.totalBytes)} bytes)\n`,
+  `verified ${String(result.clipCount)} ${phrase.slug} voice clips (${String(result.totalBytes)} bytes)\n`,
 );

--- a/packages/streambot/scripts/voice-feedback-generate.ts
+++ b/packages/streambot/scripts/voice-feedback-generate.ts
@@ -1,21 +1,70 @@
 /**
- * Regenerate the committed spoken-feedback clips in assets/voice/. macOS-only (uses the built-in
+ * Regenerate the committed spoken-feedback clips for a wake phrase. macOS-only (uses the built-in
  * `say` voice, keyless) plus ffmpeg for the 24 kHz mono PCM16 conversion the assistant sink
  * expects. Run only when the wording changes; the WAVs are committed assets, not build outputs.
  *
- *   bun run scripts/voice-feedback-generate.ts
+ *   bun run scripts/voice-feedback-generate.ts [--phrase hey-streambot|hey-scout]
+ *
+ * The hey-scout clips have not been generated yet; per the training plan, prefer OpenAI TTS
+ * output over `say` for Scout's shipped WAVs when that step lands.
  */
 import path from "node:path";
+import { parseArgs } from "node:util";
+import { resolveVoiceWakePhrase } from "@shepherdjerred/streambot/voice/corpus-phrases.ts";
 
-const LINES: readonly { file: string; text: string }[] = [
-  {
-    file: "feedback-retry.wav",
-    text: "Sorry, I didn't catch that. Say Hey Streambot and try again.",
+type FeedbackLine = { readonly file: string; readonly text: string };
+
+const FEEDBACK_LINES: Record<
+  "hey-streambot" | "hey-scout",
+  readonly FeedbackLine[]
+> = {
+  "hey-streambot": [
+    {
+      file: "feedback-retry.wav",
+      text: "Sorry, I didn't catch that. Say Hey Streambot and try again.",
+    },
+    { file: "feedback-prompt.wav", text: "What would you like me to play?" },
+  ],
+  "hey-scout": [
+    {
+      file: "feedback-retry.wav",
+      text: "Sorry, I didn't catch that. Say Hey Scout and try again.",
+    },
+    { file: "feedback-prompt.wav", text: "What would you like to know?" },
+  ],
+};
+
+const DESTINATIONS: Record<"hey-streambot" | "hey-scout", string> = {
+  "hey-streambot": path.join(import.meta.dir, "..", "assets", "voice"),
+  "hey-scout": path.join(
+    import.meta.dir,
+    "../../scout-for-lol/packages/backend/assets/voice",
+  ),
+};
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    phrase: { type: "string" },
+    help: { type: "boolean", short: "h", default: false },
   },
-  { file: "feedback-prompt.wav", text: "What would you like me to play?" },
-];
+  strict: true,
+  allowPositionals: false,
+});
 
-const assetsDir = path.join(import.meta.dir, "..", "assets", "voice");
+if (values.help) {
+  process.stdout
+    .write(`Regenerate committed spoken-feedback clips for a wake phrase.
+
+Usage:
+  bun run scripts/voice-feedback-generate.ts [--phrase hey-streambot|hey-scout]
+`);
+  process.exit(0);
+}
+
+const phrase = resolveVoiceWakePhrase(values.phrase);
+const lines = FEEDBACK_LINES[phrase.slug];
+const assetsDir = DESTINATIONS[phrase.slug];
 
 async function run(command: string[]): Promise<void> {
   const child = Bun.spawn(command, { stdout: "inherit", stderr: "inherit" });
@@ -24,7 +73,7 @@ async function run(command: string[]): Promise<void> {
   }
 }
 
-for (const line of LINES) {
+for (const line of lines) {
   const aiff = path.join("/tmp", `${line.file}.aiff`);
   await run(["say", "-v", "Samantha", "-o", aiff, line.text]);
   await run([
@@ -42,5 +91,5 @@ for (const line of LINES) {
     "s16",
     path.join(assetsDir, line.file),
   ]);
-  console.log(`wrote assets/voice/${line.file}`);
+  console.log(`wrote ${path.join(assetsDir, line.file)}`);
 }

--- a/packages/streambot/scripts/voice-feedback-generate.ts
+++ b/packages/streambot/scripts/voice-feedback-generate.ts
@@ -9,8 +9,10 @@
  * output over `say` for Scout's shipped WAVs when that step lands.
  */
 import path from "node:path";
-import { parseArgs } from "node:util";
-import { resolveVoiceWakePhrase } from "@shepherdjerred/streambot/voice/corpus-phrases.ts";
+import {
+  parsePhraseCliArgs,
+  resolveVoiceWakePhrase,
+} from "@shepherdjerred/streambot/voice/corpus-phrases.ts";
 
 type FeedbackLine = { readonly file: string; readonly text: string };
 
@@ -42,25 +44,13 @@ const DESTINATIONS: Record<"hey-streambot" | "hey-scout", string> = {
   ),
 };
 
-const { values } = parseArgs({
-  args: Bun.argv.slice(2),
-  options: {
-    phrase: { type: "string" },
-    help: { type: "boolean", short: "h", default: false },
-  },
-  strict: true,
-  allowPositionals: false,
-});
-
-if (values.help) {
-  process.stdout
-    .write(`Regenerate committed spoken-feedback clips for a wake phrase.
+const values = parsePhraseCliArgs(
+  `Regenerate committed spoken-feedback clips for a wake phrase.
 
 Usage:
   bun run scripts/voice-feedback-generate.ts [--phrase hey-streambot|hey-scout]
-`);
-  process.exit(0);
-}
+`,
+);
 
 const phrase = resolveVoiceWakePhrase(values.phrase);
 const lines = FEEDBACK_LINES[phrase.slug];

--- a/packages/streambot/scripts/voice-human-holdout-evaluate.ts
+++ b/packages/streambot/scripts/voice-human-holdout-evaluate.ts
@@ -9,8 +9,11 @@ import { atomicWrite } from "@shepherdjerred/streambot/voice/corpus-io.ts";
 import {
   cloneDiscordOpusPackets,
   evaluateDiscordOpusPackets,
+  type VoiceLifecycleDeps,
 } from "@shepherdjerred/streambot/voice/corpus-evaluator.ts";
-import { initializeLocalVoiceModelsForRuntime } from "@shepherdjerred/streambot/voice/local-voice.ts";
+import { initializeLocalVoiceModelsForRuntime } from "@shepherdjerred/voice-assistant/local-models.ts";
+import { streambotVoiceLifecycleDeps } from "@shepherdjerred/streambot/voice/local-voice.ts";
+import { resolveVoiceWakePhrase } from "@shepherdjerred/streambot/voice/corpus-phrases.ts";
 
 const ClipSchema = z.strictObject({
   file: z.string().min(1),
@@ -83,6 +86,11 @@ async function rawFileToPackets(
   }
 }
 
+const phrase = resolveVoiceWakePhrase(option("--phrase"));
+const lifecycleDeps: VoiceLifecycleDeps = {
+  ...streambotVoiceLifecycleDeps(),
+  fragmentTailMs: await phrase.loadFragmentTailMs(),
+};
 const inputDir = path.resolve(z.string().min(1).parse(option("--input-dir")));
 if (!inputDir.includes(`${path.sep}.context${path.sep}`)) {
   throw new Error(
@@ -92,13 +100,9 @@ if (!inputDir.includes(`${path.sep}.context${path.sep}`)) {
 const assetsDir = path.resolve(
   option("--assets-dir") ??
     Bun.env["VOICE_ASSETS_DIR"] ??
-    "/opt/streambot/voice",
+    phrase.defaultAssetsDir,
 );
-const reportPath = path.resolve(
-  inputDir,
-  "..",
-  "streambot-human-holdout-result.json",
-);
+const reportPath = path.resolve(inputDir, "..", phrase.humanHoldoutReportName);
 // Everything that reads the holdout runs inside this cleanup scope, because the privacy contract
 // is that only the aggregate report outlives the run: a missing or malformed manifest, wrong
 // category counts, a runtime that fails to initialize, a rejected clip, and a failed validation
@@ -111,7 +115,7 @@ const report = await (async () => {
     runtime: "native" | "wasm",
   ): Promise<LocalVoiceModels> => {
     const models = await initializeLocalVoiceModelsForRuntime(
-      assetsDir,
+      phrase.assetManifest(assetsDir),
       runtime,
     );
     opened.push(models);
@@ -165,8 +169,8 @@ const report = await (async () => {
         const [nativeResult, wasmResult] = await (async () => {
           try {
             return await Promise.all([
-              evaluateDiscordOpusPackets(native, nativePackets),
-              evaluateDiscordOpusPackets(wasm, wasmPackets),
+              evaluateDiscordOpusPackets(native, nativePackets, lifecycleDeps),
+              evaluateDiscordOpusPackets(wasm, wasmPackets, lifecycleDeps),
             ]);
           } finally {
             for (const packet of packets) packet.fill(0);

--- a/packages/streambot/scripts/voice-keywords-generate.ts
+++ b/packages/streambot/scripts/voice-keywords-generate.ts
@@ -1,0 +1,147 @@
+/**
+ * Generate a sherpa KWS keywords file for a wake phrase from the pinned base model's own
+ * tokenizer. Every BPE piece comes from encoding the fragment text with the model's `bpe.model`
+ * (the same tokenization sherpa's text2token performs) and is then checked against `tokens.txt`,
+ * so a guessed or drifted piece can never be written.
+ *
+ *   bun run scripts/voice-keywords-generate.ts [--phrase-slug hey-scout] \
+ *     [--model-dir <dir with tokens.txt + bpe.model>] [--dest <file>] [--check]
+ *
+ * Requires `uv` (runs sentencepiece via `uv run --with sentencepiece`). The default model dir is
+ * the harness export (`bun run voice:harness:prepare`). --check regenerates and compares against
+ * the destination instead of writing, proving a committed keywords file matches the pinned model.
+ */
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { z } from "zod";
+import {
+  resolveVoiceWakePhrase,
+  verifierPackagingPlan,
+  wakeVerifierFileNames,
+} from "@shepherdjerred/streambot/voice/corpus-phrases.ts";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    "phrase-slug": { type: "string", default: "hey-streambot" },
+    "model-dir": { type: "string" },
+    dest: { type: "string" },
+    check: { type: "boolean", default: false },
+    help: { type: "boolean", short: "h", default: false },
+  },
+  strict: true,
+  allowPositionals: false,
+});
+
+if (values.help) {
+  process.stdout
+    .write(`Generate a wake-phrase sherpa keywords file from the pinned tokenizer.
+
+Usage:
+  bun run scripts/voice-keywords-generate.ts [--phrase-slug hey-streambot|hey-scout]
+    [--model-dir <dir>] [--dest <file>] [--check]
+`);
+  process.exit(0);
+}
+
+const slug = z.string().min(1).parse(values["phrase-slug"]);
+const phrase = resolveVoiceWakePhrase(slug);
+const modelDir = path.resolve(
+  values["model-dir"] ??
+    path.resolve(import.meta.dir, "../../../.context/streambot-voice-models"),
+);
+const destination = path.resolve(
+  values.dest ??
+    path.join(
+      verifierPackagingPlan(slug).destination,
+      wakeVerifierFileNames(slug).keywords,
+    ),
+);
+
+const bpeModel = path.join(modelDir, "bpe.model");
+const tokensFile = path.join(modelDir, "tokens.txt");
+for (const required of [bpeModel, tokensFile]) {
+  if (!(await Bun.file(required).exists())) {
+    throw new Error(
+      `Pinned tokenizer asset is missing: ${required} (run \`bun run voice:harness:prepare\` or pass --model-dir)`,
+    );
+  }
+}
+if (Bun.which("uv") === null) {
+  throw new Error("uv is required to run sentencepiece for BPE encoding");
+}
+
+const encodeProgram = `import json, sys
+import sentencepiece as spm
+sp = spm.SentencePieceProcessor()
+sp.load(sys.argv[1])
+print(json.dumps([sp.encode(text, out_type=str) for text in json.loads(sys.argv[2])]))
+`;
+const texts = phrase.keywordFragments.map((fragment) => fragment.text);
+const child = Bun.spawn(
+  [
+    "uv",
+    "run",
+    "--with",
+    "sentencepiece",
+    "python3",
+    "-",
+    bpeModel,
+    JSON.stringify(texts),
+  ],
+  { stdin: "pipe", stdout: "pipe", stderr: "pipe" },
+);
+await child.stdin.write(encodeProgram);
+await child.stdin.end();
+const [stdout, stderr, exitCode] = await Promise.all([
+  new Response(child.stdout).text(),
+  new Response(child.stderr).text(),
+  child.exited,
+]);
+if (exitCode !== 0) {
+  throw new Error(`sentencepiece encoding failed: ${stderr.trim()}`);
+}
+const encoded = z
+  .array(z.array(z.string().min(1)))
+  .length(phrase.keywordFragments.length)
+  .parse(JSON.parse(stdout));
+
+const tokensText = await Bun.file(tokensFile).text();
+const knownTokens = new Set(
+  tokensText
+    .split("\n")
+    .map((line) => line.split(" ")[0])
+    .filter((token) => token !== undefined && token.length > 0),
+);
+const missing = encoded.flat().filter((piece) => !knownTokens.has(piece));
+if (missing.length > 0) {
+  throw new Error(
+    `BPE pieces are absent from ${tokensFile}: ${[...new Set(missing)].join(", ")}`,
+  );
+}
+
+const lines = phrase.keywordFragments.map((fragment, index) => {
+  const pieces = encoded[index];
+  if (pieces === undefined || pieces.length === 0) {
+    throw new Error(`Fragment "${fragment.label}" encoded to no BPE pieces`);
+  }
+  return `${pieces.join(" ")} :${fragment.boost.toFixed(1)} #${fragment.threshold.toFixed(2)} @${fragment.label}`;
+});
+const content = `${lines.join("\n")}\n`;
+
+if (values.check) {
+  const existing = await Bun.file(destination).text();
+  if (existing !== content) {
+    throw new Error(
+      `Committed keywords file ${destination} does not match the pinned tokenizer output`,
+    );
+  }
+  process.stdout.write(
+    `verified ${destination} against the pinned tokenizer (${String(lines.length)} fragments)\n`,
+  );
+} else {
+  await Bun.write(destination, content);
+  process.stdout.write(
+    `wrote ${destination} (${String(lines.length)} fragments)\n`,
+  );
+}

--- a/packages/streambot/scripts/voice-verifier-package.ts
+++ b/packages/streambot/scripts/voice-verifier-package.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { cp, mkdir, readdir, rename, rm } from "node:fs/promises";
 import { parseArgs } from "node:util";
 import { z } from "zod";
+import { verifierPackagingPlan } from "@shepherdjerred/streambot/voice/corpus-phrases.ts";
 
 const MIN_POSITIVES = 20_000;
 const MIN_ADVERSARIAL = 40_000;
@@ -13,6 +14,8 @@ const { values } = parseArgs({
     "livekit-dir": { type: "string" },
     "model-dir": { type: "string" },
     threshold: { type: "string" },
+    "phrase-slug": { type: "string", default: "hey-streambot" },
+    dest: { type: "string" },
     help: { type: "boolean", short: "h", default: false },
   },
   strict: true,
@@ -24,6 +27,11 @@ if (values.help) {
 
 Usage:
   bun run voice:verifier:package --livekit-dir <checkout> --model-dir <run> --threshold <0..1>
+    [--phrase-slug hey-streambot|hey-scout] [--dest <assets-dir>]
+
+The phrase slug selects the trained classifier name (<slug with underscores>_cascade.onnx) and
+the packaged output filenames; the default reproduces the historical hey-streambot packaging
+into packages/streambot/assets/voice exactly. --dest overrides the committed destination.
 
 The pinned checkout must contain the full ACAV100M feature asset. The command verifies training
 counts, copies the mel/embedding/classifier ONNX graph atomically, and writes its checksum manifest.
@@ -35,7 +43,11 @@ It does not evaluate or select a threshold; pass the reviewed synthetic-tuning t
 const livekitDir = path.resolve(z.string().min(1).parse(values["livekit-dir"]));
 const modelDir = path.resolve(z.string().min(1).parse(values["model-dir"]));
 const threshold = z.coerce.number().min(0).max(1).parse(values.threshold);
-const destination = path.resolve(import.meta.dir, "../assets/voice");
+const plan = verifierPackagingPlan(
+  z.string().min(1).parse(values["phrase-slug"]),
+  values.dest === undefined ? undefined : path.resolve(values.dest),
+);
+const destination = plan.destination;
 const temporary = path.join(destination, `.verifier-${crypto.randomUUID()}`);
 
 async function countWaves(directory: string): Promise<number> {
@@ -99,7 +111,7 @@ const sources = {
     livekitDir,
     "src/livekit/wakeword/resources/embedding_model.onnx",
   ),
-  classifier: path.join(modelDir, "hey_streambot_cascade.onnx"),
+  classifier: path.join(modelDir, plan.classifierSourceName),
   smokePositive: await firstWave(path.join(modelDir, "positive_test")),
 };
 for (const source of Object.values(sources)) {
@@ -108,13 +120,14 @@ for (const source of Object.values(sources)) {
   }
 }
 
+await mkdir(destination, { recursive: true });
 await mkdir(temporary, { recursive: false });
 try {
   const outputs = {
-    mel: path.join(temporary, "melspectrogram.onnx"),
-    embedding: path.join(temporary, "embedding_model.onnx"),
-    classifier: path.join(temporary, "hey_streambot.onnx"),
-    smokePositive: path.join(temporary, "hey-streambot-smoke.wav"),
+    mel: path.join(temporary, plan.outputs.mel),
+    embedding: path.join(temporary, plan.outputs.embedding),
+    classifier: path.join(temporary, plan.outputs.classifier),
+    smokePositive: path.join(temporary, plan.outputs.smokePositive),
   };
   await Promise.all([
     cp(sources.mel, outputs.mel),
@@ -143,10 +156,10 @@ try {
     `${JSON.stringify(manifest, null, 2)}\n`,
   );
   for (const filename of [
-    "melspectrogram.onnx",
-    "embedding_model.onnx",
-    "hey_streambot.onnx",
-    "hey-streambot-smoke.wav",
+    plan.outputs.mel,
+    plan.outputs.embedding,
+    plan.outputs.classifier,
+    plan.outputs.smokePositive,
     "wake-verifier.json",
   ]) {
     await rename(

--- a/packages/streambot/src/voice/corpus-evaluator.ts
+++ b/packages/streambot/src/voice/corpus-evaluator.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import type { ReceivedVoiceAudio } from "@shepherdjerred/discord-video-stream";
 import {
-  DEFAULT_VOICE_CORPUS_DIR,
   loadVoiceCorpusManifest,
   verifyVoiceCorpus,
 } from "@shepherdjerred/streambot/voice/corpus-io.ts";
@@ -14,11 +13,20 @@ import {
   VoiceAudioLifecycle,
   type LocalVoiceModels,
 } from "@shepherdjerred/voice-assistant";
+import type { VoiceAudioLifecycleOptions } from "@shepherdjerred/voice-assistant/audio-lifecycle-types.ts";
+import { initializeLocalVoiceModelsForRuntime } from "@shepherdjerred/voice-assistant/local-models.ts";
+import { streambotVoiceLifecycleDeps } from "@shepherdjerred/streambot/voice/local-voice.ts";
 import {
-  initializeLocalVoiceModelsForRuntime,
-  streambotVoiceLifecycleDeps,
-} from "@shepherdjerred/streambot/voice/local-voice.ts";
+  VOICE_WAKE_PHRASES,
+  type VoiceWakePhraseProfile,
+} from "@shepherdjerred/streambot/voice/corpus-phrases.ts";
 import { VOICE_WAKE_WINDOW_MS } from "@shepherdjerred/voice-assistant/constants.ts";
+
+/** The lifecycle ports the offline evaluator injects; phrase-specific via the profile. */
+export type VoiceLifecycleDeps = Pick<
+  VoiceAudioLifecycleOptions,
+  "fragmentTailMs" | "metrics" | "observability"
+>;
 
 type ClipEvaluation = {
   readonly id: string;
@@ -125,6 +133,7 @@ function verificationBarrier(): {
 export async function evaluateDiscordOpusPackets(
   models: LocalVoiceModels,
   packets: readonly Uint8Array[],
+  lifecycleDeps: VoiceLifecycleDeps = streambotVoiceLifecycleDeps(),
 ): Promise<DiscordOpusPipelineEvaluation> {
   let activated = false;
   const candidate = { detected: false };
@@ -137,7 +146,7 @@ export async function evaluateDiscordOpusPackets(
   // simulated timestamp on the frame the turn actually completed at.
   const verification = verificationBarrier();
   const lifecycle = new VoiceAudioLifecycle({
-    ...streambotVoiceLifecycleDeps(),
+    ...lifecycleDeps,
     models,
     preRollMs: VOICE_WAKE_WINDOW_MS,
     maxUtteranceMs: 15_000,
@@ -182,8 +191,13 @@ async function evaluateClip(
   models: LocalVoiceModels,
   entry: VoiceCorpusEntry,
   packets: readonly Uint8Array[],
+  lifecycleDeps: VoiceLifecycleDeps,
 ): Promise<ClipEvaluation> {
-  const result = await evaluateDiscordOpusPackets(models, packets);
+  const result = await evaluateDiscordOpusPackets(
+    models,
+    packets,
+    lifecycleDeps,
+  );
   return {
     id: entry.id,
     expected: entry.expected,
@@ -224,6 +238,7 @@ async function negativeSoak(
   corpusDir: string,
   models: LocalVoiceModels,
   manifest: VoiceCorpusManifest,
+  lifecycleDeps: VoiceLifecycleDeps,
 ): Promise<number> {
   const negatives = manifest.entries.filter(
     (entry) => entry.expected === "no-wake",
@@ -243,7 +258,7 @@ async function negativeSoak(
   let activations = 0;
   const verification = verificationBarrier();
   const lifecycle = new VoiceAudioLifecycle({
-    ...streambotVoiceLifecycleDeps(),
+    ...lifecycleDeps,
     models,
     preRollMs: VOICE_WAKE_WINDOW_MS,
     maxUtteranceMs: 15_000,
@@ -291,12 +306,21 @@ async function negativeSoak(
   return activations;
 }
 
-async function evaluateRuntime(
-  corpusDir: string,
-  manifest: VoiceCorpusManifest,
-  models: LocalVoiceModels,
-  runSoak: boolean,
-): Promise<RuntimeCorpusEvaluation> {
+type RuntimeEvaluationInputs = {
+  readonly corpusDir: string;
+  readonly manifest: VoiceCorpusManifest;
+  readonly models: LocalVoiceModels;
+  readonly runSoak: boolean;
+  readonly lifecycleDeps: VoiceLifecycleDeps;
+};
+
+async function evaluateRuntime({
+  corpusDir,
+  manifest,
+  models,
+  runSoak,
+  lifecycleDeps,
+}: RuntimeEvaluationInputs): Promise<RuntimeCorpusEvaluation> {
   const clips: ClipEvaluation[] = [];
   for (const entry of manifest.entries) {
     const container = decodeDiscordOpusContainer(
@@ -304,7 +328,9 @@ async function evaluateRuntime(
         await Bun.file(path.join(corpusDir, entry.file)).arrayBuffer(),
       ),
     );
-    clips.push(await evaluateClip(models, entry, container.packets));
+    clips.push(
+      await evaluateClip(models, entry, container.packets, lifecycleDeps),
+    );
   }
   const byId = new Map(clips.map((result) => [result.id, result]));
   const clean = manifest.entries
@@ -355,7 +381,7 @@ async function evaluateRuntime(
     ).length,
     endpointViolations,
     twoHourNegativeSoakActivations: runSoak
-      ? await negativeSoak(corpusDir, models, manifest)
+      ? await negativeSoak(corpusDir, models, manifest, lifecycleDeps)
       : null,
   };
 }
@@ -364,33 +390,46 @@ export async function evaluateVoiceCorpus(options: {
   readonly corpusDir?: string;
   readonly assetsDir: string;
   readonly runSoak?: boolean;
+  /** Which wake phrase's corpus/assets to evaluate; defaults to streambot's. */
+  readonly phrase?: VoiceWakePhraseProfile;
 }): Promise<VoiceCorpusEvaluationReport> {
-  const corpusDir = options.corpusDir ?? DEFAULT_VOICE_CORPUS_DIR;
-  await verifyVoiceCorpus(corpusDir);
-  const manifest = await loadVoiceCorpusManifest(corpusDir);
+  const phrase = options.phrase ?? VOICE_WAKE_PHRASES["hey-streambot"];
+  const corpusDir = options.corpusDir ?? phrase.corpusDir;
+  await verifyVoiceCorpus(corpusDir, true, phrase.spec);
+  const manifest = await loadVoiceCorpusManifest(corpusDir, phrase.spec.format);
+  const streambotDeps = streambotVoiceLifecycleDeps();
+  // The metrics/observability ports are phrase-agnostic offline instrumentation; only the
+  // fragment-tail table is phrase-specific.
+  const lifecycleDeps: VoiceLifecycleDeps = {
+    ...streambotDeps,
+    fragmentTailMs: await phrase.loadFragmentTailMs(),
+  };
+  const assetManifest = phrase.assetManifest(options.assetsDir);
   const nativeModels = await initializeLocalVoiceModelsForRuntime(
-    options.assetsDir,
+    assetManifest,
     "native",
   );
   const wasmModels = await initializeLocalVoiceModelsForRuntime(
-    options.assetsDir,
+    assetManifest,
     "wasm",
   );
   let native: RuntimeCorpusEvaluation;
   let wasm: RuntimeCorpusEvaluation;
   try {
-    native = await evaluateRuntime(
+    native = await evaluateRuntime({
       corpusDir,
       manifest,
-      nativeModels,
-      options.runSoak ?? true,
-    );
-    wasm = await evaluateRuntime(
+      models: nativeModels,
+      runSoak: options.runSoak ?? true,
+      lifecycleDeps,
+    });
+    wasm = await evaluateRuntime({
       corpusDir,
       manifest,
-      wasmModels,
-      options.runSoak ?? true,
-    );
+      models: wasmModels,
+      runSoak: options.runSoak ?? true,
+      lifecycleDeps,
+    });
   } finally {
     await Promise.all([nativeModels.close(), wasmModels.close()]);
   }

--- a/packages/streambot/src/voice/corpus-generator.ts
+++ b/packages/streambot/src/voice/corpus-generator.ts
@@ -3,7 +3,7 @@ import { rm } from "node:fs/promises";
 import OpenAI from "openai";
 import { DiscordOpusEncoder } from "@shepherdjerred/voice-assistant/codecs.ts";
 import {
-  VoiceCorpusManifestSchema,
+  voiceCorpusManifestSchema,
   type VoiceCorpusEntry,
   type VoiceCorpusManifest,
 } from "@shepherdjerred/streambot/voice/corpus-schema.ts";
@@ -14,6 +14,8 @@ import {
 } from "@shepherdjerred/streambot/voice/corpus-io.ts";
 import {
   expandVoiceCorpusRecipes,
+  STREAMBOT_VOICE_PHRASE_SPEC,
+  type VoiceCorpusPhraseSpec,
   type VoiceCorpusRecipe,
 } from "@shepherdjerred/streambot/voice/corpus-recipes.ts";
 import { encodeDiscordOpusContainer } from "@shepherdjerred/voice-assistant/discord-opus-container.ts";
@@ -353,6 +355,8 @@ export type GenerateVoiceCorpusOptions = {
   readonly corpusDir?: string;
   readonly ffmpegPath?: string;
   readonly refresh?: boolean;
+  /** Which wake phrase's corpus to generate; defaults to streambot's canonical corpus. */
+  readonly spec?: VoiceCorpusPhraseSpec;
   readonly recipes?: readonly VoiceCorpusRecipe[];
   readonly normalize?: (pcm: Uint8Array) => Promise<Uint8Array>;
   readonly encode?: (pcm: Uint8Array) => Uint8Array[];
@@ -365,20 +369,22 @@ export type GenerateVoiceCorpusOptions = {
 export async function generateVoiceCorpus(
   options: GenerateVoiceCorpusOptions,
 ): Promise<VoiceCorpusManifest> {
+  const spec = options.spec ?? STREAMBOT_VOICE_PHRASE_SPEC;
+  const ManifestSchema = voiceCorpusManifestSchema(spec.format);
   const corpusDir = options.corpusDir ?? DEFAULT_VOICE_CORPUS_DIR;
   const manifestPath = path.join(corpusDir, "manifest.json");
   const existingFile = Bun.file(manifestPath);
   const existing = (await existingFile.exists())
-    ? VoiceCorpusManifestSchema.parse(await existingFile.json())
-    : VoiceCorpusManifestSchema.parse({
+    ? ManifestSchema.parse(await existingFile.json())
+    : ManifestSchema.parse({
         version: 1,
-        format: "streambot-discord-opus-v1",
+        format: spec.format,
         disclosure:
           "AI-generated and procedurally generated speech/audio; no recordings of people or copyrighted media.",
         entries: [],
       });
   const entries = new Map(existing.entries.map((entry) => [entry.id, entry]));
-  for (const recipe of options.recipes ?? expandVoiceCorpusRecipes()) {
+  for (const recipe of options.recipes ?? expandVoiceCorpusRecipes(spec)) {
     const destination = path.join(corpusDir, recipe.file);
     const previous = entries.get(recipe.id);
     if (
@@ -421,7 +427,7 @@ export async function generateVoiceCorpus(
       packetCount: packets.length,
       sha256: sha256(container),
     });
-    const manifest = VoiceCorpusManifestSchema.parse({
+    const manifest = ManifestSchema.parse({
       ...existing,
       entries: [...entries.values()].sort((left, right) =>
         left.id.localeCompare(right.id),
@@ -429,5 +435,5 @@ export async function generateVoiceCorpus(
     });
     await atomicWrite(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
   }
-  return VoiceCorpusManifestSchema.parse(await Bun.file(manifestPath).json());
+  return ManifestSchema.parse(await Bun.file(manifestPath).json());
 }

--- a/packages/streambot/src/voice/corpus-io.ts
+++ b/packages/streambot/src/voice/corpus-io.ts
@@ -1,11 +1,16 @@
 import path from "node:path";
 import { mkdir, rename } from "node:fs/promises";
 import {
-  VOICE_CORPUS_CLIP_COUNT,
   VOICE_CORPUS_MAX_BYTES,
-  VoiceCorpusManifestSchema,
+  voiceCorpusManifestSchema,
+  type VoiceCorpusFormat,
   type VoiceCorpusManifest,
 } from "@shepherdjerred/streambot/voice/corpus-schema.ts";
+import {
+  STREAMBOT_VOICE_PHRASE_SPEC,
+  voiceCorpusClipCount,
+  type VoiceCorpusPhraseSpec,
+} from "@shepherdjerred/streambot/voice/corpus-recipes.ts";
 import { decodeDiscordOpusContainer } from "@shepherdjerred/voice-assistant/discord-opus-container.ts";
 
 export const DEFAULT_VOICE_CORPUS_DIR = path.resolve(
@@ -31,6 +36,7 @@ export async function atomicWrite(
 
 export async function loadVoiceCorpusManifest(
   corpusDir = DEFAULT_VOICE_CORPUS_DIR,
+  format: VoiceCorpusFormat = "streambot-discord-opus-v1",
 ): Promise<VoiceCorpusManifest> {
   const file = Bun.file(path.join(corpusDir, "manifest.json"));
   if (!(await file.exists())) {
@@ -38,7 +44,7 @@ export async function loadVoiceCorpusManifest(
       `Voice corpus manifest is missing: ${file.name ?? "manifest.json"}`,
     );
   }
-  return VoiceCorpusManifestSchema.parse(await file.json());
+  return voiceCorpusManifestSchema(format).parse(await file.json());
 }
 
 export type VoiceCorpusVerification = {
@@ -49,22 +55,24 @@ export type VoiceCorpusVerification = {
 export async function verifyVoiceCorpus(
   corpusDir = DEFAULT_VOICE_CORPUS_DIR,
   requireComplete = true,
+  spec: VoiceCorpusPhraseSpec = STREAMBOT_VOICE_PHRASE_SPEC,
 ): Promise<VoiceCorpusVerification> {
-  const manifest = await loadVoiceCorpusManifest(corpusDir);
-  if (requireComplete && manifest.entries.length !== VOICE_CORPUS_CLIP_COUNT) {
+  const manifest = await loadVoiceCorpusManifest(corpusDir, spec.format);
+  const expectedClipCount = voiceCorpusClipCount(spec);
+  if (requireComplete && manifest.entries.length !== expectedClipCount) {
     throw new Error(
-      `Voice corpus must contain ${String(VOICE_CORPUS_CLIP_COUNT)} entries, found ${String(manifest.entries.length)}`,
+      `Voice corpus must contain ${String(expectedClipCount)} entries, found ${String(manifest.entries.length)}`,
     );
   }
   if (requireComplete) {
     // Composition, not just count: recall() treats an empty bucket as 100%, so a 400-entry
     // corpus with a hollowed-out category would silently weaken every acceptance number.
     const composition: Record<string, number> = {
-      "clean-positive": 160,
-      "stress-positive": 80,
-      "near-match-negative": 60,
-      "ordinary-negative": 60,
-      "background-negative": 40,
+      "clean-positive": spec.groupCounts.cleanPositive,
+      "stress-positive": spec.groupCounts.stressPositive,
+      "near-match-negative": spec.groupCounts.nearMatchNegative,
+      "ordinary-negative": spec.groupCounts.ordinaryNegative,
+      "background-negative": spec.groupCounts.backgroundNegative,
     };
     for (const [category, expected] of Object.entries(composition)) {
       const actual = manifest.entries.filter(

--- a/packages/streambot/src/voice/corpus-phrases.ts
+++ b/packages/streambot/src/voice/corpus-phrases.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { parseArgs } from "node:util";
 import { z } from "zod";
 import type { VoiceAssetManifest } from "@shepherdjerred/voice-assistant/asset-manifest.ts";
 import {
@@ -170,6 +171,28 @@ export const VOICE_WAKE_PHRASES = {
 } as const;
 
 export type VoiceWakePhraseSlug = keyof typeof VOICE_WAKE_PHRASES;
+
+/**
+ * Shared `--phrase`/`--help` parsing for the CLIs that take no other flags. Printing `helpText`
+ * and exiting is the whole help behavior, so every such script shares this exactly rather than
+ * re-declaring the same parseArgs call and exit.
+ */
+export function parsePhraseCliArgs(helpText: string): { phrase?: string } {
+  const { values } = parseArgs({
+    args: Bun.argv.slice(2),
+    options: {
+      phrase: { type: "string" },
+      help: { type: "boolean", short: "h", default: false },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+  if (values.help) {
+    process.stdout.write(helpText);
+    process.exit(0);
+  }
+  return values;
+}
 
 export function resolveVoiceWakePhrase(
   slug = "hey-streambot",

--- a/packages/streambot/src/voice/corpus-phrases.ts
+++ b/packages/streambot/src/voice/corpus-phrases.ts
@@ -1,0 +1,219 @@
+import path from "node:path";
+import { z } from "zod";
+import type { VoiceAssetManifest } from "@shepherdjerred/voice-assistant/asset-manifest.ts";
+import {
+  SCOUT_VOICE_PHRASE_SPEC,
+  STREAMBOT_VOICE_PHRASE_SPEC,
+  type VoiceCorpusPhraseSpec,
+} from "@shepherdjerred/streambot/voice/corpus-recipes.ts";
+import { DEFAULT_VOICE_CORPUS_DIR } from "@shepherdjerred/streambot/voice/corpus-io.ts";
+import {
+  streambotVoiceAssetManifest,
+  VOICE_FRAGMENT_TAIL_MS,
+} from "@shepherdjerred/streambot/voice/constants.ts";
+
+/**
+ * The wake-word corpus/training/packaging tooling lives in streambot but serves every trained
+ * phrase. A profile bundles the per-phrase facts the tools need: the corpus spec, where that
+ * phrase's fixtures and assets live, how its asset manifest is shaped, and its fragment-tail
+ * table. Streambot's profile reproduces the historical tool behavior exactly.
+ */
+
+const REPO_ROOT = path.resolve(import.meta.dir, "../../../..");
+const SCOUT_BACKEND_DIR = path.join(
+  REPO_ROOT,
+  "packages/scout-for-lol/packages/backend",
+);
+export const SCOUT_VOICE_ASSETS_DIR = path.join(
+  SCOUT_BACKEND_DIR,
+  "assets/voice",
+);
+
+/** sherpa KWS keyword-file line: `<bpe pieces> :<boost> #<threshold> @LABEL`. */
+export type WakeKeywordFragment = {
+  readonly label: string;
+  /** Uppercase words; encoded into BPE pieces with the pinned base model's `bpe.model`. */
+  readonly text: string;
+  readonly boost: number;
+  readonly threshold: number;
+};
+
+export type VoiceWakePhraseProfile = {
+  readonly slug: "hey-streambot" | "hey-scout";
+  readonly spec: VoiceCorpusPhraseSpec;
+  /** Committed canonical corpus fixtures for this phrase. */
+  readonly corpusDir: string;
+  /** Default `--assets-dir` for offline evaluation of this phrase. */
+  readonly defaultAssetsDir: string;
+  readonly defaultCorpusReportPath: string;
+  readonly humanHoldoutReportName: string;
+  readonly assetManifest: (assetsDir: string) => VoiceAssetManifest;
+  readonly loadFragmentTailMs: () => Promise<Readonly<Record<string, number>>>;
+  readonly keywordFragments: readonly WakeKeywordFragment[];
+};
+
+/**
+ * Slug-derived wake-asset filenames shared by the packager, keyword generator, and asset
+ * manifests, so one slug can never produce two spellings of the same artifact.
+ */
+export function wakeVerifierFileNames(slug: string): {
+  readonly keywords: string;
+  readonly classifier: string;
+  readonly smokePositive: string;
+  readonly trainedModelName: string;
+} {
+  const underscored = slug.replaceAll("-", "_");
+  return {
+    keywords: `${slug}.txt`,
+    classifier: `${underscored}.onnx`,
+    smokePositive: `${slug}-smoke.wav`,
+    trainedModelName: `${underscored}_cascade`,
+  };
+}
+
+/**
+ * Base-model filenames from the pinned sherpa KWS archive plus the slug-derived wake assets.
+ * Streambot's own manifest stays in `constants.ts` (it is a runtime contract, not tooling); this
+ * builder serves phrases whose runtime integration has not landed yet.
+ */
+function wakeAssetManifestForSlug(
+  slug: string,
+): (assetsDir: string) => VoiceAssetManifest {
+  const names = wakeVerifierFileNames(slug);
+  return (assetsDir) => ({
+    assetsDir,
+    files: {
+      encoder: "encoder-epoch-12-avg-2-chunk-16-left-64.int8.onnx",
+      decoder: "decoder-epoch-12-avg-2-chunk-16-left-64.int8.onnx",
+      joiner: "joiner-epoch-12-avg-2-chunk-16-left-64.int8.onnx",
+      tokens: "tokens.txt",
+      bpe: "bpe.model",
+      keywords: names.keywords,
+      smokeKeywords: "test_wavs/test_keywords.txt",
+      smokePositive: "test_wavs/0.wav",
+      vad: "silero_vad.onnx",
+      wakeMel: "melspectrogram.onnx",
+      wakeEmbedding: "embedding_model.onnx",
+      wakeClassifier: names.classifier,
+      wakeSmokePositive: names.smokePositive,
+      wakeManifest: "wake-verifier.json",
+    },
+  });
+}
+
+const FragmentTailsFileSchema = z.strictObject({
+  note: z.string(),
+  tails: z.record(z.string(), z.number().int().nonnegative()),
+});
+
+async function loadScoutFragmentTailMs(): Promise<
+  Readonly<Record<string, number>>
+> {
+  const file = Bun.file(
+    path.join(SCOUT_VOICE_ASSETS_DIR, "fragment-tails.json"),
+  );
+  return FragmentTailsFileSchema.parse(await file.json()).tails;
+}
+
+const STREAMBOT_KEYWORD_FRAGMENTS: readonly WakeKeywordFragment[] = [
+  { label: "HEY_STREAMBOT", text: "HEY STREAMBOT", boost: 2, threshold: 0.05 },
+  {
+    label: "HEY_STREAM_BOT",
+    text: "HEY STREAM BOT",
+    boost: 2,
+    threshold: 0.05,
+  },
+  { label: "HEY", text: "HEY", boost: 2, threshold: 0.05 },
+  { label: "STREAM", text: "STREAM", boost: 2, threshold: 0.05 },
+  { label: "STREAMBOT", text: "STREAMBOT", boost: 2, threshold: 0.05 },
+  { label: "BOT", text: "BOT", boost: 2, threshold: 0.05 },
+];
+
+/**
+ * "scout" is common speech, so `@SCOUT` starts at a higher per-line threshold than the
+ * permissive 0.05 default — raise it further during evaluation if the candidate rate is high,
+ * rather than ever touching the global `keywordsThreshold`.
+ */
+const SCOUT_KEYWORD_FRAGMENTS: readonly WakeKeywordFragment[] = [
+  { label: "HEY_SCOUT", text: "HEY SCOUT", boost: 2, threshold: 0.05 },
+  { label: "SCOUT", text: "SCOUT", boost: 2, threshold: 0.15 },
+  { label: "HEY", text: "HEY", boost: 2, threshold: 0.05 },
+];
+
+const STREAMBOT_PROFILE: VoiceWakePhraseProfile = {
+  slug: "hey-streambot",
+  spec: STREAMBOT_VOICE_PHRASE_SPEC,
+  corpusDir: DEFAULT_VOICE_CORPUS_DIR,
+  defaultAssetsDir: "/opt/streambot/voice",
+  defaultCorpusReportPath: "/tmp/streambot-voice-corpus-report.json",
+  humanHoldoutReportName: "streambot-human-holdout-result.json",
+  assetManifest: streambotVoiceAssetManifest,
+  loadFragmentTailMs: () => Promise.resolve(VOICE_FRAGMENT_TAIL_MS),
+  keywordFragments: STREAMBOT_KEYWORD_FRAGMENTS,
+};
+
+const SCOUT_PROFILE: VoiceWakePhraseProfile = {
+  slug: "hey-scout",
+  spec: SCOUT_VOICE_PHRASE_SPEC,
+  corpusDir: path.join(SCOUT_BACKEND_DIR, "test/fixtures/voice-corpus"),
+  defaultAssetsDir: path.join(REPO_ROOT, ".context/scout-voice-models"),
+  defaultCorpusReportPath: "/tmp/scout-voice-corpus-report.json",
+  humanHoldoutReportName: "scout-human-holdout-result.json",
+  assetManifest: wakeAssetManifestForSlug("hey-scout"),
+  loadFragmentTailMs: loadScoutFragmentTailMs,
+  keywordFragments: SCOUT_KEYWORD_FRAGMENTS,
+};
+
+export const VOICE_WAKE_PHRASES = {
+  "hey-streambot": STREAMBOT_PROFILE,
+  "hey-scout": SCOUT_PROFILE,
+} as const;
+
+export type VoiceWakePhraseSlug = keyof typeof VOICE_WAKE_PHRASES;
+
+export function resolveVoiceWakePhrase(
+  slug = "hey-streambot",
+): VoiceWakePhraseProfile {
+  if (slug === "hey-streambot" || slug === "hey-scout") {
+    return VOICE_WAKE_PHRASES[slug];
+  }
+  throw new Error(
+    `Unknown wake phrase "${slug}"; expected one of: ${Object.keys(VOICE_WAKE_PHRASES).join(", ")}`,
+  );
+}
+
+/**
+ * Everything the verifier packager derives from its flags. Defaults reproduce the historical
+ * hey-streambot behavior byte-for-byte: same classifier source name, same destination, same
+ * output filenames.
+ */
+export function verifierPackagingPlan(
+  slug: string,
+  destination?: string,
+): {
+  readonly classifierSourceName: string;
+  readonly destination: string;
+  readonly outputs: {
+    readonly mel: string;
+    readonly embedding: string;
+    readonly classifier: string;
+    readonly smokePositive: string;
+  };
+} {
+  resolveVoiceWakePhrase(slug);
+  const names = wakeVerifierFileNames(slug);
+  return {
+    classifierSourceName: `${names.trainedModelName}.onnx`,
+    destination:
+      destination ??
+      (slug === "hey-streambot"
+        ? path.join(REPO_ROOT, "packages/streambot/assets/voice")
+        : SCOUT_VOICE_ASSETS_DIR),
+    outputs: {
+      mel: "melspectrogram.onnx",
+      embedding: "embedding_model.onnx",
+      classifier: names.classifier,
+      smokePositive: names.smokePositive,
+    },
+  };
+}

--- a/packages/streambot/src/voice/corpus-recipes.ts
+++ b/packages/streambot/src/voice/corpus-recipes.ts
@@ -150,6 +150,8 @@ const SCOUT_POSITIVE_COMMANDS = [
 /**
  * "scout" is an ordinary English word, so beyond the usual homophone traps this bucket leans on
  * bare and conversational "scout" usage — the false-wake risk called out in the training plan.
+ * None of these may contain the spoken wake phrase itself: punctuation is not an acoustic
+ * boundary, so "Hey, scout ahead" would be a labeled-negative wake utterance.
  */
 const SCOUT_NEAR_MATCHES = [
   "The boy scout troop meets on Thursday night.",
@@ -158,7 +160,7 @@ const SCOUT_NEAR_MATCHES = [
   "Hey Scott, are you watching the game tonight?",
   "Hey, scoot over so I can see the map.",
   "Send a scout to check the enemy jungle.",
-  "Hey, scout ahead and ping what you see.",
+  "Scout ahead for us and ping what you see.",
   "The talent scout watched the entire match.",
   "A good scout always wards the river.",
   "He asked the scouts to skip the meeting.",

--- a/packages/streambot/src/voice/corpus-recipes.ts
+++ b/packages/streambot/src/voice/corpus-recipes.ts
@@ -1,6 +1,7 @@
 import type {
   VoiceCorpusAugmentation,
   VoiceCorpusEntry,
+  VoiceCorpusFormat,
 } from "@shepherdjerred/streambot/voice/corpus-schema.ts";
 
 export const OPENAI_TTS_VOICES = [
@@ -35,7 +36,40 @@ export const APPLE_TTS_VOICES = [
 const STYLES = ["neutral", "quiet", "hurried", "distant", "hesitant"] as const;
 const APPLE_RATES = [130, 180, 240] as const;
 
-const POSITIVE_COMMANDS = [
+/**
+ * Everything about a corpus that is specific to one wake phrase: the spoken positives, the
+ * phrase-shaped near-match traps, and the category mix. Ordinary speech and the procedural
+ * background material are phrase-agnostic and stay shared, so two corpora differ only where the
+ * phrase itself does.
+ */
+export type VoiceCorpusGroupCounts = {
+  readonly cleanPositive: number;
+  readonly stressPositive: number;
+  readonly nearMatchNegative: number;
+  readonly ordinaryNegative: number;
+  readonly backgroundNegative: number;
+};
+
+export type VoiceCorpusPhraseSpec = {
+  readonly slug: string;
+  readonly format: VoiceCorpusFormat;
+  readonly positiveCommands: readonly string[];
+  readonly nearMatches: readonly string[];
+  readonly groupCounts: VoiceCorpusGroupCounts;
+};
+
+export function voiceCorpusClipCount(spec: VoiceCorpusPhraseSpec): number {
+  const counts = spec.groupCounts;
+  return (
+    counts.cleanPositive +
+    counts.stressPositive +
+    counts.nearMatchNegative +
+    counts.ordinaryNegative +
+    counts.backgroundNegative
+  );
+}
+
+const STREAMBOT_POSITIVE_COMMANDS = [
   "Hey Streambot, play Spirited Away from local.",
   "Hey Streambot, play Take On Me from YouTube.",
   "Hey Streambot, play The Matrix.",
@@ -59,7 +93,7 @@ const POSITIVE_COMMANDS = [
   "Hey Streambot, skip and shuffle.",
 ] as const;
 
-const NEAR_MATCHES = [
+const STREAMBOT_NEAR_MATCHES = [
   "Hey streamer, play the next thing.",
   "Okay Streambot, can you hear me?",
   "Hey dream bot, turn it up.",
@@ -71,6 +105,72 @@ const NEAR_MATCHES = [
   "Hey Stream, stop the bot.",
   "A streamboat floated by the dock.",
 ] as const;
+
+/** The canonical 400-clip category mix shared by every wake-phrase corpus design. */
+const CANONICAL_GROUP_COUNTS: VoiceCorpusGroupCounts = {
+  cleanPositive: 160,
+  stressPositive: 80,
+  nearMatchNegative: 60,
+  ordinaryNegative: 60,
+  backgroundNegative: 40,
+};
+
+export const STREAMBOT_VOICE_PHRASE_SPEC: VoiceCorpusPhraseSpec = {
+  slug: "hey-streambot",
+  format: "streambot-discord-opus-v1",
+  positiveCommands: STREAMBOT_POSITIVE_COMMANDS,
+  nearMatches: STREAMBOT_NEAR_MATCHES,
+  groupCounts: CANONICAL_GROUP_COUNTS,
+};
+
+const SCOUT_POSITIVE_COMMANDS = [
+  "Hey Scout, how much damage does Cho'Gath ult do at rank one?",
+  "Hey Scout, what's Karthus ult cooldown?",
+  "Hey Scout, is Pyke ult an execute?",
+  "Hey Scout, how much mana does Lux ult cost?",
+  "Hey Scout, what's the range on Ezreal ult?",
+  "Hey Scout, how long is Malphite ult cooldown at rank two?",
+  "Hey Scout, what does Ashe's arrow do?",
+  "Hey Scout, what's the cooldown on Thresh hook?",
+  "Hey Scout, does Garen ult do true damage?",
+  "Hey Scout, what is Kai'Sa's passive?",
+  "Hey Scout, how far does Jinx ult travel?",
+  "Hey Scout, what items are good against Zed?",
+  "Hey Scout, when does Nasus ult come back up?",
+  "Hey Scout, what's the max rank damage on Veigar ult?",
+  "Hey Scout, is Urgot ult an execute?",
+  "Hey Scout, how much does Zed ult cost?",
+  "Hey Scout, what's Amumu ult cooldown at rank three?",
+  "Hey Scout, what's Teleport's cooldown?",
+  "Hey Scout, how much armor does Rammus get in ball curl?",
+  "Hey Scout, what changed for Jinx in the latest patch?",
+  "Hey Scout, who wins level one, Darius or Garen?",
+] as const;
+
+/**
+ * "scout" is an ordinary English word, so beyond the usual homophone traps this bucket leans on
+ * bare and conversational "scout" usage — the false-wake risk called out in the training plan.
+ */
+const SCOUT_NEAR_MATCHES = [
+  "The boy scout troop meets on Thursday night.",
+  "Go scout the jungle before the next fight.",
+  "You should ask scout about the match later.",
+  "Hey Scott, are you watching the game tonight?",
+  "Hey, scoot over so I can see the map.",
+  "Send a scout to check the enemy jungle.",
+  "Hey, scout ahead and ping what you see.",
+  "The talent scout watched the entire match.",
+  "A good scout always wards the river.",
+  "He asked the scouts to skip the meeting.",
+] as const;
+
+export const SCOUT_VOICE_PHRASE_SPEC: VoiceCorpusPhraseSpec = {
+  slug: "hey-scout",
+  format: "scout-discord-opus-v1",
+  positiveCommands: SCOUT_POSITIVE_COMMANDS,
+  nearMatches: SCOUT_NEAR_MATCHES,
+  groupCounts: CANONICAL_GROUP_COUNTS,
+};
 
 const ORDINARY_SPEECH = [
   "Could somebody turn the television down?",
@@ -148,28 +248,32 @@ function speechRecipe(options: SpeechRecipeOptions): VoiceCorpusRecipe {
   };
 }
 
-function cleanPositiveRecipes(): VoiceCorpusRecipe[] {
-  return Array.from({ length: 160 }, (_, index) =>
+function cleanPositiveRecipes(
+  spec: VoiceCorpusPhraseSpec,
+): VoiceCorpusRecipe[] {
+  return Array.from({ length: spec.groupCounts.cleanPositive }, (_, index) =>
     speechRecipe({
       index,
       group: "clean-positive",
       category: "clean-positive",
       expected: "wake",
-      text: cycle(POSITIVE_COMMANDS, index),
+      text: cycle(spec.positiveCommands, index),
       effect: augmentation(index % 4 === 0 ? "moderate" : "clean"),
     }),
   );
 }
 
-function stressPositiveRecipes(): VoiceCorpusRecipe[] {
+function stressPositiveRecipes(
+  spec: VoiceCorpusPhraseSpec,
+): VoiceCorpusRecipe[] {
   const snrValues = [20, 10, 5, 0] as const;
-  return Array.from({ length: 80 }, (_, index) =>
+  return Array.from({ length: spec.groupCounts.stressPositive }, (_, index) =>
     speechRecipe({
       index,
       group: "stress-positive",
       category: "stress-positive",
       expected: "wake",
-      text: cycle(POSITIVE_COMMANDS, index),
+      text: cycle(spec.positiveCommands, index),
       effect: augmentation(
         index % 3 === 0 ? "packet-loss" : index % 2 === 0 ? "echo" : "noise",
         {
@@ -182,21 +286,25 @@ function stressPositiveRecipes(): VoiceCorpusRecipe[] {
   );
 }
 
-function nearMatchRecipes(): VoiceCorpusRecipe[] {
-  return Array.from({ length: 60 }, (_, index) =>
-    speechRecipe({
-      index,
-      group: "near-match-negative",
-      category: "near-match-negative",
-      expected: "no-wake",
-      text: cycle(NEAR_MATCHES, index),
-      effect: augmentation(index % 3 === 0 ? "moderate" : "clean"),
-    }),
+function nearMatchRecipes(spec: VoiceCorpusPhraseSpec): VoiceCorpusRecipe[] {
+  return Array.from(
+    { length: spec.groupCounts.nearMatchNegative },
+    (_, index) =>
+      speechRecipe({
+        index,
+        group: "near-match-negative",
+        category: "near-match-negative",
+        expected: "no-wake",
+        text: cycle(spec.nearMatches, index),
+        effect: augmentation(index % 3 === 0 ? "moderate" : "clean"),
+      }),
   );
 }
 
-function ordinaryNegativeRecipes(): VoiceCorpusRecipe[] {
-  return Array.from({ length: 60 }, (_, index) =>
+function ordinaryNegativeRecipes(
+  spec: VoiceCorpusPhraseSpec,
+): VoiceCorpusRecipe[] {
+  return Array.from({ length: spec.groupCounts.ordinaryNegative }, (_, index) =>
     speechRecipe({
       index,
       group: "ordinary-negative",
@@ -210,9 +318,12 @@ function ordinaryNegativeRecipes(): VoiceCorpusRecipe[] {
   );
 }
 
-function backgroundNegativeRecipe(index: number): VoiceCorpusRecipe {
+function backgroundNegativeRecipe(
+  index: number,
+  speechCount: number,
+): VoiceCorpusRecipe {
   const id = `background-negative-${String(index + 1).padStart(3, "0")}`;
-  if (index >= 32) {
+  if (index >= speechCount) {
     return {
       id,
       file: `clips/${id}.dopus`,
@@ -239,14 +350,21 @@ function backgroundNegativeRecipe(index: number): VoiceCorpusRecipe {
   });
 }
 
-export function expandVoiceCorpusRecipes(): VoiceCorpusRecipe[] {
+export function expandVoiceCorpusRecipes(
+  spec: VoiceCorpusPhraseSpec = STREAMBOT_VOICE_PHRASE_SPEC,
+): VoiceCorpusRecipe[] {
+  // The historical 40-clip background bucket split 32 overlapped-speech / 8 procedural-tone
+  // clips; the 4-in-5 ratio is the invariant, and 40 * 0.8 keeps streambot's exact split.
+  const backgroundSpeech = Math.floor(
+    spec.groupCounts.backgroundNegative * 0.8,
+  );
   return [
-    ...cleanPositiveRecipes(),
-    ...stressPositiveRecipes(),
-    ...nearMatchRecipes(),
-    ...ordinaryNegativeRecipes(),
-    ...Array.from({ length: 40 }, (_, index) =>
-      backgroundNegativeRecipe(index),
+    ...cleanPositiveRecipes(spec),
+    ...stressPositiveRecipes(spec),
+    ...nearMatchRecipes(spec),
+    ...ordinaryNegativeRecipes(spec),
+    ...Array.from({ length: spec.groupCounts.backgroundNegative }, (_, index) =>
+      backgroundNegativeRecipe(index, backgroundSpeech),
     ),
   ];
 }

--- a/packages/streambot/src/voice/corpus-schema.ts
+++ b/packages/streambot/src/voice/corpus-schema.ts
@@ -4,6 +4,18 @@ export const VOICE_CORPUS_VERSION = 1;
 export const VOICE_CORPUS_CLIP_COUNT = 400;
 export const VOICE_CORPUS_MAX_BYTES = 20 * 1024 * 1024;
 
+/**
+ * One manifest format literal per wake-phrase corpus, so a corpus can never be verified or
+ * evaluated against another phrase's fixtures by accident. Parsing always pins the exact literal
+ * for the corpus being read; the union exists only for typing manifests generically.
+ */
+export const VOICE_CORPUS_FORMATS = [
+  "streambot-discord-opus-v1",
+  "scout-discord-opus-v1",
+] as const;
+
+export type VoiceCorpusFormat = (typeof VOICE_CORPUS_FORMATS)[number];
+
 export const VoiceCorpusAugmentationSchema = z.strictObject({
   kind: z.enum([
     "clean",
@@ -46,17 +58,26 @@ export const VoiceCorpusEntrySchema = z.strictObject({
   sha256: z.string().regex(/^[0-9a-f]{64}$/),
 });
 
-export const VoiceCorpusManifestSchema = z.strictObject({
-  version: z.literal(VOICE_CORPUS_VERSION),
-  format: z.literal("streambot-discord-opus-v1"),
-  disclosure: z.literal(
-    "AI-generated and procedurally generated speech/audio; no recordings of people or copyrighted media.",
-  ),
-  entries: z.array(VoiceCorpusEntrySchema).max(VOICE_CORPUS_CLIP_COUNT),
-});
+export function voiceCorpusManifestSchema(format: VoiceCorpusFormat) {
+  return z.strictObject({
+    version: z.literal(VOICE_CORPUS_VERSION),
+    format: z.literal(format),
+    disclosure: z.literal(
+      "AI-generated and procedurally generated speech/audio; no recordings of people or copyrighted media.",
+    ),
+    entries: z.array(VoiceCorpusEntrySchema).max(VOICE_CORPUS_CLIP_COUNT),
+  });
+}
+
+/** The historical streambot corpus schema; per-phrase code uses the factory above. */
+export const VoiceCorpusManifestSchema = voiceCorpusManifestSchema(
+  "streambot-discord-opus-v1",
+);
 
 export type VoiceCorpusEntry = z.infer<typeof VoiceCorpusEntrySchema>;
-export type VoiceCorpusManifest = z.infer<typeof VoiceCorpusManifestSchema>;
+export type VoiceCorpusManifest = z.infer<
+  ReturnType<typeof voiceCorpusManifestSchema>
+>;
 export type VoiceCorpusAugmentation = z.infer<
   typeof VoiceCorpusAugmentationSchema
 >;

--- a/packages/streambot/test/voice-phrase-tooling.test.ts
+++ b/packages/streambot/test/voice-phrase-tooling.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, test } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import {
+  expandVoiceCorpusRecipes,
+  SCOUT_VOICE_PHRASE_SPEC,
+  STREAMBOT_VOICE_PHRASE_SPEC,
+  voiceCorpusClipCount,
+} from "@shepherdjerred/streambot/voice/corpus-recipes.ts";
+import {
+  voiceCorpusManifestSchema,
+  VoiceCorpusManifestSchema,
+} from "@shepherdjerred/streambot/voice/corpus-schema.ts";
+import {
+  resolveVoiceWakePhrase,
+  verifierPackagingPlan,
+  VOICE_WAKE_PHRASES,
+  wakeVerifierFileNames,
+} from "@shepherdjerred/streambot/voice/corpus-phrases.ts";
+import {
+  generateVoiceCorpus,
+  type SyntheticTtsClient,
+} from "@shepherdjerred/streambot/voice/corpus-generator.ts";
+import {
+  loadVoiceCorpusManifest,
+  verifyVoiceCorpus,
+} from "@shepherdjerred/streambot/voice/corpus-io.ts";
+
+/**
+ * SHA-256 of `JSON.stringify(expandVoiceCorpusRecipes())` captured on the commit before the
+ * phrase-spec parameterization. The streambot corpus recipes are a committed-fixture contract:
+ * any drift here would demand regenerating 400 canonical clips.
+ */
+const STREAMBOT_RECIPES_GOLDEN_SHA256 =
+  "cbcdd670d1e31c5b4aa050ea33fabfc69b18041515186d3e452cf72869dda1b2";
+
+describe("streambot recipe golden", () => {
+  test("the default expansion is byte-identical to the pre-parameterization recipes", () => {
+    const hasher = new Bun.CryptoHasher("sha256");
+    hasher.update(JSON.stringify(expandVoiceCorpusRecipes()));
+    expect(hasher.digest("hex")).toBe(STREAMBOT_RECIPES_GOLDEN_SHA256);
+  });
+
+  test("the default expansion equals the explicit streambot spec expansion", () => {
+    expect(expandVoiceCorpusRecipes(STREAMBOT_VOICE_PHRASE_SPEC)).toEqual(
+      expandVoiceCorpusRecipes(),
+    );
+  });
+});
+
+describe("scout phrase spec", () => {
+  test("expands to the canonical 400-clip category mix", () => {
+    const recipes = expandVoiceCorpusRecipes(SCOUT_VOICE_PHRASE_SPEC);
+    expect(recipes).toHaveLength(400);
+    expect(voiceCorpusClipCount(SCOUT_VOICE_PHRASE_SPEC)).toBe(400);
+    const byCategory = (category: string) =>
+      recipes.filter((recipe) => recipe.category === category).length;
+    expect(byCategory("clean-positive")).toBe(160);
+    expect(byCategory("stress-positive")).toBe(80);
+    expect(byCategory("near-match-negative")).toBe(60);
+    expect(byCategory("ordinary-negative")).toBe(60);
+    expect(byCategory("background-negative")).toBe(40);
+    expect(new Set(recipes.map((recipe) => recipe.id)).size).toBe(400);
+  });
+
+  test("every positive is a Hey Scout League question", () => {
+    const positives = expandVoiceCorpusRecipes(SCOUT_VOICE_PHRASE_SPEC).filter(
+      (recipe) => recipe.expected === "wake",
+    );
+    expect(positives.length).toBe(240);
+    for (const recipe of positives) {
+      expect(recipe.text.startsWith("Hey Scout, ")).toBe(true);
+      expect(recipe.text.endsWith("?")).toBe(true);
+    }
+  });
+
+  test("near-matches cover the bare and common scout bucket", () => {
+    const nearMatchTexts = new Set(
+      expandVoiceCorpusRecipes(SCOUT_VOICE_PHRASE_SPEC)
+        .filter((recipe) => recipe.category === "near-match-negative")
+        .map((recipe) => recipe.text),
+    );
+    for (const required of [
+      "The boy scout troop meets on Thursday night.",
+      "Go scout the jungle before the next fight.",
+      "You should ask scout about the match later.",
+      "Hey Scott, are you watching the game tonight?",
+      "Hey, scoot over so I can see the map.",
+    ]) {
+      expect(nearMatchTexts.has(required)).toBe(true);
+    }
+    for (const text of nearMatchTexts) {
+      expect(text.toLowerCase().includes("hey scout")).toBe(false);
+    }
+  });
+});
+
+function manifestJson(format: string) {
+  return {
+    version: 1,
+    format,
+    disclosure:
+      "AI-generated and procedurally generated speech/audio; no recordings of people or copyrighted media.",
+    entries: [],
+  };
+}
+
+describe("per-corpus manifest format literal", () => {
+  test("each schema pins its own format and rejects the other corpus", () => {
+    const scout = voiceCorpusManifestSchema("scout-discord-opus-v1");
+    expect(scout.parse(manifestJson("scout-discord-opus-v1")).format).toBe(
+      "scout-discord-opus-v1",
+    );
+    expect(() =>
+      scout.parse(manifestJson("streambot-discord-opus-v1")),
+    ).toThrow();
+    expect(() =>
+      VoiceCorpusManifestSchema.parse(manifestJson("scout-discord-opus-v1")),
+    ).toThrow();
+    expect(
+      VoiceCorpusManifestSchema.parse(manifestJson("streambot-discord-opus-v1"))
+        .format,
+    ).toBe("streambot-discord-opus-v1");
+  });
+});
+
+describe("phrase profiles", () => {
+  test("the default phrase is hey-streambot and unknown slugs fail loudly", () => {
+    expect(resolveVoiceWakePhrase(undefined).slug).toBe("hey-streambot");
+    expect(resolveVoiceWakePhrase("hey-scout").slug).toBe("hey-scout");
+    expect(() => resolveVoiceWakePhrase("hey-cortana")).toThrow(
+      'Unknown wake phrase "hey-cortana"',
+    );
+  });
+
+  test("slug-derived wake asset filenames", () => {
+    expect(wakeVerifierFileNames("hey-streambot")).toEqual({
+      keywords: "hey-streambot.txt",
+      classifier: "hey_streambot.onnx",
+      smokePositive: "hey-streambot-smoke.wav",
+      trainedModelName: "hey_streambot_cascade",
+    });
+    expect(wakeVerifierFileNames("hey-scout")).toEqual({
+      keywords: "hey-scout.txt",
+      classifier: "hey_scout.onnx",
+      smokePositive: "hey-scout-smoke.wav",
+      trainedModelName: "hey_scout_cascade",
+    });
+  });
+
+  test("the scout asset manifest names scout wake assets over the shared base model", () => {
+    const manifest = VOICE_WAKE_PHRASES["hey-scout"].assetManifest("/assets");
+    expect(manifest.assetsDir).toBe("/assets");
+    expect(manifest.files.keywords).toBe("hey-scout.txt");
+    expect(manifest.files.wakeClassifier).toBe("hey_scout.onnx");
+    expect(manifest.files.wakeSmokePositive).toBe("hey-scout-smoke.wav");
+    const streambot =
+      VOICE_WAKE_PHRASES["hey-streambot"].assetManifest("/assets");
+    expect(manifest.files.tokens).toBe(streambot.files.tokens);
+    expect(manifest.files.encoder).toBe(streambot.files.encoder);
+    expect(manifest.files.vad).toBe(streambot.files.vad);
+  });
+
+  test("scout fragment tails load from the committed table", async () => {
+    const tails = await VOICE_WAKE_PHRASES["hey-scout"].loadFragmentTailMs();
+    expect(tails).toEqual({ HEY_SCOUT: 0, SCOUT: 0, HEY: 500 });
+  });
+
+  test("the committed hey-scout keywords file matches the profile's fragments", async () => {
+    const profile = VOICE_WAKE_PHRASES["hey-scout"];
+    const file = path.join(
+      verifierPackagingPlan("hey-scout").destination,
+      wakeVerifierFileNames("hey-scout").keywords,
+    );
+    const contents = await Bun.file(file).text();
+    const lines = contents.trim().split("\n");
+    expect(lines).toHaveLength(profile.keywordFragments.length);
+    for (const [index, fragment] of profile.keywordFragments.entries()) {
+      const line = lines[index];
+      if (line === undefined) throw new Error("keyword line missing");
+      expect(line.endsWith(`@${fragment.label}`)).toBe(true);
+      expect(line.includes(` :${fragment.boost.toFixed(1)} `)).toBe(true);
+      expect(line.includes(` #${fragment.threshold.toFixed(2)} `)).toBe(true);
+    }
+  });
+});
+
+describe("verifier packaging plan", () => {
+  test("defaults reproduce the historical hey-streambot packaging exactly", () => {
+    const plan = verifierPackagingPlan("hey-streambot");
+    expect(plan.classifierSourceName).toBe("hey_streambot_cascade.onnx");
+    expect(
+      plan.destination.endsWith(path.join("packages/streambot/assets/voice")),
+    ).toBe(true);
+    expect(plan.outputs).toEqual({
+      mel: "melspectrogram.onnx",
+      embedding: "embedding_model.onnx",
+      classifier: "hey_streambot.onnx",
+      smokePositive: "hey-streambot-smoke.wav",
+    });
+  });
+
+  test("the scout slug retargets classifier source, destination, and outputs", () => {
+    const plan = verifierPackagingPlan("hey-scout");
+    expect(plan.classifierSourceName).toBe("hey_scout_cascade.onnx");
+    expect(
+      plan.destination.endsWith(
+        path.join("packages/scout-for-lol/packages/backend/assets/voice"),
+      ),
+    ).toBe(true);
+    expect(plan.outputs.classifier).toBe("hey_scout.onnx");
+    expect(plan.outputs.smokePositive).toBe("hey-scout-smoke.wav");
+  });
+
+  test("an explicit destination overrides the committed default", () => {
+    expect(
+      verifierPackagingPlan("hey-scout", "/tmp/elsewhere").destination,
+    ).toBe("/tmp/elsewhere");
+  });
+
+  test("an unknown slug fails loudly", () => {
+    expect(() => verifierPackagingPlan("hey-bixby")).toThrow(
+      'Unknown wake phrase "hey-bixby"',
+    );
+  });
+});
+
+describe("scout corpus generation plumbing", () => {
+  test("generates a scout-format manifest that scout-format IO round-trips", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "scout-corpus-"));
+    const client: SyntheticTtsClient = {
+      synthesize: () => Promise.resolve(new Uint8Array(960)),
+    };
+    const recipe = expandVoiceCorpusRecipes(SCOUT_VOICE_PHRASE_SPEC)[0];
+    if (recipe === undefined) throw new Error("Scout recipe expansion empty");
+    try {
+      const manifest = await generateVoiceCorpus({
+        corpusDir: directory,
+        spec: SCOUT_VOICE_PHRASE_SPEC,
+        clients: { openai: client, apple: client },
+        recipes: [recipe],
+        normalize: (pcm: Uint8Array) => Promise.resolve(pcm),
+        encode: () => [new Uint8Array([1, 2, 3])],
+      });
+      expect(manifest.format).toBe("scout-discord-opus-v1");
+      const loaded = await loadVoiceCorpusManifest(
+        directory,
+        "scout-discord-opus-v1",
+      );
+      expect(loaded.entries).toHaveLength(1);
+      // Streambot-format IO must refuse the scout corpus outright.
+      await expect(loadVoiceCorpusManifest(directory)).rejects.toThrow();
+      const verified = await verifyVoiceCorpus(
+        directory,
+        false,
+        SCOUT_VOICE_PHRASE_SPEC,
+      );
+      expect(verified.clipCount).toBe(1);
+    } finally {
+      await rm(directory, { recursive: true });
+    }
+  });
+});

--- a/packages/streambot/test/voice/voice-phrase-tooling.test.ts
+++ b/packages/streambot/test/voice/voice-phrase-tooling.test.ts
@@ -90,11 +90,29 @@ describe("scout phrase spec", () => {
     ]) {
       expect(nearMatchTexts.has(required)).toBe(true);
     }
-    for (const text of nearMatchTexts) {
-      expect(text.toLowerCase().includes("hey scout")).toBe(false);
+  });
+
+  test("no labeled negative contains the spoken wake phrase", () => {
+    const negatives = expandVoiceCorpusRecipes(SCOUT_VOICE_PHRASE_SPEC).filter(
+      (recipe) => recipe.expected === "no-wake",
+    );
+    expect(negatives.length).toBe(160);
+    for (const recipe of negatives) {
+      expect(spoken(recipe.text).includes("hey scout")).toBe(false);
     }
   });
 });
+
+/**
+ * The words TTS will actually speak: punctuation is not an acoustic boundary, so
+ * "Hey, scout ahead" is the wake phrase and a naive raw-text substring check is not enough.
+ */
+function spoken(text: string): string {
+  return text
+    .toLowerCase()
+    .replaceAll(/[^a-z]+/gu, " ")
+    .trim();
+}
 
 function manifestJson(format: string) {
   return {


### PR DESCRIPTION
## Why

Scout's voice assistant (plan M2) needs a trained "hey scout" phrase verifier. The wake-word corpus/training/packaging tooling stayed in streambot after the M1 extraction but was hard-coded to hey-streambot, and the GPU training run needs a complete handoff (training recipe, keywords, tail table, operator procedure) before it can start.

## What

- **Phrase-spec parameterization** — `VoiceCorpusPhraseSpec` (positives, near-matches, group counts) extracted from `corpus-recipes.ts`; streambot's spec is the default everywhere. The corpus manifest `format` literal is now per-corpus (`streambot-discord-opus-v1` | `scout-discord-opus-v1`) via a schema factory, so one phrase's corpus can never be verified against another's.
- **Phrase profiles + CLIs** — `corpus-phrases.ts` bundles per-phrase tooling facts (corpus dir, asset manifest, fragment tails, keyword fragments, packaging plan). `voice:corpus:generate|verify|evaluate`, `voice:human:evaluate`, and `scripts/voice-feedback-generate.ts` take `--phrase`; `voice:verifier:package` takes `--phrase-slug`/`--dest`. All defaults reproduce hey-streambot behavior byte-for-byte.
- **Scout phrase spec** — "Hey Scout" positives phrased as League questions; near-matches lean on bare/common-"scout" usage ("boy scout", "scout the jungle", "ask scout about the match", "hey scott", "hey scoot"); same 400-clip category mix.
- **Training config** — `packages/scout-for-lol/packages/backend/voice-training/scout-cascade.yaml`: `hey_scout_cascade`, `target_phrases: ["hey scout"]`, rich bare-"scout"/homophone adversarial negatives, streambot's sampling grids and 100k steps unchanged.
- **Keywords** — new `voice:keywords:generate` derives BPE pieces from the pinned base model's own `bpe.model`/`tokens.txt` (never guessed; `--check` mode verifies a committed file). Generated `hey-scout.txt` (`@HEY_SCOUT` #0.05, `@SCOUT` raised to #0.15 since "scout" is common speech, `@HEY` #0.05) plus `fragment-tails.json` (`HEY_SCOUT: 0, SCOUT: 0, HEY: 500` — the 500 ms is provisional pending measurement).
- **Handoff README** — complete operator procedure: machine split, GPU setup/run on the pinned livekit-wakeword checkout with full ACAV (never `--skip-acav`), exact packaging command, post-training acceptance (corpus + 2-hour soak, human holdout, committed dated report), acceptance criteria, ~1–2 days wall-clock on a single 24 GB-class GPU with 50–100 GB disk.
- **Tests** — golden SHA-256 of the default recipe expansion (captured pre-refactor), scout spec composition, format-literal handling, packaging-plan flag handling, profile wiring; wiki explanation updated.

## Verification

- **Source**: `bunx turbo run build typecheck lint test --filter=@shepherdjerred/streambot --filter=@shepherdjerred/voice-assistant` green (600 streambot tests, incl. all-400-clips corpus integrity), re-run after restacking on the updated base; `bunx lefthook run pre-commit` green; `git diff --stat packages/streambot/assets packages/streambot/voice-training` empty (committed streambot assets/reports byte-identical); docs-wiki lint+build green.
- **Keywords provenance**: pinned sherpa archive re-downloaded and SHA-verified (`f170013b…`), `--check` reproduces committed `hey-streambot.txt` byte-for-byte; `hey-scout.txt` loaded through `initializeLocalVoiceModelsForRuntime` (native **and** WASM) with a test manifest — `@HEY_SCOUT` fired on a synthesized "Hey Scout, what's Karthus ult cooldown?", `@HEY` on a second positive, nothing on ordinary speech.
- **Not run** (post-training, by design): GPU training, Scout corpus generation/evaluation/soak, Scout feedback clip generation, human holdout, Buildkite (pending push), any deployment layer. Pre-existing on base: `packages/temporal/src/activities` exceeds the directory file-count ceiling (139/138), untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYFFtYCcmnMGxSwwRyuazu