### PR TITLE
feat(homelab): add alloy-gateway OTLP trace gateway

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/llm-stack.md
+++ b/packages/docs/wiki/src/content/docs/explanation/llm-stack.md
@@ -47,6 +47,16 @@ transcript read a two-store join and was reversed. The archive remains because
 Tempo's retention is 30 days: it is the durable body record, not the only one.
 Redaction happens before export, so credentials stay out of both stores.
 
+Traces enter storage through `alloy-gateway`, an unprivileged Grafana Alloy
+Deployment that receives OTLP/HTTP and forwards every span to Tempo. The
+gateway exists so that adding a trace consumer is gateway configuration rather
+than a credential and an exporter in every service. It is deliberately a
+second Alloy release: the existing `alloy` app is a privileged, hostPID eBPF
+profiler whose security boundary is having no ingress at all, and a trace
+gateway needs the opposite shape. The gateway carries no Kubernetes RBAC and
+mounts no service-account token: a network-facing pod that never calls the
+Kubernetes API gets nothing to escalate with.
+
 OpenRouter Broadcast is a correlated second source of routing, provider, token,
 and actual-cost evidence. The authenticated `openrouter-broadcast-ingest`
 service archives the complete redacted OTLP JSON payload and forwards that

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
@@ -21,6 +21,7 @@ import { createPromtailApp } from "@shepherdjerred/homelab/cdk8s/src/resources/a
 import { createTempoApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/observability/tempo.ts";
 import { createPyroscopeApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/observability/pyroscope.ts";
 import { createAlloyApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/observability/alloy.ts";
+import { createAlloyGatewayApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/observability/alloy-gateway.ts";
 import { Namespace } from "cdk8s-plus-31";
 import { createStorageClasses } from "@shepherdjerred/homelab/cdk8s/src/misc/storage-classes.ts";
 import { createPriorityClasses } from "@shepherdjerred/homelab/cdk8s/src/misc/priority-classes.ts";
@@ -123,6 +124,7 @@ export async function createAppsChart(app: App) {
   createTempoApp(chart);
   createPyroscopeApp(chart);
   createAlloyApp(chart);
+  createAlloyGatewayApp(chart);
   createBuildkiteApp(chart);
   createKueueApp(chart);
   createKueueConfig(chart);

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/observability/alloy-gateway.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/observability/alloy-gateway.ts
@@ -74,6 +74,15 @@ export function createAlloyGatewayApp(chart: Chart) {
     crds: {
       create: false,
     },
+    // The gateway only receives OTLP and exports onward — it never calls the
+    // Kubernetes API, so a network-facing pod gets neither RBAC nor an
+    // automounted service-account token to escalate with.
+    rbac: {
+      create: false,
+    },
+    serviceAccount: {
+      automountServiceAccountToken: false,
+    },
     controller: {
       type: "deployment",
       // Must stay 1 once tail sampling lands: sampling decisions require every

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/observability/alloy-gateway.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/observability/alloy-gateway.ts
@@ -1,0 +1,141 @@
+import type { Chart } from "cdk8s";
+import { Application } from "@shepherdjerred/homelab/cdk8s/generated/imports/argoproj.io.ts";
+import { Namespace } from "cdk8s-plus-31";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+import type { HelmValuesForChart } from "@shepherdjerred/homelab/cdk8s/src/misc/typed-helm-parameters.ts";
+
+// Grafana Alloy River config: receive OTLP/HTTP from every in-cluster trace
+// producer and forward all spans to Tempo. This is the fan-out point for
+// additional trace consumers (Braintrust arrives in a later phase as a
+// tail-sampled branch off the receiver output); producers only ever know the
+// gateway URL.
+//
+// Every producer in the repo speaks OTLP/HTTP on 4318 (several POST OTLP JSON
+// via plain fetch, which the receiver also accepts) — no gRPC receiver until a
+// gRPC producer exists. Tempo permits 50MB traces (max_bytes_per_trace), so
+// the per-request cap must never be the smaller limit; the otelcol default of
+// 20MiB is too low.
+const ALLOY_GATEWAY_CONFIG = `
+otelcol.receiver.otlp "gateway" {
+  http {
+    endpoint = "0.0.0.0:4318"
+    max_request_body_size = "64MiB"
+  }
+
+  output {
+    traces = [otelcol.processor.batch.tempo.input]
+  }
+}
+
+otelcol.processor.batch "tempo" {
+  output {
+    traces = [otelcol.exporter.otlphttp.tempo.input]
+  }
+}
+
+otelcol.exporter.otlphttp "tempo" {
+  client {
+    endpoint = "http://tempo.tempo.svc.cluster.local:4318"
+  }
+}
+`;
+
+/**
+ * Grafana Alloy as an unprivileged OTLP trace gateway Deployment.
+ *
+ * This is a second Alloy release, deliberately separate from the `alloy` app:
+ * that one is a privileged hostPID eBPF profiling DaemonSet whose security
+ * boundary is "no ingress, pushes only to Pyroscope". A trace gateway needs
+ * the opposite shape — network ingress, external egress (later phases), no
+ * host access — so it gets its own namespace, Deployment, and Service instead
+ * of widening the profiler's boundary. Both releases share the `versions.alloy`
+ * chart pin and move together on chart bumps.
+ */
+export function createAlloyGatewayApp(chart: Chart) {
+  // Explicit Namespace (root-chart sync wave 0) rather than relying only on
+  // CreateNamespace=true: a later phase adds a OnePasswordItem into this
+  // namespace, and root-chart 1Password items apply at wave -19 — before any
+  // Application could create the namespace. Shipping the namespace one release
+  // ahead keeps that ordering safe. Default (baseline) Pod Security applies;
+  // nothing here is privileged.
+  new Namespace(chart, "alloy-gateway-namespace", {
+    metadata: {
+      name: "alloy-gateway",
+    },
+  });
+
+  const alloyGatewayValues: HelmValuesForChart<"alloy"> = {
+    // Deterministic resource/Service names regardless of helm fullname logic:
+    // producers address http://alloy-gateway.alloy-gateway.svc.cluster.local:4318.
+    fullnameOverride: "alloy-gateway",
+    controller: {
+      type: "deployment",
+      // Must stay 1 once tail sampling lands: sampling decisions require every
+      // span of a trace on the same instance. Scaling out needs a trace-ID-aware
+      // otelcol.exporter.loadbalancing tier in front — build that instead of
+      // raising this number.
+      replicas: 1,
+    },
+    alloy: {
+      // All otelcol components used here are general-availability — no
+      // stabilityLevel override (the profiler's "experimental" is for
+      // pyroscope.ebpf only).
+      configMap: {
+        content: ALLOY_GATEWAY_CONFIG,
+      },
+      // The chart's Service publishes every entry listed here alongside the
+      // built-in 12345 http port.
+      extraPorts: [
+        {
+          name: "otlp-http",
+          port: 4318,
+          targetPort: 4318,
+          protocol: "TCP",
+        },
+      ],
+      // Steady-state passthrough is cheap; revisit after tail sampling lands
+      // (it buffers decision_wait's worth of spans in memory). Requests only,
+      // no limits, per repo convention.
+      resources: {
+        requests: {
+          cpu: "100m",
+          memory: "256Mi",
+        },
+      },
+    },
+    // otelcol_* receiver/exporter metrics feed the byte-budget and failure
+    // checks for the Braintrust branch.
+    serviceMonitor: {
+      enabled: true,
+    },
+  };
+
+  return new Application(chart, "alloy-gateway-app", {
+    metadata: {
+      name: "alloy-gateway",
+    },
+    spec: {
+      revisionHistoryLimit: 5,
+      project: "default",
+      source: {
+        // https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy
+        repoUrl: "https://grafana.github.io/helm-charts",
+        targetRevision: versions.alloy,
+        chart: "alloy",
+        helm: {
+          valuesObject: alloyGatewayValues,
+        },
+      },
+      destination: {
+        server: "https://kubernetes.default.svc",
+        namespace: "alloy-gateway",
+      },
+      syncPolicy: {
+        // selfHeal per the tempo.ts precedent: renderer/Helm-version drift
+        // under a fixed chart revision must re-converge without operator action.
+        automated: { enabled: true, selfHeal: true },
+        syncOptions: ["CreateNamespace=true", "ServerSideApply=true"],
+      },
+    },
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/observability/alloy-gateway.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/observability/alloy-gateway.ts
@@ -68,6 +68,12 @@ export function createAlloyGatewayApp(chart: Chart) {
     // Deterministic resource/Service names regardless of helm fullname logic:
     // producers address http://alloy-gateway.alloy-gateway.svc.cluster.local:4318.
     fullnameOverride: "alloy-gateway",
+    // The profiler `alloy` Application already installs this chart's
+    // cluster-scoped monitoring CRDs; rendering them from a second Application
+    // would make two Argo apps own identical CRD objects.
+    crds: {
+      create: false,
+    },
     controller: {
       type: "deployment",
       // Must stay 1 once tail sampling lands: sampling decisions require every
@@ -104,9 +110,14 @@ export function createAlloyGatewayApp(chart: Chart) {
       },
     },
     // otelcol_* receiver/exporter metrics feed the byte-budget and failure
-    // checks for the Braintrust branch.
+    // checks for the Braintrust branch. Prometheus only discovers
+    // ServiceMonitors carrying release: prometheus (same convention the shared
+    // createServiceMonitor helper enforces).
     serviceMonitor: {
       enabled: true,
+      additionalLabels: {
+        release: "prometheus",
+      },
     },
   };
 


### PR DESCRIPTION
## Why

Trace producers export OTLP directly to Tempo, so adding a second trace consumer (Braintrust, for LLM eval/observability — plan phase 1 of the gateway rollout) would mean per-service credentials and exporter config. A gateway centralizes the fan-out: producers keep exactly one OTLP endpoint, and additional consumers become gateway config. The existing `alloy` release stays untouched — it is a privileged hostPID eBPF profiler whose documented no-ingress boundary must not widen; the gateway is its own unprivileged Deployment in its own namespace.

## What

- New `alloy-gateway` ArgoCD Application (Grafana Alloy chart, shared `versions.alloy` pin = chart 1.11.1 / Alloy v1.18.1): `controller.type: deployment`, `replicas: 1` (tail sampling in a later phase requires all spans of a trace on one instance), OTLP/HTTP receiver on 4318 with `max_request_body_size: 64MiB` (Tempo permits 50MB traces; otelcol's 20MiB default is too small), batch processor, `otlphttp` exporter forwarding **all** spans to Tempo unchanged.
- Service publishes `otlp-http:4318` via `alloy.extraPorts`; ServiceMonitor enabled for `otelcol_*` metrics.
- Explicit `alloy-gateway` Namespace ships now so a later phase's OnePasswordItem (root-chart sync wave −19) has its namespace; never collapse those phases.
- No producers repointed yet — that starts in Phase 2 (streambot canary).

## Verification

- `bun run build/typecheck/test/lint` green in `packages/homelab`; 707 cdk8s tests pass including `HELM_RENDER_TEST=1` `argocd-helm-render.test.ts` against the real chart.
- `helm template` output inspected: Service publishes `otlp-http:4318`, Deployment `replicas: 1`.
- River config validated with `grafana/alloy:v1.18.1`: `fmt` clean + live component load in a container with no errors.
- `check:kubeconform` valid; `check:1password` green; lefthook pre-commit green.
- Not verified live: ArgoCD sync, pod health, and the post-release smoke checks (OTLP 200 on empty payload, ServiceMonitor scrape) — those run after this merges and releases, before any producer is repointed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNjaV1EJ8o5kmee2cS8pLs