### PR TITLE
fix(homelab): allow scout OTLP egress to Tempo

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -660,13 +660,9 @@
       "clones": 1,
       "tokens": 73
     },
-    "packages/homelab/src/cdk8s/src/cdk8s-charts/home.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/redlib.ts": {
-      "clones": 1,
-      "tokens": 80
-    },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/home.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts": {
       "clones": 1,
-      "tokens": 89
+      "tokens": 131
     },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/openrouter-broadcast-ingest.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts": {
       "clones": 1,

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts
@@ -108,7 +108,7 @@ export function createScoutChart(
     },
   });
 
-  // NetworkPolicy: Allow egress to DNS, Flipt, SeaweedFS S3, PostgreSQL, and external HTTPS
+  // NetworkPolicy: Allow egress to DNS, Tempo (OTLP), Flipt, SeaweedFS S3, PostgreSQL, and external HTTPS
   new KubeNetworkPolicy(chart, "scout-egress-netpol", {
     metadata: { name: "scout-egress-netpol" },
     spec: {
@@ -128,6 +128,17 @@ export function createScoutChart(
             { port: IntOrString.fromNumber(53), protocol: "UDP" },
             { port: IntOrString.fromNumber(53), protocol: "TCP" },
           ],
+        },
+        // Tempo OTLP (tempo.tempo.svc.cluster.local:4318)
+        {
+          to: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "tempo" },
+              },
+            },
+          ],
+          ports: [{ port: IntOrString.fromNumber(4318), protocol: "TCP" }],
         },
         // SeaweedFS S3 (seaweedfs-s3.seaweedfs.svc.cluster.local:8333)
         {

--- a/packages/homelab/src/cdk8s/src/scout-network-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/scout-network-policy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { findResource, scoutResources } from "./scout-test-resources.ts";
+
+describe("Scout backend telemetry boundary", () => {
+  test.each(["beta", "prod"] as const)(
+    "%s Scout backend egress admits Tempo OTLP",
+    (stage) => {
+      expect(
+        findResource(
+          scoutResources(stage),
+          "NetworkPolicy",
+          "scout-egress-netpol",
+        ).spec,
+      ).toEqual(
+        expect.objectContaining({
+          podSelector: { matchLabels: { app: "scout-backend" } },
+          egress: expect.arrayContaining([
+            {
+              to: [
+                {
+                  namespaceSelector: {
+                    matchLabels: { "kubernetes.io/metadata.name": "tempo" },
+                  },
+                },
+              ],
+              ports: [{ port: 4318, protocol: "TCP" }],
+            },
+          ]),
+        }),
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Why

The scout backend exports traces to `http://tempo.tempo.svc.cluster.local:4318` (`TELEMETRY_ENABLED=true`), but `scout-egress-netpol` never allowed port 4318 — its egress list covers DNS, SeaweedFS 8333, Flipt 8080, in-namespace Postgres 5432, Temporal 7233, and external 443 only. Every span export is silently dropped by the network policy.

## What

- Add the tempo-namespace TCP/4318 egress rule to `scout-egress-netpol` (one chart edit covers both stages), mirroring the established birmel/openrouter-broadcast-ingest rule shape.
- Assert the rule per stage in a new `scout-network-policy.test.ts`, following the existing `<chart>-network-policy.test.ts` convention.
- The workflow-worker netpol is deliberately untouched: those pods export metrics via the Temporal Rust SDK Prometheus endpoint (9464), not OTLP.

## Verification

- `bunx turbo run build typecheck test lint --filter=@homelab/cdk8s --filter=homelab` — all green (cdk8s suite 690 passed / 13 pre-existing skips).
- New test fails without the chart change (asserts the exact tempo/4318 rule + `app: scout-backend` podSelector for beta and prod).
- **Not run:** live trace-arrival check in Tempo — requires the change deployed; will verify post-merge via Grafana that scout-backend spans arrive.

Part of SJ-187 (Phase 0 of the Scout durable-architecture program, SJ-186).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qRdG6fzJr3THzYzAJwTZB