### PR TITLE
fix(scout-for-lol): update consumer workspace to the Loaded permission shape

### DIFF
--- a/packages/scout-for-lol/packages/app/src/routes/consumer-workspace.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/consumer-workspace.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { Outlet, useLocation, useParams } from "react-router";
+import { Loaded } from "@shepherdjerred/loaded";
 import { ForbiddenPanel } from "#src/components/forbidden-panel.tsx";
 import { usePermissions } from "#src/hooks/use-permissions.ts";
 import {
@@ -15,16 +16,19 @@ export function ConsumerWorkspace() {
 export function ConsumerGuildWorkspace() {
   const { guildId } = useParams();
   const location = useLocation();
-  const { isLoading, error } = usePermissions(guildId);
+  const { access } = usePermissions(guildId);
   const contextRoute = analyticsContextRoute(location.pathname);
 
   useEffect(() => {
-    if (contextRoute === undefined || isLoading) return;
-    resolveGuildContext(contextRoute, error === null ? guildId : undefined);
+    if (contextRoute === undefined || access.status === "loading") return;
+    resolveGuildContext(
+      contextRoute,
+      access.status === "error" ? undefined : guildId,
+    );
     return () => {
       clearGuildContext();
     };
-  }, [contextRoute, error, guildId, isLoading]);
+  }, [contextRoute, access.status, guildId]);
 
   if (guildId === undefined) {
     return (
@@ -34,12 +38,12 @@ export function ConsumerGuildWorkspace() {
       />
     );
   }
-  if (isLoading) return null;
-  if (error !== null) {
+  if (access.status === "loading") return null;
+  if (access.status === "error") {
     return (
       <ForbiddenPanel
         title="No access to this server"
-        message={error.message}
+        message={Loaded.messageOf(access.errors[0].error)}
       />
     );
   }


### PR DESCRIPTION
## Why
`main` is currently red on `@scout-for-lol/app#lint`. #2723 replaced `usePermissions`'s `{isLoading, error}` pair with a `Loaded<PermissionSet>` `access` field but missed `consumer-workspace.tsx`, which still destructures the removed properties (now typed `any`, tripping `no-unsafe-assignment`/`no-unsafe-member-access`). Every branch that rebases onto `main` inherits the failure.

## What
Switch `ConsumerGuildWorkspace` to branch on `access.status`, matching the idiom already used in `guild-workspace.tsx` (`GuildWorkspace`, `GuildSectionIndex`, `GuildPermissionsGate`).

## Verification
- `bunx turbo run lint typecheck --filter=@scout-for-lol/app` passes locally.
- `bunx lefthook run pre-commit` passes.
- Exact-head Buildkite CI: pending, will confirm before merge.