### PR TITLE
fix(scout-for-lol): default missing timeline coverage to false

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/progression/progression-lake-reads.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/progression-lake-reads.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { TimelineCoverageLakeRow } from "@scout-for-lol/data";
+import { fetchProgressionMatches } from "#src/progression/progression-lake-reads.ts";
+import { timelineStagingFilePath } from "#src/report-lake/staging.ts";
+import { resetTestLake, writeTestLake } from "#src/testing/test-report-lake.ts";
+import { testPuuid } from "#src/testing/test-ids.ts";
+
+const lakeDir = await mkdtemp(path.join(tmpdir(), "scout-progression-lake-"));
+const puuid = testPuuid("progression-coverage");
+const matchWithCoverage = "NA1_progression_coverage";
+const matchWithoutCoverage = "NA1_progression_missing_coverage";
+
+function matchFact(matchId: string, gameCreationAt: Date) {
+  return {
+    playerId: 1,
+    playerAlias: "progression-test",
+    matchId,
+    puuid,
+    queue: "solo" as const,
+    win: true,
+    surrendered: false,
+    kills: 1,
+    deaths: 0,
+    assists: 2,
+    gameCreationAt,
+  };
+}
+
+const coverage: TimelineCoverageLakeRow = {
+  match_id: matchWithCoverage,
+  month: "2026-08",
+  observed_at: "2026-08-20 12:30:00.000",
+  coverage_state: "complete",
+  data_version: "2",
+  frame_interval_ms: 60_000,
+  frame_count: 2,
+  event_count: 0,
+  participant_count: 1,
+  first_frame_timestamp_ms: 0,
+  last_frame_timestamp_ms: 60_000,
+};
+
+async function fetchMatch(matchId: string) {
+  const rows = await fetchProgressionMatches({
+    puuids: [puuid],
+    startAt: new Date("2026-08-20T00:00:00.000Z"),
+    matchId,
+    lakeDir,
+  });
+  expect(rows).toHaveLength(1);
+  return rows[0];
+}
+
+beforeEach(async () => {
+  await resetTestLake(lakeDir);
+});
+
+afterAll(async () => {
+  await rm(lakeDir, { recursive: true, force: true });
+});
+
+describe("fetchProgressionMatches timeline coverage", () => {
+  test("treats a missing match coverage row as false", async () => {
+    await writeTestLake(lakeDir, {
+      serverId: "guild-progression",
+      matchFacts: [
+        matchFact(matchWithoutCoverage, new Date("2026-08-20T12:00:00.000Z")),
+        matchFact(matchWithCoverage, new Date("2026-08-20T13:00:00.000Z")),
+      ],
+      timelineCoverage: [coverage],
+    });
+
+    await expect(fetchMatch(matchWithoutCoverage)).resolves.toMatchObject({
+      timeline_complete: false,
+    });
+  });
+
+  test("returns false when the coverage lake is absent", async () => {
+    await writeTestLake(lakeDir, {
+      serverId: "guild-progression",
+      matchFacts: [
+        matchFact(matchWithoutCoverage, new Date("2026-08-20T12:00:00.000Z")),
+      ],
+    });
+
+    await expect(fetchMatch(matchWithoutCoverage)).resolves.toMatchObject({
+      timeline_complete: false,
+    });
+  });
+
+  test("returns true for a complete coverage row", async () => {
+    await writeTestLake(lakeDir, {
+      serverId: "guild-progression",
+      matchFacts: [
+        matchFact(matchWithCoverage, new Date("2026-08-20T12:00:00.000Z")),
+      ],
+      timelineCoverage: [coverage],
+    });
+
+    await expect(fetchMatch(matchWithCoverage)).resolves.toMatchObject({
+      timeline_complete: true,
+    });
+  });
+
+  test("rejects a malformed present coverage row", async () => {
+    await writeTestLake(lakeDir, {
+      serverId: "guild-progression",
+      matchFacts: [
+        matchFact(matchWithCoverage, new Date("2026-08-20T12:00:00.000Z")),
+      ],
+    });
+    await Bun.write(
+      timelineStagingFilePath(lakeDir, "timeline_coverage", matchWithCoverage),
+      `${JSON.stringify({ ...coverage, coverage_state: null })}\n`,
+    );
+
+    await expect(fetchMatch(matchWithCoverage)).rejects.toThrow(
+      /timeline_complete/u,
+    );
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/progression/progression-lake-reads.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/progression-lake-reads.ts
@@ -226,7 +226,7 @@ export async function fetchProgressionMatches(options: {
   const coverageJoin =
     coverage === undefined
       ? "false AS timeline_complete"
-      : "c.coverage_state = 'complete' AS timeline_complete";
+      : "CASE WHEN c.match_id IS NULL THEN false ELSE c.coverage_state = 'complete' END AS timeline_complete";
   const coverageCte =
     coverage === undefined ? "" : `, coverage AS (${coverage.sql})`;
   const coverageJoinSql =


### PR DESCRIPTION
## Why
A LEFT JOIN in progression lake reads returned SQL NULL when a match had no timeline coverage row, but the progression contract requires a boolean. This caused post-match progression failures and prevented cursor advancement.

## What
- Coalesce missing timeline coverage to false while preserving strict Zod validation.
- Add report-lake regression coverage for missing per-match rows, absent coverage data, and complete coverage.

## Verification
- Focused progression lake tests: 3 passed
- Post-match/progression tests: 7 passed
- Backend typecheck passed
- Backend lint and architecture checks passed with 2 pre-existing warnings
- Backend format check passed
- Lefthook pre-commit passed

Live beta deployment, Argo reconciliation, and runtime recovery are not yet verified; those will be checked after exact-head CI and merge.