### PR TITLE
feat(llm-observability): keep full redacted content on exported LLM spans

### DIFF
--- a/packages/birmel/src/observability/tracing.ts
+++ b/packages/birmel/src/observability/tracing.ts
@@ -190,9 +190,9 @@ export function initializeTracing(): void {
   });
 
   // Wrap the batch processor with the LLM archive layer. Spans carrying
-  // gen_ai.* body attributes get their bodies gzipped to SeaweedFS and
-  // replaced with a ref before the slim span reaches the OTLP exporter.
-  // No-op when LLM_OBSERVABILITY_ENABLED=false.
+  // gen_ai.* body attributes get a copy of their bodies gzipped to SeaweedFS;
+  // the span keeps the full redacted content plus the archive ref when it
+  // reaches the OTLP exporter. No-op when LLM_OBSERVABILITY_ENABLED=false.
   const rootProcessor = buildArchiveSpanProcessor({ inner: batchProcessor });
 
   // OTLP logs path. Sibling LoggerProvider shipping LogRecords to Loki via

--- a/packages/discord-plays-pokemon/packages/backend/src/index.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/index.ts
@@ -44,9 +44,10 @@ const runtime = bootGameBot({
   sentryDsn: "https://9c905c2bb5924e55b4dea32e2a95f0d1@bugsink.sjer.red/8",
   logger,
   // Wrap the batch span processor with the LLM archive layer: spans carrying
-  // gen_ai.* body attributes get their bodies gzipped to SeaweedFS and replaced
-  // with a ref before the slim span reaches Tempo. No-op when
-  // LLM_OBSERVABILITY_ENABLED=false. Same shape as birmel / scout / temporal.
+  // gen_ai.* body attributes get a copy of their bodies gzipped to SeaweedFS;
+  // the span keeps the full redacted content plus the archive ref on its way
+  // to Tempo. No-op when LLM_OBSERVABILITY_ENABLED=false. Same shape as
+  // birmel / scout / temporal.
   wrapSpanProcessor: (inner) => buildArchiveSpanProcessor({ inner }),
   wiring: {
     botToken: config.bot.discord_token,

--- a/packages/docs/wiki/src/content/docs/explanation/llm-stack.md
+++ b/packages/docs/wiki/src/content/docs/explanation/llm-stack.md
@@ -1,6 +1,6 @@
 ---
 title: LLM stack
-description: One ordinary-inference gateway, two native coding-agent exceptions, repository-owned model and eval contracts, and an observability boundary that keeps bodies out of Tempo.
+description: One ordinary-inference gateway, two native coding-agent exceptions, repository-owned model and eval contracts, and an observability boundary that puts full redacted content on every span.
 sidebar:
   order: 5
 ---
@@ -34,14 +34,23 @@ and command tools. They run in process through their native SDKs; active
 ## Observability boundary
 
 Local OpenTelemetry is authoritative. Repository-owned `gen_ai.*` spans wrap
-AI SDK and native SDK spans. Complete redacted prompt, response, and tool bodies
-go to the private SeaweedFS LLM archive. Tempo receives only body-free spans and
-archive references.
+AI SDK and native SDK spans. Spans carry the complete redacted prompt,
+response, and tool bodies. A copy of those bodies also goes to the private
+SeaweedFS LLM archive, and each span carries its archive reference.
+
+Content lives on the span because a trace without it cannot answer the
+questions LLM traces exist for. Agent failures are semantic rather than
+exceptional, so debugging one means reading the trajectory, and any downstream
+eval or observability consumer needs the same content. An earlier design
+stripped bodies from spans and kept them only in the archive; it made every
+transcript read a two-store join and was reversed. The archive remains because
+Tempo's retention is 30 days: it is the durable body record, not the only one.
+Redaction happens before export, so credentials stay out of both stores.
 
 OpenRouter Broadcast is a correlated second source of routing, provider, token,
 and actual-cost evidence. The authenticated `openrouter-broadcast-ingest`
-service archives the complete redacted OTLP JSON payload, strips bodies, and
-forwards the slim trace to Tempo. Its digest receipt makes webhook redelivery
+service archives the complete redacted OTLP JSON payload and forwards that
+same redacted payload to Tempo. Its digest receipt makes webhook redelivery
 idempotent, including retries across UTC date partitions. A `204` means both
 archive and forward completed; a failure intentionally asks OpenRouter to
 redeliver.
@@ -144,7 +153,8 @@ The migration is deployed atomically. Create one OpenRouter key per service and
 stage, create the Broadcast bearer secret, publish the Broadcast image, and
 canary Broadcast before the consumers. For each transport, verify the
 application span, SDK child spans, correlated Broadcast span, Loki log,
-Prometheus usage and cost, private body archive, and body-free Tempo record.
+Prometheus usage and cost, private body archive, and full-content Tempo
+record.
 Only after text, structured output, tools, embeddings, images, web search,
 Claude SDK, Codex SDK, and the production Temporal canary pass may old provider
 secrets be revoked.

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/agent-task-boundary.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/agent-task-boundary.md
@@ -190,9 +190,9 @@ applied effects becomes non-retryable instead of being replayed to repair only
 its final schema.
 
 With telemetry enabled, each run's prompt and response are recorded as `gen_ai.*`
-spans whose bodies are archived to the LLM-observability store before the slim
-span is exported. The email is the human-facing output, but it is not the only
-copy.
+spans that carry the full redacted bodies, with a durable copy archived to the
+LLM-observability store. The email is the human-facing output, but it is not
+the only copy.
 
 ## Related
 

--- a/packages/docs/wiki/src/content/docs/how-to/enable-openrouter-broadcast.md
+++ b/packages/docs/wiki/src/content/docs/how-to/enable-openrouter-broadcast.md
@@ -67,7 +67,7 @@ toolkit prom query 'sum by (operation, outcome) (openrouter_broadcast_operations
 # The last success is recent rather than zero
 toolkit prom query 'time() - max(openrouter_broadcast_last_success_timestamp_seconds)'
 
-# A body-free correlated span reached Tempo
+# A full-content correlated span reached Tempo
 toolkit tempo query '{resource.service.name=~".*openrouter.*"}' --since 1h --limit 5
 ```
 

--- a/packages/llm-observability/README.md
+++ b/packages/llm-observability/README.md
@@ -1,9 +1,10 @@
 # @shepherdjerred/llm-observability
 
 OpenTelemetry tracing for LLM calls: thin wrappers that emit `gen_ai.*` spans
-around provider SDK calls, plus an archive span processor that offloads large
-prompt/response bodies to S3 so the trace backend (Tempo) only ever receives
-slim spans with an archive reference. Consumers include
+around provider SDK calls, plus an archive span processor that copies large
+prompt/response bodies to S3 for durable retention while the trace backend
+(Tempo) and any additional OTLP consumer receive the full redacted content on
+the span itself, alongside an archive reference. Consumers include
 [packages/temporal](../temporal/) and
 [packages/pr-fleet-controller](../pr-fleet-controller/).
 
@@ -15,8 +16,8 @@ GenAI semantic conventions: `gen_ai.system`, `gen_ai.operation.name`,
 `gen_ai.request.model` / `max_tokens` / `temperature` / `top_p`,
 `gen_ai.response.model` / `id` / `finish_reasons`, and
 `gen_ai.usage.input_tokens` / `output_tokens` / cache read + creation tokens.
-Message bodies go on `gen_ai.input.messages` / `gen_ai.output.messages` (to be
-stripped by the archive processor).
+Message bodies go on `gen_ai.input.messages` / `gen_ai.output.messages`
+(redacted in place by the archive processor before export).
 
 | Export                                                                         | Traces                                              |
 | ------------------------------------------------------------------------------ | --------------------------------------------------- |
@@ -69,7 +70,7 @@ Subject ids are span attributes only. They must never become Prometheus labels â
 the LLM metrics carry bounded service/workload/provider/model/outcome labels by
 design, and Tempo is already the store for trace, session, and user ids.
 
-## Archive pipeline (slim spans)
+## Archive pipeline (full-content spans)
 
 `LlmArchiveSpanProcessor` (`./span-processor`) wraps an inner `SpanProcessor`
 (typically a `BatchSpanProcessor` over an OTLP exporter). On span end, if the
@@ -82,11 +83,13 @@ stdout/stderr, or Vercel AI SDK legacy keys), it:
 3. gzips and PUTs it to S3 under a deterministic key
    (`buildArchiveKey`/`uploadArchive` â€” SigV4-signed, path-style capable, so
    SeaweedFS works), and
-4. forwards a copy of the span with bodies stripped and `llm.archive.*`
-   attributes added (bucket, key, sha256, sizes, status).
+4. forwards a copy of the span with bodies redacted in place and
+   `llm.archive.*` attributes added (bucket, key, sha256, sizes, status).
 
-Spans without body attributes pass through unchanged; a `sampleRate` can skip
-archiving (bodies are still stripped). `buildArchiveSpanProcessor` +
+The forwarded span keeps the complete prompt, response, and tool content; the
+S3 archive is the durable copy that outlives trace-backend retention, not a
+substitute for content on the span. Spans without body attributes pass through
+unchanged; a `sampleRate` can skip archiving (bodies stay on the span). `buildArchiveSpanProcessor` +
 `loadLlmObservabilityConfig` assemble the processor from environment
 configuration.
 
@@ -102,4 +105,4 @@ bun run lint
 
 The e2e suite (`test/e2e/`) runs real OTLP export into Tempo and real S3
 uploads against the compose stack in `test/e2e/compose.yaml`, then verifies
-both the slim span in Tempo and the archived envelope in the bucket.
+both the full-content span in Tempo and the archived envelope in the bucket.

--- a/packages/llm-observability/src/archive-span-processor.ts
+++ b/packages/llm-observability/src/archive-span-processor.ts
@@ -14,9 +14,10 @@ import { redactSecrets } from "./redact.ts";
 
 /**
  * Span attribute keys that hold large LLM bodies. The processor extracts these
- * into the archive envelope and strips them from the forwarded span so Tempo
- * receives only a slim ref. Adding a new key here is enough to support a new
- * SDK convention without touching wrappers.
+ * into the archive envelope and redacts them in place on the forwarded span,
+ * so the trace backend receives the full redacted content alongside the
+ * archive ref. Adding a new key here is enough to support a new SDK convention
+ * without touching wrappers.
  */
 const BODY_ATTR_KEYS = [
   // OTel GenAI semconv
@@ -67,7 +68,7 @@ export type LlmArchiveSpanProcessorOptions = {
   archive: ArchiveConfig;
   /** Logger for upload failures. Defaults to JSON-stderr. */
   logger?: ArchiveLogger | undefined;
-  /** 0..1. Spans rolling above the rate are not archived (bodies still stripped). */
+  /** 0..1. Spans rolling above the rate are not archived (bodies stay on the span). */
   sampleRate?: number | undefined;
   /** Provide deterministic random for tests. */
   random?: (() => number) | undefined;
@@ -83,13 +84,17 @@ export type LlmArchiveSpanProcessorOptions = {
  *     response + usage where present).
  *  2. Redact obvious secrets.
  *  3. Gzip and PUT to S3 with a deterministic key.
- *  4. Forward a *copy* of the span to `inner` with the bodies stripped and
- *     `llm.archive.*` attributes added (bucket, key, sha256, sizes, status).
+ *  4. Forward a *copy* of the span to `inner` with the bodies redacted in
+ *     place and `llm.archive.*` attributes added (bucket, key, sha256, sizes,
+ *     status).
  *
- * Spans without LLM body attributes pass through unchanged. The S3 upload runs
- * asynchronously; the wrapped span is forwarded to `inner.onEnd` only after
- * the upload settles. Upload failures degrade gracefully — the span is still
- * forwarded with `llm.archive.status = "failed"`.
+ * The forwarded span keeps the full prompt/response/tool content — the
+ * archive is the durable copy that outlives trace-backend retention, not a
+ * substitute for content on the span. Spans without LLM body attributes pass
+ * through unchanged. The S3 upload runs asynchronously; the wrapped span is
+ * forwarded to `inner.onEnd` only after the upload settles. Upload failures
+ * degrade gracefully — the span is still forwarded with
+ * `llm.archive.status = "failed"`.
  */
 export class LlmArchiveSpanProcessor implements SpanProcessor {
   private readonly inner: SpanProcessor;
@@ -169,14 +174,14 @@ export class LlmArchiveSpanProcessor implements SpanProcessor {
     sampled: boolean,
   ): Promise<void> {
     const envelope = buildEnvelope(span);
+    const redactedAttributes = redactBodyAttributes(span.attributes);
 
     if (!sampled) {
-      const stripped = stripBodyAttributes(span.attributes);
-      const slim = copySpanWithAttributes(span, {
-        ...stripped,
+      const forwarded = copySpanWithAttributes(span, {
+        ...redactedAttributes,
         "llm.archive.status": "sampled_out",
       });
-      this.inner.onEnd(slim);
+      this.inner.onEnd(forwarded);
       return;
     }
 
@@ -203,12 +208,11 @@ export class LlmArchiveSpanProcessor implements SpanProcessor {
       });
     }
 
-    const stripped = stripBodyAttributes(span.attributes);
-    const slim = copySpanWithAttributes(span, {
-      ...stripped,
+    const forwarded = copySpanWithAttributes(span, {
+      ...redactedAttributes,
       ...refToAttributes(ref),
     });
-    this.inner.onEnd(slim);
+    this.inner.onEnd(forwarded);
   }
 }
 
@@ -219,16 +223,31 @@ function hasLlmBodyAttributes(span: ReadableSpan): boolean {
   return false;
 }
 
-function stripBodyAttributes(
+/**
+ * Copy the attribute map with every body attribute's value passed through
+ * `redactSecrets`. Body attributes are JSON-serialized strings (see
+ * `serializeBodyAttribute`); non-string body values pass through unchanged
+ * since redaction targets embedded credential text.
+ */
+function redactBodyAttributes(
   attrs: Readonly<Record<string, AttributeValue | undefined>>,
 ): Record<string, AttributeValue> {
   const result: Record<string, AttributeValue> = {};
   for (const [key, value] of Object.entries(attrs)) {
-    if (BODY_ATTR_SET.has(key)) continue;
     if (value === undefined) continue;
-    result[key] = value;
+    result[key] =
+      typeof value === "string" && BODY_ATTR_SET.has(key)
+        ? redactBodyString(value)
+        : value;
   }
   return result;
+}
+
+function redactBodyString(value: string): string {
+  const parsed = safeJsonParse(value);
+  const redacted = redactSecrets(parsed);
+  if (typeof redacted === "string") return redacted;
+  return JSON.stringify(redacted);
 }
 
 function refToAttributes(ref: ArchiveRef): Record<string, AttributeValue> {

--- a/packages/llm-observability/test/e2e/gateway-archive.e2e.test.ts
+++ b/packages/llm-observability/test/e2e/gateway-archive.e2e.test.ts
@@ -95,8 +95,15 @@ test("end-to-end: gateway span -> Tempo + private archive", async () => {
   );
   expect(llmSpan?.attributes["llm.archive.status"]).toBe("ok");
   expect(llmSpan?.attributes["llm.archive.s3_bucket"]).toBe("llm-archive");
-  expect(llmSpan?.attributes["gen_ai.input.messages"]).toBeUndefined();
-  expect(llmSpan?.attributes["gen_ai.output.messages"]).toBeUndefined();
+  expect(llmSpan?.attributes["gen_ai.input.messages"]).toBe(
+    serializeBodyAttribute([
+      { role: "system", content: "be brief" },
+      { role: "user", content: "say hi" },
+    ]),
+  );
+  expect(llmSpan?.attributes["gen_ai.output.messages"]).toBe(
+    serializeBodyAttribute([{ role: "assistant", content: "hi back" }]),
+  );
 
   const s3Key = llmSpan?.attributes["llm.archive.s3_key"];
   expect(typeof s3Key).toBe("string");

--- a/packages/llm-observability/test/unit/archive-span-processor.test.ts
+++ b/packages/llm-observability/test/unit/archive-span-processor.test.ts
@@ -103,7 +103,7 @@ const compatUploader: ArchiveUploader = async (config, key) => ({
   error: undefined,
 });
 
-test("archives a span with gen_ai.* body attributes and forwards a slim span", async () => {
+test("archives a span with gen_ai.* body attributes and forwards it with full content", async () => {
   const collector = new CollectingProcessor();
   const { uploader, uploads } = buildSuccessUploader();
   const processor = new LlmArchiveSpanProcessor({
@@ -141,8 +141,12 @@ test("archives a span with gen_ai.* body attributes and forwards a slim span", a
 
   expect(collector.spans.length).toBe(1);
   const forwarded = collector.spans[0]!;
-  expect(forwarded.attributes["gen_ai.input.messages"]).toBeUndefined();
-  expect(forwarded.attributes["gen_ai.output.messages"]).toBeUndefined();
+  expect(forwarded.attributes["gen_ai.input.messages"]).toBe(
+    JSON.stringify([{ role: "user", content: "hi" }]),
+  );
+  expect(forwarded.attributes["gen_ai.output.messages"]).toBe(
+    JSON.stringify([{ role: "assistant", content: "hello back" }]),
+  );
   expect(forwarded.attributes["llm.archive.status"]).toBe("ok");
   expect(forwarded.attributes["llm.archive.s3_bucket"]).toBe("llm-archive");
   expect(forwarded.attributes["gen_ai.usage.input_tokens"]).toBe(12);
@@ -252,9 +256,43 @@ test("marks sampled-out spans with status=sampled_out", async () => {
   expect(collector.spans[0]!.attributes["llm.archive.status"]).toBe(
     "sampled_out",
   );
-  expect(
-    collector.spans[0]!.attributes["gen_ai.input.messages"],
-  ).toBeUndefined();
+  expect(collector.spans[0]!.attributes["gen_ai.input.messages"]).toBe(
+    JSON.stringify([{ role: "user", content: "hi" }]),
+  );
+});
+
+test("redacts secrets inside body attributes on the forwarded span", async () => {
+  const collector = new CollectingProcessor();
+  const { uploader } = buildSuccessUploader();
+  const processor = new LlmArchiveSpanProcessor({
+    inner: collector,
+    archive: archiveConfig,
+    uploader,
+  });
+  const provider = buildProvider({ serviceName: "birmel", processor });
+  const tracer = provider.getTracer("test");
+
+  await tracer.startActiveSpan("gen_ai.chat", async (span) => {
+    span.setAttributes({
+      "gen_ai.system": "openrouter",
+      "gen_ai.request.model": "gpt-5-mini",
+      "gen_ai.input.messages": JSON.stringify([
+        {
+          role: "user",
+          content: "send the request with Bearer aaa-bbb-ccc attached",
+        },
+      ]),
+    });
+    span.end();
+  });
+  await flushProcessor(processor);
+
+  expect(collector.spans.length).toBe(1);
+  const body = collector.spans[0]!.attributes["gen_ai.input.messages"];
+  expect(typeof body).toBe("string");
+  if (typeof body !== "string") throw new Error("missing body attribute");
+  expect(body).not.toContain("aaa-bbb-ccc");
+  expect(body).toContain("[REDACTED]");
 });
 
 test("registers as SimpleSpanProcessor compat (does not throw)", () => {

--- a/packages/openrouter-broadcast-ingest/README.md
+++ b/packages/openrouter-broadcast-ingest/README.md
@@ -8,9 +8,8 @@ repository's existing observability boundary:
 2. reject malformed or oversized OTLP before persistence;
 3. redact secrets and archive the complete payload in the private LLM
    SeaweedFS bucket;
-4. strip prompt, response, tool, content, and credential attributes;
-5. forward the correlated slim payload to Tempo;
-6. write a digest receipt and return `204`.
+4. forward the same redacted full-content payload to Tempo;
+5. write a digest receipt and return `204`.
 
 The digest receipt is independent of the payload's UTC date partition, so an
 OpenRouter retry remains idempotent across midnight, and a duplicate reports
@@ -54,7 +53,7 @@ to Tempo and SeaweedFS. Before releasing the chart:
 3. deploy this service before migrating consumers;
 4. use OpenRouter's connection test and then send one real generation;
 5. verify a payload object and digest receipt in the private archive, a
-   body-free correlated trace in Tempo, success metrics in Prometheus, and
+   full-content redacted trace in Tempo, success metrics in Prometheus, and
    body-free structured logs in Loki.
 
 The `OpenRouterBroadcastPipelineFailure` and

--- a/packages/openrouter-broadcast-ingest/src/app.ts
+++ b/packages/openrouter-broadcast-ingest/src/app.ts
@@ -9,7 +9,6 @@ import {
   canonicalOtlpJson,
   OtlpJsonPayloadSchema,
   redactOtlpPayload,
-  slimOtlpPayload,
   summarizeOtlpPayload,
   type OtlpJsonPayload,
 } from "./otlp.ts";
@@ -196,7 +195,6 @@ function createDeliveryProcessor(
   const inFlight = new Map<string, Promise<DeliveryResult>>();
 
   const deliverOnce = async (
-    payload: OtlpJsonPayload,
     redactedJson: string,
     digest: string,
   ): Promise<DeliveryResult> => {
@@ -234,9 +232,7 @@ function createDeliveryProcessor(
     }
 
     try {
-      await dependencies.forwarder.forward(
-        JSON.stringify(slimOtlpPayload(payload)),
-      );
+      await dependencies.forwarder.forward(redactedJson);
       dependencies.metrics.operationsTotal.inc({
         operation: "forward",
         outcome: "success",
@@ -305,7 +301,7 @@ function createDeliveryProcessor(
       return { ...result, duplicate: true };
     }
 
-    const delivery = deliverOnce(redacted, redactedJson, digest);
+    const delivery = deliverOnce(redactedJson, digest);
     inFlight.set(digest, delivery);
     try {
       return await delivery;

--- a/packages/openrouter-broadcast-ingest/src/otlp.ts
+++ b/packages/openrouter-broadcast-ingest/src/otlp.ts
@@ -62,49 +62,8 @@ export const OtlpJsonPayloadSchema = z
 
 export type OtlpJsonPayload = z.infer<typeof OtlpJsonPayloadSchema>;
 
-const BODY_ATTRIBUTE_KEYS: ReadonlySet<string> = new Set([
-  "ai.prompt",
-  "ai.prompt.messages",
-  "ai.response.object",
-  "ai.response.text",
-  "gen_ai.input.messages",
-  "gen_ai.input.tools",
-  "gen_ai.output.messages",
-  "gen_ai.system_instructions",
-  "gen_ai.tool.stderr",
-  "gen_ai.tool.stdout",
-  "http.request.body",
-  "http.response.body",
-]);
-
 const SECRET_ATTRIBUTE_KEY =
   /(?:^|[._-])(?:authorization|api[_-]?key|access[_-]?key|secret(?:[_-]?(?:key|token))?|password|token|credential)(?:$|[._-])/i;
-
-function isBodyAttribute(key: string): boolean {
-  const normalized = key.toLowerCase();
-  if (SECRET_ATTRIBUTE_KEY.test(normalized)) return true;
-  if (BODY_ATTRIBUTE_KEYS.has(normalized)) return true;
-  if (normalized.includes("prompt") || normalized.includes("completion")) {
-    return true;
-  }
-  if (
-    normalized.endsWith(".content") ||
-    normalized.endsWith(".body") ||
-    normalized.includes("message.content")
-  ) {
-    return true;
-  }
-  return (
-    normalized.includes("tool") &&
-    /argument|input|output|result/i.test(normalized)
-  );
-}
-
-function stripAttributes(
-  attributes: z.infer<typeof KeyValueSchema>[] | undefined,
-): z.infer<typeof KeyValueSchema>[] | undefined {
-  return attributes?.filter((attribute) => !isBodyAttribute(attribute.key));
-}
 
 function canonicalize(value: unknown): unknown {
   if (Array.isArray(value)) return value.map((entry) => canonicalize(entry));
@@ -128,39 +87,6 @@ function canonicalize(value: unknown): unknown {
  */
 export function canonicalOtlpJson(payload: OtlpJsonPayload): string {
   return JSON.stringify(canonicalize(payload));
-}
-
-/** Strip prompt, response, and tool bodies while retaining routing, usage, and cost data. */
-export function slimOtlpPayload(payload: OtlpJsonPayload): OtlpJsonPayload {
-  return {
-    ...payload,
-    resourceSpans: payload.resourceSpans.map((resourceSpans) => ({
-      ...resourceSpans,
-      ...(resourceSpans.resource === undefined
-        ? {}
-        : {
-            resource: {
-              ...resourceSpans.resource,
-              attributes: stripAttributes(resourceSpans.resource.attributes),
-            },
-          }),
-      scopeSpans: resourceSpans.scopeSpans.map((scopeSpans) => ({
-        ...scopeSpans,
-        spans: scopeSpans.spans.map((span) => ({
-          ...span,
-          attributes: stripAttributes(span.attributes),
-          events: span.events?.map((event) => ({
-            ...event,
-            attributes: stripAttributes(event.attributes),
-          })),
-          links: span.links?.map((link) => ({
-            ...link,
-            attributes: stripAttributes(link.attributes),
-          })),
-        })),
-      })),
-    })),
-  };
 }
 
 function redactOtlpKeyValues(value: unknown): unknown {

--- a/packages/openrouter-broadcast-ingest/test/app.test.ts
+++ b/packages/openrouter-broadcast-ingest/test/app.test.ts
@@ -152,7 +152,7 @@ describe("OpenRouter Broadcast ingest", () => {
     expect(forwarded).toHaveLength(0);
   });
 
-  test("archives a redacted complete payload before forwarding a body-free trace", async () => {
+  test("archives a redacted complete payload before forwarding the same redacted trace", async () => {
     const { app, objects, forwarded } = createHarness();
     const response = await request(app);
     expect(response.status).toBe(204);
@@ -171,8 +171,9 @@ describe("OpenRouter Broadcast ingest", () => {
     expect(payloadEntry?.[1]).toContain("[REDACTED]");
 
     expect(forwarded).toHaveLength(1);
-    expect(forwarded[0]).not.toContain("private prompt");
-    expect(forwarded[0]).not.toContain("provider.api_key");
+    expect(forwarded[0]).toContain("private prompt");
+    expect(forwarded[0]).not.toContain("secret-provider-key");
+    expect(forwarded[0]).toContain("[REDACTED]");
     expect(forwarded[0]).toContain("gen_ai.usage.input_tokens");
     expect(forwarded[0]).toContain("gen_ai.usage.cost");
   });


### PR DESCRIPTION
## Why

Tempo received only body-free spans with an archive ref, so reading any LLM trajectory required a two-store join, and downstream OTLP consumers (eval platforms, trace UIs) never saw prompt/response content at all. Content shipping is acceptable for this homelab; the strip bought nothing.

## What

- `LlmArchiveSpanProcessor` forwards spans with body attributes redacted in place instead of stripped: `redactSecrets` now runs against each body value before export, in both the archived and `sampled_out` paths. The S3 archive continues unchanged as the durable copy that outlives Tempo's 30-day retention.
- `openrouter-broadcast-ingest` forwards the same redacted full-content payload it archives; `slimOtlpPayload`/`stripAttributes` and the body-attribute heuristics are removed. Secret-keyed attribute values are still replaced with `[REDACTED]` by the existing redaction pass.
- Service tracing comments (birmel, discord-plays-pokemon), both package READMEs, and the wiki (`llm-stack`, `agent-task-boundary`, `enable-openrouter-broadcast`) now describe the full-content boundary.

Tempo already runs with `max_bytes_per_trace: 50MB`, so no homelab change is needed for the larger spans.

## Verification

- `bunx turbo run build typecheck test lint` green for `@shepherdjerred/llm-observability`, `@shepherdjerred/openrouter-broadcast-ingest`, `@shepherdjerred/birmel`, `@discord-plays-pokemon/backend`, `@shepherdjerred/docs-wiki`.
- `llm-observability` e2e suite (docker compose Tempo + MinIO) green, including the updated assertion that a real Tempo returns the span with full `gen_ai.input/output.messages` content plus the archive ref, and a new unit test proving bearer tokens inside message bodies are redacted on the forwarded span.
- `bunx lefthook run pre-commit` green (gitleaks initially rejected a realistic-looking test credential; the fixture now uses a low-entropy fake).
- Not verified live: Buildkite on this head, image publication, ArgoCD sync, and content-bearing spans observed in production Tempo — the services need redeploy before production traces carry bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNjaV1EJ8o5kmee2cS8pLs