### PR TITLE
fix(root): keep release-please green for demo assets

### DIFF
--- a/scripts/lib/npm-release-eligibility.test.ts
+++ b/scripts/lib/npm-release-eligibility.test.ts
@@ -138,6 +138,8 @@ describe("consumer file classification", () => {
           `${webringPath}/src/parser.spec.ts`,
           `${webringPath}/src/testdata/rss.xml`,
           `${webringPath}/examples/demo.ts`,
+          `${webringPath}/demos/demo.cast`,
+          `${webringPath}/demo/record.sh`,
           `${webringPath}/.github/workflows/ci.yml`,
           `${webringPath}/tsconfig.json`,
           `${webringPath}/eslint.config.ts`,

--- a/scripts/lib/npm-release-eligibility.ts
+++ b/scripts/lib/npm-release-eligibility.ts
@@ -205,6 +205,8 @@ function isTestOrExamplePath(relativePath: string): boolean {
     ) ||
     relativePath.startsWith("examples/") ||
     relativePath.startsWith("example/") ||
+    relativePath.startsWith("demos/") ||
+    relativePath.startsWith("demo/") ||
     relativePath.startsWith("src/__fixtures__/")
   );
 }


### PR DESCRIPTION
Why

The main release-please lane failed while classifying the Helm Types package because its published asciicast under demos/ was neither recognized as source nor treated as a repository-only example.

What

Treat demo/ and demos/ paths like examples/ in npm consumer-change classification. Add regression coverage for both forms while preserving source, metadata, and package-file rules.

Verification

- bun --no-install --bun vitest --config vitest.config.ts run scripts/lib/npm-release-eligibility.test.ts (16 passed)
- bunx turbo run typecheck test lint --filter=@shepherdjerred/root-scripts --output-logs=errors-only
- Classifier probe against current package tags and HEAD
- bun run jscpd
- bunx lefthook run pre-commit

The exact-head Buildkite PR gate is required before merge.