### PR TITLE
fix(scout-for-lol): end the voice session when the bot is moved to another channel

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/discord/bootstrap.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/bootstrap.ts
@@ -310,9 +310,20 @@ export function registerDiscordEventHandlers(target: Client): void {
   });
 
   // Voice-assistant auto-leave: when the session's channel holds no non-bot
-  // members any more, nobody consented to being listened to. The manager
-  // ignores guilds without an active session, so this stays a cheap check.
+  // members any more, nobody consented to being listened to. Also covers
+  // Scout's OWN voice state: an admin dragging the bot to a different
+  // channel moves its connection without ever going through `/scout join`,
+  // so that must end the session too rather than silently keep listening
+  // wherever the connection ends up. The manager ignores guilds without an
+  // active or pending session, so both checks stay cheap.
   target.on(Events.VoiceStateUpdate, (_oldState, newState) => {
+    if (newState.member?.id === target.user?.id) {
+      getVoiceAssistantManager().handleBotChannelChanged(
+        newState.guild.id,
+        newState.channelId,
+      );
+      return;
+    }
     getVoiceAssistantManager().handleVoiceStateUpdate(newState.guild.id);
   });
 }

--- a/packages/scout-for-lol/packages/backend/src/voice-assistant/manager.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/voice-assistant/manager.test.ts
@@ -649,4 +649,34 @@ describe("VoiceAssistantManager handleBotChannelChanged", () => {
     await expect(join).resolves.toBe("cancelled");
     expect(h.sessionEvents).not.toContain("created");
   });
+
+  test("does not cancel a join over its own manager-initiated null transition", async () => {
+    const pendingConnections: ((connection: AssistantConnection) => void)[] =
+      [];
+    const h = managerHarness({
+      joinAssistantChannel: () =>
+        new Promise((resolve) => {
+          pendingConnections.push(resolve);
+        }),
+    });
+    const join = h.manager.join(GUILD, "channel-1");
+    await waitUntil(() => pendingConnections.length === 1);
+    // `join()` always destroys any existing connection before establishing
+    // the requested one, which briefly reports no channel while the old
+    // connection tears down — a transient `null`, not an external move.
+    h.manager.handleBotChannelChanged(GUILD, null);
+    pendingConnections[0]?.(fakeConnection());
+    await expect(join).resolves.toBe("joined");
+    expect(h.sessionEvents).toContain("created");
+  });
+
+  test("does not end an active session on a null transition", async () => {
+    const h = managerHarness();
+    await h.manager.join(GUILD, "channel-1");
+    // A genuine full disconnect is the connection-lost listener's job, not
+    // this one's.
+    h.manager.handleBotChannelChanged(GUILD, null);
+    expect(h.manager.isActive(GUILD)).toBe(true);
+    expect(h.left).toEqual([]);
+  });
 });

--- a/packages/scout-for-lol/packages/backend/src/voice-assistant/manager.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/voice-assistant/manager.test.ts
@@ -605,3 +605,48 @@ describe("VoiceAssistantManager flag-evaluation failures and external epochs", (
     expect(h.sessionEvents).not.toContain("created");
   });
 });
+
+describe("VoiceAssistantManager handleBotChannelChanged", () => {
+  test("ends an active session when Scout is moved to a different channel", async () => {
+    const h = managerHarness();
+    await h.manager.join(GUILD, "channel-1");
+    h.manager.handleBotChannelChanged(GUILD, "channel-2");
+    expect(h.manager.isActive(GUILD)).toBe(false);
+    expect(h.left).toEqual([GUILD]);
+    expect(h.sessionEvents).toContain("closed");
+  });
+
+  test("is a no-op when the reported channel matches the active one", async () => {
+    const h = managerHarness();
+    await h.manager.join(GUILD, "channel-1");
+    h.manager.handleBotChannelChanged(GUILD, "channel-1");
+    expect(h.manager.isActive(GUILD)).toBe(true);
+    expect(h.left).toEqual([]);
+  });
+
+  test("does nothing for a guild with no active or pending session", () => {
+    const h = managerHarness();
+    h.manager.handleBotChannelChanged(GUILD, "channel-2");
+    expect(h.left).toEqual([]);
+  });
+
+  test("cancels a pending join when Scout is moved before the connection resolves", async () => {
+    const pendingConnections: ((connection: AssistantConnection) => void)[] =
+      [];
+    const h = managerHarness({
+      joinAssistantChannel: () =>
+        new Promise((resolve) => {
+          pendingConnections.push(resolve);
+        }),
+    });
+    const join = h.manager.join(GUILD, "channel-1");
+    await waitUntil(() => pendingConnections.length === 1);
+    // Scout gets dragged to a different channel while the first connection
+    // is still establishing — a stray VoiceStateUpdate for the bot itself,
+    // not anything routed through join()/leave().
+    h.manager.handleBotChannelChanged(GUILD, "channel-3");
+    pendingConnections[0]?.(fakeConnection());
+    await expect(join).resolves.toBe("cancelled");
+    expect(h.sessionEvents).not.toContain("created");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/voice-assistant/manager.ts
+++ b/packages/scout-for-lol/packages/backend/src/voice-assistant/manager.ts
@@ -491,18 +491,25 @@ export class VoiceAssistantManager {
 
   /**
    * Discord's own `VoiceStateUpdate` for Scout's own member: `newChannelId`
-   * is wherever the underlying connection is bound now (`null` if
-   * disconnected). An admin dragging the bot to a different channel moves
-   * that connection without ever going through `join()` — nobody consented
-   * to being listened to there, and the stored channel ID here would
-   * otherwise keep pointing at the channel Scout just left, so the
-   * empty-channel check above (and any later teardown) would keep watching
-   * the wrong room. A bare disconnect is already handled by the
-   * connection-lost listener wired in the constructor; this only needs to
-   * act on a channel ID that changed to something else the manager didn't
-   * request.
+   * is wherever the underlying connection is bound now. An admin dragging
+   * the bot to a DIFFERENT channel moves that connection without ever going
+   * through `join()` — nobody consented to being listened to there, and the
+   * stored channel ID here would otherwise keep pointing at the channel
+   * Scout just left, so the empty-channel check above (and any later
+   * teardown) would keep watching the wrong room.
+   *
+   * A transition to `null` is excluded on purpose, not just left unhandled:
+   * `join()` always destroys any existing connection before establishing
+   * the requested one (`VoiceManager.joinChannelLocked`), which briefly
+   * reports no channel while the old connection tears down — exactly while
+   * `pendingJoinChannels` already names the NEW target as this same
+   * request's own known channel. Reacting to that transient `null` would
+   * cancel the very join causing it. A genuine full disconnect is already
+   * handled by the connection-lost listener wired in the constructor, after
+   * its own reconnect grace period.
    */
   handleBotChannelChanged(guildId: string, newChannelId: string | null): void {
+    if (newChannelId === null) return;
     const active = this.sessions.get(guildId);
     const pendingChannelId = this.pendingJoinChannels.get(guildId);
     const knownChannelId = active?.channelId ?? pendingChannelId;

--- a/packages/scout-for-lol/packages/backend/src/voice-assistant/manager.ts
+++ b/packages/scout-for-lol/packages/backend/src/voice-assistant/manager.ts
@@ -36,7 +36,8 @@ export type SessionEndReason =
   | "connection-lost"
   | "rejoined"
   | "flag-disabled"
-  | "shutdown";
+  | "shutdown"
+  | "moved";
 
 /** What the manager needs from an assistant-mode voice connection. */
 export type AssistantConnection = AssistantVoiceConnection & {
@@ -483,6 +484,33 @@ export class VoiceAssistantManager {
     if (humans === null || humans > 0) return;
     if (active !== undefined) {
       this.endSession(guildId, "empty-channel", { leaveChannel: true });
+      return;
+    }
+    this.invalidate(guildId);
+  }
+
+  /**
+   * Discord's own `VoiceStateUpdate` for Scout's own member: `newChannelId`
+   * is wherever the underlying connection is bound now (`null` if
+   * disconnected). An admin dragging the bot to a different channel moves
+   * that connection without ever going through `join()` — nobody consented
+   * to being listened to there, and the stored channel ID here would
+   * otherwise keep pointing at the channel Scout just left, so the
+   * empty-channel check above (and any later teardown) would keep watching
+   * the wrong room. A bare disconnect is already handled by the
+   * connection-lost listener wired in the constructor; this only needs to
+   * act on a channel ID that changed to something else the manager didn't
+   * request.
+   */
+  handleBotChannelChanged(guildId: string, newChannelId: string | null): void {
+    const active = this.sessions.get(guildId);
+    const pendingChannelId = this.pendingJoinChannels.get(guildId);
+    const knownChannelId = active?.channelId ?? pendingChannelId;
+    if (knownChannelId === undefined || knownChannelId === newChannelId) {
+      return;
+    }
+    if (active !== undefined) {
+      this.endSession(guildId, "moved", { leaveChannel: true });
       return;
     }
     this.invalidate(guildId);


### PR DESCRIPTION
## Why

`packages/scout-for-lol/packages/backend/src/discord/bootstrap.ts`'s `VoiceStateUpdate` handler discarded the actual event and only rechecked occupancy of the voice-assistant session's *stored* channel ID. If a guild administrator drags Scout to a different voice channel, Discord moves the underlying connection without ever going through `/scout join` — but the manager keeps believing (and watching occupancy in) the OLD channel, leaving Scout capturing audio in a channel nobody consented to, with no code path that ever notices the move.

This is a P1 Codex review finding (`discussion_r3945963986`) from #2749 ("Hey Scout" voice assistant backend integration) that was investigated, fixed, and verified, but did not make it into that PR's merge — #2749 was merged by Jerred directly at head `97c8cdc3e5eb` while this third fix was still local and unpushed (the base branches for that stack were deleted immediately on merge). This PR carries that exact fix forward as a standalone follow-up against current `main`.

## What

- `VoiceAssistantManager` gains `handleBotChannelChanged(guildId, newChannelId)`, which compares the reported channel against whatever the manager has on record (an active session or a still-establishing pending join) and ends/cancels it on any mismatch — mirroring the existing empty-channel check's active/pending branching, including the pending case's plain epoch bump with no `leaveChannel` call.
- `bootstrap.ts`'s single `VoiceStateUpdate` listener now branches on whether the event's member is Scout itself before choosing which manager method to call. A bare disconnect (`newChannelId === null`) is left to the existing connection-lost listener; this only acts on a channel ID that changed to something else — i.e. it terminates rather than silently following the move, consistent with this feature's explicit-consent-only design.
- Added `"moved"` to `SessionEndReason` for accurate lifecycle-event metrics.

## Verification

- `bunx turbo run build typecheck test lint --filter=@scout-for-lol/backend --filter=@scout-for-lol/data --filter=@shepherdjerred/feature-flags`: 27/27 tasks green, 3419 tests passing. Only 2 pre-existing lint warnings in unrelated files (`convert.ts`, `dm.ts`), 0 errors.
- Four new `manager.test.ts` unit tests cover `handleBotChannelChanged` directly (active-session move, no-op on a matching channel, no-op on an untracked guild, cancelling a still-pending join).
- Confirmed `bootstrap.test.ts`'s structural per-event handler-count tests are unaffected — the change only touches the `VoiceStateUpdate` callback body, not event registration.
- `bunx lefthook run pre-commit`: green.
- Live behavior (an admin actually dragging the bot between channels in a real guild) not yet checked — voice assistant runtime is still gated by `VOICE_ASSISTANT_ENABLED` and not yet enabled in any deployed environment.