### PR TITLE
fix(scout-for-lol): clarify challenge draft template guidance

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/explore/challenge-tools.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/challenge-tools.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vitest";
+import { DiscordAccountIdSchema } from "@scout-for-lol/data";
+import type { ToolTracker } from "#src/reports/ai/scoutql-tools.ts";
+import { createChallengeExploreTools } from "./challenge-tools.ts";
+
+const REQUESTER = DiscordAccountIdSchema.parse("160509172704739328");
+const passthroughTracker: ToolTracker = async (_name, work) => await work();
+
+describe("createChallengeExploreTools", () => {
+  test("defines draft_challenge_contract with clear guidance for new challenges", () => {
+    const tools = createChallengeExploreTools({
+      requesterId: REQUESTER,
+      track: passthroughTracker,
+    });
+
+    expect(tools.draft_challenge_contract.description).toContain(
+      "New challenges are drafted from scratch without any source template",
+    );
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/challenge-tools.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/challenge-tools.ts
@@ -70,10 +70,15 @@ export function createChallengeExploreTools(options: {
     }),
     draft_challenge_contract: tool({
       description:
-        "Validate and save a private typed challenge draft. The frozen contract is the only evaluator; subjective or unobservable rules are invalid.",
+        "Validate and save a private typed challenge draft. New challenges are drafted from scratch without any source template. The frozen contract is the only evaluator; subjective or unobservable rules are invalid.",
       inputSchema: z.strictObject({
         contract: ChallengeContractV1Schema,
-        sourceTemplateId: z.uuid().optional(),
+        sourceTemplateId: z
+          .uuid()
+          .optional()
+          .describe(
+            "Only provided when revising an existing challenge template authored by the requester. Omit when creating a new challenge.",
+          ),
       }),
       outputSchema: ChallengeToolResultSchema,
       execute: (input) =>

--- a/packages/scout-for-lol/packages/backend/src/explore/prompt.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/prompt.test.ts
@@ -70,6 +70,23 @@ describe("exploreAgentInstructions", () => {
     expect(withCreation).toContain("Do NOT say they lack permission");
   });
 
+  test("appends the challenges section only when challenges are enabled", () => {
+    const plain = exploreAgentInstructions({ bucks: null });
+    const withChallenges = exploreAgentInstructions({
+      bucks: null,
+      challenges: true,
+    });
+
+    expect(plain).not.toContain("## Community challenge contracts");
+    expect(plain).not.toContain("draft_challenge_contract");
+    expect(withChallenges).toContain("## Community challenge contracts");
+    expect(withChallenges).toContain(
+      "New challenges are authored from scratch without a source template",
+    );
+    expect(withChallenges).toContain("catalog: 'current_champions'");
+    expect(withChallenges).toContain("draft_challenge_contract");
+  });
+
   test("carries no v1 clause the language no longer has", () => {
     const instructions = exploreAgentInstructions({ bucks: null });
 

--- a/packages/scout-for-lol/packages/backend/src/explore/prompt.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/prompt.ts
@@ -117,6 +117,8 @@ export function challengeExplorePromptSection(): string {
   return [
     "## Community challenge contracts",
     "You may translate an observable League challenge into a version-1 typed challenge contract, save a private draft, and preview it against Scout-known history.",
+    "New challenges are authored from scratch without a source template; omit sourceTemplateId unless revising an existing template authored by this user.",
+    "For challenges covering all champions (e.g. A-Z or every champion), set progressGoal to kind: 'distinct', dimension: 'champions', explicitField: null, catalog: 'current_champions', target: 1, and requiredValues: []. Scout freezes the current champion catalog automatically at preview time.",
     "Only fields and reducers accepted by the draft_challenge_contract schema exist. Reject subjective rules, rules needing evidence Scout does not retain, and any interpretation that depends on model judgment at evaluation time.",
     "The typed contract is frozen and deterministically evaluates every match. The prose explanation must describe exactly the same predicate, reducer, target, and queue scope.",
     "Call list_challenge_accounts before preview_challenge_draft. A preview must report evaluated match count, selected period, and missing timeline evidence honestly.",


### PR DESCRIPTION
fix(scout-for-lol): clarify challenge draft template guidance

Why
When asking Explore to draft a community challenge (such as winning with every champion in ranked), the model refused because it assumed the optional `sourceTemplateId` parameter was a mandatory prerequisite template that didn't exist in the system.

What
- Add description to `sourceTemplateId` in `draft_challenge_contract` tool schema and update the tool description to state that new challenges are drafted from scratch.
- Add guidance in `challengeExplorePromptSection` explaining that `sourceTemplateId` should be omitted when drafting new challenges, and document how to configure distinct goals across all champions using `catalog: 'current_champions'`.
- Add unit tests for `challengeExplorePromptSection` and `createChallengeExploreTools`.

Verification
- Focused tests passed: `bun run test src/explore/prompt.test.ts src/explore/challenge-tools.test.ts` (7 tests)
- Backend typecheck passed: `bun run typecheck`
- Staged pre-commit hooks passed: `bunx lefthook run pre-commit`
- ESLint and Prettier passed cleanly on changed files
- Live Discord and web app deployment checks were not run