### PR TITLE
fix(streambot): stop YouTube playback 403s from a stale yt-dlp client

### DIFF
--- a/packages/streambot/Dockerfile
+++ b/packages/streambot/Dockerfile
@@ -149,7 +149,7 @@ RUN set -e; \
 # installed at the config-default path /usr/local/bin/yt-dlp. Per-arch asset,
 # pinned checksum, retries. Independent of the app layers below.
 # renovate: datasource=github-releases depName=yt-dlp/yt-dlp
-ARG YT_DLP_VERSION=2026.07.04
+ARG YT_DLP_VERSION=2026.08.19
 RUN set -e; \
     arch="$(dpkg --print-architecture)"; \
     if [ "$arch" = "amd64" ]; then asset=yt-dlp_linux; \
@@ -161,6 +161,15 @@ RUN set -e; \
     (cd /tmp && sha256sum -c --ignore-missing SHA2-256SUMS); \
     install -D -m 0755 "/tmp/$asset" /usr/local/bin/yt-dlp; \
     rm -f "/tmp/$asset" /tmp/SHA2-256SUMS
+
+# YouTube now 403s the android_vr client yt-dlp used to reach for a muxed
+# (single-file, video+audio) format, and every other default client (web,
+# mweb, ios, tv*, visionos) only offers split video-only/audio-only streams —
+# so `-f best` (what ytdlp.ts requests) fails outright without this. android
+# is the one client left that still serves a working muxed stream; ios/web
+# are kept as fallbacks. yt-dlp reads /etc/yt-dlp.conf automatically.
+RUN printf '%s\n' '--extractor-args "youtube:player_client=android,ios,web"' \
+      > /etc/yt-dlp.conf
 
 # Production node_modules + workspace manifests. The isolated-linker tree uses
 # relative symlinks (store at node_modules/.bun), so copying the whole install


### PR DESCRIPTION
## Why
Streambot's YouTube playback started failing in production: every attempt hit
`ffmpeg exited with code 8` / HTTP 403 from `googlevideo.com`, immediately
after a successful `yt-dlp` extraction.

The pinned `yt-dlp` (`2026.07.04`) defaults to YouTube's `android_vr` player
client to obtain a combined video+audio ("muxed") format, and YouTube began
rejecting that client's URLs with 403 sometime after early July. Upstream's
[`2026.08.19` release](https://github.com/yt-dlp/yt-dlp/releases/tag/2026.08.19)
removed `android_vr` from the default client list for the same reason
([yt-dlp/yt-dlp#17461](https://github.com/yt-dlp/yt-dlp/issues/17461)) — but
bumping the version alone isn't enough: none of the clients that remain by
default (`web`, `mweb`, `ios`, `tv*`, `visionos`) serve a muxed format at all,
only split video-only/audio-only streams. `ytdlp.ts`'s `-f best` selector
(`packages/streambot/src/sources/ytdlp.ts`) requires a single muxed URL, so it
would fail with "Requested format is not available" even on the newer yt-dlp.

## What
- Bump `YT_DLP_VERSION` in `packages/streambot/Dockerfile` to `2026.08.19`.
- Bake in `/etc/yt-dlp.conf` (auto-loaded by yt-dlp; no code change needed)
  forcing `--extractor-args "youtube:player_client=android,ios,web"` —
  `android` is the one client left that still hands out a working muxed
  stream; `ios`/`web` are fallbacks.

## Verification
- `hadolint --config .hadolint.yaml packages/streambot/Dockerfile` — clean
- `bunx turbo run typecheck lint --filter=@shepherdjerred/streambot` — passed
- `bunx lefthook run pre-commit` — passed
- **Live-validated against the running production pod before authoring this
  change**: hot-swapped a checksum-verified `yt-dlp 2026.08.19` binary into
  the running `media-streambot` container and dropped in the same
  `/etc/yt-dlp.conf`. Confirmed streambot's actual `--dump-json -f best` call
  now returns a working itag-18 URL, and `ffprobe` opens it successfully
  (reports the correct duration). That live patch was a stopgap only (lost on
  next pod restart/deploy) — this PR is the durable fix.

Not run: `bun run docker:build` (full image build/smoke) and an actual
in-Discord playback — deferred to CI image build/publish and post-deploy
verification against the live pod once this ships.