### PR TITLE
feat(feature-flags): create missing Flipt flags automatically

### DIFF
--- a/.agents/skills/feature-flags/SKILL.md
+++ b/.agents/skills/feature-flags/SKILL.md
@@ -22,7 +22,8 @@ Before adding a key:
 3. Define a Zod schema, safe production-compatible default, allowed sources,
    sensitivity, and targeting.
 4. Add the Flipt declaration and beta targeting for a new feature. Default it
-   off, ramp it, then remove the flag after rollout.
+   off, ramp it, then remove the flag after rollout. Missing declared keys are
+   created in live Flipt automatically; do not overwrite existing targeting.
 5. Test absence, explicit false/zero, invalid values, source failures, and
    provenance.
 

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/configuration.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/configuration.md
@@ -123,7 +123,9 @@ back, and silently loses every one on restart. The deployment therefore gives
 beta and production separate local git backends on a ZFS PVC backed up by
 Velero. Each repository begins from a validated declarative seed with all six
 product namespaces; subsequent restarts validate existing repositories and do
-not overwrite operator changes. Environment isolation prevents a beta model or
+not overwrite operator changes. Missing inventory keys are created through
+Flipt's management API; existing flags and targeting stay under operator
+control. Environment isolation prevents a beta model or
 rollout change from altering production, while namespaces keep product flag
 catalogs separate within a stage. Regression tests assert the storage and both
 client selectors, because any omission produces a service that looks healthy

--- a/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
+++ b/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
@@ -6,8 +6,8 @@ sidebar:
 ---
 
 Run the operator-only inventory check when you change Flipt state or need to
-diagnose runtime flag drift. A daily Temporal workflow performs the same
-contract check and publishes one independently labelled
+diagnose runtime flag drift. A Temporal workflow creates missing declared keys
+every fifteen minutes, then publishes one independently labelled
 `FliptManagedFlagDrift` warning per environment and namespace; each alert
 resolves after that pair returns to an aligned snapshot.
 
@@ -43,9 +43,25 @@ bun run check-flipt-flag-inventory -- --environment beta --namespace scout
 `FLIPT_ENVIRONMENT` and `FLIPT_NAMESPACE` are also accepted as exact filters.
 Without filters, the command always checks the complete twelve-pair matrix.
 
-## 3. Interpret failures
+## 3. Create missing declared keys
 
-The check fails when Flipt differs from the inventory in any of these areas:
+Create inventory keys that Flipt does not yet have:
+
+```bash
+bun run check-flipt-flag-inventory -- --apply-missing
+```
+
+This creates absent namespaces, segments, and flags from the inventory
+contract. It does not change flags or segments that already exist, and it does
+not delete undeclared Flipt keys. Then it re-runs the complete check.
+
+The scheduled workflow performs the same create-if-missing apply. Use the
+operator flag when you need the keys before the next run.
+
+## 4. Interpret failures
+
+The check fails when Flipt still differs from the inventory in any of these
+areas:
 
 - managed key set;
 - boolean or variant type;
@@ -54,9 +70,9 @@ The check fails when Flipt differs from the inventory in any of these areas:
 - variant rules and distributions;
 - percentage threshold rollouts.
 
-Each diagnostic names the failing namespace and environment. Fix the repository
-inventory or that pair's audited Flipt state, then run the complete check again
-until all twelve pairs report alignment.
+Each diagnostic names the failing namespace and environment. Remaining missing
+keys after `--apply-missing` are an apply failure. Contract mismatches and
+undeclared Flipt keys need an inventory edit or an audited Flipt change.
 
 When environments intentionally differ, record a full behavioral override in
 the environment's inventory entry. An override replaces the flag's default,
@@ -64,12 +80,12 @@ segment rollouts, variant rules, and threshold rollouts together. Partial
 overrides are rejected so an environment cannot inherit an accidental mixture
 of old and new behavior.
 
-The scheduled alert is read-only. It never deletes Flipt flags or edits the
-inventory. A failed snapshot request does not resolve an existing alert; the
-workflow fails so the Temporal failure watcher can report the unavailable
-check separately.
+The scheduled workflow never deletes Flipt flags, never edits the inventory,
+and never overwrites existing targeting. A failed snapshot request does not
+resolve an existing alert; the workflow fails so the Temporal failure watcher
+can report the unavailable check separately.
 
-## 4. Change one namespace in one environment
+## 5. Change one namespace in one environment
 
 Select both the intended environment and product namespace in the Flipt UI
 before editing a flag. The `beta` and `prod` repositories are independent, and

--- a/packages/feature-flags/src/flipt-boolean-rollouts.ts
+++ b/packages/feature-flags/src/flipt-boolean-rollouts.ts
@@ -1,0 +1,66 @@
+import type { ManagedFlag } from "./managed-flag-inventory.ts";
+
+export type OrderedBooleanRollout =
+  | {
+      readonly kind: "threshold";
+      readonly rank: number;
+      readonly percentage: number;
+      readonly result: boolean;
+    }
+  | {
+      readonly kind: "segment";
+      readonly rank: number;
+      readonly segmentKey: string;
+      readonly segmentOperator: string;
+      readonly result: boolean;
+    };
+
+export function orderedBooleanRollouts(
+  flag: Extract<ManagedFlag, { type: "boolean" }>,
+): OrderedBooleanRollout[] {
+  const thresholdByRank = new Map(
+    flag.thresholdRollouts.map((rollout) => [rollout.rank, rollout]),
+  );
+  if (thresholdByRank.size !== flag.thresholdRollouts.length) {
+    throw new Error(`duplicate threshold rollout rank for ${flag.key}`);
+  }
+
+  const total = flag.rollouts.length + thresholdByRank.size;
+  for (const rank of thresholdByRank.keys()) {
+    if (rank < 1 || rank > total) {
+      throw new Error(
+        `threshold rollout rank out of range for ${flag.key}: ${rank.toString()}`,
+      );
+    }
+  }
+
+  const ordered: OrderedBooleanRollout[] = [];
+  let segmentIndex = 0;
+  for (let rank = 1; rank <= total; rank += 1) {
+    const threshold = thresholdByRank.get(rank);
+    if (threshold !== undefined) {
+      ordered.push({
+        kind: "threshold",
+        rank,
+        percentage: threshold.percentage,
+        result: threshold.result,
+      });
+      continue;
+    }
+    const segment = flag.rollouts[segmentIndex];
+    if (segment === undefined) {
+      throw new Error(
+        `missing segment rollout for ${flag.key} at rank ${rank.toString()}`,
+      );
+    }
+    ordered.push({
+      kind: "segment",
+      rank,
+      segmentKey: segment.segmentKey,
+      segmentOperator: segment.segmentOperator,
+      result: segment.result,
+    });
+    segmentIndex += 1;
+  }
+  return ordered;
+}

--- a/packages/feature-flags/src/flipt-features-renderer.test.ts
+++ b/packages/feature-flags/src/flipt-features-renderer.test.ts
@@ -38,7 +38,7 @@ function parseRendered(environment: string, namespace: string) {
 function testInventory(flags: unknown[]) {
   return ManagedFlagInventorySchema.parse({
     version: 3,
-    namespaces: [{ key: "test", name: "Test", description: "Test namespace." }],
+    namespaces: [{ key: "qa", name: "QA", description: "QA namespace." }],
     environments: [
       { key: "beta", overrides: [] },
       { key: "prod", overrides: [] },
@@ -57,10 +57,10 @@ const behavior = {
 function metadata(key: string) {
   return {
     key,
-    owner: "test",
-    namespace: "test",
-    source: "test",
-    purpose: `Test ${key}.`,
+    owner: "renderer",
+    namespace: "qa",
+    source: "renderer-test",
+    purpose: `Render ${key}.`,
   };
 }
 
@@ -143,14 +143,14 @@ describe("renderFliptFeatures", () => {
             segmentOperator: "OR_SEGMENT_OPERATOR",
             segments: [
               {
-                key: "operators",
+                key: "editors",
                 matchType: "ALL_SEGMENT_MATCH_TYPE",
                 constraints: [
                   {
                     type: "STRING_CONSTRAINT_COMPARISON_TYPE",
                     property: "role",
                     operator: "eq",
-                    value: "operator",
+                    value: "editor",
                   },
                 ],
               },
@@ -169,28 +169,13 @@ describe("renderFliptFeatures", () => {
         ...metadata("boolean"),
         type: "boolean",
         default: false,
-        rollouts: [
-          {
-            segmentKey: "operators",
-            segmentOperator: "OR_SEGMENT_OPERATOR",
-            matchType: "ALL_SEGMENT_MATCH_TYPE",
-            constraints: [
-              {
-                type: "STRING_CONSTRAINT_COMPARISON_TYPE",
-                property: "role",
-                operator: "eq",
-                value: "operator",
-              },
-            ],
-            result: true,
-          },
-        ],
+        rollouts: [],
         rules: [],
         thresholdRollouts: [{ rank: 1, percentage: 25, result: true }],
       },
     ]);
     const parsed: unknown = YAML.parse(
-      renderFliptFeatures("prod", "test", inventory),
+      renderFliptFeatures("prod", "qa", inventory),
     );
     const rendered = RenderedFeaturesSchema.parse(parsed);
 
@@ -217,9 +202,6 @@ describe("renderFliptFeatures", () => {
         rollouts: [
           expect.objectContaining({
             threshold: { percentage: 25, value: true },
-          }),
-          expect.objectContaining({
-            segment: expect.objectContaining({ keys: ["operators"] }),
           }),
         ],
       }),

--- a/packages/feature-flags/src/flipt-features-renderer.test.ts
+++ b/packages/feature-flags/src/flipt-features-renderer.test.ts
@@ -186,7 +186,7 @@ describe("renderFliptFeatures", () => {
           },
         ],
         rules: [],
-        thresholdRollouts: [{ rank: 0, percentage: 25, result: true }],
+        thresholdRollouts: [{ rank: 1, percentage: 25, result: true }],
       },
     ]);
     const parsed: unknown = YAML.parse(

--- a/packages/feature-flags/src/flipt-features-renderer.ts
+++ b/packages/feature-flags/src/flipt-features-renderer.ts
@@ -182,7 +182,7 @@ function declarativeBooleanRollouts(
   }));
   const total = segmentRollouts.length + thresholdByRank.size;
   for (const rank of thresholdByRank.keys()) {
-    if (rank >= total) {
+    if (rank < 1 || rank > total) {
       throw new Error(
         `threshold rollout rank out of range for ${flag.key}: ${rank.toString()}`,
       );
@@ -191,7 +191,7 @@ function declarativeBooleanRollouts(
 
   const rendered = [];
   let segmentIndex = 0;
-  for (let rank = 0; rank < total; rank += 1) {
+  for (let rank = 1; rank <= total; rank += 1) {
     const threshold = thresholdByRank.get(rank);
     if (threshold !== undefined) {
       rendered.push({

--- a/packages/feature-flags/src/flipt-features-renderer.ts
+++ b/packages/feature-flags/src/flipt-features-renderer.ts
@@ -1,4 +1,6 @@
 import YAML from "yaml";
+import { orderedBooleanRollouts } from "./flipt-boolean-rollouts.ts";
+import { variantDefinitions as managedVariantDefinitions } from "./flipt-resource-payloads.ts";
 import {
   managedFlagInventory,
   materializeManagedNamespaceEnvironment,
@@ -98,43 +100,13 @@ function collectSegments(flags: readonly ManagedFlag[]): DeclarativeSegment[] {
   );
 }
 
-function parseAttachment(attachment: string, variantKey: string): unknown {
-  try {
-    const value: unknown = JSON.parse(attachment);
-    return value;
-  } catch (error) {
-    throw new Error(`invalid attachment JSON for variant ${variantKey}`, {
-      cause: error,
-    });
-  }
-}
-
 function variantDefinitions(flag: Extract<ManagedFlag, { type: "variant" }>) {
-  const attachments = new Map<string, string>();
-  for (const rule of flag.rules) {
-    for (const distribution of rule.distributions) {
-      const existing = attachments.get(distribution.variantKey);
-      if (
-        existing !== undefined &&
-        existing !== distribution.variantAttachment
-      ) {
-        throw new Error(
-          `conflicting variant attachment: ${flag.key}/${distribution.variantKey}`,
-        );
-      }
-      attachments.set(distribution.variantKey, distribution.variantAttachment);
-    }
-  }
-
-  const keys = new Set<string>([flag.default, ...attachments.keys()]);
-  return [...keys]
-    .sort((left, right) => left.localeCompare(right))
-    .map((key) => ({
-      default: key === flag.default,
-      key,
-      name: key,
-      attachment: parseAttachment(attachments.get(key) ?? "{}", key),
-    }));
+  return managedVariantDefinitions(flag).map((variant) => ({
+    default: variant.key === flag.default,
+    key: variant.key,
+    name: variant.name,
+    attachment: variant.attachment,
+  }));
 }
 
 function declarativeRules(flag: ManagedFlag) {
@@ -165,54 +137,25 @@ function declarativeRules(flag: ManagedFlag) {
 function declarativeBooleanRollouts(
   flag: Extract<ManagedFlag, { type: "boolean" }>,
 ) {
-  const thresholdByRank = new Map(
-    flag.thresholdRollouts.map((rollout) => [rollout.rank, rollout]),
-  );
-  if (thresholdByRank.size !== flag.thresholdRollouts.length) {
-    throw new Error(`duplicate threshold rollout rank for ${flag.key}`);
-  }
-
-  const segmentRollouts = flag.rollouts.map((rollout) => ({
-    description: `Managed segment rollout for ${rollout.segmentKey}.`,
-    segment: {
-      keys: [rollout.segmentKey],
-      operator: rollout.segmentOperator,
-      value: rollout.result,
-    },
-  }));
-  const total = segmentRollouts.length + thresholdByRank.size;
-  for (const rank of thresholdByRank.keys()) {
-    if (rank < 1 || rank > total) {
-      throw new Error(
-        `threshold rollout rank out of range for ${flag.key}: ${rank.toString()}`,
-      );
-    }
-  }
-
-  const rendered = [];
-  let segmentIndex = 0;
-  for (let rank = 1; rank <= total; rank += 1) {
-    const threshold = thresholdByRank.get(rank);
-    if (threshold !== undefined) {
-      rendered.push({
-        description: `Managed threshold rollout at rank ${rank.toString()}.`,
+  return orderedBooleanRollouts(flag).map((slot) => {
+    if (slot.kind === "threshold") {
+      return {
+        description: `Managed threshold rollout at rank ${slot.rank.toString()}.`,
         threshold: {
-          percentage: threshold.percentage,
-          value: threshold.result,
+          percentage: slot.percentage,
+          value: slot.result,
         },
-      });
-      continue;
+      };
     }
-    const segment = segmentRollouts[segmentIndex];
-    if (segment === undefined) {
-      throw new Error(
-        `missing segment rollout for ${flag.key} at rank ${rank.toString()}`,
-      );
-    }
-    rendered.push(segment);
-    segmentIndex += 1;
-  }
-  return rendered;
+    return {
+      description: `Managed segment rollout for ${slot.segmentKey}.`,
+      segment: {
+        keys: [slot.segmentKey],
+        operator: slot.segmentOperator,
+        value: slot.result,
+      },
+    };
+  });
 }
 
 function declarativeFlag(flag: ManagedFlag) {

--- a/packages/feature-flags/src/flipt-missing-flag-apply.test.ts
+++ b/packages/feature-flags/src/flipt-missing-flag-apply.test.ts
@@ -115,49 +115,63 @@ describe("planMissingFliptResources", () => {
   });
 });
 
+async function applyBetaTest(
+  fetcher: (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => Promise<Response>,
+) {
+  return applyMissingManagedFlags({
+    url: "https://flipt.example",
+    inventory,
+    environmentFilter: "beta",
+    namespaceFilter: "test",
+    fetcher,
+  });
+}
+
+function createdKey(init: RequestInit | undefined): string {
+  const parsed = z
+    .object({
+      key: z.string().optional(),
+      payload: z.object({ key: z.string().optional() }).optional(),
+    })
+    .parse(JSON.parse(requestBody(init)));
+  const key = parsed.payload?.key ?? parsed.key;
+  if (key === undefined) throw new Error("create is missing a key");
+  return key;
+}
+
 describe("applyMissingManagedFlags", () => {
   test("posts missing segments then flags and records created keys", async () => {
     const posts: string[] = [];
-    const result = await applyMissingManagedFlags({
-      url: "https://flipt.example",
-      inventory,
-      environmentFilter: "beta",
-      namespaceFilter: "test",
-      fetcher: async (input, init) => {
-        const url = requestUrl(input);
-        const method = init?.method ?? "GET";
-        if (method === "GET" && url.endsWith("/namespaces")) {
-          return json({ items: [{ key: "test" }], revision: "rev-1" });
-        }
-        if (method === "GET" && url.includes("flipt.core.Flag")) {
-          return json({
-            resources: [{ namespaceKey: "test", key: "existing-flag" }],
-            revision: "rev-1",
-          });
-        }
-        if (method === "GET" && url.includes("flipt.core.Segment")) {
-          return json({ resources: [], revision: "rev-1" });
-        }
-        if (method === "POST") {
-          const parsed = z
-            .object({
-              key: z.string().optional(),
-              payload: z.object({ key: z.string().optional() }).optional(),
-            })
-            .parse(JSON.parse(requestBody(init)));
-          const key = parsed.payload?.key ?? parsed.key;
-          if (key === undefined) throw new Error("create is missing a key");
-          posts.push(`${url} ${key}`);
-          return json(
-            {
-              resource: { namespaceKey: "test", key },
-              revision: `rev-${posts.length.toString()}`,
-            },
-            200,
-          );
-        }
-        throw new Error(`unexpected request ${method} ${url}`);
-      },
+    const result = await applyBetaTest(async (input, init) => {
+      const url = requestUrl(input);
+      const method = init?.method ?? "GET";
+      if (method === "GET" && url.endsWith("/namespaces")) {
+        return json({ items: [{ key: "test" }], revision: "rev-1" });
+      }
+      if (method === "GET" && url.includes("flipt.core.Flag")) {
+        return json({
+          resources: [{ namespaceKey: "test", key: "existing-flag" }],
+          revision: "rev-1",
+        });
+      }
+      if (method === "GET" && url.includes("flipt.core.Segment")) {
+        return json({ resources: [], revision: "rev-1" });
+      }
+      if (method === "POST") {
+        const key = createdKey(init);
+        posts.push(`${url} ${key}`);
+        return json(
+          {
+            resource: { namespaceKey: "test", key },
+            revision: `rev-${posts.length.toString()}`,
+          },
+          200,
+        );
+      }
+      throw new Error(`unexpected request ${method} ${url}`);
     });
 
     expect(posts).toEqual([
@@ -176,34 +190,71 @@ describe("applyMissingManagedFlags", () => {
   });
 
   test("treats already-exists as success without updating the resource", async () => {
-    const result = await applyMissingManagedFlags({
-      url: "https://flipt.example",
-      inventory,
-      environmentFilter: "beta",
-      namespaceFilter: "test",
-      fetcher: async (input, init) => {
-        const url = requestUrl(input);
-        const method = init?.method ?? "GET";
-        if (method === "GET" && url.endsWith("/namespaces")) {
-          return json({ items: [{ key: "test" }], revision: "rev-1" });
-        }
-        if (method === "GET") {
-          return json({
-            resources: [{ namespaceKey: "test", key: "existing-flag" }],
-            revision: "rev-2",
-          });
-        }
-        return json(
-          {
-            code: 6,
-            message: 'create resource "flipt.core.Flag/test/new-flag"',
-          },
-          409,
-        );
-      },
+    const result = await applyBetaTest(async (input, init) => {
+      const method = init?.method ?? "GET";
+      if (method === "GET" && requestUrl(input).endsWith("/namespaces")) {
+        return json({ items: [{ key: "test" }], revision: "rev-1" });
+      }
+      if (method === "GET") {
+        return json({
+          resources: [{ namespaceKey: "test", key: "existing-flag" }],
+          revision: "rev-2",
+        });
+      }
+      return json(
+        {
+          code: 6,
+          message: 'create resource "flipt.core.Flag/test/new-flag"',
+        },
+        409,
+      );
     });
     expect(result[0]?.createdFlags).toEqual([]);
     expect(result[0]?.createdSegments).toEqual([]);
+  });
+
+  test("creates a missing namespace before listing its resources", async () => {
+    const methods: string[] = [];
+    let namespaceExists = false;
+    const result = await applyBetaTest(async (input, init) => {
+      const url = requestUrl(input);
+      const method = init?.method ?? "GET";
+      methods.push(`${method} ${url}`);
+      if (method === "GET" && url.endsWith("/namespaces")) {
+        return json({
+          items: namespaceExists ? [{ key: "test" }] : [],
+          revision: "rev-1",
+        });
+      }
+      if (method === "POST" && url.endsWith("/namespaces")) {
+        namespaceExists = true;
+        return json(
+          {
+            resource: { namespaceKey: "test", key: "test" },
+            revision: "rev-2",
+          },
+          200,
+        );
+      }
+      if (!namespaceExists) {
+        throw new Error(`listed resources before creating namespace: ${url}`);
+      }
+      if (method === "GET") {
+        return json({ resources: [], revision: "rev-2" });
+      }
+      const key = createdKey(init);
+      return json(
+        { resource: { namespaceKey: "test", key }, revision: "rev-3" },
+        200,
+      );
+    });
+    expect(methods[0]).toBe(
+      "GET https://flipt.example/api/v2/environments/beta/namespaces",
+    );
+    expect(methods[1]).toBe(
+      "POST https://flipt.example/api/v2/environments/beta/namespaces",
+    );
+    expect(result[0]?.createdNamespaces).toEqual(["test"]);
   });
 });
 

--- a/packages/feature-flags/src/flipt-missing-flag-apply.test.ts
+++ b/packages/feature-flags/src/flipt-missing-flag-apply.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import { ManagedFlagInventorySchema } from "./managed-flag-inventory.ts";
+import {
+  applyMissingManagedFlags,
+  planMissingFliptResources,
+} from "./flipt-missing-flag-apply.ts";
+
+const inventory = ManagedFlagInventorySchema.parse({
+  version: 3,
+  namespaces: [{ key: "test", name: "Test", description: "Test namespace." }],
+  environments: [
+    { key: "beta", overrides: [] },
+    { key: "prod", overrides: [] },
+  ],
+  flags: [
+    {
+      key: "new-flag",
+      owner: "test",
+      namespace: "test",
+      source: "test",
+      purpose: "Create this flag.",
+      type: "boolean",
+      default: false,
+      rollouts: [
+        {
+          segmentKey: "operators",
+          segmentOperator: "OR_SEGMENT_OPERATOR",
+          matchType: "ALL_SEGMENT_MATCH_TYPE",
+          constraints: [
+            {
+              type: "STRING_CONSTRAINT_COMPARISON_TYPE",
+              property: "role",
+              operator: "eq",
+              value: "operator",
+            },
+          ],
+          result: true,
+        },
+      ],
+      rules: [],
+      thresholdRollouts: [],
+    },
+    {
+      key: "existing-flag",
+      owner: "test",
+      namespace: "test",
+      source: "test",
+      purpose: "Already present.",
+      type: "boolean",
+      default: true,
+      rollouts: [],
+      rules: [],
+      thresholdRollouts: [],
+    },
+  ],
+  exemptions: [],
+});
+
+const namespace = inventory.namespaces[0];
+if (namespace === undefined) throw new Error("test namespace is missing");
+
+describe("planMissingFliptResources", () => {
+  test("creates missing namespaces, segments, and flags without touching existing keys", () => {
+    const plan = planMissingFliptResources({
+      namespace,
+      expectedFlags: inventory.flags,
+      existingNamespaceKeys: new Set(),
+      existingFlagKeys: new Set(["existing-flag"]),
+      existingSegmentKeys: new Set(),
+    });
+    expect(plan.map((item) => `${item.kind}:${item.key}`)).toEqual([
+      "namespace:test",
+      "segment:operators",
+      "flag:new-flag",
+    ]);
+  });
+
+  test("returns nothing when the namespace and flags already exist", () => {
+    expect(
+      planMissingFliptResources({
+        namespace,
+        expectedFlags: inventory.flags,
+        existingNamespaceKeys: new Set(["test"]),
+        existingFlagKeys: new Set(["new-flag", "existing-flag"]),
+        existingSegmentKeys: new Set(),
+      }),
+    ).toEqual([]);
+  });
+
+  test("reuses an existing segment instead of recreating it", () => {
+    const plan = planMissingFliptResources({
+      namespace,
+      expectedFlags: inventory.flags,
+      existingNamespaceKeys: new Set(["test"]),
+      existingFlagKeys: new Set(["existing-flag"]),
+      existingSegmentKeys: new Set(["operators"]),
+    });
+    expect(plan.map((item) => `${item.kind}:${item.key}`)).toEqual([
+      "flag:new-flag",
+    ]);
+  });
+});
+
+describe("applyMissingManagedFlags", () => {
+  test("posts missing segments then flags and records created keys", async () => {
+    const posts: string[] = [];
+    const result = await applyMissingManagedFlags({
+      url: "https://flipt.example",
+      inventory,
+      environmentFilter: "beta",
+      namespaceFilter: "test",
+      fetcher: async (input, init) => {
+        const url = requestUrl(input);
+        const method = init?.method ?? "GET";
+        if (method === "GET" && url.endsWith("/namespaces")) {
+          return json({ items: [{ key: "test" }], revision: "rev-1" });
+        }
+        if (method === "GET" && url.includes("flipt.core.Flag")) {
+          return json({
+            resources: [{ namespaceKey: "test", key: "existing-flag" }],
+            revision: "rev-1",
+          });
+        }
+        if (method === "GET" && url.includes("flipt.core.Segment")) {
+          return json({ resources: [], revision: "rev-1" });
+        }
+        if (method === "POST") {
+          const parsed = z
+            .object({
+              key: z.string().optional(),
+              payload: z.object({ key: z.string().optional() }).optional(),
+            })
+            .parse(JSON.parse(requestBody(init)));
+          const key = parsed.payload?.key ?? parsed.key;
+          if (key === undefined) throw new Error("create is missing a key");
+          posts.push(`${url} ${key}`);
+          return json(
+            {
+              resource: { namespaceKey: "test", key },
+              revision: `rev-${posts.length.toString()}`,
+            },
+            200,
+          );
+        }
+        throw new Error(`unexpected request ${method} ${url}`);
+      },
+    });
+
+    expect(posts).toEqual([
+      "https://flipt.example/api/v2/environments/beta/namespaces/test/resources operators",
+      "https://flipt.example/api/v2/environments/beta/namespaces/test/resources new-flag",
+    ]);
+    expect(result).toEqual([
+      {
+        environment: "beta",
+        namespace: "test",
+        createdNamespaces: [],
+        createdSegments: ["operators"],
+        createdFlags: ["new-flag"],
+      },
+    ]);
+  });
+
+  test("treats already-exists as success without updating the resource", async () => {
+    const result = await applyMissingManagedFlags({
+      url: "https://flipt.example",
+      inventory,
+      environmentFilter: "beta",
+      namespaceFilter: "test",
+      fetcher: async (input, init) => {
+        const url = requestUrl(input);
+        const method = init?.method ?? "GET";
+        if (method === "GET" && url.endsWith("/namespaces")) {
+          return json({ items: [{ key: "test" }], revision: "rev-1" });
+        }
+        if (method === "GET") {
+          return json({
+            resources: [{ namespaceKey: "test", key: "existing-flag" }],
+            revision: "rev-2",
+          });
+        }
+        return json(
+          {
+            code: 6,
+            message: 'create resource "flipt.core.Flag/test/new-flag"',
+          },
+          409,
+        );
+      },
+    });
+    expect(result[0]?.createdFlags).toEqual([]);
+    expect(result[0]?.createdSegments).toEqual([]);
+  });
+});
+
+function requestUrl(input: string | URL | Request): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function requestBody(init: RequestInit | undefined): string {
+  if (init?.body === undefined) return "{}";
+  if (typeof init.body === "string") return init.body;
+  throw new Error("test fetcher expected a string body");
+}
+
+function json(body: unknown, status = 200): Response {
+  return Response.json(body, { status });
+}

--- a/packages/feature-flags/src/flipt-missing-flag-apply.test.ts
+++ b/packages/feature-flags/src/flipt-missing-flag-apply.test.ts
@@ -76,16 +76,29 @@ describe("planMissingFliptResources", () => {
     ]);
   });
 
-  test("returns nothing when the namespace and flags already exist", () => {
+  test("returns nothing when the namespace, flags, and segments already exist", () => {
     expect(
       planMissingFliptResources({
         namespace,
         expectedFlags: inventory.flags,
         existingNamespaceKeys: new Set(["test"]),
         existingFlagKeys: new Set(["new-flag", "existing-flag"]),
-        existingSegmentKeys: new Set(),
+        existingSegmentKeys: new Set(["operators"]),
       }),
     ).toEqual([]);
+  });
+
+  test("creates a missing segment even when every flag already exists", () => {
+    const plan = planMissingFliptResources({
+      namespace,
+      expectedFlags: inventory.flags,
+      existingNamespaceKeys: new Set(["test"]),
+      existingFlagKeys: new Set(["new-flag", "existing-flag"]),
+      existingSegmentKeys: new Set(),
+    });
+    expect(plan.map((item) => `${item.kind}:${item.key}`)).toEqual([
+      "segment:operators",
+    ]);
   });
 
   test("reuses an existing segment instead of recreating it", () => {

--- a/packages/feature-flags/src/flipt-missing-flag-apply.ts
+++ b/packages/feature-flags/src/flipt-missing-flag-apply.ts
@@ -1,0 +1,474 @@
+import { z } from "zod";
+import type { FliptFetcher } from "./managed-flag-drift.ts";
+import {
+  managedFlagInventory,
+  materializeManagedNamespaceEnvironment,
+  type ManagedFlag,
+  type ManagedFlagInventory,
+  type ManagedNamespace,
+} from "./managed-flag-inventory.ts";
+import {
+  collectManagedSegmentPayloads,
+  FLIPT_FLAG_TYPE_URL,
+  FLIPT_SEGMENT_TYPE_URL,
+  toFliptFlagPayload,
+  type FliptFlagPayload,
+  type FliptSegmentPayload,
+} from "./flipt-resource-payloads.ts";
+
+const GRPC_ALREADY_EXISTS = 6;
+const GRPC_ABORTED = 10;
+const MAX_CREATE_ATTEMPTS = 3;
+
+const FliptErrorSchema = z.object({
+  code: z.number().int(),
+  message: z.string(),
+});
+
+const FliptResourceSchema = z.object({
+  namespaceKey: z.string(),
+  key: z.string(),
+});
+
+const ListResourcesResponseSchema = z.object({
+  resources: z.array(FliptResourceSchema).default([]),
+  revision: z.string().min(1),
+});
+
+const ListNamespacesResponseSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        key: z.string(),
+      }),
+    )
+    .default([]),
+  revision: z.string().min(1),
+});
+
+const ResourceResponseSchema = z.object({
+  revision: z.string().min(1),
+});
+
+export type PlannedFliptCreate =
+  | {
+      readonly kind: "namespace";
+      readonly key: string;
+      readonly name: string;
+      readonly description: string;
+    }
+  | {
+      readonly kind: "segment";
+      readonly key: string;
+      readonly payload: FliptSegmentPayload;
+    }
+  | {
+      readonly kind: "flag";
+      readonly key: string;
+      readonly payload: FliptFlagPayload;
+    };
+
+export type FliptMissingFlagApplyResult = {
+  readonly environment: string;
+  readonly namespace: string;
+  readonly createdNamespaces: readonly string[];
+  readonly createdSegments: readonly string[];
+  readonly createdFlags: readonly string[];
+};
+
+export type ApplyMissingManagedFlagsOptions = {
+  readonly url: string;
+  readonly inventory?: ManagedFlagInventory;
+  readonly environmentFilter?: string;
+  readonly namespaceFilter?: string;
+  readonly fetcher?: FliptFetcher;
+};
+
+function selectedKeys(
+  keys: readonly string[],
+  filter: string | undefined,
+  kind: string,
+): string[] {
+  if (filter === undefined) return [...keys];
+  if (!keys.includes(filter)) {
+    throw new Error(`unknown managed ${kind} filter: ${filter}`);
+  }
+  return [filter];
+}
+
+export function planMissingFliptResources(input: {
+  readonly namespace: ManagedNamespace;
+  readonly expectedFlags: readonly ManagedFlag[];
+  readonly existingNamespaceKeys: ReadonlySet<string>;
+  readonly existingFlagKeys: ReadonlySet<string>;
+  readonly existingSegmentKeys: ReadonlySet<string>;
+}): PlannedFliptCreate[] {
+  const missingFlags = input.expectedFlags.filter(
+    (flag) => !input.existingFlagKeys.has(flag.key),
+  );
+  if (
+    missingFlags.length === 0 &&
+    input.existingNamespaceKeys.has(input.namespace.key)
+  ) {
+    return [];
+  }
+
+  const planned: PlannedFliptCreate[] = [];
+  if (!input.existingNamespaceKeys.has(input.namespace.key)) {
+    planned.push({
+      kind: "namespace",
+      key: input.namespace.key,
+      name: input.namespace.name,
+      description: input.namespace.description,
+    });
+  }
+
+  const existingOrPlannedSegments = new Set(input.existingSegmentKeys);
+  for (const segment of collectManagedSegmentPayloads(missingFlags)) {
+    if (existingOrPlannedSegments.has(segment.key)) continue;
+    existingOrPlannedSegments.add(segment.key);
+    planned.push({ kind: "segment", key: segment.key, payload: segment });
+  }
+  for (const flag of missingFlags) {
+    planned.push({
+      kind: "flag",
+      key: flag.key,
+      payload: toFliptFlagPayload(flag),
+    });
+  }
+  return planned;
+}
+
+function encodeTypeUrl(typeUrl: string): string {
+  return encodeURIComponent(typeUrl);
+}
+
+function fliptError(status: number, body: unknown): Error {
+  const parsed = FliptErrorSchema.safeParse(body);
+  if (!parsed.success) {
+    return new Error(`Flipt request failed: ${status.toString()}`);
+  }
+  return new Error(
+    `Flipt request failed: ${status.toString()} code ${parsed.data.code.toString()} ${parsed.data.message}`,
+  );
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  return response.json();
+}
+
+async function listNamespaces(input: {
+  readonly url: string;
+  readonly environment: string;
+  readonly fetcher: FliptFetcher;
+}): Promise<z.infer<typeof ListNamespacesResponseSchema>> {
+  const response = await input.fetcher(
+    `${input.url}/api/v2/environments/${encodeURIComponent(input.environment)}/namespaces`,
+    { headers: { Accept: "application/json" } },
+  );
+  const body: unknown = await readJson(response);
+  if (!response.ok) throw fliptError(response.status, body);
+  return ListNamespacesResponseSchema.parse(body);
+}
+
+async function listResources(input: {
+  readonly url: string;
+  readonly environment: string;
+  readonly namespace: string;
+  readonly typeUrl: string;
+  readonly fetcher: FliptFetcher;
+}): Promise<z.infer<typeof ListResourcesResponseSchema>> {
+  const response = await input.fetcher(
+    `${input.url}/api/v2/environments/${encodeURIComponent(input.environment)}/namespaces/${encodeURIComponent(input.namespace)}/resources/${encodeTypeUrl(input.typeUrl)}`,
+    { headers: { Accept: "application/json" } },
+  );
+  const body: unknown = await readJson(response);
+  if (!response.ok) throw fliptError(response.status, body);
+  return ListResourcesResponseSchema.parse(body);
+}
+
+async function postJson(input: {
+  readonly url: string;
+  readonly fetcher: FliptFetcher;
+  readonly body: Record<string, unknown>;
+}): Promise<{ readonly status: number; readonly body: unknown }> {
+  const response = await input.fetcher(input.url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(input.body),
+  });
+  return { status: response.status, body: await readJson(response) };
+}
+
+function alreadyExists(status: number, body: unknown): boolean {
+  if (status !== 409) return false;
+  const parsed = FliptErrorSchema.safeParse(body);
+  return parsed.success && parsed.data.code === GRPC_ALREADY_EXISTS;
+}
+
+function aborted(status: number, body: unknown): boolean {
+  if (status !== 409) return false;
+  const parsed = FliptErrorSchema.safeParse(body);
+  return parsed.success && parsed.data.code === GRPC_ABORTED;
+}
+
+async function refreshRevision(input: {
+  readonly url: string;
+  readonly environment: string;
+  readonly namespace: string;
+  readonly fetcher: FliptFetcher;
+}): Promise<string> {
+  const listed = await listResources({
+    url: input.url,
+    environment: input.environment,
+    namespace: input.namespace,
+    typeUrl: FLIPT_FLAG_TYPE_URL,
+    fetcher: input.fetcher,
+  });
+  return listed.revision;
+}
+
+type CreateAttemptResult = {
+  readonly status: "created" | "exists" | "aborted";
+  readonly revision: string;
+};
+
+async function createPlannedResource(input: {
+  readonly url: string;
+  readonly environment: string;
+  readonly namespace: string;
+  readonly item: PlannedFliptCreate;
+  readonly revision: string;
+  readonly fetcher: FliptFetcher;
+}): Promise<CreateAttemptResult> {
+  const endpoint =
+    input.item.kind === "namespace"
+      ? `${input.url}/api/v2/environments/${encodeURIComponent(input.environment)}/namespaces`
+      : `${input.url}/api/v2/environments/${encodeURIComponent(input.environment)}/namespaces/${encodeURIComponent(input.namespace)}/resources`;
+  const body =
+    input.item.kind === "namespace"
+      ? {
+          environmentKey: input.environment,
+          key: input.item.key,
+          name: input.item.name,
+          description: input.item.description,
+          protected: false,
+          revision: input.revision,
+        }
+      : {
+          environmentKey: input.environment,
+          namespaceKey: input.namespace,
+          key: input.item.key,
+          payload: input.item.payload,
+          revision: input.revision,
+        };
+
+  const response = await postJson({
+    url: endpoint,
+    fetcher: input.fetcher,
+    body,
+  });
+  if (response.status === 200) {
+    return {
+      status: "created",
+      revision: ResourceResponseSchema.parse(response.body).revision,
+    };
+  }
+  if (
+    alreadyExists(response.status, response.body) ||
+    aborted(response.status, response.body)
+  ) {
+    const revision = await refreshRevision({
+      url: input.url,
+      environment: input.environment,
+      namespace: input.namespace,
+      fetcher: input.fetcher,
+    });
+    return {
+      status: alreadyExists(response.status, response.body)
+        ? "exists"
+        : "aborted",
+      revision,
+    };
+  }
+  throw fliptError(response.status, response.body);
+}
+
+async function createUntilSettled(input: {
+  readonly url: string;
+  readonly environment: string;
+  readonly namespace: string;
+  readonly item: PlannedFliptCreate;
+  readonly revision: string;
+  readonly fetcher: FliptFetcher;
+}): Promise<CreateAttemptResult> {
+  let revision = input.revision;
+  for (let attempt = 0; attempt < MAX_CREATE_ATTEMPTS; attempt += 1) {
+    const result = await createPlannedResource({
+      url: input.url,
+      environment: input.environment,
+      namespace: input.namespace,
+      item: input.item,
+      revision,
+      fetcher: input.fetcher,
+    });
+    if (result.status !== "aborted") return result;
+    revision = result.revision;
+  }
+  throw new Error(
+    `Flipt create aborted after retries: ${input.item.kind} ${input.item.key}`,
+  );
+}
+
+function recordCreated(
+  item: PlannedFliptCreate,
+  createdNamespaces: string[],
+  createdSegments: string[],
+  createdFlags: string[],
+): void {
+  if (item.kind === "namespace") createdNamespaces.push(item.key);
+  if (item.kind === "segment") createdSegments.push(item.key);
+  if (item.kind === "flag") createdFlags.push(item.key);
+}
+
+async function applyPlan(input: {
+  readonly url: string;
+  readonly environment: string;
+  readonly namespace: string;
+  readonly plan: readonly PlannedFliptCreate[];
+  readonly revision: string;
+  readonly fetcher: FliptFetcher;
+}): Promise<FliptMissingFlagApplyResult> {
+  const createdNamespaces: string[] = [];
+  const createdSegments: string[] = [];
+  const createdFlags: string[] = [];
+  let revision = input.revision;
+
+  for (const item of input.plan) {
+    const result = await createUntilSettled({
+      url: input.url,
+      environment: input.environment,
+      namespace: input.namespace,
+      item,
+      revision,
+      fetcher: input.fetcher,
+    });
+    revision = result.revision;
+    if (result.status === "created") {
+      recordCreated(item, createdNamespaces, createdSegments, createdFlags);
+    }
+  }
+
+  return {
+    environment: input.environment,
+    namespace: input.namespace,
+    createdNamespaces,
+    createdSegments,
+    createdFlags,
+  };
+}
+
+async function applyNamespace(input: {
+  readonly url: string;
+  readonly inventory: ManagedFlagInventory;
+  readonly environment: string;
+  readonly namespace: ManagedNamespace;
+  readonly fetcher: FliptFetcher;
+}): Promise<FliptMissingFlagApplyResult> {
+  const expectedFlags = materializeManagedNamespaceEnvironment(
+    input.inventory,
+    input.environment,
+    input.namespace.key,
+  );
+  const [namespaces, flags, segments] = await Promise.all([
+    listNamespaces({
+      url: input.url,
+      environment: input.environment,
+      fetcher: input.fetcher,
+    }),
+    listResources({
+      url: input.url,
+      environment: input.environment,
+      namespace: input.namespace.key,
+      typeUrl: FLIPT_FLAG_TYPE_URL,
+      fetcher: input.fetcher,
+    }),
+    listResources({
+      url: input.url,
+      environment: input.environment,
+      namespace: input.namespace.key,
+      typeUrl: FLIPT_SEGMENT_TYPE_URL,
+      fetcher: input.fetcher,
+    }),
+  ]);
+  const plan = planMissingFliptResources({
+    namespace: input.namespace,
+    expectedFlags,
+    existingNamespaceKeys: new Set(namespaces.items.map((item) => item.key)),
+    existingFlagKeys: new Set(flags.resources.map((resource) => resource.key)),
+    existingSegmentKeys: new Set(
+      segments.resources.map((resource) => resource.key),
+    ),
+  });
+  if (plan.length === 0) {
+    return {
+      environment: input.environment,
+      namespace: input.namespace.key,
+      createdNamespaces: [],
+      createdSegments: [],
+      createdFlags: [],
+    };
+  }
+  return applyPlan({
+    url: input.url,
+    environment: input.environment,
+    namespace: input.namespace.key,
+    plan,
+    revision: flags.revision,
+    fetcher: input.fetcher,
+  });
+}
+
+export async function applyMissingManagedFlags(
+  options: ApplyMissingManagedFlagsOptions,
+): Promise<FliptMissingFlagApplyResult[]> {
+  const inventory = options.inventory ?? managedFlagInventory;
+  const fetcher: FliptFetcher =
+    options.fetcher ?? ((input, init) => fetch(input, init));
+  const url = options.url.replace(/\/$/u, "");
+  const environments = selectedKeys(
+    inventory.environments.map((environment) => environment.key),
+    options.environmentFilter,
+    "environment",
+  );
+  const namespaces = selectedKeys(
+    inventory.namespaces.map((namespace) => namespace.key),
+    options.namespaceFilter,
+    "namespace",
+  );
+
+  const results: FliptMissingFlagApplyResult[] = [];
+  for (const environment of environments) {
+    for (const namespaceKey of namespaces) {
+      const namespace = inventory.namespaces.find(
+        (candidate) => candidate.key === namespaceKey,
+      );
+      if (namespace === undefined) {
+        throw new Error(`unknown managed namespace: ${namespaceKey}`);
+      }
+      results.push(
+        await applyNamespace({
+          url,
+          inventory,
+          environment,
+          namespace,
+          fetcher,
+        }),
+      );
+    }
+  }
+  return results;
+}

--- a/packages/feature-flags/src/flipt-missing-flag-apply.ts
+++ b/packages/feature-flags/src/flipt-missing-flag-apply.ts
@@ -15,7 +15,6 @@ import {
   type FliptFlagPayload,
   type FliptSegmentPayload,
 } from "./flipt-resource-payloads.ts";
-
 const GRPC_ALREADY_EXISTS = 6;
 const GRPC_ABORTED = 10;
 const MAX_CREATE_ATTEMPTS = 3;
@@ -384,12 +383,35 @@ async function applyNamespace(input: {
     input.environment,
     input.namespace.key,
   );
-  const [namespaces, flags, segments] = await Promise.all([
-    listNamespaces({
+  const namespaces = await listNamespaces({
+    url: input.url,
+    environment: input.environment,
+    fetcher: input.fetcher,
+  });
+  const existingNamespaceKeys = new Set(
+    namespaces.items.map((item) => item.key),
+  );
+  const createdNamespaces: string[] = [];
+  if (!existingNamespaceKeys.has(input.namespace.key)) {
+    const created = await applyPlan({
       url: input.url,
       environment: input.environment,
+      namespace: input.namespace.key,
+      plan: [
+        {
+          kind: "namespace",
+          key: input.namespace.key,
+          name: input.namespace.name,
+          description: input.namespace.description,
+        },
+      ],
+      revision: namespaces.revision,
       fetcher: input.fetcher,
-    }),
+    });
+    createdNamespaces.push(...created.createdNamespaces);
+    existingNamespaceKeys.add(input.namespace.key);
+  }
+  const [flags, segments] = await Promise.all([
     listResources({
       url: input.url,
       environment: input.environment,
@@ -408,22 +430,22 @@ async function applyNamespace(input: {
   const plan = planMissingFliptResources({
     namespace: input.namespace,
     expectedFlags,
-    existingNamespaceKeys: new Set(namespaces.items.map((item) => item.key)),
+    existingNamespaceKeys,
     existingFlagKeys: new Set(flags.resources.map((resource) => resource.key)),
     existingSegmentKeys: new Set(
       segments.resources.map((resource) => resource.key),
     ),
-  });
+  }).filter((item) => item.kind !== "namespace");
   if (plan.length === 0) {
     return {
       environment: input.environment,
       namespace: input.namespace.key,
-      createdNamespaces: [],
+      createdNamespaces,
       createdSegments: [],
       createdFlags: [],
     };
   }
-  return applyPlan({
+  const created = await applyPlan({
     url: input.url,
     environment: input.environment,
     namespace: input.namespace.key,
@@ -431,6 +453,10 @@ async function applyNamespace(input: {
     revision: flags.revision,
     fetcher: input.fetcher,
   });
+  return {
+    ...created,
+    createdNamespaces: [...createdNamespaces, ...created.createdNamespaces],
+  };
 }
 
 export async function applyMissingManagedFlags(
@@ -457,9 +483,8 @@ export async function applyMissingManagedFlags(
       const namespace = inventory.namespaces.find(
         (candidate) => candidate.key === namespaceKey,
       );
-      if (namespace === undefined) {
+      if (namespace === undefined)
         throw new Error(`unknown managed namespace: ${namespaceKey}`);
-      }
       results.push(
         await applyNamespace({
           url,

--- a/packages/feature-flags/src/flipt-missing-flag-apply.ts
+++ b/packages/feature-flags/src/flipt-missing-flag-apply.ts
@@ -106,8 +106,12 @@ export function planMissingFliptResources(input: {
   const missingFlags = input.expectedFlags.filter(
     (flag) => !input.existingFlagKeys.has(flag.key),
   );
+  const missingSegments = collectManagedSegmentPayloads(
+    input.expectedFlags,
+  ).filter((segment) => !input.existingSegmentKeys.has(segment.key));
   if (
     missingFlags.length === 0 &&
+    missingSegments.length === 0 &&
     input.existingNamespaceKeys.has(input.namespace.key)
   ) {
     return [];
@@ -123,10 +127,7 @@ export function planMissingFliptResources(input: {
     });
   }
 
-  const existingOrPlannedSegments = new Set(input.existingSegmentKeys);
-  for (const segment of collectManagedSegmentPayloads(missingFlags)) {
-    if (existingOrPlannedSegments.has(segment.key)) continue;
-    existingOrPlannedSegments.add(segment.key);
+  for (const segment of missingSegments) {
     planned.push({ kind: "segment", key: segment.key, payload: segment });
   }
   for (const flag of missingFlags) {

--- a/packages/feature-flags/src/flipt-resource-payloads.test.ts
+++ b/packages/feature-flags/src/flipt-resource-payloads.test.ts
@@ -21,7 +21,7 @@ function metadata(key: string) {
   };
 }
 
-function testFlags() {
+function inventoryWithFlags(flags: unknown[]) {
   return ManagedFlagInventorySchema.parse({
     version: 3,
     namespaces: [{ key: "test", name: "Test", description: "Test namespace." }],
@@ -29,91 +29,84 @@ function testFlags() {
       { key: "beta", overrides: [] },
       { key: "prod", overrides: [] },
     ],
-    flags: [
-      {
-        ...metadata("boolean"),
-        type: "boolean",
-        default: false,
-        rollouts: [
-          {
-            segmentKey: "operators",
-            segmentOperator: "OR_SEGMENT_OPERATOR",
-            matchType: "ALL_SEGMENT_MATCH_TYPE",
-            constraints: [
-              {
-                type: "STRING_CONSTRAINT_COMPARISON_TYPE",
-                property: "role",
-                operator: "eq",
-                value: "operator",
-              },
-            ],
-            result: true,
-          },
-        ],
-        rules: [],
-        thresholdRollouts: [{ rank: 1, percentage: 25, result: true }],
-      },
-      {
-        ...metadata("variant"),
-        type: "variant",
-        default: "blue",
-        ...behavior,
-        rules: [
-          {
-            rank: 1,
-            segmentOperator: "OR_SEGMENT_OPERATOR",
-            segments: [
-              {
-                key: "operators",
-                matchType: "ALL_SEGMENT_MATCH_TYPE",
-                constraints: [
-                  {
-                    type: "STRING_CONSTRAINT_COMPARISON_TYPE",
-                    property: "role",
-                    operator: "eq",
-                    value: "operator",
-                  },
-                ],
-              },
-            ],
-            distributions: [
-              {
-                variantKey: "green",
-                rollout: 100,
-                variantAttachment: '{"color":"green"}',
-              },
-            ],
-          },
-        ],
-      },
-    ],
+    flags,
     exemptions: [],
-  }).flags;
+  });
+}
+
+function testFlags() {
+  return inventoryWithFlags([
+    {
+      ...metadata("boolean"),
+      type: "boolean",
+      default: false,
+      rollouts: [
+        {
+          segmentKey: "operators",
+          segmentOperator: "OR_SEGMENT_OPERATOR",
+          matchType: "ALL_SEGMENT_MATCH_TYPE",
+          constraints: [
+            {
+              type: "STRING_CONSTRAINT_COMPARISON_TYPE",
+              property: "role",
+              operator: "eq",
+              value: "operator",
+            },
+          ],
+          result: true,
+        },
+      ],
+      rules: [],
+      thresholdRollouts: [{ rank: 1, percentage: 25, result: true }],
+    },
+    {
+      ...metadata("variant"),
+      type: "variant",
+      default: "blue",
+      ...behavior,
+      rules: [
+        {
+          rank: 1,
+          segmentOperator: "OR_SEGMENT_OPERATOR",
+          segments: [
+            {
+              key: "operators",
+              matchType: "ALL_SEGMENT_MATCH_TYPE",
+              constraints: [
+                {
+                  type: "STRING_CONSTRAINT_COMPARISON_TYPE",
+                  property: "role",
+                  operator: "eq",
+                  value: "operator",
+                },
+              ],
+            },
+          ],
+          distributions: [
+            {
+              variantKey: "green",
+              rollout: 100,
+              variantAttachment: '{"color":"green"}',
+            },
+          ],
+        },
+      ],
+    },
+  ]).flags;
 }
 
 describe("Flipt resource payloads", () => {
   test("accepts Flipt one-based rank for a lone threshold rollout", () => {
-    const inventory = ManagedFlagInventorySchema.parse({
-      version: 3,
-      namespaces: [
-        { key: "test", name: "Test", description: "Test namespace." },
-      ],
-      environments: [
-        { key: "beta", overrides: [] },
-        { key: "prod", overrides: [] },
-      ],
-      flags: [
-        {
-          ...metadata("ramp"),
-          type: "boolean",
-          default: false,
-          rollouts: [],
-          rules: [],
-          thresholdRollouts: [{ rank: 1, percentage: 30, result: true }],
-        },
-      ],
-      exemptions: [],
-    });
+    const inventory = inventoryWithFlags([
+      {
+        ...metadata("ramp"),
+        type: "boolean",
+        default: false,
+        rollouts: [],
+        rules: [],
+        thresholdRollouts: [{ rank: 1, percentage: 30, result: true }],
+      },
+    ]);
     const flag = inventory.flags[0];
     if (flag === undefined) throw new Error("ramp fixture is missing");
     expect(toFliptFlagPayload(flag).rollouts).toEqual([
@@ -174,46 +167,35 @@ describe("Flipt resource payloads", () => {
   });
 
   test("normalizes a JSON null variant attachment to an empty object", () => {
-    const inventory = ManagedFlagInventorySchema.parse({
-      version: 3,
-      namespaces: [
-        { key: "test", name: "Test", description: "Test namespace." },
-      ],
-      environments: [
-        { key: "beta", overrides: [] },
-        { key: "prod", overrides: [] },
-      ],
-      flags: [
-        {
-          ...metadata("model"),
-          type: "variant",
-          default: "sol",
-          rollouts: [],
-          thresholdRollouts: [],
-          rules: [
-            {
-              rank: 1,
-              segmentOperator: "OR_SEGMENT_OPERATOR",
-              segments: [
-                {
-                  key: "everyone",
-                  matchType: "ALL_SEGMENT_MATCH_TYPE",
-                  constraints: [],
-                },
-              ],
-              distributions: [
-                {
-                  variantKey: "sol",
-                  rollout: 100,
-                  variantAttachment: "null",
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      exemptions: [],
-    });
+    const inventory = inventoryWithFlags([
+      {
+        ...metadata("model"),
+        type: "variant",
+        default: "sol",
+        rollouts: [],
+        thresholdRollouts: [],
+        rules: [
+          {
+            rank: 1,
+            segmentOperator: "OR_SEGMENT_OPERATOR",
+            segments: [
+              {
+                key: "everyone",
+                matchType: "ALL_SEGMENT_MATCH_TYPE",
+                constraints: [],
+              },
+            ],
+            distributions: [
+              {
+                variantKey: "sol",
+                rollout: 100,
+                variantAttachment: "null",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
     const flag = inventory.flags[0];
     if (flag === undefined) throw new Error("model fixture is missing");
     expect(toFliptFlagPayload(flag).variants).toEqual([
@@ -222,46 +204,35 @@ describe("Flipt resource payloads", () => {
   });
 
   test("rejects a zero-based variant rule rank", () => {
-    const inventory = ManagedFlagInventorySchema.parse({
-      version: 3,
-      namespaces: [
-        { key: "test", name: "Test", description: "Test namespace." },
-      ],
-      environments: [
-        { key: "beta", overrides: [] },
-        { key: "prod", overrides: [] },
-      ],
-      flags: [
-        {
-          ...metadata("model"),
-          type: "variant",
-          default: "sol",
-          rollouts: [],
-          thresholdRollouts: [],
-          rules: [
-            {
-              rank: 0,
-              segmentOperator: "OR_SEGMENT_OPERATOR",
-              segments: [
-                {
-                  key: "everyone",
-                  matchType: "ALL_SEGMENT_MATCH_TYPE",
-                  constraints: [],
-                },
-              ],
-              distributions: [
-                {
-                  variantKey: "sol",
-                  rollout: 100,
-                  variantAttachment: "{}",
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      exemptions: [],
-    });
+    const inventory = inventoryWithFlags([
+      {
+        ...metadata("model"),
+        type: "variant",
+        default: "sol",
+        rollouts: [],
+        thresholdRollouts: [],
+        rules: [
+          {
+            rank: 0,
+            segmentOperator: "OR_SEGMENT_OPERATOR",
+            segments: [
+              {
+                key: "everyone",
+                matchType: "ALL_SEGMENT_MATCH_TYPE",
+                constraints: [],
+              },
+            ],
+            distributions: [
+              {
+                variantKey: "sol",
+                rollout: 100,
+                variantAttachment: "{}",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
     const flag = inventory.flags[0];
     if (flag === undefined) throw new Error("model fixture is missing");
     expect(() => toFliptFlagPayload(flag)).toThrow(

--- a/packages/feature-flags/src/flipt-resource-payloads.test.ts
+++ b/packages/feature-flags/src/flipt-resource-payloads.test.ts
@@ -51,7 +51,7 @@ function testFlags() {
           },
         ],
         rules: [],
-        thresholdRollouts: [{ rank: 0, percentage: 25, result: true }],
+        thresholdRollouts: [{ rank: 1, percentage: 25, result: true }],
       },
       {
         ...metadata("variant"),
@@ -92,6 +92,39 @@ function testFlags() {
 }
 
 describe("Flipt resource payloads", () => {
+  test("accepts Flipt one-based rank for a lone threshold rollout", () => {
+    const inventory = ManagedFlagInventorySchema.parse({
+      version: 3,
+      namespaces: [
+        { key: "test", name: "Test", description: "Test namespace." },
+      ],
+      environments: [
+        { key: "beta", overrides: [] },
+        { key: "prod", overrides: [] },
+      ],
+      flags: [
+        {
+          ...metadata("ramp"),
+          type: "boolean",
+          default: false,
+          rollouts: [],
+          rules: [],
+          thresholdRollouts: [{ rank: 1, percentage: 30, result: true }],
+        },
+      ],
+      exemptions: [],
+    });
+    const flag = inventory.flags[0];
+    if (flag === undefined) throw new Error("ramp fixture is missing");
+    expect(toFliptFlagPayload(flag).rollouts).toEqual([
+      {
+        type: "THRESHOLD_ROLLOUT_TYPE",
+        description: "Managed threshold rollout at rank 1.",
+        threshold: { percentage: 30, value: true },
+      },
+    ]);
+  });
+
   test("builds boolean rollouts with threshold ranks and API segment keys", () => {
     const flag = testFlags().find((candidate) => candidate.key === "boolean");
     if (flag === undefined) throw new Error("boolean fixture is missing");

--- a/packages/feature-flags/src/flipt-resource-payloads.test.ts
+++ b/packages/feature-flags/src/flipt-resource-payloads.test.ts
@@ -60,7 +60,7 @@ function testFlags() {
         ...behavior,
         rules: [
           {
-            rank: 0,
+            rank: 1,
             segmentOperator: "OR_SEGMENT_OPERATOR",
             segments: [
               {
@@ -164,12 +164,109 @@ describe("Flipt resource payloads", () => {
       ],
       rules: [
         {
+          rank: 1,
           segmentOperator: "OR_SEGMENT_OPERATOR",
           segments: ["operators"],
           distributions: [{ variant: "green", rollout: 100 }],
         },
       ],
     });
+  });
+
+  test("normalizes a JSON null variant attachment to an empty object", () => {
+    const inventory = ManagedFlagInventorySchema.parse({
+      version: 3,
+      namespaces: [
+        { key: "test", name: "Test", description: "Test namespace." },
+      ],
+      environments: [
+        { key: "beta", overrides: [] },
+        { key: "prod", overrides: [] },
+      ],
+      flags: [
+        {
+          ...metadata("model"),
+          type: "variant",
+          default: "sol",
+          rollouts: [],
+          thresholdRollouts: [],
+          rules: [
+            {
+              rank: 1,
+              segmentOperator: "OR_SEGMENT_OPERATOR",
+              segments: [
+                {
+                  key: "everyone",
+                  matchType: "ALL_SEGMENT_MATCH_TYPE",
+                  constraints: [],
+                },
+              ],
+              distributions: [
+                {
+                  variantKey: "sol",
+                  rollout: 100,
+                  variantAttachment: "null",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      exemptions: [],
+    });
+    const flag = inventory.flags[0];
+    if (flag === undefined) throw new Error("model fixture is missing");
+    expect(toFliptFlagPayload(flag).variants).toEqual([
+      { key: "sol", name: "sol", description: "", attachment: {} },
+    ]);
+  });
+
+  test("rejects a zero-based variant rule rank", () => {
+    const inventory = ManagedFlagInventorySchema.parse({
+      version: 3,
+      namespaces: [
+        { key: "test", name: "Test", description: "Test namespace." },
+      ],
+      environments: [
+        { key: "beta", overrides: [] },
+        { key: "prod", overrides: [] },
+      ],
+      flags: [
+        {
+          ...metadata("model"),
+          type: "variant",
+          default: "sol",
+          rollouts: [],
+          thresholdRollouts: [],
+          rules: [
+            {
+              rank: 0,
+              segmentOperator: "OR_SEGMENT_OPERATOR",
+              segments: [
+                {
+                  key: "everyone",
+                  matchType: "ALL_SEGMENT_MATCH_TYPE",
+                  constraints: [],
+                },
+              ],
+              distributions: [
+                {
+                  variantKey: "sol",
+                  rollout: 100,
+                  variantAttachment: "{}",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      exemptions: [],
+    });
+    const flag = inventory.flags[0];
+    if (flag === undefined) throw new Error("model fixture is missing");
+    expect(() => toFliptFlagPayload(flag)).toThrow(
+      "variant rule rank must be contiguous and one-based for model: expected 1, got 0",
+    );
   });
 
   test("collects unique segments with Flipt comparison enums", () => {

--- a/packages/feature-flags/src/flipt-resource-payloads.test.ts
+++ b/packages/feature-flags/src/flipt-resource-payloads.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "vitest";
+import { ManagedFlagInventorySchema } from "./managed-flag-inventory.ts";
+import {
+  collectManagedSegmentPayloads,
+  toFliptFlagPayload,
+} from "./flipt-resource-payloads.ts";
+
+const behavior = {
+  rollouts: [],
+  rules: [],
+  thresholdRollouts: [],
+};
+
+function metadata(key: string) {
+  return {
+    key,
+    owner: "test",
+    namespace: "test",
+    source: "test",
+    purpose: `Test ${key}.`,
+  };
+}
+
+function testFlags() {
+  return ManagedFlagInventorySchema.parse({
+    version: 3,
+    namespaces: [{ key: "test", name: "Test", description: "Test namespace." }],
+    environments: [
+      { key: "beta", overrides: [] },
+      { key: "prod", overrides: [] },
+    ],
+    flags: [
+      {
+        ...metadata("boolean"),
+        type: "boolean",
+        default: false,
+        rollouts: [
+          {
+            segmentKey: "operators",
+            segmentOperator: "OR_SEGMENT_OPERATOR",
+            matchType: "ALL_SEGMENT_MATCH_TYPE",
+            constraints: [
+              {
+                type: "STRING_CONSTRAINT_COMPARISON_TYPE",
+                property: "role",
+                operator: "eq",
+                value: "operator",
+              },
+            ],
+            result: true,
+          },
+        ],
+        rules: [],
+        thresholdRollouts: [{ rank: 0, percentage: 25, result: true }],
+      },
+      {
+        ...metadata("variant"),
+        type: "variant",
+        default: "blue",
+        ...behavior,
+        rules: [
+          {
+            rank: 0,
+            segmentOperator: "OR_SEGMENT_OPERATOR",
+            segments: [
+              {
+                key: "operators",
+                matchType: "ALL_SEGMENT_MATCH_TYPE",
+                constraints: [
+                  {
+                    type: "STRING_CONSTRAINT_COMPARISON_TYPE",
+                    property: "role",
+                    operator: "eq",
+                    value: "operator",
+                  },
+                ],
+              },
+            ],
+            distributions: [
+              {
+                variantKey: "green",
+                rollout: 100,
+                variantAttachment: '{"color":"green"}',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    exemptions: [],
+  }).flags;
+}
+
+describe("Flipt resource payloads", () => {
+  test("builds boolean rollouts with threshold ranks and API segment keys", () => {
+    const flag = testFlags().find((candidate) => candidate.key === "boolean");
+    if (flag === undefined) throw new Error("boolean fixture is missing");
+    expect(toFliptFlagPayload(flag)).toMatchObject({
+      "@type": "flipt.core.Flag",
+      key: "boolean",
+      type: "BOOLEAN_FLAG_TYPE",
+      enabled: false,
+      rollouts: [
+        {
+          type: "THRESHOLD_ROLLOUT_TYPE",
+          threshold: { percentage: 25, value: true },
+        },
+        {
+          type: "SEGMENT_ROLLOUT_TYPE",
+          segment: {
+            value: true,
+            segments: ["operators"],
+            segmentOperator: "OR_SEGMENT_OPERATOR",
+          },
+        },
+      ],
+    });
+  });
+
+  test("builds variant flags with defaultVariant and parsed attachments", () => {
+    const flag = testFlags().find((candidate) => candidate.key === "variant");
+    if (flag === undefined) throw new Error("variant fixture is missing");
+    expect(toFliptFlagPayload(flag)).toMatchObject({
+      "@type": "flipt.core.Flag",
+      type: "VARIANT_FLAG_TYPE",
+      enabled: true,
+      defaultVariant: "blue",
+      variants: [
+        { key: "blue", attachment: {} },
+        { key: "green", attachment: { color: "green" } },
+      ],
+      rules: [
+        {
+          segmentOperator: "OR_SEGMENT_OPERATOR",
+          segments: ["operators"],
+          distributions: [{ variant: "green", rollout: 100 }],
+        },
+      ],
+    });
+  });
+
+  test("collects unique segments with Flipt comparison enums", () => {
+    expect(collectManagedSegmentPayloads(testFlags())).toEqual([
+      {
+        "@type": "flipt.core.Segment",
+        key: "operators",
+        name: "operators",
+        description: "Managed segment operators.",
+        matchType: "ALL_MATCH_TYPE",
+        constraints: [
+          {
+            type: "STRING_COMPARISON_TYPE",
+            property: "role",
+            operator: "eq",
+            value: "operator",
+            description: "Match role.",
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/feature-flags/src/flipt-resource-payloads.ts
+++ b/packages/feature-flags/src/flipt-resource-payloads.ts
@@ -183,7 +183,7 @@ function booleanRollouts(
   }));
   const total = segmentRollouts.length + thresholdByRank.size;
   for (const rank of thresholdByRank.keys()) {
-    if (rank >= total) {
+    if (rank < 1 || rank > total) {
       throw new Error(
         `threshold rollout rank out of range for ${flag.key}: ${rank.toString()}`,
       );
@@ -192,7 +192,7 @@ function booleanRollouts(
 
   const rendered: FliptRolloutPayload[] = [];
   let segmentIndex = 0;
-  for (let rank = 0; rank < total; rank += 1) {
+  for (let rank = 1; rank <= total; rank += 1) {
     const threshold = thresholdByRank.get(rank);
     if (threshold !== undefined) {
       rendered.push({

--- a/packages/feature-flags/src/flipt-resource-payloads.ts
+++ b/packages/feature-flags/src/flipt-resource-payloads.ts
@@ -35,6 +35,7 @@ export type FliptFlagPayload = {
     readonly attachment: Readonly<Record<string, unknown>>;
   }[];
   readonly rules: readonly {
+    readonly rank: number;
     readonly segmentOperator: string;
     readonly segments: readonly string[];
     readonly distributions: readonly {
@@ -89,7 +90,9 @@ function parseAttachment(
   variantKey: string,
 ): Readonly<Record<string, unknown>> {
   try {
-    return AttachmentSchema.parse(JSON.parse(attachment));
+    const value: unknown = JSON.parse(attachment);
+    if (value === null) return {};
+    return AttachmentSchema.parse(value);
   } catch (error) {
     throw new Error(`invalid attachment JSON for variant ${variantKey}`, {
       cause: error,
@@ -247,24 +250,30 @@ function variantDefinitions(flag: Extract<ManagedFlag, { type: "variant" }>) {
 
 function variantRules(flag: ManagedFlag) {
   const ranks = new Set<number>();
-  return [...flag.rules]
-    .sort((left, right) => left.rank - right.rank)
-    .map((rule) => {
-      if (ranks.has(rule.rank)) {
-        throw new Error(
-          `duplicate rule rank for ${flag.key}: ${rule.rank.toString()}`,
-        );
-      }
-      ranks.add(rule.rank);
-      return {
-        segmentOperator: rule.segmentOperator,
-        segments: rule.segments.map((segment) => segment.key),
-        distributions: rule.distributions.map((distribution) => ({
-          variant: distribution.variantKey,
-          rollout: distribution.rollout,
-        })),
-      };
-    });
+  const ordered = [...flag.rules].sort((left, right) => left.rank - right.rank);
+  return ordered.map((rule, index) => {
+    const expectedRank = index + 1;
+    if (ranks.has(rule.rank)) {
+      throw new Error(
+        `duplicate rule rank for ${flag.key}: ${rule.rank.toString()}`,
+      );
+    }
+    ranks.add(rule.rank);
+    if (rule.rank !== expectedRank) {
+      throw new Error(
+        `variant rule rank must be contiguous and one-based for ${flag.key}: expected ${expectedRank.toString()}, got ${rule.rank.toString()}`,
+      );
+    }
+    return {
+      rank: rule.rank,
+      segmentOperator: rule.segmentOperator,
+      segments: rule.segments.map((segment) => segment.key),
+      distributions: rule.distributions.map((distribution) => ({
+        variant: distribution.variantKey,
+        rollout: distribution.rollout,
+      })),
+    };
+  });
 }
 
 export function toFliptFlagPayload(flag: ManagedFlag): FliptFlagPayload {

--- a/packages/feature-flags/src/flipt-resource-payloads.ts
+++ b/packages/feature-flags/src/flipt-resource-payloads.ts
@@ -1,0 +1,303 @@
+import { z } from "zod";
+import type { ManagedFlag } from "./managed-flag-inventory.ts";
+
+export const FLIPT_FLAG_TYPE_URL = "flipt.core.Flag";
+export const FLIPT_SEGMENT_TYPE_URL = "flipt.core.Segment";
+
+const AttachmentSchema = z.record(z.string(), z.unknown());
+
+export type FliptSegmentPayload = {
+  readonly "@type": typeof FLIPT_SEGMENT_TYPE_URL;
+  readonly key: string;
+  readonly name: string;
+  readonly description: string;
+  readonly matchType: string;
+  readonly constraints: readonly {
+    readonly type: string;
+    readonly property: string;
+    readonly operator: string;
+    readonly value: string;
+    readonly description: string;
+  }[];
+};
+
+export type FliptFlagPayload = {
+  readonly "@type": typeof FLIPT_FLAG_TYPE_URL;
+  readonly key: string;
+  readonly name: string;
+  readonly description: string;
+  readonly enabled: boolean;
+  readonly type: "BOOLEAN_FLAG_TYPE" | "VARIANT_FLAG_TYPE";
+  readonly variants: readonly {
+    readonly key: string;
+    readonly name: string;
+    readonly description: string;
+    readonly attachment: Readonly<Record<string, unknown>>;
+  }[];
+  readonly rules: readonly {
+    readonly segmentOperator: string;
+    readonly segments: readonly string[];
+    readonly distributions: readonly {
+      readonly variant: string;
+      readonly rollout: number;
+    }[];
+  }[];
+  readonly rollouts: readonly FliptRolloutPayload[];
+  readonly defaultVariant?: string;
+  readonly metadata: {
+    readonly owner: string;
+    readonly source: string;
+    readonly namespace: string;
+  };
+};
+
+export type FliptRolloutPayload =
+  | {
+      readonly type: "SEGMENT_ROLLOUT_TYPE";
+      readonly description: string;
+      readonly segment: {
+        readonly value: boolean;
+        readonly segments: readonly string[];
+        readonly segmentOperator: string;
+      };
+    }
+  | {
+      readonly type: "THRESHOLD_ROLLOUT_TYPE";
+      readonly description: string;
+      readonly threshold: {
+        readonly percentage: number;
+        readonly value: boolean;
+      };
+    };
+
+function fliptComparisonType(type: string): string {
+  if (!type.includes("_CONSTRAINT_")) {
+    throw new Error(`unsupported Flipt snapshot constraint type: ${type}`);
+  }
+  return type.replace("_CONSTRAINT_", "_");
+}
+
+function fliptMatchType(type: string): string {
+  if (!type.includes("_SEGMENT_")) {
+    throw new Error(`unsupported Flipt snapshot match type: ${type}`);
+  }
+  return type.replace("_SEGMENT_", "_");
+}
+
+function parseAttachment(
+  attachment: string,
+  variantKey: string,
+): Readonly<Record<string, unknown>> {
+  try {
+    return AttachmentSchema.parse(JSON.parse(attachment));
+  } catch (error) {
+    throw new Error(`invalid attachment JSON for variant ${variantKey}`, {
+      cause: error,
+    });
+  }
+}
+
+function segmentPayload(input: {
+  readonly key: string;
+  readonly matchType: string;
+  readonly constraints: ManagedFlag["rollouts"][number]["constraints"];
+}): FliptSegmentPayload {
+  return {
+    "@type": FLIPT_SEGMENT_TYPE_URL,
+    key: input.key,
+    name: input.key,
+    description: `Managed segment ${input.key}.`,
+    matchType: fliptMatchType(input.matchType),
+    constraints: input.constraints.map((constraint) => ({
+      type: fliptComparisonType(constraint.type),
+      property: constraint.property,
+      operator: constraint.operator,
+      value: constraint.value,
+      description: `Match ${constraint.property}.`,
+    })),
+  };
+}
+
+function flagSegments(flag: ManagedFlag): FliptSegmentPayload[] {
+  return [
+    ...flag.rollouts.map((rollout) =>
+      segmentPayload({
+        key: rollout.segmentKey,
+        matchType: rollout.matchType,
+        constraints: rollout.constraints,
+      }),
+    ),
+    ...flag.rules.flatMap((rule) =>
+      rule.segments.map((segment) =>
+        segmentPayload({
+          key: segment.key,
+          matchType: segment.matchType,
+          constraints: segment.constraints,
+        }),
+      ),
+    ),
+  ];
+}
+
+export function collectManagedSegmentPayloads(
+  flags: readonly ManagedFlag[],
+): FliptSegmentPayload[] {
+  const definitions = new Map<string, FliptSegmentPayload>();
+  for (const flag of flags) {
+    for (const payload of flagSegments(flag)) {
+      const existing = definitions.get(payload.key);
+      if (
+        existing !== undefined &&
+        JSON.stringify(existing) !== JSON.stringify(payload)
+      ) {
+        throw new Error(
+          `conflicting managed segment definition: ${payload.key}`,
+        );
+      }
+      definitions.set(payload.key, payload);
+    }
+  }
+  return [...definitions.values()].sort((left, right) =>
+    left.key.localeCompare(right.key),
+  );
+}
+
+function booleanRollouts(
+  flag: Extract<ManagedFlag, { type: "boolean" }>,
+): FliptRolloutPayload[] {
+  const thresholdByRank = new Map(
+    flag.thresholdRollouts.map((rollout) => [rollout.rank, rollout]),
+  );
+  if (thresholdByRank.size !== flag.thresholdRollouts.length) {
+    throw new Error(`duplicate threshold rollout rank for ${flag.key}`);
+  }
+
+  const segmentRollouts = flag.rollouts.map((rollout) => ({
+    type: "SEGMENT_ROLLOUT_TYPE" as const,
+    description: `Managed segment rollout for ${rollout.segmentKey}.`,
+    segment: {
+      value: rollout.result,
+      segments: [rollout.segmentKey],
+      segmentOperator: rollout.segmentOperator,
+    },
+  }));
+  const total = segmentRollouts.length + thresholdByRank.size;
+  for (const rank of thresholdByRank.keys()) {
+    if (rank >= total) {
+      throw new Error(
+        `threshold rollout rank out of range for ${flag.key}: ${rank.toString()}`,
+      );
+    }
+  }
+
+  const rendered: FliptRolloutPayload[] = [];
+  let segmentIndex = 0;
+  for (let rank = 0; rank < total; rank += 1) {
+    const threshold = thresholdByRank.get(rank);
+    if (threshold !== undefined) {
+      rendered.push({
+        type: "THRESHOLD_ROLLOUT_TYPE",
+        description: `Managed threshold rollout at rank ${rank.toString()}.`,
+        threshold: {
+          percentage: threshold.percentage,
+          value: threshold.result,
+        },
+      });
+      continue;
+    }
+    const segment = segmentRollouts[segmentIndex];
+    if (segment === undefined) {
+      throw new Error(
+        `missing segment rollout for ${flag.key} at rank ${rank.toString()}`,
+      );
+    }
+    rendered.push(segment);
+    segmentIndex += 1;
+  }
+  return rendered;
+}
+
+function variantDefinitions(flag: Extract<ManagedFlag, { type: "variant" }>) {
+  const attachments = new Map<string, string>();
+  for (const rule of flag.rules) {
+    for (const distribution of rule.distributions) {
+      const existing = attachments.get(distribution.variantKey);
+      if (
+        existing !== undefined &&
+        existing !== distribution.variantAttachment
+      ) {
+        throw new Error(
+          `conflicting variant attachment: ${flag.key}/${distribution.variantKey}`,
+        );
+      }
+      attachments.set(distribution.variantKey, distribution.variantAttachment);
+    }
+  }
+
+  const keys = new Set<string>([flag.default, ...attachments.keys()]);
+  return [...keys]
+    .sort((left, right) => left.localeCompare(right))
+    .map((key) => ({
+      key,
+      name: key,
+      description: "",
+      attachment: parseAttachment(attachments.get(key) ?? "{}", key),
+    }));
+}
+
+function variantRules(flag: ManagedFlag) {
+  const ranks = new Set<number>();
+  return [...flag.rules]
+    .sort((left, right) => left.rank - right.rank)
+    .map((rule) => {
+      if (ranks.has(rule.rank)) {
+        throw new Error(
+          `duplicate rule rank for ${flag.key}: ${rule.rank.toString()}`,
+        );
+      }
+      ranks.add(rule.rank);
+      return {
+        segmentOperator: rule.segmentOperator,
+        segments: rule.segments.map((segment) => segment.key),
+        distributions: rule.distributions.map((distribution) => ({
+          variant: distribution.variantKey,
+          rollout: distribution.rollout,
+        })),
+      };
+    });
+}
+
+export function toFliptFlagPayload(flag: ManagedFlag): FliptFlagPayload {
+  const metadata = {
+    owner: flag.owner,
+    source: flag.source,
+    namespace: flag.namespace,
+  };
+  if (flag.type === "boolean") {
+    return {
+      "@type": FLIPT_FLAG_TYPE_URL,
+      key: flag.key,
+      name: flag.key,
+      description: flag.purpose,
+      enabled: flag.default,
+      type: "BOOLEAN_FLAG_TYPE",
+      variants: [],
+      rules: [],
+      rollouts: booleanRollouts(flag),
+      metadata,
+    };
+  }
+  return {
+    "@type": FLIPT_FLAG_TYPE_URL,
+    key: flag.key,
+    name: flag.key,
+    description: flag.purpose,
+    enabled: true,
+    type: "VARIANT_FLAG_TYPE",
+    variants: variantDefinitions(flag),
+    rules: variantRules(flag),
+    rollouts: [],
+    defaultVariant: flag.default,
+    metadata,
+  };
+}

--- a/packages/feature-flags/src/flipt-resource-payloads.ts
+++ b/packages/feature-flags/src/flipt-resource-payloads.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { orderedBooleanRollouts } from "./flipt-boolean-rollouts.ts";
 import type { ManagedFlag } from "./managed-flag-inventory.ts";
 
 export const FLIPT_FLAG_TYPE_URL = "flipt.core.Flag";
@@ -168,59 +169,32 @@ export function collectManagedSegmentPayloads(
 function booleanRollouts(
   flag: Extract<ManagedFlag, { type: "boolean" }>,
 ): FliptRolloutPayload[] {
-  const thresholdByRank = new Map(
-    flag.thresholdRollouts.map((rollout) => [rollout.rank, rollout]),
-  );
-  if (thresholdByRank.size !== flag.thresholdRollouts.length) {
-    throw new Error(`duplicate threshold rollout rank for ${flag.key}`);
-  }
-
-  const segmentRollouts = flag.rollouts.map((rollout) => ({
-    type: "SEGMENT_ROLLOUT_TYPE" as const,
-    description: `Managed segment rollout for ${rollout.segmentKey}.`,
-    segment: {
-      value: rollout.result,
-      segments: [rollout.segmentKey],
-      segmentOperator: rollout.segmentOperator,
-    },
-  }));
-  const total = segmentRollouts.length + thresholdByRank.size;
-  for (const rank of thresholdByRank.keys()) {
-    if (rank < 1 || rank > total) {
-      throw new Error(
-        `threshold rollout rank out of range for ${flag.key}: ${rank.toString()}`,
-      );
-    }
-  }
-
-  const rendered: FliptRolloutPayload[] = [];
-  let segmentIndex = 0;
-  for (let rank = 1; rank <= total; rank += 1) {
-    const threshold = thresholdByRank.get(rank);
-    if (threshold !== undefined) {
-      rendered.push({
+  return orderedBooleanRollouts(flag).map((slot) => {
+    if (slot.kind === "threshold") {
+      return {
         type: "THRESHOLD_ROLLOUT_TYPE",
-        description: `Managed threshold rollout at rank ${rank.toString()}.`,
+        description: `Managed threshold rollout at rank ${slot.rank.toString()}.`,
         threshold: {
-          percentage: threshold.percentage,
-          value: threshold.result,
+          percentage: slot.percentage,
+          value: slot.result,
         },
-      });
-      continue;
+      };
     }
-    const segment = segmentRollouts[segmentIndex];
-    if (segment === undefined) {
-      throw new Error(
-        `missing segment rollout for ${flag.key} at rank ${rank.toString()}`,
-      );
-    }
-    rendered.push(segment);
-    segmentIndex += 1;
-  }
-  return rendered;
+    return {
+      type: "SEGMENT_ROLLOUT_TYPE",
+      description: `Managed segment rollout for ${slot.segmentKey}.`,
+      segment: {
+        value: slot.result,
+        segments: [slot.segmentKey],
+        segmentOperator: slot.segmentOperator,
+      },
+    };
+  });
 }
 
-function variantDefinitions(flag: Extract<ManagedFlag, { type: "variant" }>) {
+export function variantDefinitions(
+  flag: Extract<ManagedFlag, { type: "variant" }>,
+) {
   const attachments = new Map<string, string>();
   for (const rule of flag.rules) {
     for (const distribution of rule.distributions) {

--- a/packages/temporal/src/activities/flipt-flag-inventory.ts
+++ b/packages/temporal/src/activities/flipt-flag-inventory.ts
@@ -1,4 +1,5 @@
 import { createAlertmanagerPoster } from "#lib/alertmanager.ts";
+import { applyMissingManagedFlags } from "@shepherdjerred/feature-flags/flipt-missing-flag-apply.ts";
 import {
   compareManagedFlagInventory,
   fetchFliptSnapshot,
@@ -15,6 +16,8 @@ import {
 
 export type FliptFlagInventoryResult = FliptFlagDriftAlertInput & {
   readonly observedAt: string;
+  readonly createdFlags: readonly string[];
+  readonly createdSegments: readonly string[];
 };
 
 function requiredEnvironment(name: string): string {
@@ -31,6 +34,13 @@ export const fliptFlagInventoryActivities = {
   async checkFliptFlagInventory(): Promise<FliptFlagInventoryResult[]> {
     const url = requiredEnvironment("FLIPT_URL");
     const observedAt = new Date().toISOString();
+    const created = await applyMissingManagedFlags({ url });
+    const createdByPair = new Map(
+      created.map((result) => [
+        `${result.environment}/${result.namespace}`,
+        result,
+      ]),
+    );
     const results = await Promise.all(
       managedFlagInventory.environments.flatMap((environment) =>
         managedFlagNamespaces.map(async (namespace) => {
@@ -45,12 +55,15 @@ export const fliptFlagInventoryActivities = {
             environment: environment.key,
           });
           const drift = compareManagedFlagInventory(snapshot, expectedFlags);
+          const applied = createdByPair.get(`${environment.key}/${namespace}`);
           return {
             namespace,
             environment: environment.key,
             missingInFlipt: drift.missingInFlipt,
             undeclaredInInventory: drift.undeclaredInInventory,
             contractMismatches: drift.contractMismatches,
+            createdFlags: applied?.createdFlags ?? [],
+            createdSegments: applied?.createdSegments ?? [],
             observedAt,
           };
         }),

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -295,11 +295,12 @@ test("Flipt inventory drift starts on the shared Workflow queue", () => {
     args: [],
     timing: {
       kind: "cron",
-      expression: "15 6 * * *",
+      expression: "*/15 * * * *",
       timezone: "America/Los_Angeles",
     },
     taskQueue: TASK_QUEUES.WORKFLOWS,
     overlap: ScheduleOverlapPolicy.SKIP,
+    catchupWindow: "5 minutes",
     workflowExecutionTimeout: "15 minutes",
   });
 });

--- a/packages/temporal/src/schedules/schedule-definitions-early.ts
+++ b/packages/temporal/src/schedules/schedule-definitions-early.ts
@@ -66,13 +66,14 @@ export const EARLY_SCHEDULES = schedulesInNamespace("prod", [
     args: [],
     timing: {
       kind: "cron",
-      expression: "15 6 * * *",
+      expression: "*/15 * * * *",
       timezone: "America/Los_Angeles",
     },
     taskQueue: TASK_QUEUES.WORKFLOWS,
     overlap: ScheduleOverlapPolicy.SKIP,
+    catchupWindow: "5 minutes",
     workflowExecutionTimeout: "15 minutes",
-    memo: "Daily Flipt managed-flag inventory drift check with Alertmanager fire/resolve",
+    memo: "Create missing managed Flipt flags, then alert on remaining inventory drift",
   },
   {
     id: "buildkite-bun-cache-gc",

--- a/packages/temporal/src/shared/alerts/flipt-flag-drift-alert.ts
+++ b/packages/temporal/src/shared/alerts/flipt-flag-drift-alert.ts
@@ -32,7 +32,7 @@ export function buildFliptFlagDriftAlert(
         `Declared keys missing from Flipt: ${formatKeys(input.missingInFlipt)}`,
         `Flipt keys absent from the inventory: ${formatKeys(input.undeclaredInInventory)}`,
         `Behavior contract mismatches: ${formatKeys(input.contractMismatches)}`,
-        "Reconcile the reviewed inventory and Flipt state, then run the operator check again.",
+        "Missing declared keys are created automatically. Remaining drift is live targeting or undeclared Flipt keys; update the inventory or the audited Flipt state.",
       ].join("\n")
     : `The repository inventory and Flipt are aligned in ${input.environment}/${input.namespace}.`;
 

--- a/packages/temporal/src/workflows/flipt-flag-inventory.test.ts
+++ b/packages/temporal/src/workflows/flipt-flag-inventory.test.ts
@@ -17,6 +17,8 @@ describe("runFliptFlagInventory", () => {
             missingInFlipt: [],
             undeclaredInInventory: [],
             contractMismatches: [],
+            createdFlags: [],
+            createdSegments: [],
             observedAt: "2026-08-28T15:00:00.000Z",
           },
         ];

--- a/scripts/checks/check-flipt-flag-inventory.ts
+++ b/scripts/checks/check-flipt-flag-inventory.ts
@@ -1,3 +1,4 @@
+import { applyMissingManagedFlags } from "../../packages/feature-flags/src/flipt-missing-flag-apply.ts";
 import {
   compareManagedFlagInventory,
   fetchFliptSnapshot,
@@ -111,6 +112,28 @@ async function main(): Promise<void> {
   const environmentFilter =
     argument("--environment") ?? Bun.env["FLIPT_ENVIRONMENT"];
   const url = requiredUrl();
+  if (Bun.argv.includes("--apply-missing")) {
+    const created = await applyMissingManagedFlags({
+      url,
+      ...(environmentFilter === undefined ? {} : { environmentFilter }),
+      ...(namespaceFilter === undefined ? {} : { namespaceFilter }),
+    });
+    for (const result of created) {
+      if (
+        result.createdFlags.length === 0 &&
+        result.createdSegments.length === 0 &&
+        result.createdNamespaces.length === 0
+      ) {
+        continue;
+      }
+      const namespaces = result.createdNamespaces.join(",") || "none";
+      const segments = result.createdSegments.join(",") || "none";
+      const flags = result.createdFlags.join(",") || "none";
+      console.log(
+        `created missing Flipt resources in ${result.environment}/${result.namespace}: namespaces=${namespaces} segments=${segments} flags=${flags}`,
+      );
+    }
+  }
   const messages = await checkManagedFlagMatrix({
     namespaceFilter,
     environmentFilter,


### PR DESCRIPTION
## Why

Declared inventory keys never reached live Flipt after the first PVC seed. Every new flag produced `FLAG_NOT_FOUND` drift until someone created it in the UI.

## What

- Create absent namespaces, segments, and flags through the Flipt v2 management API.
- Leave existing flags and targeting unchanged.
- Run the apply from the inventory Temporal workflow every 15 minutes.
- Add operator `--apply-missing` for an immediate apply.

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/feature-flags`
- `bunx turbo run typecheck lint --filter=@shepherdjerred/temporal --filter=@shepherdjerred/root-scripts`
- `bunx turbo run typecheck test lint build --filter=@shepherdjerred/docs-wiki`
- Focused Temporal inventory, schedule, and alert tests
- Live `bun run check-flipt-flag-inventory -- --apply-missing` created the missing Scout keys in beta and prod. Remaining drift is operator targeting that was not overwritten.
- `bunx lefthook run pre-commit`

CI, artifact publication, and ArgoCD rollout of the Temporal worker were not run.