### PR TITLE
feat(birmel): narrate turn progress into the reply it already owns

### DIFF
--- a/packages/birmel/AGENTS.md
+++ b/packages/birmel/AGENTS.md
@@ -16,8 +16,10 @@ the architecture and capability surface.
   cites in `reliedOnToolCallIds` must have actually succeeded; that check
   (`requireGroundedAnswer`) is the anti-hallucination gate and must not be
   weakened. Missing capability is an honest limitation, not a safety refusal.
-- One source message gets one placeholder and one final edit. Source-channel
-  tools must not send a second final response.
+- One source message gets one reply, and that reply ends on the answer. The
+  runtime may edit it while the turn runs to show progress; those edits are
+  coalesced, must never persist, and a failed progress edit must not fail the
+  turn. Source-channel tools must not send a second response.
 - Keep stable tool IDs and Zod schemas. Validate model-facing tool results.
   Tool metadata and the executable registry must stay identical; startup calls
   `getCapabilityCatalog` and refuses to boot on a mismatch.

--- a/packages/birmel/README.md
+++ b/packages/birmel/README.md
@@ -6,7 +6,12 @@ assembled into a context bundle, and handed to one agent that works the request
 to a conclusion. The agent sees every registered tool and decides as it goes,
 so investigating and then changing approach is normal rather than an error.
 It finishes with a structured answer whose cited tool calls must match calls
-that actually succeeded, and the runtime edits one Discord reply.
+that actually succeeded.
+
+While it works, the turn narrates into the single Discord reply it owns: a
+throttled timeline of what ran, with the agent's own one-line description of
+what it is doing, resolving to the answer. Progress edits are best-effort and
+never persisted.
 
 There is deliberately no up-front router. Routing used to pick one specialist
 and one primary tool from assembled context alone, before any tool could run,

--- a/packages/birmel/src/agent-runtime/agent.ts
+++ b/packages/birmel/src/agent-runtime/agent.ts
@@ -26,15 +26,16 @@ const ToolIdSchema = z
   .max(64)
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
 const EffectDispositionSchema = z.enum(["not_applied", "applied", "unknown"]);
+const ToolDomainResultSchema = z.object({
+  success: z.boolean(),
+  message: z.string().min(1),
+  effectDisposition: EffectDispositionSchema.optional(),
+});
 const ToolResultForSessionSchema = z.object({
   toolCallId: z.string().min(1).max(200),
   toolName: ToolIdSchema,
   input: z.unknown(),
-  output: z.object({
-    success: z.boolean(),
-    message: z.string().min(1),
-    effectDisposition: EffectDispositionSchema.optional(),
-  }),
+  output: ToolDomainResultSchema,
 });
 const SessionToolEventSchema = z.strictObject({
   toolCallId: z.string().min(1).max(200),
@@ -79,7 +80,7 @@ export type TurnOptions = {
    * Live progress sink. Absent for scheduled jobs, which own no Discord
    * message to narrate into.
    */
-  progress?: ProgressReporter;
+  progress?: ProgressReporter | undefined;
 };
 
 export type IsolatedAgentOptions = {
@@ -390,14 +391,37 @@ export async function executeTurn(
                 toolOutput,
                 toolExecutionMs,
               }) => {
+                // A tool that resolves rather than throws still reports its
+                // own success/failure inside the resolved value (the same
+                // field summarizeToolResultForSession reads), so a validation
+                // failure inside the tool would otherwise render as a
+                // misleading ✓. Fall back to "resolved at all" only for a
+                // shape this check does not recognize.
+                const domainResult = ToolDomainResultSchema.safeParse(
+                  toolOutput.type === "tool-result"
+                    ? toolOutput.output
+                    : undefined,
+                );
+                const succeeded = domainResult.success
+                  ? domainResult.data.success
+                  : toolOutput.type !== "tool-error";
                 progress.toolFinished(
                   toolCall.toolCallId,
-                  toolOutput.type !== "tool-error",
+                  succeeded,
                   toolExecutionMs,
                 );
               },
-              onStepFinish: ({ text }) => {
-                progress.stepFinished(text);
+              onStepStart: ({ stepNumber }) => {
+                progress.stepStarted(stepNumber);
+              },
+              onStepFinish: ({ stepNumber, text, toolCalls }) => {
+                // The finishing step answers with structured TurnAnswer JSON
+                // and calls no tool, so its "text" is wire JSON, not the
+                // requested plain-language sentence. Narration only ever
+                // comes from a step that actually did something.
+                if (toolCalls.length > 0) {
+                  progress.stepFinished(stepNumber, text);
+                }
               },
             }),
         ...runtime.callOptions({

--- a/packages/birmel/src/agent-runtime/agent.ts
+++ b/packages/birmel/src/agent-runtime/agent.ts
@@ -16,6 +16,7 @@ import { withSpan } from "@shepherdjerred/birmel/observability/tracing.ts";
 import { loggers } from "@shepherdjerred/birmel/utils/logger.ts";
 import { getOpenRouterProviderOptions } from "./provider-options.ts";
 import { AGENT_INSTRUCTIONS } from "./prompts.ts";
+import type { ProgressReporter } from "./progress.ts";
 
 const logger = loggers.agent.child("execution");
 
@@ -71,6 +72,14 @@ export type AgentExecutionResult = {
   outputTokens: number;
   stepCount: number;
   toolEvents: SessionToolEvent[];
+};
+
+export type TurnOptions = {
+  /**
+   * Live progress sink. Absent for scheduled jobs, which own no Discord
+   * message to narrate into.
+   */
+  progress?: ProgressReporter;
 };
 
 export type IsolatedAgentOptions = {
@@ -323,7 +332,7 @@ export function requireGroundedAnswer(
 
 export async function executeTurn(
   rawPacket: TaskPacket,
-  options: IsolatedAgentOptions = {},
+  options: IsolatedAgentOptions & TurnOptions = {},
 ): Promise<AgentExecutionResult> {
   const packet = TaskPacketSchema.parse(rawPacket);
   const config = getConfig();
@@ -360,11 +369,37 @@ export async function executeTurn(
         providerOptions: getOpenRouterProviderOptions(options),
         output: Output.object({ schema: TurnAnswerSchema }),
       });
+      const progress = options.progress;
       const result = await agent.generate({
         messages: taskMessages(packet),
         abortSignal: AbortSignal.timeout(
           options.timeoutMs ?? config.agent.responseTimeoutMs,
         ),
+        ...(progress === undefined
+          ? {}
+          : {
+              onToolExecutionStart: ({ toolCall }) => {
+                progress.toolStarted(
+                  toolCall.toolCallId,
+                  toolCall.toolName,
+                  toolCall.input,
+                );
+              },
+              onToolExecutionEnd: ({
+                toolCall,
+                toolOutput,
+                toolExecutionMs,
+              }) => {
+                progress.toolFinished(
+                  toolCall.toolCallId,
+                  toolOutput.type !== "tool-error",
+                  toolExecutionMs,
+                );
+              },
+              onStepFinish: ({ text }) => {
+                progress.stepFinished(text);
+              },
+            }),
         ...runtime.callOptions({
           workload: "birmel.agent.turn",
           sessionId: packet.threadId ?? packet.channelId,

--- a/packages/birmel/src/agent-runtime/message-handler.ts
+++ b/packages/birmel/src/agent-runtime/message-handler.ts
@@ -13,7 +13,10 @@ import {
   type AgentExecutionResult,
 } from "@shepherdjerred/birmel/agent-runtime/agent.ts";
 import { createTaskPacket } from "@shepherdjerred/birmel/agent-runtime/runtime.ts";
-import { createProgressReporter } from "@shepherdjerred/birmel/agent-runtime/progress.ts";
+import {
+  createProgressReporter,
+  type ProgressReporter,
+} from "@shepherdjerred/birmel/agent-runtime/progress.ts";
 import { withTurnQueue } from "@shepherdjerred/birmel/agent-runtime/turn-queue.ts";
 import {
   runWithRequestContext,
@@ -199,6 +202,7 @@ async function processAdmittedTurn(
 ): Promise<void> {
   let responseMessage: Message | undefined;
   let finalResponseDelivered = false;
+  let progress: ProgressReporter | undefined;
   const discordContext: DiscordContext = {
     guildId: context.turn.guildId,
     channelId: context.turn.channelId,
@@ -270,7 +274,7 @@ async function processAdmittedTurn(
     // The turn narrates into the message it already owns. Still one reply and
     // one final state; the intermediate edits are what make a multi-step turn
     // legible instead of a silent wait behind a placeholder.
-    const progress = createProgressReporter({
+    progress = createProgressReporter({
       maxSteps: getConfig().agent.maxSteps,
       publish: async (body) => {
         await deliveredResponseMessage.edit(body);
@@ -381,6 +385,10 @@ async function processAdmittedTurn(
       });
       return;
     }
+    // A launched-but-not-yet-settled progress edit must not land after the
+    // incident edit below - that would leave "Working…" on screen forever
+    // even though the turn already failed and reported it.
+    await progress?.flush();
     const reference = incidentId();
     if (responseMessage != null) {
       try {

--- a/packages/birmel/src/agent-runtime/message-handler.ts
+++ b/packages/birmel/src/agent-runtime/message-handler.ts
@@ -13,6 +13,7 @@ import {
   type AgentExecutionResult,
 } from "@shepherdjerred/birmel/agent-runtime/agent.ts";
 import { createTaskPacket } from "@shepherdjerred/birmel/agent-runtime/runtime.ts";
+import { createProgressReporter } from "@shepherdjerred/birmel/agent-runtime/progress.ts";
 import { withTurnQueue } from "@shepherdjerred/birmel/agent-runtime/turn-queue.ts";
 import {
   runWithRequestContext,
@@ -266,6 +267,22 @@ async function processAdmittedTurn(
           }
         : {}),
     };
+    // The turn narrates into the message it already owns. Still one reply and
+    // one final state; the intermediate edits are what make a multi-step turn
+    // legible instead of a silent wait behind a placeholder.
+    const progress = createProgressReporter({
+      maxSteps: getConfig().agent.maxSteps,
+      publish: async (body) => {
+        await deliveredResponseMessage.edit(body);
+      },
+      onPublishError: (error) => {
+        logger.warn("Could not deliver Birmel turn progress", {
+          runId,
+          messageId: context.turn.discordMessageId,
+          error: toError(error).message,
+        });
+      },
+    });
     const execution = await runWithRequestContext(
       requestContext,
       async () =>
@@ -276,8 +293,12 @@ async function processAdmittedTurn(
             personaId: persona,
             persona: personaPrompt,
           }),
+          { progress },
         ),
     );
+    // Settle in-flight progress edits before the final one so a late progress
+    // write cannot land on top of the delivered answer.
+    await progress.flush();
     const response = validateResponse(execution.text);
     const stagedAttachments = requestContext.stagedAttachments ?? [];
     const files = stagedAttachments.map(

--- a/packages/birmel/src/agent-runtime/progress.ts
+++ b/packages/birmel/src/agent-runtime/progress.ts
@@ -1,0 +1,212 @@
+import { z } from "zod";
+
+/**
+ * Live turn progress, rendered into the one Discord message the turn owns.
+ *
+ * Before the agentic loop a turn was a single pre-planned tool call, so there
+ * was nothing to narrate: the reply either arrived or an incident reference
+ * did. Now a turn investigates and can change approach, which is worth seeing -
+ * and can take a while, which makes a static "…" placeholder the worst part of
+ * the experience.
+ *
+ * Rendering is pure and the publish side is coalesced, so this module can be
+ * tested without Discord and without timers.
+ */
+
+const MAX_VISIBLE_ENTRIES = 8;
+const MAX_NARRATION_CHARACTERS = 280;
+const MAX_LABEL_CHARACTERS = 96;
+/** Discord hard-caps a message at 2000 characters. */
+const MAX_PROGRESS_CHARACTERS = 1900;
+const DEFAULT_MIN_PUBLISH_INTERVAL_MS = 1500;
+
+export const ProgressEntryStatusSchema = z.enum(["running", "done", "failed"]);
+export type ProgressEntryStatus = z.infer<typeof ProgressEntryStatusSchema>;
+
+export type ProgressEntry = {
+  toolCallId: string;
+  label: string;
+  status: ProgressEntryStatus;
+  durationMs?: number;
+};
+
+export type ProgressState = {
+  entries: ProgressEntry[];
+  narration: string | undefined;
+  stepNumber: number;
+  maxSteps: number;
+  elapsedMs: number;
+};
+
+function truncate(value: string, maxLength: number): string {
+  const collapsed = value.replaceAll(/\s+/gu, " ").trim();
+  return collapsed.length <= maxLength
+    ? collapsed
+    : `${collapsed.slice(0, maxLength - 1)}…`;
+}
+
+/**
+ * Turn a tool id and its input into something a person can read.
+ *
+ * Deliberately derived rather than hand-maintained per tool: a label table
+ * would be one more thing to forget when a tool is added, and a stale label is
+ * worse than a plain one. The model's own narration carries the nuance.
+ */
+export function humanizeToolLabel(toolId: string, input: unknown): string {
+  const words = toolId.split("-").filter((part) => part.length > 0);
+  const base =
+    words.length === 0
+      ? toolId
+      : `${(words[0] ?? "").charAt(0).toUpperCase()}${(words[0] ?? "").slice(1)}${
+          words.length > 1 ? ` ${words.slice(1).join(" ")}` : ""
+        }`;
+  const action = z
+    .object({ action: z.string().min(1).max(40) })
+    .safeParse(input);
+  return truncate(
+    action.success ? `${base} (${action.data.action})` : base,
+    MAX_LABEL_CHARACTERS,
+  );
+}
+
+function formatDuration(ms: number): string {
+  return ms < 1000
+    ? `${String(Math.max(0, Math.round(ms)))}ms`
+    : `${(ms / 1000).toFixed(1)}s`;
+}
+
+function renderEntry(entry: ProgressEntry): string {
+  const marker =
+    entry.status === "done" ? "✓" : entry.status === "failed" ? "✗" : "⋯";
+  const duration =
+    entry.status === "running" || entry.durationMs === undefined
+      ? ""
+      : ` · ${formatDuration(entry.durationMs)}`;
+  return `${marker} ${entry.label}${duration}`;
+}
+
+export function renderProgress(state: ProgressState): string {
+  const hidden = Math.max(0, state.entries.length - MAX_VISIBLE_ENTRIES);
+  const visible = state.entries.slice(-MAX_VISIBLE_ENTRIES);
+  const lines = [
+    "🔎 Working…",
+    "",
+    ...(state.narration === undefined
+      ? []
+      : [`> ${truncate(state.narration, MAX_NARRATION_CHARACTERS)}`, ""]),
+    ...(hidden === 0
+      ? []
+      : [`… ${String(hidden)} earlier step${hidden === 1 ? "" : "s"}`]),
+    ...visible.map((entry) => renderEntry(entry)),
+    ...(visible.length === 0 ? [] : [""]),
+    `step ${String(state.stepNumber)}/${String(state.maxSteps)} · ${formatDuration(state.elapsedMs)}`,
+  ];
+  const rendered = lines.join("\n");
+  return rendered.length <= MAX_PROGRESS_CHARACTERS
+    ? rendered
+    : `${rendered.slice(0, MAX_PROGRESS_CHARACTERS - 1)}…`;
+}
+
+export type ProgressReporter = {
+  toolStarted: (toolCallId: string, toolId: string, input: unknown) => void;
+  toolFinished: (
+    toolCallId: string,
+    succeeded: boolean,
+    durationMs: number,
+  ) => void;
+  stepFinished: (stepText: string) => void;
+  /** Publish anything still pending. Safe to call more than once. */
+  flush: () => Promise<void>;
+  snapshot: () => ProgressState;
+};
+
+export function createProgressReporter(options: {
+  maxSteps: number;
+  publish: (body: string) => Promise<void>;
+  onPublishError: (error: unknown) => void;
+  now?: () => number;
+  minPublishIntervalMs?: number;
+}): ProgressReporter {
+  const now = options.now ?? (() => Date.now());
+  const minInterval =
+    options.minPublishIntervalMs ?? DEFAULT_MIN_PUBLISH_INTERVAL_MS;
+  const startedAt = now();
+  const entries: ProgressEntry[] = [];
+  let narration: string | undefined;
+  let stepNumber = 0;
+  let lastPublishedAt = Number.NEGATIVE_INFINITY;
+  let pending = false;
+  let inFlight: Promise<void> = Promise.resolve();
+
+  function snapshot(): ProgressState {
+    return {
+      entries: [...entries],
+      narration,
+      stepNumber,
+      maxSteps: options.maxSteps,
+      elapsedMs: now() - startedAt,
+    };
+  }
+
+  function publishNow(): void {
+    lastPublishedAt = now();
+    pending = false;
+    const body = renderProgress(snapshot());
+    const previous = inFlight;
+    // A failed progress edit must not fail the turn: this message is cosmetic
+    // and the final edit is the actual contract. It is reported rather than
+    // swallowed so a persistently rate-limited channel is visible in logs.
+    inFlight = (async () => {
+      await previous;
+      try {
+        await options.publish(body);
+      } catch (error: unknown) {
+        options.onPublishError(error);
+      }
+    })();
+  }
+
+  function notify(): void {
+    if (now() - lastPublishedAt >= minInterval) {
+      publishNow();
+      return;
+    }
+    pending = true;
+  }
+
+  return {
+    toolStarted(toolCallId, toolId, input) {
+      entries.push({
+        toolCallId,
+        label: humanizeToolLabel(toolId, input),
+        status: "running",
+      });
+      notify();
+    },
+    toolFinished(toolCallId, succeeded, durationMs) {
+      const entry = entries.findLast(
+        (candidate) => candidate.toolCallId === toolCallId,
+      );
+      if (entry !== undefined) {
+        entry.status = succeeded ? "done" : "failed";
+        entry.durationMs = durationMs;
+      }
+      notify();
+    },
+    stepFinished(stepText) {
+      stepNumber += 1;
+      const trimmed = stepText.trim();
+      if (trimmed.length > 0) {
+        narration = trimmed;
+      }
+      notify();
+    },
+    async flush() {
+      if (pending) {
+        publishNow();
+      }
+      await inFlight;
+    },
+    snapshot,
+  };
+}

--- a/packages/birmel/src/agent-runtime/progress.ts
+++ b/packages/birmel/src/agent-runtime/progress.ts
@@ -114,7 +114,10 @@ export type ProgressReporter = {
     succeeded: boolean,
     durationMs: number,
   ) => void;
-  stepFinished: (stepText: string) => void;
+  /** stepNumber is the AI SDK's own 0-based step index, from onStepStart. */
+  stepStarted: (stepNumber: number) => void;
+  /** stepNumber must match the stepStarted call for the same step. */
+  stepFinished: (stepNumber: number, stepText: string) => void;
   /** Publish anything still pending. Safe to call more than once. */
   flush: () => Promise<void>;
   snapshot: () => ProgressState;
@@ -133,7 +136,10 @@ export function createProgressReporter(options: {
   const startedAt = now();
   const entries: ProgressEntry[] = [];
   let narration: string | undefined;
-  let stepNumber = 0;
+  // Which displayed step (1-based) the current narration was written for, so
+  // it can be hidden once a newer step starts - see stepStarted below.
+  let narrationStepNumber = 0;
+  let displayStepNumber = 0;
   let lastPublishedAt = Number.NEGATIVE_INFINITY;
   let pending = false;
   let inFlight: Promise<void> = Promise.resolve();
@@ -141,8 +147,9 @@ export function createProgressReporter(options: {
   function snapshot(): ProgressState {
     return {
       entries: [...entries],
-      narration,
-      stepNumber,
+      narration:
+        narrationStepNumber === displayStepNumber ? narration : undefined,
+      stepNumber: displayStepNumber,
       maxSteps: options.maxSteps,
       elapsedMs: now() - startedAt,
     };
@@ -193,11 +200,15 @@ export function createProgressReporter(options: {
       }
       notify();
     },
-    stepFinished(stepText) {
-      stepNumber += 1;
+    stepStarted(stepNumber) {
+      displayStepNumber = stepNumber + 1;
+      notify();
+    },
+    stepFinished(stepNumber, stepText) {
       const trimmed = stepText.trim();
       if (trimmed.length > 0) {
         narration = trimmed;
+        narrationStepNumber = stepNumber + 1;
       }
       notify();
     },

--- a/packages/birmel/src/agent-runtime/prompts.ts
+++ b/packages/birmel/src/agent-runtime/prompts.ts
@@ -16,6 +16,8 @@ export const AGENT_INSTRUCTIONS = `${CORE_SYSTEM_POLICY}
 
 Work the request to a conclusion using your registered tools. Investigate first when the answer depends on live state: read before you write, and let what you find change your approach. Choosing a tool, seeing that it was the wrong one, and trying another is normal and expected - it is not a failure.
 
+Before each tool call, say in one short sentence what you are about to do and why, in plain language. That line is shown live to the person waiting, so write it for them: no tool names, no internal identifiers, no reasoning transcript.
+
 Do not infer capabilities from names in the request, prior assistant text, context, shell access, or general knowledge. Only your registered tools exist. General shell, browser, and research tools do not imply access to a private application's database, API, currency, or mutation surface. Verify writes with a read-back before reporting success. Durable delayed work must use manage-job.
 
 When generating or editing images, write a rich descriptive prompt; when editing an image from a message attachment or referenced reply, leave referenceImageUrl omitted so the tool automatically uses turn context, and only provide referenceImageUrl if the user explicitly provided an external image URL in their text.

--- a/packages/birmel/tests/flow/contracts.ts
+++ b/packages/birmel/tests/flow/contracts.ts
@@ -17,6 +17,9 @@ export const FlowScenarioSchema = z.enum([
   "agent-run-persistence",
   "session-persistence-failure",
   "agent-run-completion-failure",
+  // Appended: scenario order derives fixture message IDs, so inserting in the
+  // middle renumbers every existing expectation.
+  "agent-progress",
 ]);
 
 export type FlowScenario = z.infer<typeof FlowScenarioSchema>;

--- a/packages/birmel/tests/flow/flow-harness.ts
+++ b/packages/birmel/tests/flow/flow-harness.ts
@@ -21,6 +21,43 @@ import {
 } from "./message-fixture.ts";
 import { suppressAutomaticMemoryExtraction } from "@shepherdjerred/birmel/agent-tools/tools/request-context.ts";
 import { memoryExtractionErrorCount } from "./metrics-inspection.ts";
+const ProgressReporterSchema = z.custom<{
+  stepFinished: (text: string) => void;
+  toolStarted: (id: string, toolId: string, input: unknown) => void;
+  toolFinished: (id: string, ok: boolean, ms: number) => void;
+  flush: () => Promise<void>;
+}>(
+  (value) =>
+    typeof value === "object" &&
+    value !== null &&
+    ["stepFinished", "toolStarted", "toolFinished", "flush"].every(
+      (key) => typeof Reflect.get(value, key) === "function",
+    ),
+  "Invalid progress reporter",
+);
+const ProgressOptionsSchema = z.object({ progress: ProgressReporterSchema });
+
+function successfulToolTurn(text: string) {
+  return {
+    text,
+    disposition: "supported",
+    finishReason: "stop",
+    inputTokens: 20,
+    outputTokens: 8,
+    stepCount: 2,
+    toolEvents: [
+      {
+        toolCallId: "flow-tool-call-1",
+        toolId: "manage-message",
+        inputSummary: "{}",
+        resultSummary: "Message completed",
+        content: "Tool manage-message completed",
+        success: true,
+      },
+    ],
+  };
+}
+
 // The agent now receives a task packet, not a turn plus a route decision.
 const AgentPacketSchema = z.object({
   request: z.string(),
@@ -116,9 +153,21 @@ vi.doMock("@shepherdjerred/birmel/context/turn-context.ts", () => ({
 }));
 
 vi.doMock("@shepherdjerred/birmel/agent-runtime/agent.ts", () => ({
-  executeTurn: (rawPacket: unknown) => {
+  executeTurn: async (rawPacket: unknown, options?: unknown) => {
     const packet = AgentPacketSchema.parse(rawPacket);
     state.agentCalls += 1;
+
+    // Only this scenario drives progress, so every other flow assertion keeps
+    // observing exactly one delivered edit.
+    if (state.scenario === "agent-progress") {
+      const { progress } = ProgressOptionsSchema.parse(options);
+      progress.stepFinished("Checking who has been active.");
+      progress.toolStarted("flow-tool-call-1", "get-activity-stats", {});
+      progress.toolFinished("flow-tool-call-1", true, 42);
+      await progress.flush();
+      state.toolCalls += 1;
+      return successfulToolTurn(`agent reply for ${packet.request}`);
+    }
 
     if (state.scenario === "agent-failure") {
       throw new Error("AGENT_SECRET_EXCEPTION");
@@ -170,24 +219,7 @@ vi.doMock("@shepherdjerred/birmel/agent-runtime/agent.ts", () => ({
       );
     }
 
-    return {
-      text: `agent reply for ${packet.request}`,
-      disposition: "supported",
-      finishReason: "stop",
-      inputTokens: 20,
-      outputTokens: 8,
-      stepCount: 2,
-      toolEvents: [
-        {
-          toolCallId: "flow-tool-call-1",
-          toolId: "manage-message",
-          inputSummary: "{}",
-          resultSummary: "Message completed",
-          content: "Tool manage-message completed",
-          success: true,
-        },
-      ],
-    };
+    return successfulToolTurn(`agent reply for ${packet.request}`);
   },
 }));
 
@@ -221,6 +253,7 @@ vi.doMock("@shepherdjerred/birmel/config/index.ts", () => ({
   getConfig: () => ({
     responder: { transcriptWindowMs: 3_600_000, transcriptMaxMessages: 50 },
     persona: { enabled: true },
+    agent: { maxSteps: 12 },
   }),
 }));
 

--- a/packages/birmel/tests/flow/flow-harness.ts
+++ b/packages/birmel/tests/flow/flow-harness.ts
@@ -22,7 +22,8 @@ import {
 import { suppressAutomaticMemoryExtraction } from "@shepherdjerred/birmel/agent-tools/tools/request-context.ts";
 import { memoryExtractionErrorCount } from "./metrics-inspection.ts";
 const ProgressReporterSchema = z.custom<{
-  stepFinished: (text: string) => void;
+  stepStarted: (stepNumber: number) => void;
+  stepFinished: (stepNumber: number, text: string) => void;
   toolStarted: (id: string, toolId: string, input: unknown) => void;
   toolFinished: (id: string, ok: boolean, ms: number) => void;
   flush: () => Promise<void>;
@@ -30,9 +31,13 @@ const ProgressReporterSchema = z.custom<{
   (value) =>
     typeof value === "object" &&
     value !== null &&
-    ["stepFinished", "toolStarted", "toolFinished", "flush"].every(
-      (key) => typeof Reflect.get(value, key) === "function",
-    ),
+    [
+      "stepStarted",
+      "stepFinished",
+      "toolStarted",
+      "toolFinished",
+      "flush",
+    ].every((key) => typeof Reflect.get(value, key) === "function"),
   "Invalid progress reporter",
 );
 const ProgressOptionsSchema = z.object({ progress: ProgressReporterSchema });
@@ -151,7 +156,6 @@ vi.doMock("@shepherdjerred/birmel/context/turn-context.ts", () => ({
     return createContextBundle();
   },
 }));
-
 vi.doMock("@shepherdjerred/birmel/agent-runtime/agent.ts", () => ({
   executeTurn: async (rawPacket: unknown, options?: unknown) => {
     const packet = AgentPacketSchema.parse(rawPacket);
@@ -161,7 +165,8 @@ vi.doMock("@shepherdjerred/birmel/agent-runtime/agent.ts", () => ({
     // observing exactly one delivered edit.
     if (state.scenario === "agent-progress") {
       const { progress } = ProgressOptionsSchema.parse(options);
-      progress.stepFinished("Checking who has been active.");
+      progress.stepStarted(0);
+      progress.stepFinished(0, "Checking who has been active.");
       progress.toolStarted("flow-tool-call-1", "get-activity-stats", {});
       progress.toolFinished("flow-tool-call-1", true, 42);
       await progress.flush();
@@ -222,7 +227,6 @@ vi.doMock("@shepherdjerred/birmel/agent-runtime/agent.ts", () => ({
     return successfulToolTurn(`agent reply for ${packet.request}`);
   },
 }));
-
 vi.doMock("@shepherdjerred/birmel/agent-runtime/memory-extraction.ts", () => ({
   extractAndApplyTurnMemory: () => {
     state.memoryExtractionCalls += 1;
@@ -232,11 +236,9 @@ vi.doMock("@shepherdjerred/birmel/agent-runtime/memory-extraction.ts", () => ({
     return Promise.resolve();
   },
 }));
-
 vi.doMock("@shepherdjerred/birmel/persona/guild-persona.ts", () => ({
   getGuildPersona: () => Promise.resolve("Compact elected persona"),
 }));
-
 vi.doMock("@shepherdjerred/birmel/discord/utils/channel-history.ts", () => ({
   getConversationTranscriptResult: () =>
     Promise.resolve({
@@ -244,11 +246,9 @@ vi.doMock("@shepherdjerred/birmel/discord/utils/channel-history.ts", () => ({
       fetchFailed: false,
     }),
 }));
-
 vi.doMock("@shepherdjerred/birmel/discord/engagement-tracker.ts", () => ({
   markEngaged: () => null,
 }));
-
 vi.doMock("@shepherdjerred/birmel/config/index.ts", () => ({
   getConfig: () => ({
     responder: { transcriptWindowMs: 3_600_000, transcriptMaxMessages: 50 },
@@ -256,7 +256,6 @@ vi.doMock("@shepherdjerred/birmel/config/index.ts", () => ({
     agent: { maxSteps: 12 },
   }),
 }));
-
 vi.doMock("@shepherdjerred/birmel/sessions/service.ts", () => ({
   appendSessionEvent: (rawOptions: unknown) => {
     const options = SessionEventOptionsSchema.parse(rawOptions);
@@ -287,17 +286,14 @@ vi.doMock("@shepherdjerred/birmel/sessions/service.ts", () => ({
     return Promise.resolve(state.sessionActive);
   },
 }));
-
 vi.doMock("@shepherdjerred/birmel/sessions/summarization.ts", () => ({
   summarizeSessionIfNeeded: () => Promise.resolve(),
 }));
-
 vi.doMock("@shepherdjerred/birmel/observability/sentry.ts", () => ({
   captureException: () => null,
   clearSentryContext: () => null,
   setSentryContext: () => null,
 }));
-
 vi.doMock("@shepherdjerred/birmel/observability/tracing.ts", () => ({
   withSpan: async (
     _name: string,
@@ -305,7 +301,6 @@ vi.doMock("@shepherdjerred/birmel/observability/tracing.ts", () => ({
     operation: (span: typeof fakeSpan) => Promise<unknown>,
   ) => await operation(fakeSpan),
 }));
-
 vi.doMock("@shepherdjerred/birmel/utils/logger.ts", () => ({
   logger: {
     info: (..._values: unknown[]) => null,

--- a/packages/birmel/tests/flow/turn-flow.test.ts
+++ b/packages/birmel/tests/flow/turn-flow.test.ts
@@ -107,6 +107,27 @@ describe("successful deterministic turn flow", () => {
     expect(result.toolCallCounts).toEqual([1]);
   });
 
+  test("a working turn narrates into its own message and still ends on the answer", () => {
+    const result = resultFor("agent-progress");
+
+    expect(result.runStatuses).toEqual(["completed"]);
+    // Still one reply. The extra edits are progress on that same message, so
+    // the "one placeholder, one final state" contract is intact.
+    expect(result.replyCalls).toBe(1);
+    expect(result.deliveredEdits.length).toBeGreaterThan(1);
+    expect(
+      result.deliveredEdits.some((edit) => edit.includes("🔎 Working…")),
+    ).toBe(true);
+    expect(
+      result.deliveredEdits.some((edit) =>
+        edit.includes("Checking who has been active."),
+      ),
+    ).toBe(true);
+    // Whatever progress showed, the last thing on screen is the answer.
+    expect(result.deliveredEdits.at(-1)).toMatch(/^agent reply/u);
+    expect(result.deliveredEdits.at(-1)).not.toContain("🔎 Working…");
+  });
+
   test("restart-safe Discord message deduplication produces only one response", () => {
     const result = resultFor("dedupe");
 

--- a/packages/birmel/tests/runtime/progress.test.ts
+++ b/packages/birmel/tests/runtime/progress.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from "vitest";
+import {
+  createProgressReporter,
+  humanizeToolLabel,
+  renderProgress,
+} from "@shepherdjerred/birmel/agent-runtime/progress.ts";
+
+describe("humanizeToolLabel", () => {
+  test("reads a tool id as words", () => {
+    expect(humanizeToolLabel("get-activity-stats", {})).toBe(
+      "Get activity stats",
+    );
+  });
+
+  test("includes the action when the input names one", () => {
+    expect(humanizeToolLabel("manage-role", { action: "add" })).toBe(
+      "Manage role (add)",
+    );
+  });
+
+  test("ignores input that is not an action-shaped object", () => {
+    expect(humanizeToolLabel("web-research", { query: "anything" })).toBe(
+      "Web research",
+    );
+  });
+});
+
+describe("renderProgress", () => {
+  test("marks running, done, and failed steps distinctly", () => {
+    const body = renderProgress({
+      entries: [
+        {
+          toolCallId: "a",
+          label: "Get activity stats",
+          status: "done",
+          durationMs: 400,
+        },
+        {
+          toolCallId: "b",
+          label: "Manage role (add)",
+          status: "failed",
+          durationMs: 1200,
+        },
+        { toolCallId: "c", label: "Manage role (list)", status: "running" },
+      ],
+      narration: "Checking who has been active, then updating the role.",
+      stepNumber: 3,
+      maxSteps: 12,
+      elapsedMs: 14_000,
+    });
+
+    expect(body).toContain("✓ Get activity stats · 400ms");
+    expect(body).toContain("✗ Manage role (add) · 1.2s");
+    expect(body).toContain("⋯ Manage role (list)");
+    expect(body).toContain("> Checking who has been active");
+    expect(body).toContain("step 3/12 · 14.0s");
+  });
+
+  test("summarizes older steps instead of growing without bound", () => {
+    const body = renderProgress({
+      entries: Array.from({ length: 12 }, (_, index) => ({
+        toolCallId: String(index),
+        label: `Step ${String(index)}`,
+        status: "done" as const,
+        durationMs: 10,
+      })),
+      narration: undefined,
+      stepNumber: 12,
+      maxSteps: 12,
+      elapsedMs: 1000,
+    });
+
+    expect(body).toContain("… 4 earlier steps");
+    expect(body).not.toContain("Step 0");
+    expect(body).toContain("Step 11");
+  });
+
+  test("stays inside Discord's message ceiling", () => {
+    const body = renderProgress({
+      entries: Array.from({ length: 8 }, (_, index) => ({
+        toolCallId: String(index),
+        label: "x".repeat(400),
+        status: "done" as const,
+        durationMs: 10,
+      })),
+      narration: "y".repeat(4000),
+      stepNumber: 8,
+      maxSteps: 12,
+      elapsedMs: 1000,
+    });
+
+    expect(body.length).toBeLessThanOrEqual(2000);
+  });
+});
+
+function harness(startAt = 0) {
+  const published: string[] = [];
+  const errors: unknown[] = [];
+  let clock = startAt;
+  const reporter = createProgressReporter({
+    maxSteps: 12,
+    now: () => clock,
+    minPublishIntervalMs: 1000,
+    publish: async (body) => {
+      published.push(body);
+    },
+    onPublishError: (error) => {
+      errors.push(error);
+    },
+  });
+  return {
+    reporter,
+    published,
+    errors,
+    advance: (ms: number) => {
+      clock += ms;
+    },
+  };
+}
+
+describe("createProgressReporter", () => {
+  test("publishes the first update immediately", async () => {
+    const { reporter, published } = harness();
+    reporter.toolStarted("call-1", "get-activity-stats", {});
+    await reporter.flush();
+
+    expect(published).toHaveLength(1);
+    expect(published[0]).toContain("⋯ Get activity stats");
+  });
+
+  test("coalesces rapid updates instead of editing per event", async () => {
+    const { reporter, published, advance } = harness();
+    reporter.toolStarted("call-1", "get-activity-stats", {});
+    reporter.toolFinished("call-1", true, 10);
+    reporter.toolStarted("call-2", "manage-role", { action: "add" });
+    advance(10);
+    await reporter.flush();
+
+    // One immediate publish, then a single coalesced flush for the rest.
+    expect(published).toHaveLength(2);
+    expect(published.at(-1)).toContain("⋯ Manage role (add)");
+    expect(published.at(-1)).toContain("✓ Get activity stats");
+  });
+
+  test("publishes again once the interval has passed", async () => {
+    const { reporter, published, advance } = harness();
+    reporter.toolStarted("call-1", "get-activity-stats", {});
+    advance(1500);
+    reporter.toolFinished("call-1", true, 1500);
+    await reporter.flush();
+
+    expect(published).toHaveLength(2);
+  });
+
+  test("records a failed tool as failed", async () => {
+    const { reporter, published, advance } = harness();
+    reporter.toolStarted("call-1", "manage-role", { action: "add" });
+    advance(1500);
+    reporter.toolFinished("call-1", false, 900);
+    await reporter.flush();
+
+    expect(published.at(-1)).toContain("✗ Manage role (add)");
+  });
+
+  test("uses the model's own narration when it gives one", async () => {
+    const { reporter, published, advance } = harness();
+    reporter.stepFinished("Looking up who has been active this week.");
+    advance(1500);
+    reporter.toolStarted("call-1", "get-activity-stats", {});
+    await reporter.flush();
+
+    expect(published.at(-1)).toContain(
+      "> Looking up who has been active this week.",
+    );
+  });
+
+  test("keeps the previous narration when a step adds none", async () => {
+    const { reporter, published, advance } = harness();
+    reporter.stepFinished("First thing.");
+    advance(1500);
+    reporter.stepFinished("   ");
+    await reporter.flush();
+
+    expect(published.at(-1)).toContain("> First thing.");
+  });
+
+  test("reports a failed edit without failing the turn", async () => {
+    const published: string[] = [];
+    const errors: unknown[] = [];
+    const reporter = createProgressReporter({
+      maxSteps: 12,
+      now: () => 0,
+      minPublishIntervalMs: 0,
+      publish: async () => {
+        published.push("attempted");
+        throw new Error("discord rate limited");
+      },
+      onPublishError: (error) => {
+        errors.push(error);
+      },
+    });
+
+    reporter.toolStarted("call-1", "get-activity-stats", {});
+    await expect(reporter.flush()).resolves.toBeUndefined();
+    expect(published).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+  });
+
+  test("counts steps against the budget", async () => {
+    const { reporter, published, advance } = harness();
+    reporter.stepFinished("one");
+    advance(1500);
+    reporter.stepFinished("two");
+    await reporter.flush();
+
+    expect(published.at(-1)).toContain("step 2/12");
+  });
+});

--- a/packages/birmel/tests/runtime/progress.test.ts
+++ b/packages/birmel/tests/runtime/progress.test.ts
@@ -164,7 +164,8 @@ describe("createProgressReporter", () => {
 
   test("uses the model's own narration when it gives one", async () => {
     const { reporter, published, advance } = harness();
-    reporter.stepFinished("Looking up who has been active this week.");
+    reporter.stepStarted(0);
+    reporter.stepFinished(0, "Looking up who has been active this week.");
     advance(1500);
     reporter.toolStarted("call-1", "get-activity-stats", {});
     await reporter.flush();
@@ -174,14 +175,31 @@ describe("createProgressReporter", () => {
     );
   });
 
-  test("keeps the previous narration when a step adds none", async () => {
+  test("keeps narration visible while its own step's tool is still running", async () => {
     const { reporter, published, advance } = harness();
-    reporter.stepFinished("First thing.");
+    reporter.stepStarted(0);
+    reporter.stepFinished(0, "First thing.");
     advance(1500);
-    reporter.stepFinished("   ");
+    reporter.toolStarted("call-1", "manage-role", {});
     await reporter.flush();
 
     expect(published.at(-1)).toContain("> First thing.");
+  });
+
+  test("hides narration once a newer step starts without giving one", async () => {
+    // The narration describes the step it came from. Leaving it on screen
+    // once a different step's tool is running would mislabel that new work
+    // as whatever the old text described - exactly the staleness a
+    // throttled, coalesced timeline has to avoid.
+    const { reporter, published, advance } = harness();
+    reporter.stepStarted(0);
+    reporter.stepFinished(0, "First thing.");
+    advance(1500);
+    reporter.stepStarted(1);
+    reporter.toolStarted("call-1", "manage-role", {});
+    await reporter.flush();
+
+    expect(published.at(-1)).not.toContain("First thing.");
   });
 
   test("reports a failed edit without failing the turn", async () => {
@@ -206,13 +224,26 @@ describe("createProgressReporter", () => {
     expect(errors).toHaveLength(1);
   });
 
-  test("counts steps against the budget", async () => {
+  test("counts steps against the budget as each one starts", async () => {
     const { reporter, published, advance } = harness();
-    reporter.stepFinished("one");
+    reporter.stepStarted(0);
     advance(1500);
-    reporter.stepFinished("two");
+    reporter.stepStarted(1);
     await reporter.flush();
 
     expect(published.at(-1)).toContain("step 2/12");
+  });
+
+  test("advances the displayed step before that step's tool has finished", async () => {
+    // The old design bumped the counter in stepFinished, so the very first
+    // progress edit under-counted by one - "step 0/12" while a tool from
+    // step 1 was already running. onStepStart fires before any of that
+    // step's tools do, so the counter has to move there instead.
+    const { reporter, published } = harness();
+    reporter.stepStarted(0);
+    reporter.toolStarted("call-1", "get-activity-stats", {});
+    await reporter.flush();
+
+    expect(published.at(-1)).toContain("step 1/12");
   });
 });


### PR DESCRIPTION
Stacked on #2769.

## Why

The agentic loop in #2769 made turns longer and more variable, and the placeholder was a single `…` for up to the whole response timeout. A multi-step turn looked identical to a stuck one, and the only other signal a person ever got was an incident reference.

Showing the work is most of what makes Claude Code and Codex feel responsive. This is the payoff for the temporary regression #2769 introduced.

## What

The turn narrates into the single Discord message it already owns:

```
🔎 Working…

> Checking who has been active, then updating the Regulars role.

✓ Get activity stats · 0.4s
✓ Manage role (list) · 0.9s
⋯ Manage role (add)

step 3/12 · 14s
```

The `>` line is the agent's own sentence — it's instructed to say what it's about to do *for the person waiting*, not as a reasoning transcript. The timeline is derived from tool ids and inputs, so it's always present even if the model says nothing.

**Driven by callbacks, not a stream.** `onToolExecutionStart` / `onToolExecutionEnd` / `onStepFinish` give per-step granularity, which is all a coalesced Discord edit can show. Draining a dual stream (Scout's `explore/stream.ts` approach) buys token-level updates that a throttled message edit would immediately discard.

**Rendering is pure; publishing is coalesced.** A minimum interval with a trailing flush, no internal timers, injected clock — so the whole module is tested without Discord and without fake timers.

## Notes for review

**A failed progress edit does not fail the turn.** This message is cosmetic and the final edit is the actual contract. It's reported through `onPublishError` rather than swallowed, so a persistently rate-limited channel is visible in logs.

**Progress is flushed before the final edit**, so a late progress write cannot land on top of the delivered answer. There's a flow test asserting exactly that.

**Nothing is persisted.** `AgentRun` and session events are untouched — `AGENTS.md` forbids persisting reasoning, and progress lines are ephemeral UI.

**Scheduled jobs pass no reporter** — they own no Discord message to narrate into.

**The `AGENTS.md` invariant changed deliberately.** From *"one placeholder and one final edit"* to *"one reply that ends on the answer"*. The reason the rule was written — never a second reply — is unchanged; the letter of it was blocking the property that actually matters.

**Flow scenario ordering:** `agent-progress` is appended to the scenario enum rather than grouped with its siblings, because scenario order derives fixture message IDs and inserting mid-enum renumbers every existing expectation.

## Verification

- `typecheck` clean; `lint` + architecture clean (153 modules)
- **birmel: 354/354 tests across 43 files**, including 14 progress unit tests (render, truncation, coalescing, failure reporting) and a flow test proving a turn narrates *and* still ends on the answer with exactly one reply
- `docker:build`, image smoke, `knip`, and the `jscpd` ratchet all pass

**Not verified:** Buildkite, image publication, ArgoCD, and live Discord behavior. **The rendering has not been seen against a real Discord client yet** — that needs a live turn through the toolkit Discord daemon, which is the acceptance step for this PR.