### PR TITLE
feat(scout-for-lol): add operational match facts and receipts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -870,7 +870,7 @@
     },
     "packages/homelab/src/helm-types": {
       "name": "@shepherdjerred/helm-types",
-      "version": "1.7.0",
+      "version": "2.0.0",
       "bin": {
         "helm-types": "dist/cli.js",
       },
@@ -1289,6 +1289,7 @@
         "@prisma/client": "^7.9.1",
         "@prisma/client-runtime-utils": "7.9.1",
         "@scout-for-lol/data": "workspace:*",
+        "@scout-for-lol/domain": "workspace:*",
         "@scout-for-lol/report": "workspace:*",
         "@scout-for-lol/temporal": "workspace:*",
         "@sentry/bun": "^10.70.0",

--- a/packages/scout-for-lol/packages/backend/package.json
+++ b/packages/scout-for-lol/packages/backend/package.json
@@ -64,6 +64,7 @@
     "@prisma/client": "^7.9.1",
     "@prisma/client-runtime-utils": "7.9.1",
     "@scout-for-lol/data": "workspace:*",
+    "@scout-for-lol/domain": "workspace:*",
     "@scout-for-lol/report": "workspace:*",
     "@scout-for-lol/temporal": "workspace:*",
     "@sentry/bun": "^10.70.0",

--- a/packages/scout-for-lol/packages/backend/prisma/migrations/20260907000000_durable_match_operational_facts/migration.sql
+++ b/packages/scout-for-lol/packages/backend/prisma/migrations/20260907000000_durable_match_operational_facts/migration.sql
@@ -1,0 +1,310 @@
+-- Durable match pipeline: operational facts and receipts.
+--
+-- Persistence for the @scout-for-lol/domain unions (match-processing,
+-- notifications, recovery) plus workflow-start requests and an append-only
+-- operator audit trail. Purely additive. Enum-shaped columns are TEXT with
+-- CHECK constraints mirroring each union's closed vocabulary, and per-variant
+-- payload columns are CHECKed present exactly in the states that carry them,
+-- following the InitialMatchHistoryImport precedent.
+
+-- One row per observed Riot match; the primary key on riotMatchId is the
+-- ownership claim. pipelineOwner NULL is the domain's `unowned` variant.
+-- promotedAt mirrors promoteArchiveOnlyToFull: only a FULL row may carry it,
+-- and a FULL row without it was born FULL (promotion is impossible there).
+CREATE TABLE "MatchObservation" (
+    "riotMatchId" TEXT NOT NULL,
+    "platformRoute" TEXT NOT NULL,
+    "processingPolicy" TEXT NOT NULL,
+    "pipelineOwner" TEXT,
+    "promotedAt" TIMESTAMP(3),
+    "gameCreatedAt" TIMESTAMP(3) NOT NULL,
+    "observedAt" TIMESTAMP(3) NOT NULL,
+    "matchObjectKey" TEXT,
+    "matchDigest" TEXT,
+    "timelineObjectKey" TEXT,
+    "timelineDigest" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MatchObservation_pkey" PRIMARY KEY ("riotMatchId"),
+    CONSTRAINT "MatchObservation_policy_check"
+      CHECK ("processingPolicy" IN ('ARCHIVE_ONLY', 'FULL')),
+    CONSTRAINT "MatchObservation_owner_check"
+      CHECK ("pipelineOwner" IS NULL OR "pipelineOwner" IN ('LEGACY_V1', 'TEMPORAL_V2')),
+    CONSTRAINT "MatchObservation_promotion_check"
+      CHECK ("promotedAt" IS NULL OR "processingPolicy" = 'FULL'),
+    CONSTRAINT "MatchObservation_platform_route_check"
+      CHECK ("platformRoute" IN (
+        'BR1', 'EUN1', 'EUW1', 'JP1', 'KR', 'LA1', 'LA2', 'ME1',
+        'NA1', 'OC1', 'RU', 'SG2', 'TR1', 'TW2', 'VN2', 'PBE1'
+      )),
+    -- Riot match ids are `{platform}_{gameId}`; the row's platformRoute must
+    -- be the id's own platform prefix.
+    CONSTRAINT "MatchObservation_match_id_platform_check"
+      CHECK (split_part("riotMatchId", '_', 1) = "platformRoute"),
+    -- An artifact reference is a key + digest pair; never half of one.
+    CONSTRAINT "MatchObservation_match_artifact_check"
+      CHECK (("matchObjectKey" IS NULL) = ("matchDigest" IS NULL)),
+    CONSTRAINT "MatchObservation_timeline_artifact_check"
+      CHECK (("timelineObjectKey" IS NULL) = ("timelineDigest" IS NULL)),
+    CONSTRAINT "MatchObservation_match_digest_format_check"
+      CHECK ("matchDigest" IS NULL OR "matchDigest" ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT "MatchObservation_timeline_digest_format_check"
+      CHECK ("timelineDigest" IS NULL OR "timelineDigest" ~ '^[0-9a-f]{64}$')
+);
+
+CREATE INDEX "MatchObservation_processingPolicy_observedAt_idx"
+ON "MatchObservation"("processingPolicy", "observedAt");
+
+CREATE INDEX "MatchObservation_gameCreatedAt_idx"
+ON "MatchObservation"("gameCreatedAt");
+
+-- Observation <-> tracked account association. FK-by-value on riotMatchId,
+-- no relation: ingestion records participants independently of other tables.
+CREATE TABLE "MatchTrackedAccount" (
+    "riotMatchId" TEXT NOT NULL,
+    "puuid" TEXT NOT NULL,
+    "playerId" INTEGER,
+    "accountId" INTEGER,
+    "cursorAdvancedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MatchTrackedAccount_pkey" PRIMARY KEY ("riotMatchId", "puuid")
+);
+
+CREATE INDEX "MatchTrackedAccount_puuid_cursorAdvancedAt_idx"
+ON "MatchTrackedAccount"("puuid", "cursorAdvancedAt");
+
+-- Durable processing receipts. scopeKey is the domain's receiptScopeKey and
+-- is what the unique identity uses, because the split scope columns are
+-- nullable and Postgres unique indexes treat NULLs as distinct; the scope_key
+-- CHECK keeps the two representations consistent so neither can drift.
+CREATE TABLE "MatchProcessingReceipt" (
+    "id" SERIAL NOT NULL,
+    "riotMatchId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "version" INTEGER NOT NULL,
+    "scopeKind" TEXT NOT NULL,
+    "scopeGuildId" TEXT,
+    "scopeAccountId" INTEGER,
+    "scopeKey" TEXT NOT NULL,
+    "evidence" TEXT,
+    "recordedAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MatchProcessingReceipt_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "MatchProcessingReceipt_version_check"
+      CHECK ("version" >= 1),
+    CONSTRAINT "MatchProcessingReceipt_scope_kind_check"
+      CHECK ("scopeKind" IN ('global', 'guild', 'account')),
+    -- Each scope variant carries exactly its own column: guild has a guild id
+    -- and no account id, account the reverse, global neither. Written as
+    -- per-kind implications so an unknown kind fails only the vocabulary
+    -- constraint above, keeping the two concerns separately testable.
+    CONSTRAINT "MatchProcessingReceipt_scope_fields_check"
+      CHECK (
+        ("scopeKind" <> 'global' OR ("scopeGuildId" IS NULL AND "scopeAccountId" IS NULL)) AND
+        ("scopeKind" <> 'guild' OR ("scopeGuildId" IS NOT NULL AND "scopeAccountId" IS NULL)) AND
+        ("scopeKind" <> 'account' OR ("scopeGuildId" IS NULL AND "scopeAccountId" IS NOT NULL))
+      ),
+    CONSTRAINT "MatchProcessingReceipt_scope_key_check"
+      CHECK ("scopeKey" = CASE "scopeKind"
+        WHEN 'global' THEN 'global'
+        WHEN 'guild' THEN 'guild:' || "scopeGuildId"
+        WHEN 'account' THEN 'account:' || "scopeAccountId"::text
+      END)
+);
+
+CREATE UNIQUE INDEX "MatchProcessingReceipt_riotMatchId_kind_version_scopeKey_key"
+ON "MatchProcessingReceipt"("riotMatchId", "kind", "version", "scopeKey");
+
+CREATE INDEX "MatchProcessingReceipt_kind_recordedAt_idx"
+ON "MatchProcessingReceipt"("kind", "recordedAt");
+
+-- Durable notification intents. The NotificationIntentState union is
+-- flattened: `state` is the discriminant, and every per-variant payload
+-- column is CHECKed present in exactly the states that carry it, so a row
+-- always round-trips into a well-formed domain value.
+CREATE TABLE "MatchNotificationIntent" (
+    "intentKey" TEXT NOT NULL,
+    "riotMatchId" TEXT NOT NULL,
+    "targetKind" TEXT NOT NULL,
+    "targetId" TEXT NOT NULL,
+    "state" TEXT NOT NULL DEFAULT 'pending',
+    "attemptCount" INTEGER NOT NULL DEFAULT 0,
+    "attemptNonce" TEXT,
+    "sendStartedAt" TIMESTAMP(3),
+    "deliveredAt" TIMESTAMP(3),
+    "messageId" TEXT,
+    "suppressedReason" TEXT,
+    "unknownObservedAt" TIMESTAMP(3),
+    "lastFailure" TEXT,
+    "freshnessDeadline" TIMESTAMP(3) NOT NULL,
+    "payload" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MatchNotificationIntent_pkey" PRIMARY KEY ("intentKey"),
+    CONSTRAINT "MatchNotificationIntent_state_check"
+      CHECK ("state" IN (
+        'pending', 'ready', 'sending', 'delivered', 'suppressed',
+        'expired', 'permission-denied', 'unknown-delivery'
+      )),
+    CONSTRAINT "MatchNotificationIntent_target_kind_check"
+      CHECK ("targetKind" IN ('channel', 'dm')),
+    CONSTRAINT "MatchNotificationIntent_attempt_count_check"
+      CHECK ("attemptCount" >= 0),
+    -- sending and unknown-delivery are only reachable after beginSend, which
+    -- mints the nonce and increments the count.
+    CONSTRAINT "MatchNotificationIntent_attempted_states_check"
+      CHECK (
+        ("state" NOT IN ('sending', 'unknown-delivery')) OR
+        ("attemptNonce" IS NOT NULL AND "attemptCount" >= 1)
+      ),
+    CONSTRAINT "MatchNotificationIntent_attempt_nonce_check"
+      CHECK (("attemptNonce" IS NOT NULL) = ("state" IN ('sending', 'unknown-delivery'))),
+    CONSTRAINT "MatchNotificationIntent_send_started_check"
+      CHECK (("sendStartedAt" IS NOT NULL) = ("state" = 'sending')),
+    CONSTRAINT "MatchNotificationIntent_delivered_at_check"
+      CHECK (("deliveredAt" IS NOT NULL) = ("state" = 'delivered')),
+    -- delivered MAY carry a message id; no other state may.
+    CONSTRAINT "MatchNotificationIntent_message_id_check"
+      CHECK ("messageId" IS NULL OR "state" = 'delivered'),
+    CONSTRAINT "MatchNotificationIntent_suppressed_reason_check"
+      CHECK (("suppressedReason" IS NOT NULL) = ("state" = 'suppressed')),
+    CONSTRAINT "MatchNotificationIntent_suppressed_reason_vocab_check"
+      CHECK (
+        "suppressedReason" IS NULL OR
+        "suppressedReason" IN ('stale', 'feature-disabled', 'recipient-preference')
+      ),
+    CONSTRAINT "MatchNotificationIntent_unknown_observed_check"
+      CHECK (("unknownObservedAt" IS NOT NULL) = ("state" = 'unknown-delivery'))
+);
+
+CREATE INDEX "MatchNotificationIntent_state_freshnessDeadline_idx"
+ON "MatchNotificationIntent"("state", "freshnessDeadline");
+
+CREATE INDEX "MatchNotificationIntent_riotMatchId_idx"
+ON "MatchNotificationIntent"("riotMatchId");
+
+-- Recovery batches. Cursor columns exist only in `scanning` and count columns
+-- only in `processing`, exactly mirroring the RecoveryBatchState union.
+-- workflowId is the Temporal retry-adoption key, unique when present.
+CREATE TABLE "MatchRecoveryBatch" (
+    "recoveryBatchId" TEXT NOT NULL,
+    "policy" TEXT NOT NULL,
+    "state" TEXT NOT NULL DEFAULT 'planned',
+    "cursorPosition" TEXT,
+    "pagesScanned" INTEGER,
+    "pageBudget" INTEGER,
+    "discoveredCount" INTEGER,
+    "succeededCount" INTEGER,
+    "suppressedCount" INTEGER,
+    "failedCount" INTEGER,
+    "abandonReason" TEXT,
+    "workflowId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MatchRecoveryBatch_pkey" PRIMARY KEY ("recoveryBatchId"),
+    CONSTRAINT "MatchRecoveryBatch_policy_check"
+      CHECK ("policy" IN ('normal', 'stale-private-only', 'no-external')),
+    CONSTRAINT "MatchRecoveryBatch_state_check"
+      CHECK ("state" IN (
+        'planned', 'scanning', 'processing', 'digesting', 'complete', 'abandoned'
+      )),
+    CONSTRAINT "MatchRecoveryBatch_cursor_presence_check"
+      CHECK (
+        ("state" = 'scanning' AND "pagesScanned" IS NOT NULL AND "pageBudget" IS NOT NULL) OR
+        ("state" <> 'scanning' AND "pagesScanned" IS NULL AND "pageBudget" IS NULL
+          AND "cursorPosition" IS NULL)
+      ),
+    -- The position is produced by an advance, so it exists exactly when at
+    -- least one page has been scanned.
+    CONSTRAINT "MatchRecoveryBatch_cursor_position_check"
+      CHECK (("cursorPosition" IS NOT NULL) = (COALESCE("pagesScanned", 0) > 0)),
+    CONSTRAINT "MatchRecoveryBatch_cursor_bounds_check"
+      CHECK (
+        "pagesScanned" IS NULL OR
+        ("pagesScanned" >= 0 AND "pageBudget" >= 1 AND "pagesScanned" <= "pageBudget")
+      ),
+    -- All four counts exist in `processing` and none exists anywhere else; a
+    -- plain biconditional would let a partial count set through outside
+    -- `processing`, so both directions are spelled out.
+    CONSTRAINT "MatchRecoveryBatch_counts_presence_check"
+      CHECK (
+        ("state" = 'processing' AND
+          "discoveredCount" IS NOT NULL AND "succeededCount" IS NOT NULL AND
+          "suppressedCount" IS NOT NULL AND "failedCount" IS NOT NULL) OR
+        ("state" <> 'processing' AND
+          "discoveredCount" IS NULL AND "succeededCount" IS NULL AND
+          "suppressedCount" IS NULL AND "failedCount" IS NULL)
+      ),
+    CONSTRAINT "MatchRecoveryBatch_counts_bounds_check"
+      CHECK (
+        "discoveredCount" IS NULL OR (
+          "discoveredCount" >= 0 AND "succeededCount" >= 0 AND
+          "suppressedCount" >= 0 AND "failedCount" >= 0 AND
+          "succeededCount" + "suppressedCount" + "failedCount" <= "discoveredCount"
+        )
+      ),
+    CONSTRAINT "MatchRecoveryBatch_abandon_reason_check"
+      CHECK (("abandonReason" IS NOT NULL) = ("state" = 'abandoned')),
+    CONSTRAINT "MatchRecoveryBatch_abandon_reason_vocab_check"
+      CHECK (
+        "abandonReason" IS NULL OR
+        "abandonReason" IN (
+          'operator-cancelled', 'scan-budget-exhausted',
+          'upstream-unavailable', 'superseded'
+        )
+      )
+);
+
+CREATE UNIQUE INDEX "MatchRecoveryBatch_workflowId_key"
+ON "MatchRecoveryBatch"("workflowId");
+
+CREATE INDEX "MatchRecoveryBatch_state_createdAt_idx"
+ON "MatchRecoveryBatch"("state", "createdAt");
+
+-- Workflow start requests. Only "start requested" / "start accepted" live
+-- here (ScoutTemporalWork owns execution state); the primary key is the
+-- requested workflow id so a crashed requester adopts its own request.
+CREATE TABLE "ScoutWorkflowStart" (
+    "requestedWorkflowId" TEXT NOT NULL,
+    "workflowType" TEXT NOT NULL,
+    "requestedBy" TEXT,
+    "requestSource" TEXT NOT NULL,
+    "inputPayload" TEXT NOT NULL,
+    "requestedAt" TIMESTAMP(3) NOT NULL,
+    "acceptedAt" TIMESTAMP(3),
+    "runId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ScoutWorkflowStart_pkey" PRIMARY KEY ("requestedWorkflowId"),
+    -- A run id is Temporal's acceptance evidence, so it cannot precede one.
+    CONSTRAINT "ScoutWorkflowStart_run_id_check"
+      CHECK ("runId" IS NULL OR "acceptedAt" IS NOT NULL)
+);
+
+CREATE INDEX "ScoutWorkflowStart_workflowType_requestedAt_idx"
+ON "ScoutWorkflowStart"("workflowType", "requestedAt");
+
+-- Append-only operator audit trail. No update path by design.
+CREATE TABLE "ScoutOperatorAuditEvent" (
+    "id" SERIAL NOT NULL,
+    "actorDiscordId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "subjectKind" TEXT NOT NULL,
+    "subjectId" TEXT NOT NULL,
+    "detail" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ScoutOperatorAuditEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ScoutOperatorAuditEvent_subjectKind_subjectId_createdAt_idx"
+ON "ScoutOperatorAuditEvent"("subjectKind", "subjectId", "createdAt");
+
+CREATE INDEX "ScoutOperatorAuditEvent_actorDiscordId_createdAt_idx"
+ON "ScoutOperatorAuditEvent"("actorDiscordId", "createdAt");

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -2650,3 +2650,170 @@ model DuelStatusOutbox {
 
   @@index([deliveryStatus, createdAt])
 }
+
+// =============================================================================
+// Durable match pipeline: operational facts and receipts
+//
+// Persistence for the @scout-for-lol/domain unions (match-processing,
+// notifications, recovery). Enum-shaped and JSON columns are TEXT validated by
+// the domain schemas at every read/write boundary (src/database/durable/), per
+// the provider-neutral convention above; the hand-authored migration adds
+// CHECK constraints mirroring each union's vocabulary and per-variant field
+// presence, following the InitialMatchHistoryImport precedent.
+// =============================================================================
+
+/// One row per observed Riot match. Match ownership lives here: the unique
+/// riotMatchId is the claim key, `pipelineOwner` NULL is the domain's
+/// `unowned` variant, and promotion mirrors promoteArchiveOnlyToFull — a FULL
+/// row with NULL promotedAt was born FULL and can never have been promoted.
+model MatchObservation {
+  riotMatchId      String    @id
+  platformRoute    String
+  processingPolicy String // MatchProcessingPolicy: ARCHIVE_ONLY | FULL
+  pipelineOwner    String? // LEGACY_V1 | TEMPORAL_V2; NULL = unowned
+  promotedAt       DateTime?
+  gameCreatedAt    DateTime
+  observedAt       DateTime
+
+  // Raw capture artifact references (S3 object key + SHA-256 digest, always
+  // paired). NULL means the artifact has not been stored yet.
+  matchObjectKey    String?
+  matchDigest       String?
+  timelineObjectKey String?
+  timelineDigest    String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([processingPolicy, observedAt])
+  @@index([gameCreatedAt])
+}
+
+/// Association between an observation and one tracked account seen in the
+/// match. FK-by-value on riotMatchId (no relation) so ingestion can record
+/// participants before/independently of any other table. playerId/accountId
+/// are NULL when the puuid was tracked but not registered at observation time.
+model MatchTrackedAccount {
+  riotMatchId      String
+  puuid            String
+  playerId         Int?
+  accountId        Int?
+  cursorAdvancedAt DateTime?
+  createdAt        DateTime  @default(now())
+
+  @@id([riotMatchId, puuid])
+  @@index([puuid, cursorAdvancedAt])
+}
+
+/// One durable processing receipt. `scopeKey` is receiptScopeKey(scope) from
+/// the domain — the canonical scope identity — kept alongside the split scope
+/// columns so the unique constraint has no nullable members (Postgres treats
+/// NULLs as distinct in unique indexes); a CHECK ties the two representations
+/// together. Receipt identity is (riotMatchId, kind, version, scopeKey):
+/// recordReceipt is idempotent over it regardless of timestamp or evidence.
+model MatchProcessingReceipt {
+  id             Int      @id @default(autoincrement())
+  riotMatchId    String
+  kind           String
+  version        Int
+  scopeKind      String // ReceiptScope kind: global | guild | account
+  scopeGuildId   String?
+  scopeAccountId Int?
+  scopeKey       String // receiptScopeKey(scope), e.g. "guild:123"
+  evidence       String? // JSON, opaque to SQL
+  recordedAt     DateTime
+  createdAt      DateTime @default(now())
+
+  @@unique([riotMatchId, kind, version, scopeKey])
+  @@index([kind, recordedAt])
+}
+
+/// One durable notification intent (domain NotificationIntent). The state
+/// union is flattened: `state` is the discriminant and each variant's payload
+/// lives in a dedicated column whose presence the migration CHECKs to exactly
+/// the states that carry it. `payload` is the versioned message-content
+/// envelope ({ kind, version, data }) — what to deliver, which the domain
+/// intent deliberately does not model.
+model MatchNotificationIntent {
+  intentKey   String @id
+  riotMatchId String
+  targetKind  String // NotificationTarget kind: channel | dm
+  targetId    String
+
+  state             String    @default("pending") // NotificationIntentState kind
+  attemptCount      Int       @default(0)
+  attemptNonce      String? // sending / unknown-delivery only
+  sendStartedAt     DateTime? // sending only
+  deliveredAt       DateTime? // delivered only
+  messageId         String? // delivered only (optional there)
+  suppressedReason  String? // suppressed only: stale | feature-disabled | recipient-preference
+  unknownObservedAt DateTime? // unknown-delivery only
+  lastFailure       String? // JSON NotificationFailure
+  freshnessDeadline DateTime
+  payload           String // JSON versioned codec envelope
+
+  createdAt DateTime
+  updatedAt DateTime @updatedAt
+
+  @@index([state, freshnessDeadline])
+  @@index([riotMatchId])
+}
+
+/// One recovery batch (domain RecoveryBatch). Cursor and count columns mirror
+/// the state union's per-variant payloads, so they are nullable and CHECKed
+/// present exactly in the variant that carries them (cursor in `scanning`,
+/// counts in `processing`). workflowId is the Temporal retry-adoption business
+/// key, minted when a workflow takes the batch over.
+model MatchRecoveryBatch {
+  recoveryBatchId String  @id
+  policy          String // RecoveryPolicy: normal | stale-private-only | no-external
+  state           String  @default("planned") // RecoveryBatchState kind
+  cursorPosition  String? // scanning only, and only after the first advance
+  pagesScanned    Int? // scanning only
+  pageBudget      Int? // scanning only
+  discoveredCount Int? // processing only
+  succeededCount  Int? // processing only
+  suppressedCount Int? // processing only
+  failedCount     Int? // processing only
+  abandonReason   String? // abandoned only
+  workflowId      String? @unique
+
+  createdAt DateTime
+  updatedAt DateTime @updatedAt
+
+  @@index([state, createdAt])
+}
+
+/// A requested Temporal workflow start and its acknowledgement. Deliberately
+/// separate from ScoutTemporalWork: this records only "start requested" /
+/// "start accepted" so a crashed requester can adopt its own request by
+/// requestedWorkflowId instead of starting a duplicate workflow.
+model ScoutWorkflowStart {
+  requestedWorkflowId String    @id
+  workflowType        String
+  requestedBy         String? // operator/actor discord id; NULL for system requests
+  requestSource       String
+  inputPayload        String // JSON versioned codec envelope
+  requestedAt         DateTime
+  acceptedAt          DateTime?
+  runId               String?
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
+
+  @@index([workflowType, requestedAt])
+}
+
+/// Append-only operator audit trail for the durable pipeline. No update path:
+/// rows are only ever inserted and read.
+model ScoutOperatorAuditEvent {
+  id             Int      @id @default(autoincrement())
+  actorDiscordId String
+  action         String
+  subjectKind    String
+  subjectId      String
+  detail         String // JSON, opaque to SQL
+  createdAt      DateTime @default(now())
+
+  @@index([subjectKind, subjectId, createdAt])
+  @@index([actorDiscordId, createdAt])
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/audit-event-row.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/audit-event-row.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { IsoInstantSchema } from "@scout-for-lol/domain/identity/brands.ts";
+import { DiscordAccountIdSchema } from "@scout-for-lol/domain/identity/discord.ts";
+
+/**
+ * Row codec for ScoutOperatorAuditEvent.
+ *
+ * Append-only: there is no update mapper on purpose. The detail column is
+ * arbitrary JSON — it is parsed so a stored event is at least well-formed
+ * JSON, and otherwise left to the reader.
+ */
+
+export type ScoutOperatorAuditEventRecord = z.infer<
+  typeof ScoutOperatorAuditEventRecordSchema
+>;
+export const ScoutOperatorAuditEventRecordSchema = z.strictObject({
+  id: z.int().positive(),
+  actorDiscordId: DiscordAccountIdSchema,
+  action: z.string().min(1),
+  subjectKind: z.string().min(1),
+  subjectId: z.string().min(1),
+  detail: z.unknown(),
+  createdAt: IsoInstantSchema,
+});
+
+const RawAuditEventRowSchema = z.object({
+  id: z.number().int(),
+  actorDiscordId: z.string(),
+  action: z.string(),
+  subjectKind: z.string(),
+  subjectId: z.string(),
+  detail: z.string(),
+  createdAt: z.date(),
+});
+
+export function scoutOperatorAuditEventRowToRecord(
+  row: unknown,
+): ScoutOperatorAuditEventRecord {
+  const raw = RawAuditEventRowSchema.parse(row);
+  const detail: unknown = JSON.parse(raw.detail);
+  return ScoutOperatorAuditEventRecordSchema.parse({
+    id: raw.id,
+    actorDiscordId: raw.actorDiscordId,
+    action: raw.action,
+    subjectKind: raw.subjectKind,
+    subjectId: raw.subjectId,
+    detail,
+    createdAt: raw.createdAt.toISOString(),
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/audit-repository.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/audit-repository.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import type { DiscordAccountId } from "@scout-for-lol/domain/identity/discord.ts";
+import {
+  scoutOperatorAuditEventRowToRecord,
+  type ScoutOperatorAuditEventRecord,
+} from "#src/database/durable/audit-event-row.ts";
+
+/**
+ * Repository for ScoutOperatorAuditEvent. Append-only by design: there is no
+ * update or delete operation, and none should ever be added.
+ */
+
+type AuditDb = Pick<ExtendedPrismaClient, "scoutOperatorAuditEvent">;
+
+export type OperatorAuditEventInput = {
+  actorDiscordId: DiscordAccountId;
+  action: string;
+  subjectKind: string;
+  subjectId: string;
+  /** Arbitrary JSON-serializable detail; rejected loudly when it is not. */
+  detail: unknown;
+};
+
+const JsonDetailSchema = z.json();
+
+export async function appendAuditEvent(
+  db: AuditDb,
+  input: OperatorAuditEventInput,
+): Promise<ScoutOperatorAuditEventRecord> {
+  const detail = JsonDetailSchema.parse(input.detail);
+  const created = await db.scoutOperatorAuditEvent.create({
+    data: {
+      actorDiscordId: input.actorDiscordId,
+      action: input.action,
+      subjectKind: input.subjectKind,
+      subjectId: input.subjectId,
+      detail: JSON.stringify(detail),
+    },
+  });
+  return scoutOperatorAuditEventRowToRecord(created);
+}
+
+export async function listAuditEvents(
+  db: AuditDb,
+  args: { subjectKind: string; subjectId: string },
+): Promise<ScoutOperatorAuditEventRecord[]> {
+  const rows = await db.scoutOperatorAuditEvent.findMany({
+    where: { subjectKind: args.subjectKind, subjectId: args.subjectId },
+    orderBy: { id: "asc" },
+  });
+  return rows.map((row) => scoutOperatorAuditEventRowToRecord(row));
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/intent-repository.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/intent-repository.integration.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, describe, expect, test } from "vitest";
+import { IsoInstantSchema } from "@scout-for-lol/domain/identity/brands.ts";
+import { NotificationAttemptNonceSchema } from "@scout-for-lol/domain/notifications/intent.ts";
+import {
+  beginSend,
+  confirmDelivered,
+  markReady,
+  suppressStale,
+} from "@scout-for-lol/domain/notifications/intent-transitions.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  matchNotificationIntentRowToRecord,
+  type MatchNotificationIntentRecord,
+} from "#src/database/durable/intent-row.ts";
+import {
+  getIntent,
+  transitionIntent,
+  upsertIntent,
+} from "#src/database/durable/intent-repository.ts";
+
+const { prisma } = createTestDatabase("durable-intent-repository");
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+const AT = new Date("2026-09-07T10:00:00.000Z");
+const DEADLINE = new Date("2026-09-07T11:00:00.000Z");
+const STARTED_AT = IsoInstantSchema.parse("2026-09-07T10:30:00.000Z");
+const DELIVERED_AT = IsoInstantSchema.parse("2026-09-07T10:31:00.000Z");
+const AFTER_DEADLINE = IsoInstantSchema.parse("2026-09-07T12:00:00.000Z");
+const NONCE_A = NotificationAttemptNonceSchema.parse("nonce-a");
+const NONCE_B = NotificationAttemptNonceSchema.parse("nonce-b");
+
+function intent(key: string): MatchNotificationIntentRecord {
+  return matchNotificationIntentRowToRecord({
+    intentKey: key,
+    riotMatchId: "NA1_9000",
+    targetKind: "channel",
+    targetId: "300000000000000001",
+    state: "pending",
+    attemptCount: 0,
+    attemptNonce: null,
+    sendStartedAt: null,
+    deliveredAt: null,
+    messageId: null,
+    suppressedReason: null,
+    unknownObservedAt: null,
+    lastFailure: null,
+    freshnessDeadline: DEADLINE,
+    payload: JSON.stringify({ kind: "post-match", version: 1, data: {} }),
+    createdAt: AT,
+  });
+}
+
+describe("upsertIntent", () => {
+  test("applies once, answers an identical retry, and conflicts on drift", async () => {
+    const record = intent("upsert-1");
+    expect(await upsertIntent(prisma, record)).toEqual({ outcome: "applied" });
+    expect(await upsertIntent(prisma, record)).toEqual({
+      outcome: "already-applied",
+    });
+
+    const drifted = matchNotificationIntentRowToRecord({
+      intentKey: "upsert-1",
+      riotMatchId: "NA1_9000",
+      targetKind: "dm",
+      targetId: "200000000000000001",
+      state: "pending",
+      attemptCount: 0,
+      attemptNonce: null,
+      sendStartedAt: null,
+      deliveredAt: null,
+      messageId: null,
+      suppressedReason: null,
+      unknownObservedAt: null,
+      lastFailure: null,
+      freshnessDeadline: DEADLINE,
+      payload: JSON.stringify({ kind: "post-match", version: 1, data: {} }),
+      createdAt: AT,
+    });
+    expect(await upsertIntent(prisma, drifted)).toEqual({
+      outcome: "conflict",
+      reason: "intent-differs",
+    });
+  });
+});
+
+describe("transitionIntent", () => {
+  test("walks pending -> ready -> sending -> delivered through guarded updates", async () => {
+    await upsertIntent(prisma, intent("walk-1"));
+    const key = intent("walk-1").intent.key;
+
+    const readied = await transitionIntent(prisma, {
+      intentKey: key,
+      transition: markReady,
+    });
+    expect(readied.outcome).toBe("applied");
+    const sending = await transitionIntent(prisma, {
+      intentKey: key,
+      transition: (value) =>
+        beginSend(value, { attemptNonce: NONCE_A, startedAt: STARTED_AT }),
+    });
+    expect(sending.outcome).toBe("applied");
+    const delivered = await transitionIntent(prisma, {
+      intentKey: key,
+      transition: (value) =>
+        confirmDelivered(value, {
+          attemptNonce: NONCE_A,
+          deliveredAt: DELIVERED_AT,
+        }),
+    });
+    expect(delivered.outcome).toBe("applied");
+
+    const stored = await getIntent(prisma, { intentKey: key });
+    expect(stored?.intent.state).toEqual({
+      kind: "delivered",
+      deliveredAt: DELIVERED_AT,
+    });
+    expect(stored?.intent.attemptCount).toBe(1);
+  });
+
+  test("returns the domain's conflict for an illegal transition", async () => {
+    await upsertIntent(prisma, intent("illegal-1"));
+    const key = intent("illegal-1").intent.key;
+    expect(
+      await transitionIntent(prisma, {
+        intentKey: key,
+        transition: (value) => suppressStale(value, { at: STARTED_AT }),
+      }),
+    ).toEqual({ outcome: "conflict", reason: "not-stale" });
+    expect(
+      await transitionIntent(prisma, {
+        intentKey: key,
+        transition: (value) => suppressStale(value, { at: AFTER_DEADLINE }),
+      }),
+    ).toEqual(expect.objectContaining({ outcome: "applied" }));
+  });
+
+  test("exactly one of two concurrent sends from ready applies", async () => {
+    await upsertIntent(prisma, intent("race-1"));
+    const key = intent("race-1").intent.key;
+    await transitionIntent(prisma, { intentKey: key, transition: markReady });
+
+    const outcomes = await Promise.all([
+      transitionIntent(prisma, {
+        intentKey: key,
+        transition: (value) =>
+          beginSend(value, { attemptNonce: NONCE_A, startedAt: STARTED_AT }),
+      }),
+      transitionIntent(prisma, {
+        intentKey: key,
+        transition: (value) =>
+          beginSend(value, { attemptNonce: NONCE_B, startedAt: STARTED_AT }),
+      }),
+    ]);
+    expect(outcomes.map((result) => result.outcome).sort()).toEqual([
+      "applied",
+      "conflict",
+    ]);
+    const conflict = outcomes.find((result) => result.outcome === "conflict");
+    expect(conflict).toEqual({
+      outcome: "conflict",
+      reason: "already-sending",
+    });
+
+    const stored = await getIntent(prisma, { intentKey: key });
+    expect(stored?.intent.state.kind).toBe("sending");
+    expect(stored?.intent.attemptCount).toBe(1);
+  });
+
+  test("two concurrent identical markReady calls settle as applied plus already-applied", async () => {
+    await upsertIntent(prisma, intent("race-2"));
+    const key = intent("race-2").intent.key;
+    const outcomes = await Promise.all([
+      transitionIntent(prisma, { intentKey: key, transition: markReady }),
+      transitionIntent(prisma, { intentKey: key, transition: markReady }),
+    ]);
+    expect(outcomes.map((result) => result.outcome).sort()).toEqual([
+      "already-applied",
+      "applied",
+    ]);
+  });
+
+  test("transitioning an intent that was never upserted fails loudly", async () => {
+    await expect(
+      transitionIntent(prisma, {
+        intentKey: intent("ghost-1").intent.key,
+        transition: markReady,
+      }),
+    ).rejects.toThrow(/never upserted/);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/database/durable/intent-repository.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/intent-repository.ts
@@ -1,0 +1,130 @@
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import type { NotificationIntentKey } from "@scout-for-lol/domain/identity/brands.ts";
+import type { NotificationIntent } from "@scout-for-lol/domain/notifications/intent.ts";
+import type { NotificationTransitionResult } from "@scout-for-lol/domain/notifications/intent-transitions.ts";
+import {
+  matchNotificationIntentRecordToRow,
+  matchNotificationIntentRowToRecord,
+  notificationIntentStateColumns,
+  type MatchNotificationIntentRecord,
+} from "#src/database/durable/intent-row.ts";
+
+/**
+ * Repository for MatchNotificationIntent.
+ *
+ * Writes follow the confirmation-intent claimAndExecute idiom: the domain
+ * transition decides legality over a parsed snapshot, and the update is
+ * guarded by the exact state that snapshot observed (discriminant, attempt
+ * count, attempt nonce), so a racing writer's transition either applies to
+ * the state it actually saw or comes back as the domain's own
+ * `already-applied`/`conflict` answer after a re-read.
+ */
+
+type IntentDb = Pick<ExtendedPrismaClient, "matchNotificationIntent">;
+
+const TRANSITION_ATTEMPTS = 3;
+
+export type UpsertIntentResult =
+  | { outcome: "applied" }
+  | { outcome: "already-applied" }
+  | { outcome: "conflict"; reason: "intent-differs" };
+
+/**
+ * Ensure the intent row exists. A byte-identical retry is `already-applied`;
+ * an existing row with different facts is a conflict, because an intent key
+ * is minted for exactly one decision to notify.
+ */
+export async function upsertIntent(
+  db: IntentDb,
+  record: MatchNotificationIntentRecord,
+): Promise<UpsertIntentResult> {
+  const row = matchNotificationIntentRecordToRow(record);
+  const created = await db.matchNotificationIntent.createMany({
+    data: [row],
+    skipDuplicates: true,
+  });
+  if (created.count === 1) {
+    return { outcome: "applied" };
+  }
+  const existing = await db.matchNotificationIntent.findUnique({
+    where: { intentKey: row.intentKey },
+  });
+  if (existing === null) {
+    throw new Error(
+      `MatchNotificationIntent ${row.intentKey} vanished between a duplicate insert and its read-back`,
+    );
+  }
+  const existingRow = matchNotificationIntentRecordToRow(
+    matchNotificationIntentRowToRecord(existing),
+  );
+  return Bun.deepEquals(existingRow, row, true)
+    ? { outcome: "already-applied" }
+    : { outcome: "conflict", reason: "intent-differs" };
+}
+
+export async function getIntent(
+  db: IntentDb,
+  args: { intentKey: NotificationIntentKey },
+): Promise<MatchNotificationIntentRecord | null> {
+  const row = await db.matchNotificationIntent.findUnique({
+    where: { intentKey: args.intentKey },
+  });
+  return row === null ? null : matchNotificationIntentRowToRecord(row);
+}
+
+function observedAttemptNonce(intent: NotificationIntent): string | null {
+  const state = intent.state;
+  return state.kind === "sending" || state.kind === "unknown-delivery"
+    ? state.attemptNonce
+    : null;
+}
+
+/**
+ * Apply one pure domain transition to the stored intent.
+ *
+ * Reads the row, runs `transition` over the parsed domain value, and writes
+ * the applied result with an update guarded by everything the snapshot
+ * observed. A guard miss means a concurrent writer moved the intent first;
+ * the transition is then re-evaluated against the fresh state, which turns a
+ * lost race into the domain's own answer (`already-applied` for an identical
+ * retry, `conflict` otherwise). Transitioning an intent that was never
+ * upserted is a broken caller contract and throws.
+ */
+export async function transitionIntent(
+  db: IntentDb,
+  args: {
+    intentKey: NotificationIntentKey;
+    transition: (intent: NotificationIntent) => NotificationTransitionResult;
+  },
+): Promise<NotificationTransitionResult> {
+  for (let attempt = 0; attempt < TRANSITION_ATTEMPTS; attempt += 1) {
+    const row = await db.matchNotificationIntent.findUnique({
+      where: { intentKey: args.intentKey },
+    });
+    if (row === null) {
+      throw new Error(
+        `Cannot transition ${args.intentKey}: the intent was never upserted`,
+      );
+    }
+    const record = matchNotificationIntentRowToRecord(row);
+    const result = args.transition(record.intent);
+    if (result.outcome !== "applied") {
+      return result;
+    }
+    const updated = await db.matchNotificationIntent.updateMany({
+      where: {
+        intentKey: args.intentKey,
+        state: record.intent.state.kind,
+        attemptCount: record.intent.attemptCount,
+        attemptNonce: observedAttemptNonce(record.intent),
+      },
+      data: notificationIntentStateColumns(result.next),
+    });
+    if (updated.count === 1) {
+      return result;
+    }
+  }
+  throw new Error(
+    `Gave up transitioning ${args.intentKey} after ${String(TRANSITION_ATTEMPTS)} contended attempts`,
+  );
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/intent-row.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/intent-row.ts
@@ -1,0 +1,225 @@
+import { z } from "zod";
+import { RiotMatchIdSchema } from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  NotificationIntentSchema,
+  type NotificationIntent,
+  type NotificationTarget,
+} from "@scout-for-lol/domain/notifications/intent.ts";
+import {
+  dateFromIsoInstant,
+  parsePayloadEnvelopeColumn,
+  serializePayloadEnvelope,
+  VersionedPayloadEnvelopeSchema,
+} from "#src/database/durable/row-values.ts";
+
+/**
+ * Row codec for MatchNotificationIntent.
+ *
+ * The NotificationIntentState union is flattened into the discriminant
+ * `state` column plus one column per variant payload; the migration CHECKs
+ * pin each column to exactly the states that carry it, and this codec is the
+ * only translation between the two shapes. The payload column is the
+ * versioned message-content envelope — what to deliver — which the domain
+ * intent deliberately does not model.
+ */
+
+export type MatchNotificationIntentRecord = z.infer<
+  typeof MatchNotificationIntentRecordSchema
+>;
+export const MatchNotificationIntentRecordSchema = z.strictObject({
+  matchId: RiotMatchIdSchema,
+  intent: NotificationIntentSchema,
+  payload: VersionedPayloadEnvelopeSchema,
+});
+
+/** The columns owned by the state machine, written on every transition. */
+export type NotificationIntentStateColumns = {
+  state: string;
+  attemptCount: number;
+  attemptNonce: string | null;
+  sendStartedAt: Date | null;
+  deliveredAt: Date | null;
+  messageId: string | null;
+  suppressedReason: string | null;
+  unknownObservedAt: Date | null;
+  lastFailure: string | null;
+};
+
+/** Column shape of a MatchNotificationIntent row, minus DB-managed columns. */
+export type MatchNotificationIntentRow = NotificationIntentStateColumns & {
+  intentKey: string;
+  riotMatchId: string;
+  targetKind: string;
+  targetId: string;
+  freshnessDeadline: Date;
+  payload: string;
+  createdAt: Date;
+};
+
+const RawIntentRowSchema = z.object({
+  intentKey: z.string(),
+  riotMatchId: z.string(),
+  targetKind: z.string(),
+  targetId: z.string(),
+  state: z.string(),
+  attemptCount: z.number().int(),
+  attemptNonce: z.string().nullable(),
+  sendStartedAt: z.date().nullable(),
+  deliveredAt: z.date().nullable(),
+  messageId: z.string().nullable(),
+  suppressedReason: z.string().nullable(),
+  unknownObservedAt: z.date().nullable(),
+  lastFailure: z.string().nullable(),
+  freshnessDeadline: z.date(),
+  payload: z.string(),
+  createdAt: z.date(),
+});
+type RawIntentRow = z.infer<typeof RawIntentRowSchema>;
+
+function targetCandidate(raw: RawIntentRow): Record<string, unknown> {
+  switch (raw.targetKind) {
+    case "channel":
+      return { kind: "channel", channelId: raw.targetId };
+    case "dm":
+      return { kind: "dm", accountId: raw.targetId };
+    default:
+      throw new Error(`Unknown targetKind column value: ${raw.targetKind}`);
+  }
+}
+
+function stateCandidate(raw: RawIntentRow): Record<string, unknown> {
+  switch (raw.state) {
+    case "pending":
+    case "ready":
+    case "expired":
+    case "permission-denied":
+      return { kind: raw.state };
+    case "sending":
+      return {
+        kind: "sending",
+        attemptNonce: raw.attemptNonce,
+        startedAt: raw.sendStartedAt?.toISOString(),
+      };
+    case "delivered":
+      return {
+        kind: "delivered",
+        deliveredAt: raw.deliveredAt?.toISOString(),
+        ...(raw.messageId === null ? {} : { messageId: raw.messageId }),
+      };
+    case "suppressed":
+      return { kind: "suppressed", reason: raw.suppressedReason };
+    case "unknown-delivery":
+      return {
+        kind: "unknown-delivery",
+        attemptNonce: raw.attemptNonce,
+        observedAt: raw.unknownObservedAt?.toISOString(),
+      };
+    default:
+      throw new Error(`Unknown intent state column value: ${raw.state}`);
+  }
+}
+
+function failureCandidate(raw: RawIntentRow): Record<string, unknown> {
+  if (raw.lastFailure === null) {
+    return {};
+  }
+  const parsed: unknown = JSON.parse(raw.lastFailure);
+  return { lastFailure: parsed };
+}
+
+export function matchNotificationIntentRowToRecord(
+  row: unknown,
+): MatchNotificationIntentRecord {
+  const raw = RawIntentRowSchema.parse(row);
+  return MatchNotificationIntentRecordSchema.parse({
+    matchId: raw.riotMatchId,
+    intent: {
+      key: raw.intentKey,
+      target: targetCandidate(raw),
+      freshnessDeadline: raw.freshnessDeadline.toISOString(),
+      createdAt: raw.createdAt.toISOString(),
+      attemptCount: raw.attemptCount,
+      ...failureCandidate(raw),
+      state: stateCandidate(raw),
+    },
+    payload: parsePayloadEnvelopeColumn(raw.payload),
+  });
+}
+
+function targetColumns(target: NotificationTarget): {
+  targetKind: string;
+  targetId: string;
+} {
+  switch (target.kind) {
+    case "channel":
+      return { targetKind: "channel", targetId: target.channelId };
+    case "dm":
+      return { targetKind: "dm", targetId: target.accountId };
+  }
+}
+
+/**
+ * The state-machine columns for one domain intent. Shared by the full row
+ * mapper and by transitionIntent's guarded update patch, so a transition can
+ * never write a column set that disagrees with what a fresh insert would.
+ */
+export function notificationIntentStateColumns(
+  intent: NotificationIntent,
+): NotificationIntentStateColumns {
+  const state = intent.state;
+  const base: NotificationIntentStateColumns = {
+    state: state.kind,
+    attemptCount: intent.attemptCount,
+    attemptNonce: null,
+    sendStartedAt: null,
+    deliveredAt: null,
+    messageId: null,
+    suppressedReason: null,
+    unknownObservedAt: null,
+    lastFailure:
+      intent.lastFailure === undefined
+        ? null
+        : JSON.stringify(intent.lastFailure),
+  };
+  switch (state.kind) {
+    case "pending":
+    case "ready":
+    case "expired":
+    case "permission-denied":
+      return base;
+    case "sending":
+      return {
+        ...base,
+        attemptNonce: state.attemptNonce,
+        sendStartedAt: dateFromIsoInstant(state.startedAt),
+      };
+    case "delivered":
+      return {
+        ...base,
+        deliveredAt: dateFromIsoInstant(state.deliveredAt),
+        messageId: state.messageId ?? null,
+      };
+    case "suppressed":
+      return { ...base, suppressedReason: state.reason };
+    case "unknown-delivery":
+      return {
+        ...base,
+        attemptNonce: state.attemptNonce,
+        unknownObservedAt: dateFromIsoInstant(state.observedAt),
+      };
+  }
+}
+
+export function matchNotificationIntentRecordToRow(
+  record: MatchNotificationIntentRecord,
+): MatchNotificationIntentRow {
+  return {
+    intentKey: record.intent.key,
+    riotMatchId: record.matchId,
+    ...targetColumns(record.intent.target),
+    ...notificationIntentStateColumns(record.intent),
+    freshnessDeadline: dateFromIsoInstant(record.intent.freshnessDeadline),
+    payload: serializePayloadEnvelope(record.payload),
+    createdAt: dateFromIsoInstant(record.intent.createdAt),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/observation-repository.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/observation-repository.integration.test.ts
@@ -1,0 +1,239 @@
+import { afterAll, describe, expect, test } from "vitest";
+import { IsoInstantSchema } from "@scout-for-lol/domain/identity/brands.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  matchObservationRowToRecord,
+  type MatchObservationRecord,
+} from "#src/database/durable/observation-row.ts";
+import {
+  matchProcessingReceiptRowToRecord,
+  type MatchProcessingReceiptRecord,
+} from "#src/database/durable/receipt-row.ts";
+import {
+  getObservation,
+  getProcessingState,
+  observeMatch,
+  promoteObservation,
+} from "#src/database/durable/observation-repository.ts";
+import {
+  listReceipts,
+  recordReceipt,
+} from "#src/database/durable/receipt-repository.ts";
+
+const { prisma } = createTestDatabase("durable-observation-repository");
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+const AT = new Date("2026-09-07T10:00:00.000Z");
+const LATER = new Date("2026-09-07T11:00:00.000Z");
+const PROMOTED_AT = IsoInstantSchema.parse("2026-09-07T12:00:00.000Z");
+
+function observation(
+  gameId: number,
+  overrides: Partial<{
+    processingPolicy: string;
+    pipelineOwner: string | null;
+    promotedAt: Date | null;
+  }> = {},
+): MatchObservationRecord {
+  return matchObservationRowToRecord({
+    riotMatchId: `NA1_${String(gameId)}`,
+    platformRoute: "NA1",
+    processingPolicy: "ARCHIVE_ONLY",
+    pipelineOwner: null,
+    promotedAt: null,
+    gameCreatedAt: AT,
+    observedAt: LATER,
+    matchObjectKey: null,
+    matchDigest: null,
+    timelineObjectKey: null,
+    timelineDigest: null,
+    ...overrides,
+  });
+}
+
+function receipt(
+  gameId: number,
+  scopeKind: "global" | "guild",
+): MatchProcessingReceiptRecord {
+  return matchProcessingReceiptRowToRecord({
+    riotMatchId: `NA1_${String(gameId)}`,
+    kind: "report-posted",
+    version: 1,
+    scopeKind,
+    scopeGuildId: scopeKind === "guild" ? "100000000000000001" : null,
+    scopeAccountId: null,
+    scopeKey: scopeKind === "guild" ? "guild:100000000000000001" : "global",
+    evidence: null,
+    recordedAt: AT,
+  });
+}
+
+describe("observeMatch", () => {
+  test("applies once and answers an identical retry with already-applied", async () => {
+    const record = observation(101);
+    expect(await observeMatch(prisma, record)).toEqual({ outcome: "applied" });
+    expect(await observeMatch(prisma, record)).toEqual({
+      outcome: "already-applied",
+    });
+    expect(await getObservation(prisma, { matchId: record.matchId })).toEqual(
+      record,
+    );
+  });
+
+  test("exactly one of two concurrent identical observers applies", async () => {
+    const record = observation(102);
+    const outcomes = await Promise.all([
+      observeMatch(prisma, record),
+      observeMatch(prisma, record),
+    ]);
+    expect(outcomes.map((result) => result.outcome).sort()).toEqual([
+      "already-applied",
+      "applied",
+    ]);
+  });
+
+  test("a different pipeline claiming an owned match conflicts", async () => {
+    const legacy = observation(103, { pipelineOwner: "LEGACY_V1" });
+    const temporal = observation(103, { pipelineOwner: "TEMPORAL_V2" });
+    const outcomes = await Promise.all([
+      observeMatch(prisma, legacy),
+      observeMatch(prisma, temporal),
+    ]);
+    expect(outcomes.map((result) => result.outcome).sort()).toEqual([
+      "applied",
+      "conflict",
+    ]);
+    const stored = await getObservation(prisma, { matchId: legacy.matchId });
+    expect(stored?.owner.kind).not.toBe("unowned");
+  });
+
+  test("an assigned observer claims an unowned observation", async () => {
+    const unowned = observation(104);
+    const claimed = observation(104, { pipelineOwner: "TEMPORAL_V2" });
+    expect(await observeMatch(prisma, unowned)).toEqual({
+      outcome: "applied",
+    });
+    expect(await observeMatch(prisma, claimed)).toEqual({
+      outcome: "applied",
+    });
+    const stored = await getObservation(prisma, { matchId: unowned.matchId });
+    expect(stored?.owner).toEqual({ kind: "temporal-v2" });
+    // The claim is one-way: observing again without an owner is a no-op.
+    expect(await observeMatch(prisma, unowned)).toEqual({
+      outcome: "already-applied",
+    });
+  });
+
+  test("disagreeing observation facts conflict", async () => {
+    const record = observation(105);
+    const differing = observation(105, { processingPolicy: "FULL" });
+    expect(await observeMatch(prisma, record)).toEqual({ outcome: "applied" });
+    expect(await observeMatch(prisma, differing)).toEqual({
+      outcome: "conflict",
+      reason: "observation-differs",
+    });
+  });
+});
+
+describe("promoteObservation", () => {
+  test("promotes at most once and conflicts on a born-FULL match", async () => {
+    const record = observation(110);
+    await observeMatch(prisma, record);
+    expect(
+      await promoteObservation(prisma, {
+        matchId: record.matchId,
+        promotedAt: PROMOTED_AT,
+      }),
+    ).toEqual({ outcome: "applied" });
+    expect(
+      await promoteObservation(prisma, {
+        matchId: record.matchId,
+        promotedAt: PROMOTED_AT,
+      }),
+    ).toEqual({ outcome: "already-applied" });
+
+    const bornFull = observation(111, { processingPolicy: "FULL" });
+    await observeMatch(prisma, bornFull);
+    expect(
+      await promoteObservation(prisma, {
+        matchId: bornFull.matchId,
+        promotedAt: PROMOTED_AT,
+      }),
+    ).toEqual({ outcome: "conflict", reason: "promotion-target-born-full" });
+  });
+
+  test("promoting an unobserved match fails loudly", async () => {
+    const ghost = observation(112);
+    await expect(
+      promoteObservation(prisma, {
+        matchId: ghost.matchId,
+        promotedAt: PROMOTED_AT,
+      }),
+    ).rejects.toThrow(/never observed/);
+  });
+});
+
+describe("receipts and state assembly", () => {
+  test("recordReceipt is idempotent by scope identity", async () => {
+    await observeMatch(prisma, observation(120));
+    const globalReceipt = receipt(120, "global");
+    expect(await recordReceipt(prisma, globalReceipt)).toEqual({
+      outcome: "applied",
+    });
+    expect(await recordReceipt(prisma, globalReceipt)).toEqual({
+      outcome: "already-applied",
+    });
+  });
+
+  test("exactly one of two concurrent identical receipt writers applies", async () => {
+    await observeMatch(prisma, observation(121));
+    const guildReceipt = receipt(121, "guild");
+    const outcomes = await Promise.all([
+      recordReceipt(prisma, guildReceipt),
+      recordReceipt(prisma, guildReceipt),
+    ]);
+    expect(outcomes.map((result) => result.outcome).sort()).toEqual([
+      "already-applied",
+      "applied",
+    ]);
+  });
+
+  test("assembles the domain MatchProcessingState with its receipts", async () => {
+    const record = observation(122, { pipelineOwner: "TEMPORAL_V2" });
+    await observeMatch(prisma, record);
+    await recordReceipt(prisma, receipt(122, "global"));
+    await recordReceipt(prisma, receipt(122, "guild"));
+
+    const state = await getProcessingState(prisma, {
+      matchId: record.matchId,
+      receiptKind: "report-posted",
+      receiptVersion: 1,
+    });
+    expect(state?.owner).toEqual({ kind: "temporal-v2" });
+    expect(state?.receipts).toHaveLength(2);
+
+    const listed = await listReceipts(prisma, { matchId: record.matchId });
+    expect(listed).toHaveLength(2);
+    expect(
+      await getProcessingState(prisma, {
+        matchId: record.matchId,
+        receiptKind: "report-posted",
+        receiptVersion: 2,
+      }),
+    ).toMatchObject({ receipts: [] });
+  });
+
+  test("returns null for a match that was never observed", async () => {
+    const ghost = observation(123);
+    expect(
+      await getProcessingState(prisma, {
+        matchId: ghost.matchId,
+        receiptKind: "report-posted",
+        receiptVersion: 1,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/database/durable/observation-repository.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/observation-repository.ts
@@ -1,0 +1,198 @@
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import type {
+  IsoInstant,
+  RiotMatchId,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  MatchProcessingStateSchema,
+  type MatchProcessingState,
+} from "@scout-for-lol/domain/match-processing/states.ts";
+import {
+  matchObservationRecordToRow,
+  matchObservationRowToRecord,
+  type MatchObservationRecord,
+  type MatchObservationRow,
+} from "#src/database/durable/observation-row.ts";
+import { matchProcessingReceiptRowToRecord } from "#src/database/durable/receipt-row.ts";
+import { dateFromIsoInstant } from "#src/database/durable/row-values.ts";
+
+/**
+ * Repository for MatchObservation.
+ *
+ * Ownership of a match lives on the row's primary key: observeMatch is an
+ * insert-or-conflict claim, and promotion is a guarded update, both mirroring
+ * the pure domain transitions (claimOwnership, promoteArchiveOnlyToFull) as
+ * single guarded statements so racing writers get an expected `conflict`
+ * result instead of an exception or a silent overwrite.
+ */
+
+type ObservationDb = Pick<ExtendedPrismaClient, "matchObservation">;
+type ProcessingDb = Pick<
+  ExtendedPrismaClient,
+  "matchObservation" | "matchProcessingReceipt"
+>;
+
+export type ObserveMatchResult =
+  | { outcome: "applied" }
+  | { outcome: "already-applied" }
+  | {
+      outcome: "conflict";
+      reason: "ownership-held-by-another-owner" | "observation-differs";
+    };
+
+function ownerNeutral(row: MatchObservationRow): MatchObservationRow {
+  return { ...row, pipelineOwner: null };
+}
+
+async function resolveObservedConflict(
+  db: ObservationDb,
+  row: MatchObservationRow,
+): Promise<ObserveMatchResult> {
+  const existing = await db.matchObservation.findUnique({
+    where: { riotMatchId: row.riotMatchId },
+  });
+  if (existing === null) {
+    throw new Error(
+      `MatchObservation ${row.riotMatchId} vanished between a duplicate insert and its read-back`,
+    );
+  }
+  const existingRow = matchObservationRecordToRow(
+    matchObservationRowToRecord(existing),
+  );
+  if (Bun.deepEquals(existingRow, row, true)) {
+    return { outcome: "already-applied" };
+  }
+  if (!Bun.deepEquals(ownerNeutral(existingRow), ownerNeutral(row), true)) {
+    return { outcome: "conflict", reason: "observation-differs" };
+  }
+  // Same observation, different owner columns. NULL is the domain's
+  // `unowned`: an observation that arrives with an assigned owner claims an
+  // unowned row with a guarded update, exactly like claimOwnership.
+  if (existingRow.pipelineOwner === null && row.pipelineOwner !== null) {
+    const claimed = await db.matchObservation.updateMany({
+      where: { riotMatchId: row.riotMatchId, pipelineOwner: null },
+      data: { pipelineOwner: row.pipelineOwner },
+    });
+    if (claimed.count === 1) {
+      return { outcome: "applied" };
+    }
+    return await resolveObservedConflict(db, row);
+  }
+  if (row.pipelineOwner === null) {
+    // The observation itself is already recorded; not claiming is not a
+    // conflict with whoever did.
+    return { outcome: "already-applied" };
+  }
+  return { outcome: "conflict", reason: "ownership-held-by-another-owner" };
+}
+
+/**
+ * Record one observed match, claiming ownership when the record carries an
+ * assigned owner. Exactly one of two racing writers applies; the loser gets
+ * `already-applied` for an identical retry, an ownership conflict for a
+ * different claimant, and `observation-differs` when the facts themselves
+ * disagree (which is a bug upstream, surfaced as a conflict so the caller
+ * decides how loudly to fail).
+ */
+export async function observeMatch(
+  db: ObservationDb,
+  record: MatchObservationRecord,
+): Promise<ObserveMatchResult> {
+  const row = matchObservationRecordToRow(record);
+  const created = await db.matchObservation.createMany({
+    data: [row],
+    skipDuplicates: true,
+  });
+  if (created.count === 1) {
+    return { outcome: "applied" };
+  }
+  return await resolveObservedConflict(db, row);
+}
+
+export type PromoteObservationResult =
+  | { outcome: "applied" }
+  | { outcome: "already-applied" }
+  | { outcome: "conflict"; reason: "promotion-target-born-full" };
+
+/**
+ * Promote an ARCHIVE_ONLY observation to FULL, at most once. Mirrors
+ * promoteArchiveOnlyToFull: a retry on the promoted row is `already-applied`
+ * and a row born FULL is a conflict. Promoting a match that was never
+ * observed is a broken caller contract and throws.
+ */
+export async function promoteObservation(
+  db: ObservationDb,
+  args: { matchId: RiotMatchId; promotedAt: IsoInstant },
+): Promise<PromoteObservationResult> {
+  const promoted = await db.matchObservation.updateMany({
+    where: { riotMatchId: args.matchId, processingPolicy: "ARCHIVE_ONLY" },
+    data: {
+      processingPolicy: "FULL",
+      promotedAt: dateFromIsoInstant(args.promotedAt),
+    },
+  });
+  if (promoted.count === 1) {
+    return { outcome: "applied" };
+  }
+  const existing = await db.matchObservation.findUnique({
+    where: { riotMatchId: args.matchId },
+  });
+  if (existing === null) {
+    throw new Error(
+      `Cannot promote ${args.matchId}: the match was never observed`,
+    );
+  }
+  const record = matchObservationRowToRecord(existing);
+  return record.promotion === null
+    ? { outcome: "conflict", reason: "promotion-target-born-full" }
+    : { outcome: "already-applied" };
+}
+
+export async function getObservation(
+  db: ObservationDb,
+  args: { matchId: RiotMatchId },
+): Promise<MatchObservationRecord | null> {
+  const row = await db.matchObservation.findUnique({
+    where: { riotMatchId: args.matchId },
+  });
+  return row === null ? null : matchObservationRowToRecord(row);
+}
+
+/**
+ * Assemble the full domain MatchProcessingState for one match, scoped to one
+ * receipt (kind, version). The stored receipt identity is wider than the
+ * domain's (which keys receipts by scope alone), so the domain's
+ * one-receipt-per-scope invariant holds per (kind, version) — the caller
+ * names which receipt family it is transitioning over.
+ */
+export async function getProcessingState(
+  db: ProcessingDb,
+  args: { matchId: RiotMatchId; receiptKind: string; receiptVersion: number },
+): Promise<MatchProcessingState | null> {
+  const observation = await db.matchObservation.findUnique({
+    where: { riotMatchId: args.matchId },
+  });
+  if (observation === null) {
+    return null;
+  }
+  const record = matchObservationRowToRecord(observation);
+  const receiptRows = await db.matchProcessingReceipt.findMany({
+    where: {
+      riotMatchId: args.matchId,
+      kind: args.receiptKind,
+      version: args.receiptVersion,
+    },
+    orderBy: { id: "asc" },
+  });
+  const receipts = receiptRows.map((receiptRow) => {
+    const receiptRecord = matchProcessingReceiptRowToRecord(receiptRow);
+    return receiptRecord.receipt;
+  });
+  return MatchProcessingStateSchema.parse({
+    matchId: record.matchId,
+    owner: record.owner,
+    policy: record.policy,
+    promotion: record.promotion,
+    receipts,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/observation-row.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/observation-row.ts
@@ -1,0 +1,177 @@
+import { z } from "zod";
+import {
+  RiotMatchIdSchema,
+  S3ObjectKeySchema,
+  Sha256DigestSchema,
+  IsoInstantSchema,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import { PlatformRouteSchema } from "@scout-for-lol/domain/identity/routes.ts";
+import {
+  MatchProcessingPolicySchema,
+  PipelineOwnerSchema,
+  type PipelineOwner,
+} from "@scout-for-lol/domain/match-processing/states.ts";
+import { dateFromIsoInstant } from "#src/database/durable/row-values.ts";
+
+/**
+ * Row codec for MatchObservation.
+ *
+ * The row flattens the domain's processing facts: `pipelineOwner` NULL is the
+ * `unowned` variant, and the promotion record is the nullable `promotedAt`
+ * column (legal only under FULL, which both the CHECK constraint and this
+ * codec's schema enforce). Receipts live in their own table; assembling a full
+ * MatchProcessingState is the observation repository's job.
+ */
+
+const StoredArtifactReferenceSchema = z.strictObject({
+  key: S3ObjectKeySchema,
+  digest: Sha256DigestSchema,
+});
+export type StoredArtifactReference = z.infer<
+  typeof StoredArtifactReferenceSchema
+>;
+
+export type MatchObservationRecord = z.infer<
+  typeof MatchObservationRecordSchema
+>;
+export const MatchObservationRecordSchema = z
+  .strictObject({
+    matchId: RiotMatchIdSchema,
+    platformRoute: PlatformRouteSchema,
+    policy: MatchProcessingPolicySchema,
+    owner: PipelineOwnerSchema,
+    promotion: z.strictObject({ promotedAt: IsoInstantSchema }).nullable(),
+    gameCreatedAt: IsoInstantSchema,
+    observedAt: IsoInstantSchema,
+    artifacts: z.strictObject({
+      match: StoredArtifactReferenceSchema.nullable(),
+      timeline: StoredArtifactReferenceSchema.nullable(),
+    }),
+  })
+  .superRefine((record, ctx) => {
+    if (record.policy === "ARCHIVE_ONLY" && record.promotion !== null) {
+      ctx.addIssue({
+        code: "custom",
+        message: "an ARCHIVE_ONLY observation cannot carry a promotion record",
+        path: ["promotion"],
+      });
+    }
+    if (!record.matchId.startsWith(`${record.platformRoute}_`)) {
+      ctx.addIssue({
+        code: "custom",
+        message: `platformRoute ${record.platformRoute} is not the platform prefix of ${record.matchId}`,
+        path: ["platformRoute"],
+      });
+    }
+  });
+
+/** Column shape of a MatchObservation row, minus the DB-managed timestamps. */
+export type MatchObservationRow = {
+  riotMatchId: string;
+  platformRoute: string;
+  processingPolicy: string;
+  pipelineOwner: string | null;
+  promotedAt: Date | null;
+  gameCreatedAt: Date;
+  observedAt: Date;
+  matchObjectKey: string | null;
+  matchDigest: string | null;
+  timelineObjectKey: string | null;
+  timelineDigest: string | null;
+};
+
+const RawObservationRowSchema = z.object({
+  riotMatchId: z.string(),
+  platformRoute: z.string(),
+  processingPolicy: z.string(),
+  pipelineOwner: z.string().nullable(),
+  promotedAt: z.date().nullable(),
+  gameCreatedAt: z.date(),
+  observedAt: z.date(),
+  matchObjectKey: z.string().nullable(),
+  matchDigest: z.string().nullable(),
+  timelineObjectKey: z.string().nullable(),
+  timelineDigest: z.string().nullable(),
+});
+
+function ownerFromColumn(column: string | null): { kind: string } {
+  switch (column) {
+    case null:
+      return { kind: "unowned" };
+    case "LEGACY_V1":
+      return { kind: "legacy-v1" };
+    case "TEMPORAL_V2":
+      return { kind: "temporal-v2" };
+    default:
+      throw new Error(`Unknown pipelineOwner column value: ${column}`);
+  }
+}
+
+function ownerToColumn(owner: PipelineOwner): string | null {
+  switch (owner.kind) {
+    case "unowned":
+      return null;
+    case "legacy-v1":
+      return "LEGACY_V1";
+    case "temporal-v2":
+      return "TEMPORAL_V2";
+  }
+}
+
+function artifactCandidate(
+  key: string | null,
+  digest: string | null,
+): { key: string; digest: string } | null {
+  if (key === null || digest === null) {
+    if (key !== null || digest !== null) {
+      throw new Error(
+        "artifact reference columns must be paired: key and digest are always stored together",
+      );
+    }
+    return null;
+  }
+  return { key, digest };
+}
+
+export function matchObservationRowToRecord(
+  row: unknown,
+): MatchObservationRecord {
+  const raw = RawObservationRowSchema.parse(row);
+  return MatchObservationRecordSchema.parse({
+    matchId: raw.riotMatchId,
+    platformRoute: raw.platformRoute,
+    policy: raw.processingPolicy,
+    owner: ownerFromColumn(raw.pipelineOwner),
+    promotion:
+      raw.promotedAt === null
+        ? null
+        : { promotedAt: raw.promotedAt.toISOString() },
+    gameCreatedAt: raw.gameCreatedAt.toISOString(),
+    observedAt: raw.observedAt.toISOString(),
+    artifacts: {
+      match: artifactCandidate(raw.matchObjectKey, raw.matchDigest),
+      timeline: artifactCandidate(raw.timelineObjectKey, raw.timelineDigest),
+    },
+  });
+}
+
+export function matchObservationRecordToRow(
+  record: MatchObservationRecord,
+): MatchObservationRow {
+  return {
+    riotMatchId: record.matchId,
+    platformRoute: record.platformRoute,
+    processingPolicy: record.policy,
+    pipelineOwner: ownerToColumn(record.owner),
+    promotedAt:
+      record.promotion === null
+        ? null
+        : dateFromIsoInstant(record.promotion.promotedAt),
+    gameCreatedAt: dateFromIsoInstant(record.gameCreatedAt),
+    observedAt: dateFromIsoInstant(record.observedAt),
+    matchObjectKey: record.artifacts.match?.key ?? null,
+    matchDigest: record.artifacts.match?.digest ?? null,
+    timelineObjectKey: record.artifacts.timeline?.key ?? null,
+    timelineDigest: record.artifacts.timeline?.digest ?? null,
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/receipt-repository.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/receipt-repository.ts
@@ -1,0 +1,47 @@
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import type { RiotMatchId } from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  matchProcessingReceiptRecordToRow,
+  matchProcessingReceiptRowToRecord,
+  type MatchProcessingReceiptRecord,
+} from "#src/database/durable/receipt-row.ts";
+
+/**
+ * Repository for MatchProcessingReceipt.
+ *
+ * Mirrors the domain's recordReceipt: receipt identity is the scope key
+ * (within one match, kind, and version), and recording the same identity
+ * twice is `already-applied` regardless of timestamp or evidence — the
+ * database's unique constraint is what makes that answer authoritative under
+ * concurrency.
+ */
+
+type ReceiptDb = Pick<ExtendedPrismaClient, "matchProcessingReceipt">;
+
+export type RecordReceiptResult =
+  { outcome: "applied" } | { outcome: "already-applied" };
+
+export async function recordReceipt(
+  db: ReceiptDb,
+  record: MatchProcessingReceiptRecord,
+): Promise<RecordReceiptResult> {
+  const row = matchProcessingReceiptRecordToRow(record);
+  const created = await db.matchProcessingReceipt.createMany({
+    data: [row],
+    skipDuplicates: true,
+  });
+  return created.count === 1
+    ? { outcome: "applied" }
+    : { outcome: "already-applied" };
+}
+
+export async function listReceipts(
+  db: ReceiptDb,
+  args: { matchId: RiotMatchId },
+): Promise<MatchProcessingReceiptRecord[]> {
+  const rows = await db.matchProcessingReceipt.findMany({
+    where: { riotMatchId: args.matchId },
+    orderBy: { id: "asc" },
+  });
+  return rows.map((row) => matchProcessingReceiptRowToRecord(row));
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/receipt-row.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/receipt-row.ts
@@ -1,0 +1,134 @@
+import { z } from "zod";
+import { RiotMatchIdSchema } from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  MatchProcessingReceiptSchema,
+  receiptScopeKey,
+  type ReceiptScope,
+} from "@scout-for-lol/domain/match-processing/states.ts";
+
+/**
+ * Row codec for MatchProcessingReceipt.
+ *
+ * The stored identity widens the domain receipt with `kind` and `version`
+ * (which pipeline step wrote it, under which semantics revision); within one
+ * (matchId, kind, version) the domain invariant holds — one receipt per scope
+ * identity, keyed by receiptScopeKey. The scopeKey column is that canonical
+ * key; the migration CHECK keeps it consistent with the split scope columns,
+ * and this codec recomputes it on write so the two can never disagree.
+ */
+
+export type MatchProcessingReceiptRecord = z.infer<
+  typeof MatchProcessingReceiptRecordSchema
+>;
+export const MatchProcessingReceiptRecordSchema = z.strictObject({
+  matchId: RiotMatchIdSchema,
+  kind: z.string().min(1),
+  version: z.int().min(1),
+  receipt: MatchProcessingReceiptSchema,
+  /** Raw JSON evidence, opaque here; the owning feature parses it. */
+  evidence: z.string().nullable(),
+});
+
+/** Column shape of a MatchProcessingReceipt row, minus DB-managed columns. */
+export type MatchProcessingReceiptRow = {
+  riotMatchId: string;
+  kind: string;
+  version: number;
+  scopeKind: string;
+  scopeGuildId: string | null;
+  scopeAccountId: number | null;
+  scopeKey: string;
+  evidence: string | null;
+  recordedAt: Date;
+};
+
+const RawReceiptRowSchema = z.object({
+  riotMatchId: z.string(),
+  kind: z.string(),
+  version: z.number().int(),
+  scopeKind: z.string(),
+  scopeGuildId: z.string().nullable(),
+  scopeAccountId: z.number().int().nullable(),
+  scopeKey: z.string(),
+  evidence: z.string().nullable(),
+  recordedAt: z.date(),
+});
+
+function scopeCandidate(raw: {
+  scopeKind: string;
+  scopeGuildId: string | null;
+  scopeAccountId: number | null;
+}): Record<string, unknown> {
+  switch (raw.scopeKind) {
+    case "global":
+      return { kind: "global" };
+    case "guild":
+      return { kind: "guild", guildId: raw.scopeGuildId };
+    case "account":
+      return { kind: "account", accountId: raw.scopeAccountId };
+    default:
+      throw new Error(
+        `Unknown receipt scopeKind column value: ${raw.scopeKind}`,
+      );
+  }
+}
+
+export function matchProcessingReceiptRowToRecord(
+  row: unknown,
+): MatchProcessingReceiptRecord {
+  const raw = RawReceiptRowSchema.parse(row);
+  const record = MatchProcessingReceiptRecordSchema.parse({
+    matchId: raw.riotMatchId,
+    kind: raw.kind,
+    version: raw.version,
+    receipt: {
+      scope: scopeCandidate(raw),
+      recordedAt: raw.recordedAt.toISOString(),
+    },
+    evidence: raw.evidence,
+  });
+  const expectedScopeKey = receiptScopeKey(record.receipt.scope);
+  if (raw.scopeKey !== expectedScopeKey) {
+    throw new Error(
+      `Receipt scopeKey column ${raw.scopeKey} does not match its scope columns (${expectedScopeKey})`,
+    );
+  }
+  return record;
+}
+
+function scopeColumns(scope: ReceiptScope): {
+  scopeKind: string;
+  scopeGuildId: string | null;
+  scopeAccountId: number | null;
+} {
+  switch (scope.kind) {
+    case "global":
+      return { scopeKind: "global", scopeGuildId: null, scopeAccountId: null };
+    case "guild":
+      return {
+        scopeKind: "guild",
+        scopeGuildId: scope.guildId,
+        scopeAccountId: null,
+      };
+    case "account":
+      return {
+        scopeKind: "account",
+        scopeGuildId: null,
+        scopeAccountId: scope.accountId,
+      };
+  }
+}
+
+export function matchProcessingReceiptRecordToRow(
+  record: MatchProcessingReceiptRecord,
+): MatchProcessingReceiptRow {
+  return {
+    riotMatchId: record.matchId,
+    kind: record.kind,
+    version: record.version,
+    ...scopeColumns(record.receipt.scope),
+    scopeKey: receiptScopeKey(record.receipt.scope),
+    evidence: record.evidence,
+    recordedAt: new Date(record.receipt.recordedAt),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/recovery-repository.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/recovery-repository.integration.test.ts
@@ -1,0 +1,212 @@
+import { afterAll, describe, expect, test } from "vitest";
+import {
+  RecoveryBatchIdSchema,
+  type RecoveryBatchId,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  abandonBatch,
+  beginScan,
+  operatorReleasePolicy,
+} from "@scout-for-lol/domain/recovery/batch-transitions.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  matchRecoveryBatchRowToRecord,
+  type MatchRecoveryBatchRecord,
+} from "#src/database/durable/recovery-row.ts";
+import {
+  advanceRecoveryCursor,
+  createRecoveryBatch,
+  getRecoveryBatch,
+  transitionRecoveryBatch,
+} from "#src/database/durable/recovery-repository.ts";
+
+const { prisma } = createTestDatabase("durable-recovery-repository");
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+const AT = new Date("2026-09-07T10:00:00.000Z");
+
+function batch(
+  id: string,
+  overrides: Partial<{ policy: string; workflowId: string | null }> = {},
+): MatchRecoveryBatchRecord {
+  return matchRecoveryBatchRowToRecord({
+    recoveryBatchId: id,
+    policy: "normal",
+    state: "planned",
+    cursorPosition: null,
+    pagesScanned: null,
+    pageBudget: null,
+    discoveredCount: null,
+    succeededCount: null,
+    suppressedCount: null,
+    failedCount: null,
+    abandonReason: null,
+    workflowId: null,
+    createdAt: AT,
+    ...overrides,
+  });
+}
+
+function batchId(id: string): RecoveryBatchId {
+  return RecoveryBatchIdSchema.parse(id);
+}
+
+describe("createRecoveryBatch", () => {
+  test("applies once and answers an identical retry with already-applied", async () => {
+    const record = batch("rb-create-1");
+    expect(await createRecoveryBatch(prisma, record)).toEqual({
+      outcome: "applied",
+    });
+    expect(await createRecoveryBatch(prisma, record)).toEqual({
+      outcome: "already-applied",
+    });
+  });
+
+  test("conflicts when the batch id exists with different facts", async () => {
+    await createRecoveryBatch(prisma, batch("rb-create-2"));
+    expect(
+      await createRecoveryBatch(
+        prisma,
+        batch("rb-create-2", { policy: "no-external" }),
+      ),
+    ).toEqual({ outcome: "conflict", reason: "batch-differs" });
+  });
+
+  test("conflicts when another batch already adopted the workflow id", async () => {
+    await createRecoveryBatch(
+      prisma,
+      batch("rb-create-3", { workflowId: "wf-shared" }),
+    );
+    expect(
+      await createRecoveryBatch(
+        prisma,
+        batch("rb-create-4", { workflowId: "wf-shared" }),
+      ),
+    ).toEqual({
+      outcome: "conflict",
+      reason: "workflow-adopted-by-another-batch",
+    });
+  });
+});
+
+async function scanningBatch(id: string): Promise<void> {
+  await createRecoveryBatch(prisma, batch(id));
+  const began = await transitionRecoveryBatch(prisma, {
+    recoveryBatchId: batchId(id),
+    transition: (value) => beginScan(value, { pageBudget: 3 }),
+  });
+  expect(began.outcome).toBe("applied");
+}
+
+describe("advanceRecoveryCursor", () => {
+  test("advances page by page, guarded by the expected position", async () => {
+    await scanningBatch("rb-scan-1");
+    const id = batchId("rb-scan-1");
+
+    const advanced = await advanceRecoveryCursor(prisma, {
+      recoveryBatchId: id,
+      expectedPosition: undefined,
+      nextPosition: "p1",
+    });
+    expect(advanced.outcome).toBe("applied");
+    // A delayed retry of the same advance is idempotent.
+    expect(
+      await advanceRecoveryCursor(prisma, {
+        recoveryBatchId: id,
+        expectedPosition: undefined,
+        nextPosition: "p1",
+      }),
+    ).toEqual({ outcome: "already-applied" });
+    // An advance from a stale view of the cursor conflicts.
+    expect(
+      await advanceRecoveryCursor(prisma, {
+        recoveryBatchId: id,
+        expectedPosition: undefined,
+        nextPosition: "p2",
+      }),
+    ).toEqual({ outcome: "conflict", reason: "stale-cursor" });
+
+    const stored = await getRecoveryBatch(prisma, { recoveryBatchId: id });
+    expect(stored?.batch.state).toEqual({
+      kind: "scanning",
+      cursor: { position: "p1", pagesScanned: 1, pageBudget: 3 },
+    });
+  });
+
+  test("exactly one of two concurrent advances from the same position applies", async () => {
+    await scanningBatch("rb-scan-2");
+    const id = batchId("rb-scan-2");
+    const outcomes = await Promise.all([
+      advanceRecoveryCursor(prisma, {
+        recoveryBatchId: id,
+        expectedPosition: undefined,
+        nextPosition: "worker-a-p1",
+      }),
+      advanceRecoveryCursor(prisma, {
+        recoveryBatchId: id,
+        expectedPosition: undefined,
+        nextPosition: "worker-b-p1",
+      }),
+    ]);
+    expect(outcomes.map((result) => result.outcome).sort()).toEqual([
+      "applied",
+      "conflict",
+    ]);
+    const stored = await getRecoveryBatch(prisma, { recoveryBatchId: id });
+    expect(stored?.batch.state.kind).toBe("scanning");
+  });
+
+  test("advancing a batch that was never created fails loudly", async () => {
+    await expect(
+      advanceRecoveryCursor(prisma, {
+        recoveryBatchId: batchId("rb-ghost"),
+        expectedPosition: undefined,
+        nextPosition: "p1",
+      }),
+    ).rejects.toThrow(/never created/);
+  });
+});
+
+describe("policy and terminal transitions", () => {
+  test("releases no-external to stale-private-only but never to normal", async () => {
+    await createRecoveryBatch(
+      prisma,
+      batch("rb-policy-1", { policy: "no-external" }),
+    );
+    const id = batchId("rb-policy-1");
+    const released = await transitionRecoveryBatch(prisma, {
+      recoveryBatchId: id,
+      transition: (value) =>
+        operatorReleasePolicy(value, { to: "stale-private-only" }),
+    });
+    expect(released.outcome).toBe("applied");
+    expect(
+      await transitionRecoveryBatch(prisma, {
+        recoveryBatchId: id,
+        transition: (value) => operatorReleasePolicy(value, { to: "normal" }),
+      }),
+    ).toEqual({ outcome: "conflict", reason: "policy-release-forbidden" });
+    const stored = await getRecoveryBatch(prisma, { recoveryBatchId: id });
+    expect(stored?.batch.policy).toBe("stale-private-only");
+  });
+
+  test("abandonment persists its reason and stays terminal", async () => {
+    await createRecoveryBatch(prisma, batch("rb-abandon-1"));
+    const id = batchId("rb-abandon-1");
+    const abandoned = await transitionRecoveryBatch(prisma, {
+      recoveryBatchId: id,
+      transition: (value) =>
+        abandonBatch(value, { reason: "operator-cancelled" }),
+    });
+    expect(abandoned.outcome).toBe("applied");
+    expect(
+      await transitionRecoveryBatch(prisma, {
+        recoveryBatchId: id,
+        transition: (value) => beginScan(value, { pageBudget: 3 }),
+      }),
+    ).toEqual({ outcome: "conflict", reason: "terminal-state" });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/database/durable/recovery-repository.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/recovery-repository.ts
@@ -1,0 +1,143 @@
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import type { RecoveryBatchId } from "@scout-for-lol/domain/identity/brands.ts";
+import type { RecoveryBatch } from "@scout-for-lol/domain/recovery/batch.ts";
+import {
+  advanceScanCursor,
+  type RecoveryTransitionResult,
+} from "@scout-for-lol/domain/recovery/batch-transitions.ts";
+import {
+  matchRecoveryBatchRecordToRow,
+  matchRecoveryBatchRowToRecord,
+  recoveryBatchStateColumns,
+  type MatchRecoveryBatchRecord,
+} from "#src/database/durable/recovery-row.ts";
+
+/**
+ * Repository for MatchRecoveryBatch.
+ *
+ * Transitions run the pure domain machine over a parsed snapshot and write
+ * the result behind a guard on every state-machine column that snapshot
+ * observed, so a delayed retry of an earlier cursor advance conflicts through
+ * the domain's own `stale-cursor` answer rather than rewinding the cursor.
+ */
+
+type RecoveryDb = Pick<ExtendedPrismaClient, "matchRecoveryBatch">;
+
+const TRANSITION_ATTEMPTS = 3;
+
+export type CreateRecoveryBatchResult =
+  | { outcome: "applied" }
+  | { outcome: "already-applied" }
+  | {
+      outcome: "conflict";
+      reason: "batch-differs" | "workflow-adopted-by-another-batch";
+    };
+
+/**
+ * Create one recovery batch. Identical retries are `already-applied`. A
+ * skipped insert with no row under this batch id means the unique workflowId
+ * collided with a different batch — the adoption key is already spoken for.
+ */
+export async function createRecoveryBatch(
+  db: RecoveryDb,
+  record: MatchRecoveryBatchRecord,
+): Promise<CreateRecoveryBatchResult> {
+  const row = matchRecoveryBatchRecordToRow(record);
+  const created = await db.matchRecoveryBatch.createMany({
+    data: [row],
+    skipDuplicates: true,
+  });
+  if (created.count === 1) {
+    return { outcome: "applied" };
+  }
+  const existing = await db.matchRecoveryBatch.findUnique({
+    where: { recoveryBatchId: row.recoveryBatchId },
+  });
+  if (existing === null) {
+    return {
+      outcome: "conflict",
+      reason: "workflow-adopted-by-another-batch",
+    };
+  }
+  const existingRow = matchRecoveryBatchRecordToRow(
+    matchRecoveryBatchRowToRecord(existing),
+  );
+  return Bun.deepEquals(existingRow, row, true)
+    ? { outcome: "already-applied" }
+    : { outcome: "conflict", reason: "batch-differs" };
+}
+
+export async function getRecoveryBatch(
+  db: RecoveryDb,
+  args: { recoveryBatchId: RecoveryBatchId },
+): Promise<MatchRecoveryBatchRecord | null> {
+  const row = await db.matchRecoveryBatch.findUnique({
+    where: { recoveryBatchId: args.recoveryBatchId },
+  });
+  return row === null ? null : matchRecoveryBatchRowToRecord(row);
+}
+
+/**
+ * Apply one pure domain transition to the stored batch, guarded by the full
+ * state-machine column set the snapshot observed (policy included, because
+ * operatorReleasePolicy transitions it). A guard miss re-evaluates against
+ * the fresh state so a lost race returns the domain's own non-applied answer.
+ */
+export async function transitionRecoveryBatch(
+  db: RecoveryDb,
+  args: {
+    recoveryBatchId: RecoveryBatchId;
+    transition: (batch: RecoveryBatch) => RecoveryTransitionResult;
+  },
+): Promise<RecoveryTransitionResult> {
+  for (let attempt = 0; attempt < TRANSITION_ATTEMPTS; attempt += 1) {
+    const row = await db.matchRecoveryBatch.findUnique({
+      where: { recoveryBatchId: args.recoveryBatchId },
+    });
+    if (row === null) {
+      throw new Error(
+        `Cannot transition ${args.recoveryBatchId}: the batch was never created`,
+      );
+    }
+    const record = matchRecoveryBatchRowToRecord(row);
+    const result = args.transition(record.batch);
+    if (result.outcome !== "applied") {
+      return result;
+    }
+    const updated = await db.matchRecoveryBatch.updateMany({
+      where: {
+        recoveryBatchId: args.recoveryBatchId,
+        ...recoveryBatchStateColumns(record.batch),
+      },
+      data: recoveryBatchStateColumns(result.next),
+    });
+    if (updated.count === 1) {
+      return result;
+    }
+  }
+  throw new Error(
+    `Gave up transitioning ${args.recoveryBatchId} after ${String(TRANSITION_ATTEMPTS)} contended attempts`,
+  );
+}
+
+/**
+ * Advance the scan cursor by one page, guarded by the caller's expected
+ * position exactly as the domain transition defines it.
+ */
+export async function advanceRecoveryCursor(
+  db: RecoveryDb,
+  args: {
+    recoveryBatchId: RecoveryBatchId;
+    expectedPosition: string | undefined;
+    nextPosition: string;
+  },
+): Promise<RecoveryTransitionResult> {
+  return await transitionRecoveryBatch(db, {
+    recoveryBatchId: args.recoveryBatchId,
+    transition: (batch) =>
+      advanceScanCursor(batch, {
+        expectedPosition: args.expectedPosition,
+        nextPosition: args.nextPosition,
+      }),
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/recovery-row.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/recovery-row.ts
@@ -1,0 +1,169 @@
+import { z } from "zod";
+import {
+  RecoveryBatchSchema,
+  type RecoveryBatch,
+} from "@scout-for-lol/domain/recovery/batch.ts";
+import { dateFromIsoInstant } from "#src/database/durable/row-values.ts";
+
+/**
+ * Row codec for MatchRecoveryBatch.
+ *
+ * The RecoveryBatchState union is flattened: cursor columns exist only in
+ * `scanning`, count columns only in `processing`, and the abandon reason only
+ * in `abandoned` — the migration CHECKs make any other combination
+ * unrepresentable, so a stored row always parses back into a well-formed
+ * domain batch. `workflowId` is the Temporal retry-adoption key and is not
+ * part of the domain value.
+ */
+
+export type MatchRecoveryBatchRecord = z.infer<
+  typeof MatchRecoveryBatchRecordSchema
+>;
+export const MatchRecoveryBatchRecordSchema = z.strictObject({
+  batch: RecoveryBatchSchema,
+  workflowId: z.string().min(1).nullable(),
+});
+
+/** The columns owned by the state machine, written on every transition. */
+export type RecoveryBatchStateColumns = {
+  policy: string;
+  state: string;
+  cursorPosition: string | null;
+  pagesScanned: number | null;
+  pageBudget: number | null;
+  discoveredCount: number | null;
+  succeededCount: number | null;
+  suppressedCount: number | null;
+  failedCount: number | null;
+  abandonReason: string | null;
+};
+
+/** Column shape of a MatchRecoveryBatch row, minus DB-managed columns. */
+export type MatchRecoveryBatchRow = RecoveryBatchStateColumns & {
+  recoveryBatchId: string;
+  workflowId: string | null;
+  createdAt: Date;
+};
+
+const RawRecoveryRowSchema = z.object({
+  recoveryBatchId: z.string(),
+  policy: z.string(),
+  state: z.string(),
+  cursorPosition: z.string().nullable(),
+  pagesScanned: z.number().int().nullable(),
+  pageBudget: z.number().int().nullable(),
+  discoveredCount: z.number().int().nullable(),
+  succeededCount: z.number().int().nullable(),
+  suppressedCount: z.number().int().nullable(),
+  failedCount: z.number().int().nullable(),
+  abandonReason: z.string().nullable(),
+  workflowId: z.string().nullable(),
+  createdAt: z.date(),
+});
+type RawRecoveryRow = z.infer<typeof RawRecoveryRowSchema>;
+
+function stateCandidate(raw: RawRecoveryRow): Record<string, unknown> {
+  switch (raw.state) {
+    case "planned":
+    case "digesting":
+    case "complete":
+      return { kind: raw.state };
+    case "scanning":
+      return {
+        kind: "scanning",
+        cursor: {
+          ...(raw.cursorPosition === null
+            ? {}
+            : { position: raw.cursorPosition }),
+          pagesScanned: raw.pagesScanned,
+          pageBudget: raw.pageBudget,
+        },
+      };
+    case "processing":
+      return {
+        kind: "processing",
+        counts: {
+          discovered: raw.discoveredCount,
+          succeeded: raw.succeededCount,
+          suppressed: raw.suppressedCount,
+          failed: raw.failedCount,
+        },
+      };
+    case "abandoned":
+      return { kind: "abandoned", reason: raw.abandonReason };
+    default:
+      throw new Error(`Unknown recovery state column value: ${raw.state}`);
+  }
+}
+
+export function matchRecoveryBatchRowToRecord(
+  row: unknown,
+): MatchRecoveryBatchRecord {
+  const raw = RawRecoveryRowSchema.parse(row);
+  return MatchRecoveryBatchRecordSchema.parse({
+    batch: {
+      id: raw.recoveryBatchId,
+      policy: raw.policy,
+      createdAt: raw.createdAt.toISOString(),
+      state: stateCandidate(raw),
+    },
+    workflowId: raw.workflowId,
+  });
+}
+
+/**
+ * The state-machine columns for one domain batch. Shared by the full row
+ * mapper and by the guarded transition patch, so both write paths always
+ * produce the same flattening.
+ */
+export function recoveryBatchStateColumns(
+  batch: RecoveryBatch,
+): RecoveryBatchStateColumns {
+  const base: RecoveryBatchStateColumns = {
+    policy: batch.policy,
+    state: batch.state.kind,
+    cursorPosition: null,
+    pagesScanned: null,
+    pageBudget: null,
+    discoveredCount: null,
+    succeededCount: null,
+    suppressedCount: null,
+    failedCount: null,
+    abandonReason: null,
+  };
+  const state = batch.state;
+  switch (state.kind) {
+    case "planned":
+    case "digesting":
+    case "complete":
+      return base;
+    case "scanning":
+      return {
+        ...base,
+        cursorPosition: state.cursor.position ?? null,
+        pagesScanned: state.cursor.pagesScanned,
+        pageBudget: state.cursor.pageBudget,
+      };
+    case "processing":
+      return {
+        ...base,
+        discoveredCount: state.counts.discovered,
+        succeededCount: state.counts.succeeded,
+        suppressedCount: state.counts.suppressed,
+        failedCount: state.counts.failed,
+      };
+    case "abandoned":
+      return { ...base, abandonReason: state.reason };
+  }
+}
+
+export function matchRecoveryBatchRecordToRow(
+  record: MatchRecoveryBatchRecord,
+): MatchRecoveryBatchRow {
+  return {
+    recoveryBatchId: record.batch.id,
+    ...recoveryBatchStateColumns(record.batch),
+    workflowId: record.workflowId,
+    createdAt: dateFromIsoInstant(record.batch.createdAt),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/row-codecs.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/row-codecs.test.ts
@@ -1,0 +1,480 @@
+import { describe, expect, test } from "vitest";
+import {
+  matchObservationRecordToRow,
+  matchObservationRowToRecord,
+} from "#src/database/durable/observation-row.ts";
+import {
+  matchProcessingReceiptRecordToRow,
+  matchProcessingReceiptRowToRecord,
+} from "#src/database/durable/receipt-row.ts";
+import {
+  matchNotificationIntentRecordToRow,
+  matchNotificationIntentRowToRecord,
+} from "#src/database/durable/intent-row.ts";
+import {
+  matchRecoveryBatchRecordToRow,
+  matchRecoveryBatchRowToRecord,
+} from "#src/database/durable/recovery-row.ts";
+import {
+  scoutWorkflowStartRecordToRow,
+  scoutWorkflowStartRowToRecord,
+} from "#src/database/durable/workflow-start-row.ts";
+import { scoutOperatorAuditEventRowToRecord } from "#src/database/durable/audit-event-row.ts";
+import {
+  matchTrackedAccountRecordToRow,
+  matchTrackedAccountRowToRecord,
+} from "#src/database/durable/tracked-account-row.ts";
+
+/**
+ * Row -> domain record -> row round-trips for every durable model, covering
+ * every member of each state vocabulary. The row is the fixed point: the
+ * database normalises instants to UTC milliseconds, so a stored row must map
+ * into the domain unions and back without changing a single column.
+ */
+
+const MATCH_ID = "NA1_5312279829";
+const GUILD_ID = "100000000000000001";
+const CHANNEL_ID = "300000000000000001";
+const ACCOUNT_DISCORD_ID = "200000000000000001";
+const MESSAGE_ID = "400000000000000001";
+const DIGEST = "a".repeat(64);
+const PAYLOAD = JSON.stringify({
+  kind: "match-report",
+  version: 1,
+  data: { body: "hello" },
+});
+const AT = new Date("2026-09-07T10:00:00.000Z");
+const LATER = new Date("2026-09-07T11:00:00.000Z");
+
+describe("MatchObservation codec", () => {
+  const baseRow = {
+    riotMatchId: MATCH_ID,
+    platformRoute: "NA1",
+    processingPolicy: "ARCHIVE_ONLY",
+    pipelineOwner: null,
+    promotedAt: null,
+    gameCreatedAt: AT,
+    observedAt: LATER,
+    matchObjectKey: null,
+    matchDigest: null,
+    timelineObjectKey: null,
+    timelineDigest: null,
+  };
+
+  const variants = [
+    ["archive-only unowned", baseRow],
+    [
+      "full promoted legacy-v1 with artifacts",
+      {
+        ...baseRow,
+        processingPolicy: "FULL",
+        pipelineOwner: "LEGACY_V1",
+        promotedAt: LATER,
+        matchObjectKey: "games/2026/09/07/NA1_5312279829/match.json",
+        matchDigest: DIGEST,
+        timelineObjectKey: "games/2026/09/07/NA1_5312279829/timeline.json",
+        timelineDigest: DIGEST,
+      },
+    ],
+    [
+      "full born-full temporal-v2",
+      { ...baseRow, processingPolicy: "FULL", pipelineOwner: "TEMPORAL_V2" },
+    ],
+  ] as const;
+
+  test.each(variants)("round-trips %s", (_name, row) => {
+    const record = matchObservationRowToRecord(row);
+    expect(matchObservationRecordToRow(record)).toEqual(row);
+  });
+
+  test("rejects a promotion on an ARCHIVE_ONLY row", () => {
+    expect(() =>
+      matchObservationRowToRecord({ ...baseRow, promotedAt: LATER }),
+    ).toThrow(/promotion/);
+  });
+
+  test("rejects an unpaired artifact reference", () => {
+    expect(() =>
+      matchObservationRowToRecord({ ...baseRow, matchDigest: DIGEST }),
+    ).toThrow(/paired/);
+  });
+
+  test("rejects an unknown owner column value", () => {
+    expect(() =>
+      matchObservationRowToRecord({ ...baseRow, pipelineOwner: "V3" }),
+    ).toThrow(/pipelineOwner/);
+  });
+
+  test("rejects a platform route that is not the match id prefix", () => {
+    expect(() =>
+      matchObservationRowToRecord({ ...baseRow, platformRoute: "EUW1" }),
+    ).toThrow(/prefix/);
+  });
+});
+
+describe("MatchProcessingReceipt codec", () => {
+  const baseRow = {
+    riotMatchId: MATCH_ID,
+    kind: "report-posted",
+    version: 2,
+    scopeKind: "global",
+    scopeGuildId: null,
+    scopeAccountId: null,
+    scopeKey: "global",
+    evidence: null,
+    recordedAt: AT,
+  };
+
+  const variants = [
+    ["global scope", baseRow],
+    [
+      "guild scope with evidence",
+      {
+        ...baseRow,
+        scopeKind: "guild",
+        scopeGuildId: GUILD_ID,
+        scopeKey: `guild:${GUILD_ID}`,
+        evidence: JSON.stringify({ messageId: MESSAGE_ID }),
+      },
+    ],
+    [
+      "account scope",
+      {
+        ...baseRow,
+        scopeKind: "account",
+        scopeAccountId: 42,
+        scopeKey: "account:42",
+      },
+    ],
+  ] as const;
+
+  test.each(variants)("round-trips %s", (_name, row) => {
+    const record = matchProcessingReceiptRowToRecord(row);
+    expect(matchProcessingReceiptRecordToRow(record)).toEqual(row);
+  });
+
+  test("rejects a scopeKey that disagrees with the scope columns", () => {
+    expect(() =>
+      matchProcessingReceiptRowToRecord({ ...baseRow, scopeKey: "guild:1" }),
+    ).toThrow(/scopeKey/);
+  });
+
+  test("rejects an unknown scope kind", () => {
+    expect(() =>
+      matchProcessingReceiptRowToRecord({ ...baseRow, scopeKind: "server" }),
+    ).toThrow(/scopeKind/);
+  });
+});
+
+describe("MatchNotificationIntent codec", () => {
+  const baseRow = {
+    intentKey: "intent-NA1_5312279829-post-match",
+    riotMatchId: MATCH_ID,
+    targetKind: "channel",
+    targetId: CHANNEL_ID,
+    state: "pending",
+    attemptCount: 0,
+    attemptNonce: null,
+    sendStartedAt: null,
+    deliveredAt: null,
+    messageId: null,
+    suppressedReason: null,
+    unknownObservedAt: null,
+    lastFailure: null,
+    freshnessDeadline: LATER,
+    payload: PAYLOAD,
+    createdAt: AT,
+  };
+
+  const variants = [
+    ["pending", baseRow],
+    ["ready", { ...baseRow, state: "ready" }],
+    [
+      "sending",
+      {
+        ...baseRow,
+        state: "sending",
+        attemptCount: 1,
+        attemptNonce: "nonce-1",
+        sendStartedAt: AT,
+      },
+    ],
+    [
+      "delivered with message id",
+      {
+        ...baseRow,
+        state: "delivered",
+        attemptCount: 1,
+        deliveredAt: LATER,
+        messageId: MESSAGE_ID,
+      },
+    ],
+    [
+      "delivered without message id",
+      { ...baseRow, state: "delivered", attemptCount: 1, deliveredAt: LATER },
+    ],
+    [
+      "suppressed",
+      { ...baseRow, state: "suppressed", suppressedReason: "stale" },
+    ],
+    ["expired", { ...baseRow, state: "expired" }],
+    ["permission-denied", { ...baseRow, state: "permission-denied" }],
+    [
+      "unknown-delivery with a recorded failure",
+      {
+        ...baseRow,
+        state: "unknown-delivery",
+        attemptCount: 2,
+        attemptNonce: "nonce-2",
+        unknownObservedAt: LATER,
+        lastFailure: JSON.stringify({
+          classification: "retryable",
+          reason: "timeout",
+        }),
+      },
+    ],
+    [
+      "dm target",
+      { ...baseRow, targetKind: "dm", targetId: ACCOUNT_DISCORD_ID },
+    ],
+  ] as const;
+
+  test.each(variants)("round-trips %s", (_name, row) => {
+    const record = matchNotificationIntentRowToRecord(row);
+    expect(matchNotificationIntentRecordToRow(record)).toEqual(row);
+  });
+
+  test("rejects sending without an attempt nonce", () => {
+    expect(() =>
+      matchNotificationIntentRowToRecord({
+        ...baseRow,
+        state: "sending",
+        attemptCount: 1,
+        sendStartedAt: AT,
+      }),
+    ).toThrow();
+  });
+
+  test("rejects sending with a zero attempt count", () => {
+    expect(() =>
+      matchNotificationIntentRowToRecord({
+        ...baseRow,
+        state: "sending",
+        attemptNonce: "nonce-1",
+        sendStartedAt: AT,
+      }),
+    ).toThrow(/attemptCount/);
+  });
+
+  test("rejects a payload column that is not a versioned envelope", () => {
+    expect(() =>
+      matchNotificationIntentRowToRecord({
+        ...baseRow,
+        payload: JSON.stringify({ body: "hello" }),
+      }),
+    ).toThrow();
+  });
+
+  test("rejects an unknown state column value", () => {
+    expect(() =>
+      matchNotificationIntentRowToRecord({ ...baseRow, state: "queued" }),
+    ).toThrow(/state/);
+  });
+});
+
+describe("MatchRecoveryBatch codec", () => {
+  const baseRow = {
+    recoveryBatchId: "recovery-2026-09-07",
+    policy: "normal",
+    state: "planned",
+    cursorPosition: null,
+    pagesScanned: null,
+    pageBudget: null,
+    discoveredCount: null,
+    succeededCount: null,
+    suppressedCount: null,
+    failedCount: null,
+    abandonReason: null,
+    workflowId: null,
+    createdAt: AT,
+  };
+
+  const variants = [
+    ["planned", baseRow],
+    [
+      "scanning before the first advance",
+      { ...baseRow, state: "scanning", pagesScanned: 0, pageBudget: 5 },
+    ],
+    [
+      "scanning mid-scan under stale-private-only",
+      {
+        ...baseRow,
+        policy: "stale-private-only",
+        state: "scanning",
+        cursorPosition: "page-3",
+        pagesScanned: 3,
+        pageBudget: 5,
+        workflowId: "recovery-workflow-1",
+      },
+    ],
+    [
+      "processing under no-external",
+      {
+        ...baseRow,
+        policy: "no-external",
+        state: "processing",
+        discoveredCount: 10,
+        succeededCount: 4,
+        suppressedCount: 2,
+        failedCount: 1,
+      },
+    ],
+    ["digesting", { ...baseRow, state: "digesting" }],
+    ["complete", { ...baseRow, state: "complete" }],
+    [
+      "abandoned",
+      { ...baseRow, state: "abandoned", abandonReason: "superseded" },
+    ],
+  ] as const;
+
+  test.each(variants)("round-trips %s", (_name, row) => {
+    const record = matchRecoveryBatchRowToRecord(row);
+    expect(matchRecoveryBatchRecordToRow(record)).toEqual(row);
+  });
+
+  test("rejects a scanning row without a page budget", () => {
+    expect(() =>
+      matchRecoveryBatchRowToRecord({
+        ...baseRow,
+        state: "scanning",
+        pagesScanned: 0,
+      }),
+    ).toThrow();
+  });
+
+  test("rejects a cursor position with zero pages scanned", () => {
+    expect(() =>
+      matchRecoveryBatchRowToRecord({
+        ...baseRow,
+        state: "scanning",
+        cursorPosition: "page-1",
+        pagesScanned: 0,
+        pageBudget: 5,
+      }),
+    ).toThrow(/position/);
+  });
+
+  test("rejects counts that exceed discovered", () => {
+    expect(() =>
+      matchRecoveryBatchRowToRecord({
+        ...baseRow,
+        state: "processing",
+        discoveredCount: 2,
+        succeededCount: 2,
+        suppressedCount: 1,
+        failedCount: 0,
+      }),
+    ).toThrow(/discovered/);
+  });
+
+  test("rejects an unknown state column value", () => {
+    expect(() =>
+      matchRecoveryBatchRowToRecord({ ...baseRow, state: "paused" }),
+    ).toThrow(/state/);
+  });
+});
+
+describe("ScoutWorkflowStart codec", () => {
+  const baseRow = {
+    requestedWorkflowId: "scout-recovery-2026-09-07",
+    workflowType: "match-recovery",
+    requestedBy: null,
+    requestSource: "operator-command",
+    inputPayload: PAYLOAD,
+    requestedAt: AT,
+    acceptedAt: null,
+    runId: null,
+  };
+
+  const variants = [
+    ["requested only", baseRow],
+    [
+      "accepted with run id",
+      {
+        ...baseRow,
+        requestedBy: ACCOUNT_DISCORD_ID,
+        acceptedAt: LATER,
+        runId: "run-abc-123",
+      },
+    ],
+    ["accepted without run id", { ...baseRow, acceptedAt: LATER }],
+  ] as const;
+
+  test.each(variants)("round-trips %s", (_name, row) => {
+    const record = scoutWorkflowStartRowToRecord(row);
+    expect(scoutWorkflowStartRecordToRow(record)).toEqual(row);
+  });
+
+  test("rejects a run id without acceptance", () => {
+    expect(() =>
+      scoutWorkflowStartRowToRecord({ ...baseRow, runId: "run-abc-123" }),
+    ).toThrow(/runId/);
+  });
+});
+
+describe("MatchTrackedAccount codec", () => {
+  const baseRow = {
+    riotMatchId: MATCH_ID,
+    puuid: "p".repeat(78),
+    playerId: null,
+    accountId: null,
+    cursorAdvancedAt: null,
+  };
+
+  const variants = [
+    ["unregistered account", baseRow],
+    [
+      "registered account with an advanced cursor",
+      { ...baseRow, playerId: 7, accountId: 11, cursorAdvancedAt: LATER },
+    ],
+  ] as const;
+
+  test.each(variants)("round-trips %s", (_name, row) => {
+    const record = matchTrackedAccountRowToRecord(row);
+    expect(matchTrackedAccountRecordToRow(record)).toEqual(row);
+  });
+});
+
+describe("ScoutOperatorAuditEvent codec", () => {
+  test("parses a stored event", () => {
+    const record = scoutOperatorAuditEventRowToRecord({
+      id: 1,
+      actorDiscordId: ACCOUNT_DISCORD_ID,
+      action: "recovery-policy-released",
+      subjectKind: "recovery-batch",
+      subjectId: "recovery-2026-09-07",
+      detail: JSON.stringify({ from: "no-external", to: "stale-private-only" }),
+      createdAt: AT,
+    });
+    expect(record.actorDiscordId).toBe(ACCOUNT_DISCORD_ID);
+    expect(record.detail).toEqual({
+      from: "no-external",
+      to: "stale-private-only",
+    });
+    expect(record.createdAt).toBe("2026-09-07T10:00:00.000Z");
+  });
+
+  test("rejects a detail column that is not JSON", () => {
+    expect(() =>
+      scoutOperatorAuditEventRowToRecord({
+        id: 2,
+        actorDiscordId: ACCOUNT_DISCORD_ID,
+        action: "x",
+        subjectKind: "y",
+        subjectId: "z",
+        detail: "not json",
+        createdAt: AT,
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/database/durable/row-values.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/row-values.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { type IsoInstant } from "@scout-for-lol/domain/identity/brands.ts";
+
+/**
+ * Column-level value conversions shared by the durable row codecs.
+ *
+ * Timestamps are stored as TIMESTAMP(3) and exposed to the domain as branded
+ * ISO instants; the database normalises every instant to UTC millisecond
+ * precision, which is the round-trip contract the codec tests pin down.
+ */
+
+export function dateFromIsoInstant(instant: IsoInstant): Date {
+  return new Date(instant);
+}
+
+/**
+ * The wire shape every versioned payload column must carry: a strict
+ * `{ kind, version, data }` envelope, structurally identical to the domain's
+ * VersionedEnvelope with the `data` left opaque. The owning feature decodes
+ * `data` with its own versioned codec, but a column that is not even an
+ * envelope is broken persisted data and fails loudly.
+ */
+export type VersionedPayloadEnvelope = {
+  readonly kind: string;
+  readonly version: number;
+  readonly data: unknown;
+};
+export const VersionedPayloadEnvelopeSchema = z.strictObject({
+  kind: z.string().min(1),
+  version: z.int().min(1),
+  data: z.unknown(),
+});
+
+export function parsePayloadEnvelopeColumn(
+  column: string,
+): VersionedPayloadEnvelope {
+  return VersionedPayloadEnvelopeSchema.parse(JSON.parse(column));
+}
+
+export function serializePayloadEnvelope(
+  envelope: VersionedPayloadEnvelope,
+): string {
+  return JSON.stringify(VersionedPayloadEnvelopeSchema.parse(envelope));
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/schema-constraints.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/schema-constraints.integration.test.ts
@@ -1,0 +1,431 @@
+import { afterAll, describe, expect, test } from "vitest";
+import { z } from "zod";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+
+/**
+ * The durable operational tables are guarded by hand-authored CHECK
+ * constraints; this suite proves each one actually rejects the shape it
+ * exists to reject, against a real Postgres carrying the deployed
+ * migrations (the test-template database is built with `prisma migrate
+ * deploy`, so a migration that fails to apply fails here first).
+ *
+ * Every invalid row below is a copy of a known-good row with exactly one
+ * violation, so the asserted constraint name is the only one that can fire.
+ */
+
+const { prisma } = createTestDatabase("durable-schema-constraints");
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+function insertSql(table: string, values: Record<string, string>): string {
+  const columns = Object.keys(values)
+    .map((column) => `"${column}"`)
+    .join(", ");
+  const literals = Object.values(values).join(", ");
+  return `INSERT INTO "${table}" (${columns}) VALUES (${literals})`;
+}
+
+async function expectRejected(sql: string, constraint: string): Promise<void> {
+  await expect(prisma.$executeRawUnsafe(sql)).rejects.toThrow(constraint);
+}
+
+const NOW = "'2026-09-07 10:00:00'";
+const DIGEST = `'${"a".repeat(64)}'`;
+
+test("the migration created every durable operational table", async () => {
+  const rows: unknown = await prisma.$queryRawUnsafe(
+    `SELECT table_name FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name IN (
+        'MatchObservation', 'MatchTrackedAccount', 'MatchProcessingReceipt',
+        'MatchNotificationIntent', 'MatchRecoveryBatch', 'ScoutWorkflowStart',
+        'ScoutOperatorAuditEvent'
+      ) ORDER BY table_name`,
+  );
+  const names = z
+    .array(z.object({ table_name: z.string() }))
+    .parse(rows)
+    .map((row) => row.table_name);
+  expect(names).toEqual([
+    "MatchNotificationIntent",
+    "MatchObservation",
+    "MatchProcessingReceipt",
+    "MatchRecoveryBatch",
+    "MatchTrackedAccount",
+    "ScoutOperatorAuditEvent",
+    "ScoutWorkflowStart",
+  ]);
+});
+
+describe("MatchObservation constraints", () => {
+  const valid: Record<string, string> = {
+    riotMatchId: "'NA1_1'",
+    platformRoute: "'NA1'",
+    processingPolicy: "'ARCHIVE_ONLY'",
+    gameCreatedAt: NOW,
+    observedAt: NOW,
+    updatedAt: NOW,
+  };
+
+  test("accepts a valid row", async () => {
+    await prisma.$executeRawUnsafe(insertSql("MatchObservation", valid));
+  });
+
+  test.each([
+    [
+      "policy vocabulary",
+      { ...valid, riotMatchId: "'NA1_2'", processingPolicy: "'PARTIAL'" },
+      "MatchObservation_policy_check",
+    ],
+    [
+      "owner vocabulary",
+      { ...valid, riotMatchId: "'NA1_3'", pipelineOwner: "'V3'" },
+      "MatchObservation_owner_check",
+    ],
+    [
+      "promotion under ARCHIVE_ONLY",
+      { ...valid, riotMatchId: "'NA1_4'", promotedAt: NOW },
+      "MatchObservation_promotion_check",
+    ],
+    [
+      "platform route vocabulary",
+      {
+        ...valid,
+        riotMatchId: "'XX9_5'",
+        platformRoute: "'XX9'",
+      },
+      "MatchObservation_platform_route_check",
+    ],
+    [
+      "match id platform prefix",
+      { ...valid, riotMatchId: "'EUW1_6'" },
+      "MatchObservation_match_id_platform_check",
+    ],
+    [
+      "unpaired match artifact",
+      { ...valid, riotMatchId: "'NA1_7'", matchObjectKey: "'k'" },
+      "MatchObservation_match_artifact_check",
+    ],
+    [
+      "unpaired timeline artifact",
+      { ...valid, riotMatchId: "'NA1_8'", timelineDigest: DIGEST },
+      "MatchObservation_timeline_artifact_check",
+    ],
+    [
+      "match digest format",
+      {
+        ...valid,
+        riotMatchId: "'NA1_9'",
+        matchObjectKey: "'k'",
+        matchDigest: "'NOTHEX'",
+      },
+      "MatchObservation_match_digest_format_check",
+    ],
+    [
+      "timeline digest format",
+      {
+        ...valid,
+        riotMatchId: "'NA1_10'",
+        timelineObjectKey: "'k'",
+        timelineDigest: "'NOTHEX'",
+      },
+      "MatchObservation_timeline_digest_format_check",
+    ],
+  ])("rejects %s", async (_name, values, constraint) => {
+    await expectRejected(insertSql("MatchObservation", values), constraint);
+  });
+});
+
+describe("MatchProcessingReceipt constraints", () => {
+  const valid: Record<string, string> = {
+    riotMatchId: "'NA1_1'",
+    kind: "'report-posted'",
+    version: "1",
+    scopeKind: "'global'",
+    scopeKey: "'global'",
+    recordedAt: NOW,
+  };
+
+  test("accepts a valid row", async () => {
+    await prisma.$executeRawUnsafe(insertSql("MatchProcessingReceipt", valid));
+  });
+
+  test.each([
+    [
+      "a zero version",
+      { ...valid, version: "0" },
+      "MatchProcessingReceipt_version_check",
+    ],
+    [
+      "an unknown scope kind",
+      { ...valid, version: "2", scopeKind: "'server'", scopeKey: "'server'" },
+      "MatchProcessingReceipt_scope_kind_check",
+    ],
+    [
+      "a guild scope without a guild id",
+      {
+        ...valid,
+        version: "3",
+        scopeKind: "'guild'",
+        scopeKey: "'guild:1'",
+      },
+      "MatchProcessingReceipt_scope_fields_check",
+    ],
+    [
+      "an account scope carrying a guild id",
+      {
+        ...valid,
+        version: "4",
+        scopeKind: "'account'",
+        scopeAccountId: "42",
+        scopeGuildId: "'1'",
+        scopeKey: "'account:42'",
+      },
+      "MatchProcessingReceipt_scope_fields_check",
+    ],
+    [
+      "a global scope carrying an account id",
+      { ...valid, version: "5", scopeAccountId: "42" },
+      "MatchProcessingReceipt_scope_fields_check",
+    ],
+    [
+      "a scope key that disagrees with the scope columns",
+      {
+        ...valid,
+        version: "6",
+        scopeKind: "'guild'",
+        scopeGuildId: "'123'",
+        scopeKey: "'guild:456'",
+      },
+      "MatchProcessingReceipt_scope_key_check",
+    ],
+  ])("rejects %s", async (_name, values, constraint) => {
+    await expectRejected(
+      insertSql("MatchProcessingReceipt", values),
+      constraint,
+    );
+  });
+});
+
+describe("MatchNotificationIntent constraints", () => {
+  const valid: Record<string, string> = {
+    intentKey: "'intent-1'",
+    riotMatchId: "'NA1_1'",
+    targetKind: "'channel'",
+    targetId: "'300000000000000001'",
+    state: "'pending'",
+    attemptCount: "0",
+    freshnessDeadline: NOW,
+    payload: `'{"kind":"k","version":1,"data":{}}'`,
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+
+  test("accepts a valid row", async () => {
+    await prisma.$executeRawUnsafe(insertSql("MatchNotificationIntent", valid));
+  });
+
+  test.each([
+    [
+      "an unknown state",
+      { ...valid, intentKey: "'i2'", state: "'queued'" },
+      "MatchNotificationIntent_state_check",
+    ],
+    [
+      "an unknown target kind",
+      { ...valid, intentKey: "'i3'", targetKind: "'webhook'" },
+      "MatchNotificationIntent_target_kind_check",
+    ],
+    [
+      "a negative attempt count",
+      { ...valid, intentKey: "'i4'", attemptCount: "-1" },
+      "MatchNotificationIntent_attempt_count_check",
+    ],
+    [
+      "sending with a zero attempt count",
+      {
+        ...valid,
+        intentKey: "'i5'",
+        state: "'sending'",
+        attemptNonce: "'n1'",
+        sendStartedAt: NOW,
+      },
+      "MatchNotificationIntent_attempted_states_check",
+    ],
+    [
+      "an attempt nonce outside sending or unknown-delivery",
+      { ...valid, intentKey: "'i6'", state: "'ready'", attemptNonce: "'n1'" },
+      "MatchNotificationIntent_attempt_nonce_check",
+    ],
+    [
+      "sending without its started-at",
+      {
+        ...valid,
+        intentKey: "'i7'",
+        state: "'sending'",
+        attemptCount: "1",
+        attemptNonce: "'n1'",
+      },
+      "MatchNotificationIntent_send_started_check",
+    ],
+    [
+      "delivered without its delivered-at",
+      { ...valid, intentKey: "'i8'", state: "'delivered'", attemptCount: "1" },
+      "MatchNotificationIntent_delivered_at_check",
+    ],
+    [
+      "a message id outside delivered",
+      { ...valid, intentKey: "'i9'", messageId: "'400000000000000001'" },
+      "MatchNotificationIntent_message_id_check",
+    ],
+    [
+      "suppressed without a reason",
+      { ...valid, intentKey: "'i10'", state: "'suppressed'" },
+      "MatchNotificationIntent_suppressed_reason_check",
+    ],
+    [
+      "an unknown suppression reason",
+      {
+        ...valid,
+        intentKey: "'i11'",
+        state: "'suppressed'",
+        suppressedReason: "'bored'",
+      },
+      "MatchNotificationIntent_suppressed_reason_vocab_check",
+    ],
+    [
+      "unknown-delivery without its observed-at",
+      {
+        ...valid,
+        intentKey: "'i12'",
+        state: "'unknown-delivery'",
+        attemptCount: "1",
+        attemptNonce: "'n1'",
+      },
+      "MatchNotificationIntent_unknown_observed_check",
+    ],
+  ])("rejects %s", async (_name, values, constraint) => {
+    await expectRejected(
+      insertSql("MatchNotificationIntent", values),
+      constraint,
+    );
+  });
+});
+
+describe("MatchRecoveryBatch constraints", () => {
+  const valid: Record<string, string> = {
+    recoveryBatchId: "'rb-1'",
+    policy: "'normal'",
+    state: "'planned'",
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+
+  test("accepts a valid row", async () => {
+    await prisma.$executeRawUnsafe(insertSql("MatchRecoveryBatch", valid));
+  });
+
+  test.each([
+    [
+      "an unknown policy",
+      { ...valid, recoveryBatchId: "'rb-2'", policy: "'yolo'" },
+      "MatchRecoveryBatch_policy_check",
+    ],
+    [
+      "an unknown state",
+      { ...valid, recoveryBatchId: "'rb-3'", state: "'paused'" },
+      "MatchRecoveryBatch_state_check",
+    ],
+    [
+      "cursor columns outside scanning",
+      { ...valid, recoveryBatchId: "'rb-4'", pagesScanned: "0" },
+      "MatchRecoveryBatch_cursor_presence_check",
+    ],
+    [
+      "a cursor position with zero pages scanned",
+      {
+        ...valid,
+        recoveryBatchId: "'rb-5'",
+        state: "'scanning'",
+        cursorPosition: "'p1'",
+        pagesScanned: "0",
+        pageBudget: "5",
+      },
+      "MatchRecoveryBatch_cursor_position_check",
+    ],
+    [
+      "pages scanned beyond the budget",
+      {
+        ...valid,
+        recoveryBatchId: "'rb-6'",
+        state: "'scanning'",
+        cursorPosition: "'p1'",
+        pagesScanned: "6",
+        pageBudget: "5",
+      },
+      "MatchRecoveryBatch_cursor_bounds_check",
+    ],
+    [
+      "counts outside processing",
+      { ...valid, recoveryBatchId: "'rb-7'", discoveredCount: "1" },
+      "MatchRecoveryBatch_counts_presence_check",
+    ],
+    [
+      "processed counts beyond discovered",
+      {
+        ...valid,
+        recoveryBatchId: "'rb-8'",
+        state: "'processing'",
+        discoveredCount: "2",
+        succeededCount: "2",
+        suppressedCount: "1",
+        failedCount: "0",
+      },
+      "MatchRecoveryBatch_counts_bounds_check",
+    ],
+    [
+      "abandoned without a reason",
+      { ...valid, recoveryBatchId: "'rb-9'", state: "'abandoned'" },
+      "MatchRecoveryBatch_abandon_reason_check",
+    ],
+    [
+      "an unknown abandon reason",
+      {
+        ...valid,
+        recoveryBatchId: "'rb-10'",
+        state: "'abandoned'",
+        abandonReason: "'tired'",
+      },
+      "MatchRecoveryBatch_abandon_reason_vocab_check",
+    ],
+  ])("rejects %s", async (_name, values, constraint) => {
+    await expectRejected(insertSql("MatchRecoveryBatch", values), constraint);
+  });
+});
+
+describe("ScoutWorkflowStart constraints", () => {
+  const valid: Record<string, string> = {
+    requestedWorkflowId: "'wf-1'",
+    workflowType: "'match-recovery'",
+    requestSource: "'operator'",
+    inputPayload: `'{"kind":"k","version":1,"data":{}}'`,
+    requestedAt: NOW,
+    updatedAt: NOW,
+  };
+
+  test("accepts a valid row", async () => {
+    await prisma.$executeRawUnsafe(insertSql("ScoutWorkflowStart", valid));
+  });
+
+  test("rejects a run id without acceptance", async () => {
+    await expectRejected(
+      insertSql("ScoutWorkflowStart", {
+        ...valid,
+        requestedWorkflowId: "'wf-2'",
+        runId: "'run-1'",
+      }),
+      "ScoutWorkflowStart_run_id_check",
+    );
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/database/durable/tracked-account-repository.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/tracked-account-repository.ts
@@ -1,0 +1,87 @@
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import type {
+  IsoInstant,
+  RiotMatchId,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import type { LeaguePuuid } from "@scout-for-lol/domain/identity/league-account.ts";
+import {
+  matchTrackedAccountRecordToRow,
+  matchTrackedAccountRowToRecord,
+  type MatchTrackedAccountRecord,
+} from "#src/database/durable/tracked-account-row.ts";
+import { dateFromIsoInstant } from "#src/database/durable/row-values.ts";
+
+/**
+ * Repository for MatchTrackedAccount.
+ *
+ * Recording the association is idempotent on the (match, puuid) primary key;
+ * marking the cursor advanced is a one-way guarded update so exactly one
+ * worker advances a given account's cursor off a given match.
+ */
+
+type TrackedAccountDb = Pick<ExtendedPrismaClient, "matchTrackedAccount">;
+
+/** How many of the given associations were newly recorded (rest existed). */
+export type RecordTrackedAccountsResult = {
+  recorded: number;
+  existing: number;
+};
+
+export async function recordTrackedAccounts(
+  db: TrackedAccountDb,
+  records: MatchTrackedAccountRecord[],
+): Promise<RecordTrackedAccountsResult> {
+  const rows = records.map((record) => matchTrackedAccountRecordToRow(record));
+  const created = await db.matchTrackedAccount.createMany({
+    data: rows,
+    skipDuplicates: true,
+  });
+  return { recorded: created.count, existing: rows.length - created.count };
+}
+
+export async function listTrackedAccounts(
+  db: TrackedAccountDb,
+  args: { matchId: RiotMatchId },
+): Promise<MatchTrackedAccountRecord[]> {
+  const rows = await db.matchTrackedAccount.findMany({
+    where: { riotMatchId: args.matchId },
+    orderBy: { puuid: "asc" },
+  });
+  return rows.map((row) => matchTrackedAccountRowToRecord(row));
+}
+
+export type MarkCursorAdvancedResult =
+  { outcome: "applied" } | { outcome: "already-applied" };
+
+/**
+ * Mark that this match advanced the account's processing cursor. One-way:
+ * the first writer applies, every retry is `already-applied`. Marking an
+ * association that was never recorded is a broken caller contract and throws.
+ */
+export async function markTrackedAccountCursorAdvanced(
+  db: TrackedAccountDb,
+  args: { matchId: RiotMatchId; puuid: LeaguePuuid; advancedAt: IsoInstant },
+): Promise<MarkCursorAdvancedResult> {
+  const advanced = await db.matchTrackedAccount.updateMany({
+    where: {
+      riotMatchId: args.matchId,
+      puuid: args.puuid,
+      cursorAdvancedAt: null,
+    },
+    data: { cursorAdvancedAt: dateFromIsoInstant(args.advancedAt) },
+  });
+  if (advanced.count === 1) {
+    return { outcome: "applied" };
+  }
+  const existing = await db.matchTrackedAccount.findUnique({
+    where: {
+      riotMatchId_puuid: { riotMatchId: args.matchId, puuid: args.puuid },
+    },
+  });
+  if (existing === null) {
+    throw new Error(
+      `Cannot advance the cursor for ${args.puuid} on ${args.matchId}: the association was never recorded`,
+    );
+  }
+  return { outcome: "already-applied" };
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/tracked-account-row.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/tracked-account-row.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import {
+  IsoInstantSchema,
+  RiotMatchIdSchema,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  AccountIdSchema,
+  PlayerIdSchema,
+} from "@scout-for-lol/domain/identity/database-ids.ts";
+import { LeaguePuuidSchema } from "@scout-for-lol/domain/identity/league-account.ts";
+
+/**
+ * Row codec for MatchTrackedAccount.
+ *
+ * The association is FK-by-value: `playerId`/`accountId` are snapshots of the
+ * registration at observation time and stay NULL for a tracked puuid that was
+ * not registered. `cursorAdvancedAt` records when this match advanced the
+ * account's processing cursor — NULL until it has.
+ */
+
+export type MatchTrackedAccountRecord = z.infer<
+  typeof MatchTrackedAccountRecordSchema
+>;
+export const MatchTrackedAccountRecordSchema = z.strictObject({
+  matchId: RiotMatchIdSchema,
+  puuid: LeaguePuuidSchema,
+  playerId: PlayerIdSchema.nullable(),
+  accountId: AccountIdSchema.nullable(),
+  cursorAdvancedAt: IsoInstantSchema.nullable(),
+});
+
+/** Column shape of a MatchTrackedAccount row, minus DB-managed columns. */
+export type MatchTrackedAccountRow = {
+  riotMatchId: string;
+  puuid: z.infer<typeof LeaguePuuidSchema>;
+  playerId: z.infer<typeof PlayerIdSchema> | null;
+  accountId: z.infer<typeof AccountIdSchema> | null;
+  cursorAdvancedAt: Date | null;
+};
+
+const RawTrackedAccountRowSchema = z.object({
+  riotMatchId: z.string(),
+  puuid: z.string(),
+  playerId: z.number().int().nullable(),
+  accountId: z.number().int().nullable(),
+  cursorAdvancedAt: z.date().nullable(),
+});
+
+export function matchTrackedAccountRowToRecord(
+  row: unknown,
+): MatchTrackedAccountRecord {
+  const raw = RawTrackedAccountRowSchema.parse(row);
+  return MatchTrackedAccountRecordSchema.parse({
+    matchId: raw.riotMatchId,
+    puuid: raw.puuid,
+    playerId: raw.playerId,
+    accountId: raw.accountId,
+    cursorAdvancedAt: raw.cursorAdvancedAt?.toISOString() ?? null,
+  });
+}
+
+export function matchTrackedAccountRecordToRow(
+  record: MatchTrackedAccountRecord,
+): MatchTrackedAccountRow {
+  return {
+    riotMatchId: record.matchId,
+    puuid: record.puuid,
+    playerId: record.playerId,
+    accountId: record.accountId,
+    cursorAdvancedAt:
+      record.cursorAdvancedAt === null
+        ? null
+        : new Date(record.cursorAdvancedAt),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/workflow-start-repository.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/workflow-start-repository.integration.test.ts
@@ -1,0 +1,237 @@
+import { afterAll, describe, expect, test } from "vitest";
+import {
+  IsoInstantSchema,
+  RiotMatchIdSchema,
+  WorkflowRunIdSchema,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import { DiscordAccountIdSchema } from "@scout-for-lol/domain/identity/discord.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  scoutWorkflowStartRowToRecord,
+  type ScoutWorkflowStartRecord,
+} from "#src/database/durable/workflow-start-row.ts";
+import {
+  getWorkflowStart,
+  recordWorkflowStartAccepted,
+  requestWorkflowStart,
+} from "#src/database/durable/workflow-start-repository.ts";
+import {
+  appendAuditEvent,
+  listAuditEvents,
+} from "#src/database/durable/audit-repository.ts";
+import { matchTrackedAccountRowToRecord } from "#src/database/durable/tracked-account-row.ts";
+import {
+  listTrackedAccounts,
+  markTrackedAccountCursorAdvanced,
+  recordTrackedAccounts,
+} from "#src/database/durable/tracked-account-repository.ts";
+
+const { prisma } = createTestDatabase("durable-workflow-start-repository");
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+const AT = new Date("2026-09-07T10:00:00.000Z");
+const ACCEPTED_AT = IsoInstantSchema.parse("2026-09-07T10:01:00.000Z");
+const RUN_ID = WorkflowRunIdSchema.parse("run-1");
+const OPERATOR = DiscordAccountIdSchema.parse("200000000000000001");
+
+function request(
+  id: string,
+  overrides: Partial<{ workflowType: string }> = {},
+): ScoutWorkflowStartRecord {
+  return scoutWorkflowStartRowToRecord({
+    requestedWorkflowId: id,
+    workflowType: "match-recovery",
+    requestedBy: null,
+    requestSource: "operator-command",
+    inputPayload: JSON.stringify({ kind: "recovery", version: 1, data: {} }),
+    requestedAt: AT,
+    acceptedAt: null,
+    runId: null,
+    ...overrides,
+  });
+}
+
+describe("requestWorkflowStart", () => {
+  test("inserts once and adopts the identical re-request", async () => {
+    const record = request("wf-req-1");
+    const first = await requestWorkflowStart(prisma, record);
+    expect(first.outcome).toBe("applied");
+    const second = await requestWorkflowStart(prisma, record);
+    expect(second).toEqual({ outcome: "adopted", record });
+  });
+
+  test("exactly one of two concurrent identical requests inserts, the other adopts", async () => {
+    const record = request("wf-req-2");
+    const outcomes = await Promise.all([
+      requestWorkflowStart(prisma, record),
+      requestWorkflowStart(prisma, record),
+    ]);
+    expect(outcomes.map((result) => result.outcome).sort()).toEqual([
+      "adopted",
+      "applied",
+    ]);
+  });
+
+  test("conflicts when the same id is re-requested with different work", async () => {
+    await requestWorkflowStart(prisma, request("wf-req-3"));
+    expect(
+      await requestWorkflowStart(
+        prisma,
+        request("wf-req-3", { workflowType: "hall-baseline" }),
+      ),
+    ).toEqual({ outcome: "conflict", reason: "request-differs" });
+  });
+
+  test("adoption returns the recorded acceptance", async () => {
+    const record = request("wf-req-4");
+    await requestWorkflowStart(prisma, record);
+    await recordWorkflowStartAccepted(prisma, {
+      requestedWorkflowId: record.requestedWorkflowId,
+      acceptedAt: ACCEPTED_AT,
+      runId: RUN_ID,
+    });
+    const adopted = await requestWorkflowStart(prisma, record);
+    expect(adopted.outcome).toBe("adopted");
+    if (adopted.outcome === "adopted") {
+      expect(adopted.record.acceptance).toEqual({
+        acceptedAt: ACCEPTED_AT,
+        runId: RUN_ID,
+      });
+    }
+  });
+});
+
+describe("recordWorkflowStartAccepted", () => {
+  test("accepts once, tolerates the identical retry, conflicts on drift", async () => {
+    const record = request("wf-acc-1");
+    await requestWorkflowStart(prisma, record);
+    const args = {
+      requestedWorkflowId: record.requestedWorkflowId,
+      acceptedAt: ACCEPTED_AT,
+      runId: RUN_ID,
+    };
+    expect(await recordWorkflowStartAccepted(prisma, args)).toEqual({
+      outcome: "applied",
+    });
+    expect(await recordWorkflowStartAccepted(prisma, args)).toEqual({
+      outcome: "already-applied",
+    });
+    expect(
+      await recordWorkflowStartAccepted(prisma, {
+        ...args,
+        runId: WorkflowRunIdSchema.parse("run-2"),
+      }),
+    ).toEqual({ outcome: "conflict", reason: "acceptance-differs" });
+    const stored = await getWorkflowStart(prisma, {
+      requestedWorkflowId: record.requestedWorkflowId,
+    });
+    expect(stored?.acceptance?.runId).toBe(RUN_ID);
+  });
+
+  test("accepting a start that was never requested fails loudly", async () => {
+    await expect(
+      recordWorkflowStartAccepted(prisma, {
+        requestedWorkflowId: "wf-ghost",
+        acceptedAt: ACCEPTED_AT,
+        runId: null,
+      }),
+    ).rejects.toThrow(/never requested/);
+  });
+});
+
+describe("appendAuditEvent", () => {
+  test("appends and lists events in insertion order", async () => {
+    const first = await appendAuditEvent(prisma, {
+      actorDiscordId: OPERATOR,
+      action: "recovery-policy-released",
+      subjectKind: "recovery-batch",
+      subjectId: "rb-1",
+      detail: { from: "no-external", to: "stale-private-only" },
+    });
+    const second = await appendAuditEvent(prisma, {
+      actorDiscordId: OPERATOR,
+      action: "unknown-delivery-resolved",
+      subjectKind: "recovery-batch",
+      subjectId: "rb-1",
+      detail: { outcome: "confirmed-unsent" },
+    });
+    expect(second.id).toBeGreaterThan(first.id);
+
+    const listed = await listAuditEvents(prisma, {
+      subjectKind: "recovery-batch",
+      subjectId: "rb-1",
+    });
+    expect(listed.map((event) => event.action)).toEqual([
+      "recovery-policy-released",
+      "unknown-delivery-resolved",
+    ]);
+    expect(listed[0]?.detail).toEqual({
+      from: "no-external",
+      to: "stale-private-only",
+    });
+  });
+
+  test("rejects a detail that cannot be serialized as JSON", async () => {
+    await expect(
+      appendAuditEvent(prisma, {
+        actorDiscordId: OPERATOR,
+        action: "x",
+        subjectKind: "y",
+        subjectId: "z",
+        detail: { bad: 1n },
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("tracked accounts", () => {
+  const association = matchTrackedAccountRowToRecord({
+    riotMatchId: "NA1_7000",
+    puuid: "q".repeat(78),
+    playerId: null,
+    accountId: null,
+    cursorAdvancedAt: null,
+  });
+
+  test("records idempotently and advances the cursor exactly once", async () => {
+    expect(await recordTrackedAccounts(prisma, [association])).toEqual({
+      recorded: 1,
+      existing: 0,
+    });
+    expect(await recordTrackedAccounts(prisma, [association])).toEqual({
+      recorded: 0,
+      existing: 1,
+    });
+
+    const advance = {
+      matchId: association.matchId,
+      puuid: association.puuid,
+      advancedAt: ACCEPTED_AT,
+    };
+    expect(await markTrackedAccountCursorAdvanced(prisma, advance)).toEqual({
+      outcome: "applied",
+    });
+    expect(await markTrackedAccountCursorAdvanced(prisma, advance)).toEqual({
+      outcome: "already-applied",
+    });
+
+    const listed = await listTrackedAccounts(prisma, {
+      matchId: association.matchId,
+    });
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.cursorAdvancedAt).toBe(ACCEPTED_AT);
+  });
+
+  test("advancing an unrecorded association fails loudly", async () => {
+    await expect(
+      markTrackedAccountCursorAdvanced(prisma, {
+        matchId: RiotMatchIdSchema.parse("NA1_7001"),
+        puuid: association.puuid,
+        advancedAt: ACCEPTED_AT,
+      }),
+    ).rejects.toThrow(/never recorded/);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/database/durable/workflow-start-repository.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/workflow-start-repository.ts
@@ -1,0 +1,118 @@
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import type {
+  IsoInstant,
+  WorkflowRunId,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  scoutWorkflowStartRecordToRow,
+  scoutWorkflowStartRowToRecord,
+  type ScoutWorkflowStartRecord,
+} from "#src/database/durable/workflow-start-row.ts";
+import { dateFromIsoInstant } from "#src/database/durable/row-values.ts";
+
+/**
+ * Repository for ScoutWorkflowStart.
+ *
+ * requestWorkflowStart is insert-or-adopt by the requested workflow id: a
+ * crashed requester re-requesting the same start adopts the existing request
+ * (including any acceptance already recorded) instead of starting a second
+ * workflow. Adoption compares what identifies the start — type and input
+ * payload — not when or by whom it was re-requested.
+ */
+
+type WorkflowStartDb = Pick<ExtendedPrismaClient, "scoutWorkflowStart">;
+
+export type RequestWorkflowStartResult =
+  | { outcome: "applied"; record: ScoutWorkflowStartRecord }
+  | { outcome: "adopted"; record: ScoutWorkflowStartRecord }
+  | { outcome: "conflict"; reason: "request-differs" };
+
+export async function requestWorkflowStart(
+  db: WorkflowStartDb,
+  record: ScoutWorkflowStartRecord,
+): Promise<RequestWorkflowStartResult> {
+  const row = scoutWorkflowStartRecordToRow(record);
+  const created = await db.scoutWorkflowStart.createMany({
+    data: [row],
+    skipDuplicates: true,
+  });
+  if (created.count === 1) {
+    return { outcome: "applied", record };
+  }
+  const existing = await db.scoutWorkflowStart.findUnique({
+    where: { requestedWorkflowId: row.requestedWorkflowId },
+  });
+  if (existing === null) {
+    throw new Error(
+      `ScoutWorkflowStart ${row.requestedWorkflowId} vanished between a duplicate insert and its read-back`,
+    );
+  }
+  const existingRecord = scoutWorkflowStartRowToRecord(existing);
+  const identityMatches =
+    existingRecord.workflowType === record.workflowType &&
+    Bun.deepEquals(existingRecord.inputPayload, record.inputPayload, true);
+  return identityMatches
+    ? { outcome: "adopted", record: existingRecord }
+    : { outcome: "conflict", reason: "request-differs" };
+}
+
+export type RecordWorkflowStartAcceptedResult =
+  | { outcome: "applied" }
+  | { outcome: "already-applied" }
+  | { outcome: "conflict"; reason: "acceptance-differs" };
+
+/**
+ * Record that Temporal accepted the start. Guarded on the not-yet-accepted
+ * row; a retry carrying the identical acceptance is `already-applied`, and a
+ * different acceptance for an already-accepted start is a conflict.
+ */
+export async function recordWorkflowStartAccepted(
+  db: WorkflowStartDb,
+  args: {
+    requestedWorkflowId: string;
+    acceptedAt: IsoInstant;
+    runId: WorkflowRunId | null;
+  },
+): Promise<RecordWorkflowStartAcceptedResult> {
+  const accepted = await db.scoutWorkflowStart.updateMany({
+    where: { requestedWorkflowId: args.requestedWorkflowId, acceptedAt: null },
+    data: {
+      acceptedAt: dateFromIsoInstant(args.acceptedAt),
+      runId: args.runId,
+    },
+  });
+  if (accepted.count === 1) {
+    return { outcome: "applied" };
+  }
+  const existing = await db.scoutWorkflowStart.findUnique({
+    where: { requestedWorkflowId: args.requestedWorkflowId },
+  });
+  if (existing === null) {
+    throw new Error(
+      `Cannot accept ${args.requestedWorkflowId}: the start was never requested`,
+    );
+  }
+  const record = scoutWorkflowStartRowToRecord(existing);
+  if (record.acceptance === null) {
+    throw new Error(
+      `Acceptance update for ${args.requestedWorkflowId} matched no row yet the start is unaccepted`,
+    );
+  }
+  const sameAcceptance =
+    dateFromIsoInstant(record.acceptance.acceptedAt).getTime() ===
+      dateFromIsoInstant(args.acceptedAt).getTime() &&
+    record.acceptance.runId === args.runId;
+  return sameAcceptance
+    ? { outcome: "already-applied" }
+    : { outcome: "conflict", reason: "acceptance-differs" };
+}
+
+export async function getWorkflowStart(
+  db: WorkflowStartDb,
+  args: { requestedWorkflowId: string },
+): Promise<ScoutWorkflowStartRecord | null> {
+  const row = await db.scoutWorkflowStart.findUnique({
+    where: { requestedWorkflowId: args.requestedWorkflowId },
+  });
+  return row === null ? null : scoutWorkflowStartRowToRecord(row);
+}

--- a/packages/scout-for-lol/packages/backend/src/database/durable/workflow-start-row.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/workflow-start-row.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+import {
+  IsoInstantSchema,
+  WorkflowRunIdSchema,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import { DiscordAccountIdSchema } from "@scout-for-lol/domain/identity/discord.ts";
+import {
+  dateFromIsoInstant,
+  parsePayloadEnvelopeColumn,
+  serializePayloadEnvelope,
+  VersionedPayloadEnvelopeSchema,
+} from "#src/database/durable/row-values.ts";
+
+/**
+ * Row codec for ScoutWorkflowStart.
+ *
+ * Acceptance is modelled as one nullable object because a run id is
+ * acceptance evidence: it can never exist without `acceptedAt`, which the
+ * migration CHECK also enforces. The domain has no brand for a Temporal
+ * workflow id (only WorkflowRunId, the run id), so `requestedWorkflowId`
+ * stays a plain non-empty string.
+ */
+
+export type ScoutWorkflowStartRecord = z.infer<
+  typeof ScoutWorkflowStartRecordSchema
+>;
+export const ScoutWorkflowStartRecordSchema = z.strictObject({
+  requestedWorkflowId: z.string().min(1),
+  workflowType: z.string().min(1),
+  requestedBy: DiscordAccountIdSchema.nullable(),
+  requestSource: z.string().min(1),
+  inputPayload: VersionedPayloadEnvelopeSchema,
+  requestedAt: IsoInstantSchema,
+  acceptance: z
+    .strictObject({
+      acceptedAt: IsoInstantSchema,
+      runId: WorkflowRunIdSchema.nullable(),
+    })
+    .nullable(),
+});
+
+/** Column shape of a ScoutWorkflowStart row, minus DB-managed columns. */
+export type ScoutWorkflowStartRow = {
+  requestedWorkflowId: string;
+  workflowType: string;
+  requestedBy: string | null;
+  requestSource: string;
+  inputPayload: string;
+  requestedAt: Date;
+  acceptedAt: Date | null;
+  runId: string | null;
+};
+
+const RawWorkflowStartRowSchema = z.object({
+  requestedWorkflowId: z.string(),
+  workflowType: z.string(),
+  requestedBy: z.string().nullable(),
+  requestSource: z.string(),
+  inputPayload: z.string(),
+  requestedAt: z.date(),
+  acceptedAt: z.date().nullable(),
+  runId: z.string().nullable(),
+});
+
+export function scoutWorkflowStartRowToRecord(
+  row: unknown,
+): ScoutWorkflowStartRecord {
+  const raw = RawWorkflowStartRowSchema.parse(row);
+  if (raw.acceptedAt === null && raw.runId !== null) {
+    throw new Error(
+      `Workflow start ${raw.requestedWorkflowId} carries a runId without acceptedAt`,
+    );
+  }
+  return ScoutWorkflowStartRecordSchema.parse({
+    requestedWorkflowId: raw.requestedWorkflowId,
+    workflowType: raw.workflowType,
+    requestedBy: raw.requestedBy,
+    requestSource: raw.requestSource,
+    inputPayload: parsePayloadEnvelopeColumn(raw.inputPayload),
+    requestedAt: raw.requestedAt.toISOString(),
+    acceptance:
+      raw.acceptedAt === null
+        ? null
+        : { acceptedAt: raw.acceptedAt.toISOString(), runId: raw.runId },
+  });
+}
+
+export function scoutWorkflowStartRecordToRow(
+  record: ScoutWorkflowStartRecord,
+): ScoutWorkflowStartRow {
+  return {
+    requestedWorkflowId: record.requestedWorkflowId,
+    workflowType: record.workflowType,
+    requestedBy: record.requestedBy,
+    requestSource: record.requestSource,
+    inputPayload: serializePayloadEnvelope(record.inputPayload),
+    requestedAt: dateFromIsoInstant(record.requestedAt),
+    acceptedAt:
+      record.acceptance === null
+        ? null
+        : dateFromIsoInstant(record.acceptance.acceptedAt),
+    runId: record.acceptance?.runId ?? null,
+  };
+}


### PR DESCRIPTION
## Why

The durable pipeline (SJ-186 / SJ-188) needs Postgres to be the operational source of truth: who owns a match, which processing effects are receipted, what notification and recovery state exists, and which Workflow starts were requested. Today those facts are implicit in v1 code paths and unrecoverable after a crash.

**Stacked on #2771** (consumes the @scout-for-lol/domain unions).

## What

Seven additive Prisma models persisting the domain unions — string states + **30 hand-authored CHECK constraints** (no enums, per schema policy), following the InitialMatchHistoryImport precedent:

- **MatchObservation** — riotMatchId PK as the ownership claim; `promotedAt` only on FULL (born-FULL rows can't carry it).
- **MatchTrackedAccount** — observation↔account association with cursor advancement.
- **MatchProcessingReceipt** — non-null `scopeKey` mirrors the domain `receiptScopeKey`, so receipt uniqueness cannot be defeated by Postgres NULLs-distinct semantics; a CHECK ties it to the split scope columns.
- **MatchNotificationIntent** — the full intent state vocabulary; per-variant columns (attemptNonce, sendStartedAt, deliveredAt, suppressedReason, unknownObservedAt, messageId) CHECKed present exactly in their states.
- **MatchRecoveryBatch** — cursor/counts present iff the state carries them; unique `workflowId` adoption key (the convention Hall/Challenge/Duel established).
- **ScoutWorkflowStart** — "start requested"/"start accepted" only; deliberately separate from ScoutTemporalWork.
- **ScoutOperatorAuditEvent** — append-only.

New `src/database/durable/` layer: row codecs parse every read into the domain unions (no Prisma type crosses the boundary; brands parsed at the edge), repositories return expected-result unions (applied | already-applied | adopted | conflict), and transitions follow the claimAndExecute idiom — read → pure domain transition → guarded updateMany → bounded re-read on race.

## Verification

- `bunx turbo run typecheck test lint --filter=@scout-for-lol/backend` — 20/20 tasks, **3544 tests (122 new)**, architecture clean at 1199 modules; re-verified after restack onto the current #2771 head.
- Every CHECK has a named-constraint rejection test (the suite caught two real constraint bugs during development — a masked vocabulary CHECK and a partial-counts admission — both fixed in the migration).
- Real concurrent races (Promise.all on one pool): one ownership claim wins, one beginSend wins, identical replays return already-applied, workflow-start adoption, stale-cursor rejection.
- Tests run against `prisma migrate deploy` of the real migration SQL via the test-template DB, so the CHECKs are live in every integration test — not db push.
- Pure persistence layer — no runtime behavior change; no media needed.

Part of SJ-188 (Wave 1 of the Scout durable-architecture program, SJ-186).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qRdG6fzJr3THzYzAJwTZB