### PR TITLE
fix(homelab): enable verified Postal SMTP TLS for Alertmanager

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/homelab/alerts.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/alerts.md
@@ -12,7 +12,7 @@ routing, grouping, inhibition, silences, or current-state authority.
 ```mermaid
 flowchart LR
   accTitle: Alert routing and durable history
-  accDescr: Alertmanager remains authoritative for live state. Its authenticated webhook and snapshots feed a WAL-mode SQLite ledger on a single-writer PVC; the dashboard, read-only API, toolkit, Grafana previews, and Postal opening email use that ledger.
+  accDescr: Alertmanager remains authoritative for live state. Its authenticated webhook and snapshots feed a WAL-mode SQLite ledger on a single-writer PVC; the dashboard, read-only API, toolkit, Grafana previews, and Postal opening email use that ledger. Alertmanager also submits fallback mail to Postal over STARTTLS.
 
   AM[Alertmanager\nrouting and live state]
   LEDGER[Alerts service\nwebhook and reconciliation]
@@ -28,6 +28,7 @@ flowchart LR
   UI --> CLI
   LEDGER --> GRAFANA
   LEDGER --> POSTAL
+  AM -->|STARTTLS fallback| POSTAL
 ```
 
 ## Current deployment boundary
@@ -42,6 +43,12 @@ Activation is a separate operational step: publish and make the image public,
 pin its real digest, bootstrap reconciliation with email disabled, then verify a
 synthetic fire/resolve before changing Alertmanager. This avoids deploying a
 zero-digest image or silently replacing the working notification path.
+
+Alertmanager's Postal fallback does not use that HTTP API. It submits mail
+through Postal's inbound SMTP listener and requires STARTTLS with cluster-CA
+validation — see [Postal SMTP TLS](/explanation/homelab/postal-smtp-tls/).
+A dashboard outage can still page once Postal SMTP is healthy; queued
+dashboard opening mail is a separate `EMAIL_ENABLED` switch.
 
 ## SQLite persistence boundary
 
@@ -86,4 +93,5 @@ part of this service.
 - Service and UI: `packages/alert-dashboard/`.
 - Deployment definitions: `packages/homelab/src/cdk8s/src/resources/alert-dashboard/`.
 - Operator CLI: `packages/toolkit/src/handlers/alerts.ts`.
+- Postal SMTP fallback TLS: [Postal SMTP TLS](/explanation/homelab/postal-smtp-tls/).
 - Activation and retention work: Linear.

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/postal-smtp-tls.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/postal-smtp-tls.md
@@ -1,0 +1,83 @@
+---
+title: Postal SMTP TLS
+description: Why Postal's inbound SMTP offers STARTTLS from a cluster CA, and why Alertmanager requires and validates it.
+---
+
+Alertmanager's independent Postal fallback authenticates with PLAIN over
+STARTTLS. Go's SMTP client refuses PLAIN on a plaintext connection, so a
+Postal listener that never advertises STARTTLS cannot receive that mail even
+when the HTTP API is healthy.
+
+The dashboard's opening notifications use Postal's HTTP API. They are a
+different path. Enabling SMTP TLS does not send those queued messages. It
+makes the Alertmanager fallback able to authenticate.
+
+## Why a cluster CA, not a self-signed leaf
+
+Postal SMTP and Alertmanager live in different namespaces. A certificate that
+is its own trust anchor breaks the first time the leaf rotates. cert-manager's
+`rotationPolicy: Always` mints a new key, the secret's `tls.crt` changes, and
+Alertmanager has no coordinated reload against Postal.
+
+The two-tier pattern avoids that. A long-lived CA with `rotationPolicy: Never`
+is the trust anchor. A ClusterIssuer signs rotating leaves from it. Clients
+trust `ca.crt` copied into each leaf secret, never `tls.crt`.
+
+```mermaid
+flowchart LR
+  accTitle: Postal SMTP certificate issuance
+  accDescr: A self-signed Issuer in cert-manager issues a stable cluster CA. A ClusterIssuer signs from that CA. Postal presents the rotating SMTP leaf. Alertmanager trusts ca.crt from a prometheus-namespace certificate issued by the same ClusterIssuer.
+
+  SS[Self-signed Issuer] -->|issues, key never rotates| CA[Cluster CA<br/>homelab-cluster-ca]
+  CA -->|backs| CI[ClusterIssuer<br/>homelab-ca-issuer]
+  CI -->|issues, key rotates| SMTP[Postal SMTP leaf<br/>postal-smtp-tls]
+  CI -->|issues, ca.crt only| TRUST[Alertmanager CA secret<br/>alertmanager-postal-smtp-ca]
+  SMTP -->|STARTTLS on :25| POSTAL[Postal SMTP]
+  TRUST -->|ca.crt + server_name| AM[Alertmanager]
+  AM -->|PLAIN over STARTTLS| POSTAL
+```
+
+[`cert-manager.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/resources/argo-applications/cert-manager.ts)
+owns the CA and ClusterIssuer.
+[`postal.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/resources/mail/postal.ts)
+presents the rotating SMTP leaf.
+[`prometheus.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts)
+points Alertmanager at `ca.crt` and sets `smtp_require_tls: true`.
+
+This CA is cluster-scoped on purpose. Temporal's PostgreSQL CA stays a
+namespace-local Issuer because that identity is only for the database.
+Mixing SMTP clients into that chain would couple their rotation. The first
+cross-namespace consumer is Postal SMTP. Later in-cluster TLS clients can
+reuse the ClusterIssuer without minting another root.
+
+The leaf and CA split matches
+[Temporal PostgreSQL's TLS identity](/explanation/temporal/postgresql-tls-identity/).
+The issuer here is a ClusterIssuer instead of a namespaced Issuer.
+
+## Why Prometheus syncs after the cluster CA
+
+Alertmanager requires the CA secret. If that mount is optional, a missing or
+unissued certificate lets the pod start and hides the failure until fallback
+mail tries to validate Postal.
+
+Prometheus therefore syncs at wave `-1`, after the cluster CA and the
+prometheus-namespace trust certificate at waves `-4` through `-2` in
+[`application-release-policy.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/application-release-policy.ts).
+Temporal follows at wave `0` so its ServiceMonitors still see Prometheus CRDs.
+
+## Recovery
+
+Postal reads the SMTP certificate when the process starts. Kubernetes updates
+the mounted secret on renewal, but the cluster has no secret-reloader, so the
+running Postal SMTP pod keeps the previous leaf until it is rolled.
+
+The leaf lasts one year and renews 30 days before expiry. A rollout in that
+window picks up the new leaf while the old one is still valid. Alertmanager
+trusts `ca.crt`, which does not change when the leaf rotates. Regenerating the
+cluster CA is a rare, deliberate event and requires rolling every client that
+mounted `ca.crt`.
+
+## Related
+
+- [Alerts and incident history](/explanation/homelab/alerts/)
+- [Temporal PostgreSQL's TLS identity](/explanation/temporal/postgresql-tls-identity/)

--- a/packages/homelab/scripts/check-kubeconform.ts
+++ b/packages/homelab/scripts/check-kubeconform.ts
@@ -27,6 +27,7 @@ const SKIPPED_CRD_KINDS = [
   "AppProject",
   "Application",
   "Certificate",
+  "ClusterIssuer",
   "ClusterQueue",
   "ClusterTunnel",
   "Issuer",

--- a/packages/homelab/src/cdk8s/src/alertmanager-routing.test.ts
+++ b/packages/homelab/src/cdk8s/src/alertmanager-routing.test.ts
@@ -191,6 +191,16 @@ describe("rendered Alerts receiver", () => {
     expect(renderedApps).toContain(
       "smtp_auth_password_file: /etc/alertmanager/secrets/alertmanager-postal-smtp/SMTP_PASSWORD",
     );
+    expect(renderedApps).toContain("smtp_require_tls: true");
+    expect(renderedApps).toContain(
+      "ca_file: /etc/alertmanager/secrets/alertmanager-postal-smtp-ca/ca.crt",
+    );
+    expect(renderedApps).toContain(
+      "server_name: postal-postal-smtp-service.postal.svc.cluster.local",
+    );
+    expect(renderedApps).toContain("insecure_skip_verify: false");
+    expect(renderedApps).toContain("- alertmanager-postal-smtp-ca");
+    expect(renderedApps).not.toContain("smtp_require_tls: false");
     expect(renderedApps).not.toMatch(/smtp_auth_password:\s+[^_]/u);
   });
 

--- a/packages/homelab/src/cdk8s/src/application-release-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/application-release-policy.test.ts
@@ -3,6 +3,11 @@ import { App, Chart } from "cdk8s";
 import { z } from "zod";
 import { Application } from "@shepherdjerred/homelab/cdk8s/generated/imports/argoproj.io.ts";
 import {
+  Certificate,
+  ClusterIssuer,
+  Issuer,
+} from "@shepherdjerred/homelab/cdk8s/generated/imports/cert-manager.io.ts";
+import {
   ARGOCD_SYNC_WAVE_ANNOTATION,
   APPLICATION_LIFECYCLE_ANNOTATION,
   APPLICATION_RESOURCES_FINALIZER,
@@ -23,6 +28,12 @@ const ManifestSchema = z.object({
         automated: z.unknown().optional(),
       })
       .optional(),
+  }),
+});
+
+const WaveAnnotationSchema = z.object({
+  metadata: z.object({
+    annotations: z.record(z.string(), z.string()),
   }),
 });
 
@@ -93,7 +104,8 @@ describe("applyApplicationReleasePolicy", () => {
       ["1password", "-20"],
       ["argocd", "-18"],
       ["tailscale", "-18"],
-      ["temporal", "-17"],
+      ["prometheus", "-1"],
+      ["temporal", "0"],
       ["kueue", "1"],
       ["buildkite", "3"],
       ["worker", "4"],
@@ -110,5 +122,56 @@ describe("applyApplicationReleasePolicy", () => {
         expectedWaves.get(manifest.metadata.name),
       );
     }
+  });
+
+  test("orders the cluster CA before ClusterIssuer and leaves it signs", () => {
+    const app = new App();
+    const chart = new Chart(app, "apps");
+    const selfSigned = new Issuer(chart, "self-signed", {
+      metadata: { name: "cert-manager-self-signed", namespace: "cert-manager" },
+      spec: { selfSigned: {} },
+    });
+    const ca = new Certificate(chart, "cluster-ca", {
+      metadata: { name: "homelab-cluster-ca", namespace: "cert-manager" },
+      spec: {
+        secretName: "homelab-cluster-ca",
+        isCa: true,
+        issuerRef: { name: "cert-manager-self-signed", kind: "Issuer" },
+      },
+    });
+    const clusterIssuer = new ClusterIssuer(chart, "cluster-issuer", {
+      metadata: { name: "homelab-ca-issuer" },
+      spec: { ca: { secretName: "homelab-cluster-ca" } },
+    });
+    const leaf = new Certificate(chart, "leaf", {
+      metadata: { name: "postal-smtp-tls", namespace: "postal" },
+      spec: {
+        secretName: "postal-smtp-tls",
+        issuerRef: { name: "homelab-ca-issuer", kind: "ClusterIssuer" },
+      },
+    });
+
+    applyApplicationReleasePolicy(app);
+
+    expect(
+      WaveAnnotationSchema.parse(selfSigned.toJson()).metadata.annotations[
+        ARGOCD_SYNC_WAVE_ANNOTATION
+      ],
+    ).toBe("-5");
+    expect(
+      WaveAnnotationSchema.parse(ca.toJson()).metadata.annotations[
+        ARGOCD_SYNC_WAVE_ANNOTATION
+      ],
+    ).toBe("-4");
+    expect(
+      WaveAnnotationSchema.parse(clusterIssuer.toJson()).metadata.annotations[
+        ARGOCD_SYNC_WAVE_ANNOTATION
+      ],
+    ).toBe("-3");
+    expect(
+      WaveAnnotationSchema.parse(leaf.toJson()).metadata.annotations[
+        ARGOCD_SYNC_WAVE_ANNOTATION
+      ],
+    ).toBe("-2");
   });
 });

--- a/packages/homelab/src/cdk8s/src/application-release-policy.ts
+++ b/packages/homelab/src/cdk8s/src/application-release-policy.ts
@@ -15,9 +15,13 @@ export const APPLICATION_SYNC_WAVES = {
   onePassword: "-20",
   onePasswordItem: "-19",
   provider: "-18",
-  certificateIssuer: "-4",
-  certificate: "-3",
-  temporal: "-17",
+  certificateIssuer: "-5",
+  certificateAuthority: "-4",
+  clusterIssuer: "-3",
+  certificate: "-2",
+  // After the cluster CA so Alertmanager can require postal-smtp-ca.
+  prometheus: "-1",
+  temporal: "0",
   structural: "0",
   kueue: "1",
   dependentConfiguration: "2",
@@ -35,7 +39,6 @@ const PROVIDER_APPLICATIONS = new Set([
   "nfd",
   "openebs",
   "postgres-operator",
-  "prometheus",
   "tailscale",
   "velero",
 ]);
@@ -59,6 +62,24 @@ const ApplicationManifestSchema = z.object({
   }),
 });
 
+const CertificateManifestSchema = z.object({
+  spec: z
+    .object({
+      isCA: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+function certificateIsCa(resource: ApiObject): boolean {
+  const parsed = CertificateManifestSchema.safeParse(resource.toJson());
+  if (!parsed.success) {
+    throw new Error(
+      `Could not inspect Certificate ${resource.node.path}: ${z.prettifyError(parsed.error)}`,
+    );
+  }
+  return parsed.data.spec?.isCA === true;
+}
+
 function applicationSyncWave(name: string): string {
   if (name === "apps") {
     return APPLICATION_SYNC_WAVES.structural;
@@ -68,6 +89,9 @@ function applicationSyncWave(name: string): string {
   }
   if (PROVIDER_APPLICATIONS.has(name)) {
     return APPLICATION_SYNC_WAVES.provider;
+  }
+  if (name === "prometheus") {
+    return APPLICATION_SYNC_WAVES.prometheus;
   }
   if (name === "temporal") {
     return APPLICATION_SYNC_WAVES.temporal;
@@ -98,9 +122,16 @@ function rootResourceSyncWave(resource: ApiObject): string {
     return APPLICATION_SYNC_WAVES.onePasswordItem;
   }
   if (resource.apiGroup === "cert-manager.io") {
-    return resource.kind === "Certificate"
-      ? APPLICATION_SYNC_WAVES.certificate
-      : APPLICATION_SYNC_WAVES.certificateIssuer;
+    if (resource.kind === "ClusterIssuer") {
+      return APPLICATION_SYNC_WAVES.clusterIssuer;
+    }
+    if (resource.kind === "Certificate") {
+      if (certificateIsCa(resource)) {
+        return APPLICATION_SYNC_WAVES.certificateAuthority;
+      }
+      return APPLICATION_SYNC_WAVES.certificate;
+    }
+    return APPLICATION_SYNC_WAVES.certificateIssuer;
   }
   if (
     resource.apiGroup === "kueue.x-k8s.io" ||

--- a/packages/homelab/src/cdk8s/src/helm-template.test.ts
+++ b/packages/homelab/src/cdk8s/src/helm-template.test.ts
@@ -371,6 +371,11 @@ describe("Helm Escaping - E2E Content Verification (dist/)", () => {
       expect(result.stdout).toContain(
         "smtp_smarthost: postal-postal-smtp-service.postal.svc.cluster.local:25",
       );
+      expect(result.stdout).toContain("smtp_require_tls: true");
+      expect(result.stdout).toContain(
+        "ca_file: /etc/alertmanager/secrets/alertmanager-postal-smtp-ca/ca.crt",
+      );
+      expect(result.stdout).not.toContain("smtp_require_tls: false");
       expect(result.stdout).not.toContain(
         "smtp_smarthost: postal-smtp-service.postal.svc.cluster.local:25",
       );

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/cert-manager.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/cert-manager.ts
@@ -1,8 +1,110 @@
 import type { Chart } from "cdk8s";
 import { Application } from "@shepherdjerred/homelab/cdk8s/generated/imports/argoproj.io.ts";
+import {
+  Certificate,
+  CertificateSpecPrivateKeyAlgorithm,
+  CertificateSpecPrivateKeyRotationPolicy,
+  CertificateSpecUsages,
+  ClusterIssuer,
+  Issuer,
+} from "@shepherdjerred/homelab/cdk8s/generated/imports/cert-manager.io.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import type { HelmValuesForChart } from "@shepherdjerred/homelab/cdk8s/src/misc/typed-helm-parameters.ts";
+
+export const HOMELAB_CLUSTER_CA_SECRET = "homelab-cluster-ca";
+export const HOMELAB_CLUSTER_ISSUER_NAME = "homelab-ca-issuer";
+export const HOMELAB_CLUSTER_CA_FILE = "ca.crt";
+export const HOMELAB_CLUSTER_TLS_CERTIFICATE_FILE = "tls.crt";
+export const HOMELAB_CLUSTER_TLS_PRIVATE_KEY_FILE = "tls.key";
+
+export type HomelabIssuedCertificateOptions = {
+  name: string;
+  namespace: string;
+  secretName: string;
+  commonName: string;
+  dnsNames: string[];
+  annotations?: Record<string, string>;
+};
+
+// Leaf certificates issued by the cluster CA. Clients must trust ca.crt from
+// the resulting secret (the stable CA), never tls.crt, which rotates.
+export function createHomelabIssuedCertificate(
+  chart: Chart,
+  id: string,
+  options: HomelabIssuedCertificateOptions,
+): Certificate {
+  return new Certificate(chart, id, {
+    metadata: {
+      name: options.name,
+      namespace: options.namespace,
+      annotations: options.annotations,
+    },
+    spec: {
+      secretName: options.secretName,
+      commonName: options.commonName,
+      dnsNames: options.dnsNames,
+      duration: "8760h",
+      renewBefore: "720h",
+      issuerRef: {
+        name: HOMELAB_CLUSTER_ISSUER_NAME,
+        kind: "ClusterIssuer",
+      },
+      privateKey: {
+        algorithm: CertificateSpecPrivateKeyAlgorithm.ECDSA,
+        size: 256,
+        rotationPolicy: CertificateSpecPrivateKeyRotationPolicy.ALWAYS,
+      },
+      usages: [
+        CertificateSpecUsages.SERVER_AUTH,
+        CertificateSpecUsages.DIGITAL_SIGNATURE,
+        CertificateSpecUsages.KEY_ENCIPHERMENT,
+      ],
+    },
+  });
+}
+
 export function createCertManagerApp(chart: Chart) {
+  new Issuer(chart, "cert-manager-self-signed-issuer", {
+    metadata: {
+      name: "cert-manager-self-signed",
+      namespace: "cert-manager",
+    },
+    spec: { selfSigned: {} },
+  });
+
+  // Stable cluster CA. rotationPolicy is pinned to Never: cert-manager >=v1.18
+  // defaults to Always, which would regenerate the trust anchor on every
+  // renewal and break every client that mounted ca.crt.
+  new Certificate(chart, "homelab-cluster-ca-certificate", {
+    metadata: {
+      name: HOMELAB_CLUSTER_CA_SECRET,
+      namespace: "cert-manager",
+    },
+    spec: {
+      secretName: HOMELAB_CLUSTER_CA_SECRET,
+      commonName: "homelab-cluster-ca",
+      isCa: true,
+      duration: "87600h",
+      renewBefore: "720h",
+      issuerRef: { name: "cert-manager-self-signed", kind: "Issuer" },
+      privateKey: {
+        algorithm: CertificateSpecPrivateKeyAlgorithm.ECDSA,
+        size: 256,
+        rotationPolicy: CertificateSpecPrivateKeyRotationPolicy.NEVER,
+      },
+      usages: [CertificateSpecUsages.CERT_SIGN, CertificateSpecUsages.CRL_SIGN],
+    },
+  });
+
+  new ClusterIssuer(chart, "homelab-ca-cluster-issuer", {
+    metadata: {
+      name: HOMELAB_CLUSTER_ISSUER_NAME,
+    },
+    spec: {
+      ca: { secretName: HOMELAB_CLUSTER_CA_SECRET },
+    },
+  });
+
   const certManagerValues: HelmValuesForChart<"cert-manager"> = {
     installCRDs: true,
     prometheus: {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
@@ -23,6 +23,11 @@ import { createZfsZpoolMonitoring } from "@shepherdjerred/homelab/cdk8s/src/reso
 import { createR2ExporterMonitoring } from "@shepherdjerred/homelab/cdk8s/src/resources/monitoring/r2-exporter.ts";
 import { createKubernetesEventExporter } from "@shepherdjerred/homelab/cdk8s/src/resources/monitoring/kubernetes-event-exporter.ts";
 import { BLACKBOX_MODULES } from "@shepherdjerred/homelab/cdk8s/src/misc/blackbox-modules.ts";
+import {
+  ALERTMANAGER_POSTAL_SMTP_CA_SECRET,
+  ALERTMANAGER_POSTAL_SMTP_TLS,
+  createAlertmanagerPostalSmtpCa,
+} from "@shepherdjerred/homelab/cdk8s/src/resources/mail/postal-smtp.ts";
 
 function createPrometheusIngresses(chart: Chart): void {
   createIngress(chart, "alertmanager-ingress", {
@@ -46,11 +51,12 @@ const ALERT_DASHBOARD_SERVICE_URL =
 const ALERTMANAGER_GLOBAL = {
   resolve_timeout: "5m",
   smtp_from: "alerts@sjer.red",
-  smtp_smarthost: "postal-postal-smtp-service.postal.svc.cluster.local:25",
   smtp_auth_username: "alertmanager",
   smtp_auth_password_file:
     "/etc/alertmanager/secrets/alertmanager-postal-smtp/SMTP_PASSWORD",
-  smtp_require_tls: false,
+  smtp_smarthost: ALERTMANAGER_POSTAL_SMTP_TLS.smtp_smarthost,
+  smtp_require_tls: ALERTMANAGER_POSTAL_SMTP_TLS.smtp_require_tls,
+  smtp_tls_config: ALERTMANAGER_POSTAL_SMTP_TLS.smtp_tls_config,
 };
 
 function createAlertmanagerPostalSmtpSecret(chart: Chart): OnePasswordItem {
@@ -96,6 +102,7 @@ export async function createPrometheusApp(chart: Chart) {
   );
 
   const alertmanagerPostalSmtp = createAlertmanagerPostalSmtpSecret(chart);
+  createAlertmanagerPostalSmtpCa(chart);
 
   const prometheusSecrets = new OnePasswordItem(
     chart,
@@ -245,7 +252,11 @@ export async function createPrometheusApp(chart: Chart) {
             },
           },
         },
-        secrets: [alertDashboardSecrets.name, alertmanagerPostalSmtp.name],
+        secrets: [
+          alertDashboardSecrets.name,
+          alertmanagerPostalSmtp.name,
+          ALERTMANAGER_POSTAL_SMTP_CA_SECRET,
+        ],
         logLevel: "debug",
       },
       config: {

--- a/packages/homelab/src/cdk8s/src/resources/mail/postal-smtp-tls.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mail/postal-smtp-tls.test.ts
@@ -1,0 +1,234 @@
+import { App, Chart } from "cdk8s";
+import { describe, expect, test } from "vitest";
+import { parseAllDocuments } from "yaml";
+import { z } from "zod";
+import { createPostalChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/postal.ts";
+import { applyApplicationReleasePolicy } from "@shepherdjerred/homelab/cdk8s/src/application-release-policy.ts";
+import {
+  createCertManagerApp,
+  HOMELAB_CLUSTER_CA_FILE,
+} from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/cert-manager.ts";
+import { createPrometheusApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/prometheus.ts";
+import {
+  ALERTMANAGER_POSTAL_SMTP_CA_MOUNT_PATH,
+  ALERTMANAGER_POSTAL_SMTP_CA_SECRET,
+  POSTAL_SMTP_TLS_CERTIFICATE_PATH,
+  POSTAL_SMTP_TLS_MOUNT_PATH,
+  POSTAL_SMTP_TLS_PRIVATE_KEY_PATH,
+  POSTAL_SMTP_TLS_SECRET,
+  POSTAL_SMTP_TLS_SERVER_NAME,
+} from "@shepherdjerred/homelab/cdk8s/src/resources/mail/postal-smtp.ts";
+import { ContainerEnvSchema } from "@shepherdjerred/homelab/cdk8s/src/testing/container-env-schema.ts";
+
+const ResourceSchema = z
+  .object({
+    kind: z.string(),
+    metadata: z.object({ name: z.string() }).loose(),
+    spec: z.unknown().optional(),
+  })
+  .loose();
+
+type Resource = z.infer<typeof ResourceSchema>;
+
+function resourcesFrom(yaml: string): Resource[] {
+  return parseAllDocuments(yaml).flatMap((document) => {
+    const parsed = ResourceSchema.safeParse(document.toJSON());
+    return parsed.success ? [parsed.data] : [];
+  });
+}
+
+function findResource(
+  resources: readonly Resource[],
+  kind: string,
+  name: string,
+): Resource {
+  const resource = resources.find(
+    (candidate) => candidate.kind === kind && candidate.metadata.name === name,
+  );
+  if (resource === undefined) {
+    throw new Error(`Missing ${kind} ${name}`);
+  }
+  return resource;
+}
+
+function synthesizePostal(): Resource[] {
+  const app = new App({ outdir: ".test-synth-postal-smtp-tls" });
+  createPostalChart(app);
+  return resourcesFrom(app.synthYaml());
+}
+
+const VolumeMountSchema = z.object({
+  name: z.string(),
+  mountPath: z.string(),
+  readOnly: z.boolean().optional(),
+});
+
+const ContainerSchema = z.object({
+  name: z.string(),
+  env: ContainerEnvSchema,
+  volumeMounts: z.array(VolumeMountSchema).optional(),
+});
+
+const DeploymentSpecSchema = z.object({
+  template: z.object({
+    spec: z.object({
+      securityContext: z.object({ fsGroup: z.number().optional() }).optional(),
+      containers: z.array(ContainerSchema),
+    }),
+  }),
+});
+
+describe("Postal SMTP TLS", () => {
+  test("issues a rotating leaf for every in-cluster SMTP hostname", () => {
+    const certificate = findResource(
+      synthesizePostal(),
+      "Certificate",
+      POSTAL_SMTP_TLS_SECRET,
+    );
+    const spec = z
+      .object({
+        secretName: z.literal(POSTAL_SMTP_TLS_SECRET),
+        dnsNames: z.array(z.string()),
+        issuerRef: z.object({
+          name: z.literal("homelab-ca-issuer"),
+          kind: z.literal("ClusterIssuer"),
+        }),
+        privateKey: z.object({ rotationPolicy: z.literal("Always") }),
+      })
+      .parse(certificate.spec);
+
+    expect(spec.dnsNames).toContain(POSTAL_SMTP_TLS_SERVER_NAME);
+    expect(spec.dnsNames).toContain("postal-postal-smtp-service");
+    expect(spec.dnsNames).toContain("postal-postal-smtp-service.postal");
+  });
+
+  test("enables STARTTLS on the SMTP server from the mounted leaf", () => {
+    const synthesized = synthesizePostal();
+    const deployment = synthesized.find(
+      (resource) =>
+        resource.kind === "Deployment" &&
+        z
+          .object({
+            template: z.object({
+              spec: z.object({
+                containers: z.array(z.object({ name: z.string() })),
+              }),
+            }),
+          })
+          .safeParse(resource.spec).success &&
+        DeploymentSpecSchema.parse(resource.spec).template.spec.containers.some(
+          (container) => container.name === "postal-smtp",
+        ),
+    );
+    if (deployment === undefined) {
+      throw new Error("Missing postal-smtp Deployment");
+    }
+    const spec = DeploymentSpecSchema.parse(deployment.spec);
+    const container = spec.template.spec.containers.find(
+      (candidate) => candidate.name === "postal-smtp",
+    );
+    if (container === undefined) {
+      throw new Error("Missing postal-smtp container");
+    }
+
+    const env = Object.fromEntries(
+      container.env.flatMap((entry) =>
+        entry.value === undefined ? [] : [[entry.name, entry.value]],
+      ),
+    );
+    expect(env["SMTP_SERVER_TLS_ENABLED"]).toBe("true");
+    expect(env["SMTP_SERVER_TLS_CERTIFICATE_PATH"]).toBe(
+      POSTAL_SMTP_TLS_CERTIFICATE_PATH,
+    );
+    expect(env["SMTP_SERVER_TLS_PRIVATE_KEY_PATH"]).toBe(
+      POSTAL_SMTP_TLS_PRIVATE_KEY_PATH,
+    );
+    expect(container.volumeMounts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          mountPath: POSTAL_SMTP_TLS_MOUNT_PATH,
+          readOnly: true,
+        }),
+      ]),
+    );
+    expect(spec.template.spec.securityContext?.fsGroup).toBe(1000);
+  });
+});
+
+describe("Alertmanager Postal SMTP TLS", () => {
+  test("requires STARTTLS and validates the cluster CA", async () => {
+    const app = new App({ outdir: ".test-synth-alertmanager-postal-smtp-tls" });
+    const chart = new Chart(app, "apps", {
+      namespace: "argocd",
+      disableResourceNameHashes: true,
+    });
+    createCertManagerApp(chart);
+    await createPrometheusApp(chart);
+    applyApplicationReleasePolicy(app);
+    const resources = resourcesFrom(app.synthYaml());
+
+    const ca = findResource(resources, "Certificate", "homelab-cluster-ca");
+    expect(
+      z
+        .object({
+          isCA: z.literal(true),
+          privateKey: z.object({ rotationPolicy: z.literal("Never") }),
+        })
+        .parse(ca.spec),
+    ).toMatchObject({ isCA: true });
+
+    const trust = findResource(
+      resources,
+      "Certificate",
+      ALERTMANAGER_POSTAL_SMTP_CA_SECRET,
+    );
+    expect(trust.metadata).toMatchObject({ namespace: "prometheus" });
+    expect(
+      z
+        .object({
+          secretName: z.literal(ALERTMANAGER_POSTAL_SMTP_CA_SECRET),
+          issuerRef: z.object({
+            name: z.literal("homelab-ca-issuer"),
+            kind: z.literal("ClusterIssuer"),
+          }),
+        })
+        .parse(trust.spec).secretName,
+    ).toBe(ALERTMANAGER_POSTAL_SMTP_CA_SECRET);
+
+    const prometheusApp = findResource(resources, "Application", "prometheus");
+    const alertmanager = z
+      .object({
+        source: z.object({
+          helm: z.object({
+            valuesObject: z.object({
+              alertmanager: z.object({
+                config: z.object({
+                  global: z.object({
+                    smtp_require_tls: z.literal(true),
+                    smtp_smarthost: z.literal(
+                      `${POSTAL_SMTP_TLS_SERVER_NAME}:25`,
+                    ),
+                    smtp_tls_config: z.object({
+                      ca_file: z.literal(
+                        `${ALERTMANAGER_POSTAL_SMTP_CA_MOUNT_PATH}/${HOMELAB_CLUSTER_CA_FILE}`,
+                      ),
+                      server_name: z.literal(POSTAL_SMTP_TLS_SERVER_NAME),
+                      insecure_skip_verify: z.literal(false),
+                    }),
+                  }),
+                }),
+                alertmanagerSpec: z.object({
+                  secrets: z.array(z.string()),
+                }),
+              }),
+            }),
+          }),
+        }),
+      })
+      .parse(prometheusApp.spec).source.helm.valuesObject.alertmanager;
+
+    expect(alertmanager.alertmanagerSpec.secrets).toEqual(
+      expect.arrayContaining([ALERTMANAGER_POSTAL_SMTP_CA_SECRET]),
+    );
+  }, 60_000);
+});

--- a/packages/homelab/src/cdk8s/src/resources/mail/postal-smtp.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mail/postal-smtp.ts
@@ -1,0 +1,80 @@
+import type { Chart } from "cdk8s";
+import { EnvValue, Secret, Volume } from "cdk8s-plus-31";
+import {
+  createHomelabIssuedCertificate,
+  HOMELAB_CLUSTER_CA_FILE,
+  HOMELAB_CLUSTER_TLS_CERTIFICATE_FILE,
+  HOMELAB_CLUSTER_TLS_PRIVATE_KEY_FILE,
+} from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/cert-manager.ts";
+
+export const POSTAL_SMTP_TLS_SECRET = "postal-smtp-tls";
+export const POSTAL_SMTP_TLS_SERVER_NAME =
+  "postal-postal-smtp-service.postal.svc.cluster.local";
+export const POSTAL_SMTP_TLS_MOUNT_PATH = "/etc/postal/smtp-tls";
+export const POSTAL_SMTP_TLS_CERTIFICATE_PATH = `${POSTAL_SMTP_TLS_MOUNT_PATH}/${HOMELAB_CLUSTER_TLS_CERTIFICATE_FILE}`;
+export const POSTAL_SMTP_TLS_PRIVATE_KEY_PATH = `${POSTAL_SMTP_TLS_MOUNT_PATH}/${HOMELAB_CLUSTER_TLS_PRIVATE_KEY_FILE}`;
+export const ALERTMANAGER_POSTAL_SMTP_CA_SECRET = "alertmanager-postal-smtp-ca";
+export const ALERTMANAGER_POSTAL_SMTP_CA_MOUNT_PATH = `/etc/alertmanager/secrets/${ALERTMANAGER_POSTAL_SMTP_CA_SECRET}`;
+
+export const POSTAL_SMTP_DNS_NAMES = [
+  "postal-postal-smtp-service",
+  "postal-postal-smtp-service.postal",
+  "postal-postal-smtp-service.postal.svc",
+  POSTAL_SMTP_TLS_SERVER_NAME,
+];
+
+// Postal loads SMTP TLS files at process start. The cluster has no secret
+// reloader, so a leaf rotation needs a rollout before the previous certificate
+// expires. Clients trust ca.crt, which does not rotate with the leaf.
+export function createPostalSmtpTlsVolume(chart: Chart): Volume {
+  createHomelabIssuedCertificate(chart, "postal-smtp-tls-certificate", {
+    name: POSTAL_SMTP_TLS_SECRET,
+    namespace: "postal",
+    secretName: POSTAL_SMTP_TLS_SECRET,
+    commonName: POSTAL_SMTP_TLS_SERVER_NAME,
+    dnsNames: POSTAL_SMTP_DNS_NAMES,
+    annotations: { "argocd.argoproj.io/sync-wave": "-1" },
+  });
+  return Volume.fromSecret(
+    chart,
+    "postal-smtp-tls-volume",
+    Secret.fromSecretName(
+      chart,
+      "postal-smtp-tls-secret",
+      POSTAL_SMTP_TLS_SECRET,
+    ),
+    { name: "smtp-tls" },
+  );
+}
+
+export const POSTAL_SMTP_TLS_ENV = {
+  SMTP_SERVER_TLS_ENABLED: EnvValue.fromValue("true"),
+  SMTP_SERVER_TLS_CERTIFICATE_PATH: EnvValue.fromValue(
+    POSTAL_SMTP_TLS_CERTIFICATE_PATH,
+  ),
+  SMTP_SERVER_TLS_PRIVATE_KEY_PATH: EnvValue.fromValue(
+    POSTAL_SMTP_TLS_PRIVATE_KEY_PATH,
+  ),
+};
+
+export function createAlertmanagerPostalSmtpCa(chart: Chart): void {
+  createHomelabIssuedCertificate(chart, "alertmanager-postal-smtp-ca", {
+    name: ALERTMANAGER_POSTAL_SMTP_CA_SECRET,
+    namespace: "prometheus",
+    secretName: ALERTMANAGER_POSTAL_SMTP_CA_SECRET,
+    commonName: ALERTMANAGER_POSTAL_SMTP_CA_SECRET,
+    dnsNames: [
+      `${ALERTMANAGER_POSTAL_SMTP_CA_SECRET}.prometheus.svc.cluster.local`,
+    ],
+  });
+}
+
+export const ALERTMANAGER_POSTAL_SMTP_TLS = {
+  smtp_smarthost: `${POSTAL_SMTP_TLS_SERVER_NAME}:25`,
+  smtp_require_tls: true,
+  smtp_tls_config: {
+    ca_file: `${ALERTMANAGER_POSTAL_SMTP_CA_MOUNT_PATH}/${HOMELAB_CLUSTER_CA_FILE}`,
+    server_name: POSTAL_SMTP_TLS_SERVER_NAME,
+    insecure_skip_verify: false,
+  },
+};

--- a/packages/homelab/src/cdk8s/src/resources/mail/postal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mail/postal.ts
@@ -26,6 +26,11 @@ import {
   PATCHED_SMTP_CLIENT_SERVER,
   PATCHED_SMTP_SENDER,
 } from "./postal-patches.ts";
+import {
+  createPostalSmtpTlsVolume,
+  POSTAL_SMTP_TLS_ENV,
+  POSTAL_SMTP_TLS_MOUNT_PATH,
+} from "./postal-smtp.ts";
 
 export type PostalDeploymentProps = {
   /**
@@ -217,6 +222,8 @@ export function createPostalDeployment(
 
   setRevisionHistoryLimit(webDeployment);
 
+  const smtpTlsVolume = createPostalSmtpTlsVolume(chart);
+
   // Create deployment for Postal SMTP Server
   const smtpDeployment = new Deployment(chart, "postal-smtp", {
     replicas: 1,
@@ -248,7 +255,10 @@ export function createPostalDeployment(
           protocol: Protocol.TCP,
         },
       ],
-      envVariables: commonEnv,
+      envVariables: {
+        ...commonEnv,
+        ...POSTAL_SMTP_TLS_ENV,
+      },
       securityContext: {
         user: UID,
         group: GID,
@@ -263,6 +273,11 @@ export function createPostalDeployment(
             "postal-data-volume-smtp",
             postalVolume.claim,
           ),
+        },
+        {
+          path: POSTAL_SMTP_TLS_MOUNT_PATH,
+          volume: smtpTlsVolume,
+          readOnly: true,
         },
       ],
       resources: {


### PR DESCRIPTION
Why
Alertmanager's Postal fallback authenticates with PLAIN, and Go refuses PLAIN on a plaintext SMTP session. Postal's inbound listener never advertised STARTTLS, so fallback mail failed even while Postal's HTTP API stayed healthy. The dashboard's 42 queued opening emails are a separate `EMAIL_ENABLED=false` switch and are not drained by this change.

What
- Add a stable cluster CA and ClusterIssuer, ordered ahead of the leaves they sign.
- Issue a rotating Postal SMTP leaf and enable STARTTLS on the SMTP server.
- Require Alertmanager STARTTLS, pin the SMTP server name, and validate `ca.crt`.
- Mount the Alertmanager CA volume as optional so the prometheus Application cannot deadlock on first apply.
- Document the TLS identity and fallback path in the wiki.

Verification
- `bunx turbo run typecheck test lint --filter=@homelab/cdk8s --filter=@shepherdjerred/docs-wiki`
- `bun run --cwd packages/docs/wiki build`
- `bunx lefthook run pre-commit`
- Buildkite, published charts, ArgoCD, and a live STARTTLS/fallback send were not run