### PR TITLE
feat(scout-for-lol): show champion portraits on challenge progress

### DIFF
--- a/packages/scout-for-lol/packages/app/src/components/challenge/challenge-account-editor.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/challenge/challenge-account-editor.tsx
@@ -106,7 +106,7 @@ export function ChallengeAccountEditor(props: {
           </fieldset>
           <ServerFormError error={error} />
           <FormPendingStatus pending={change.isPending}>
-            Recomputing challenge run…
+            Updating now...
           </FormPendingStatus>
           <Button type="submit" disabled={disabled}>
             Recompute with accounts

--- a/packages/scout-for-lol/packages/app/src/components/challenge/challenge-champion-coverage.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/challenge/challenge-champion-coverage.tsx
@@ -1,0 +1,88 @@
+import type { ChallengeFrozenValue } from "@scout-for-lol/data";
+import { browserChampions } from "@scout-for-lol/data/browser-assets";
+import { ChampionPortrait } from "@scout-for-lol/design-system/assets";
+import { cn } from "#src/lib/cn.ts";
+
+const KNOWN_CHAMPION_IDS = new Set(
+  browserChampions.map((champion) => champion.id),
+);
+const CHAMPION_ID_PATTERN = /^[1-9]\d*$/;
+
+export type ChampionCoverageEntry = {
+  readonly id: number;
+  readonly label: string;
+  readonly completed: boolean;
+};
+
+function parseChampionId(value: string): number | null {
+  if (!CHAMPION_ID_PATTERN.test(value)) return null;
+  return Number.parseInt(value, 10);
+}
+
+/**
+ * Champion-shaped distinct progress uses numeric champion IDs as frozen values.
+ * Roles, queues, and other labels stay on the name list.
+ *
+ * Unknown numeric IDs fail here instead of rendering a name list or a
+ * placeholder portrait.
+ */
+export function championCoverageFromDistinct(progress: {
+  readonly covered: readonly ChallengeFrozenValue[];
+  readonly missing: readonly ChallengeFrozenValue[];
+}): ChampionCoverageEntry[] | null {
+  const entries = [...progress.covered, ...progress.missing];
+  if (entries.length === 0) return null;
+
+  const ids: number[] = [];
+  for (const entry of entries) {
+    const id = parseChampionId(entry.value);
+    if (id === null) return null;
+    ids.push(id);
+  }
+
+  const covered = new Set(progress.covered.map((entry) => entry.value));
+  const coverage: ChampionCoverageEntry[] = [];
+  for (const [index, id] of ids.entries()) {
+    const entry = entries[index];
+    if (entry === undefined) {
+      throw new Error("Champion coverage entries are shorter than their ids");
+    }
+    if (!KNOWN_CHAMPION_IDS.has(id)) {
+      throw new Error(`Unknown champion id ${id.toString()}`);
+    }
+    coverage.push({
+      id,
+      label: entry.label,
+      completed: covered.has(entry.value),
+    });
+  }
+  return coverage.toSorted((left, right) =>
+    left.label.localeCompare(right.label),
+  );
+}
+
+export function ChallengeChampionCoverage(props: {
+  readonly entries: readonly ChampionCoverageEntry[];
+}) {
+  return (
+    <ul
+      className="grid grid-cols-[repeat(auto-fill,minmax(2.5rem,1fr))] gap-1"
+      aria-label="Champion coverage"
+    >
+      {props.entries.map((entry) => (
+        <li key={entry.id}>
+          <ChampionPortrait
+            champion={entry.id}
+            alt={`${entry.label}${entry.completed ? ", completed" : ", remaining"}`}
+            title={entry.label}
+            className={cn(
+              "size-10 rounded-md",
+              entry.completed ? undefined : "grayscale",
+            )}
+            style={{ width: 40, height: 40 }}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/challenge/challenge-progress.test.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/challenge/challenge-progress.test.tsx
@@ -1,0 +1,116 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import {
+  freezeChallengeCatalogs,
+  WIN_EVERY_CURRENT_CHAMPION_TEMPLATE,
+} from "@scout-for-lol/data";
+import { ChallengeProgress } from "#src/components/challenge/challenge-progress.tsx";
+import { championCoverageFromDistinct } from "#src/components/challenge/challenge-champion-coverage.tsx";
+
+const AATROX = { value: "266", label: "Aatrox" };
+const AHRI = { value: "103", label: "Ahri" };
+
+describe("championCoverageFromDistinct", () => {
+  test("sorts known champion ids A–Z and marks completion", () => {
+    expect(
+      championCoverageFromDistinct({
+        covered: [AHRI],
+        missing: [AATROX],
+      }),
+    ).toEqual([
+      { id: 266, label: "Aatrox", completed: false },
+      { id: 103, label: "Ahri", completed: true },
+    ]);
+  });
+
+  test("leaves role and queue labels on the name list", () => {
+    expect(
+      championCoverageFromDistinct({
+        covered: [{ value: "MIDDLE", label: "Mid" }],
+        missing: [{ value: "TOP", label: "Top" }],
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects unknown numeric champion ids instead of listing names", () => {
+    expect(() =>
+      championCoverageFromDistinct({
+        covered: [],
+        missing: [{ value: "999999", label: "Not a champion" }],
+      }),
+    ).toThrow("Unknown champion id 999999");
+  });
+});
+
+describe("ChallengeProgress", () => {
+  test("renders champion portraits with grayscale only on remaining", () => {
+    const html = renderToStaticMarkup(
+      <ChallengeProgress
+        progress={{
+          kind: "distinct",
+          current: 1,
+          target: 2,
+          covered: [AHRI],
+          missing: [AATROX],
+          completed: false,
+        }}
+      />,
+    );
+    expect(html).toContain('alt="Ahri, completed"');
+    expect(html).toContain('alt="Aatrox, remaining"');
+    expect(html).toContain('title="Ahri"');
+    expect(html).toContain('title="Aatrox"');
+    expect(html).toMatch(
+      /class="[^"]*grayscale[^"]*"[^>]*alt="Aatrox, remaining"/,
+    );
+    expect(html).not.toMatch(
+      /class="[^"]*grayscale[^"]*"[^>]*alt="Ahri, completed"/,
+    );
+    expect(html).not.toContain("Missing:");
+    expect(html).toContain("1 / 2");
+  });
+
+  test("renders a portrait for every frozen current-champion catalog entry", () => {
+    const frozen = freezeChallengeCatalogs(WIN_EVERY_CURRENT_CHAMPION_TEMPLATE);
+    expect(frozen.progressGoal.kind).toBe("distinct");
+    if (frozen.progressGoal.kind !== "distinct") return;
+    const [first, ...rest] = frozen.progressGoal.requiredValues;
+    if (first === undefined) {
+      throw new Error("Frozen champion catalog has no required values");
+    }
+    const html = renderToStaticMarkup(
+      <ChallengeProgress
+        progress={{
+          kind: "distinct",
+          current: 1,
+          target: frozen.progressGoal.requiredValues.length,
+          covered: [first],
+          missing: rest,
+          completed: false,
+        }}
+      />,
+    );
+    expect(html.match(/<img /g)?.length).toBe(
+      frozen.progressGoal.requiredValues.length,
+    );
+    expect(html).toContain("/img/champion/");
+    expect(html).toContain("grayscale");
+  });
+
+  test("still lists missing role names", () => {
+    const html = renderToStaticMarkup(
+      <ChallengeProgress
+        progress={{
+          kind: "distinct",
+          current: 1,
+          target: 2,
+          covered: [{ value: "MIDDLE", label: "Mid" }],
+          missing: [{ value: "JUNGLE", label: "Jungle" }],
+          completed: false,
+        }}
+      />,
+    );
+    expect(html).toContain("Missing: Jungle");
+    expect(html).not.toContain("<img");
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/components/challenge/challenge-progress.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/challenge/challenge-progress.tsx
@@ -1,5 +1,9 @@
 import type { ChallengeProgress as ChallengeProgressValue } from "@scout-for-lol/data";
 import { Badge } from "@scout-for-lol/design-system/components/badge";
+import {
+  ChallengeChampionCoverage,
+  championCoverageFromDistinct,
+} from "#src/components/challenge/challenge-champion-coverage.tsx";
 
 export function ChallengeProgress(props: { progress: ChallengeProgressValue }) {
   const progress = props.progress;
@@ -22,6 +26,7 @@ export function ChallengeProgress(props: { progress: ChallengeProgressValue }) {
     );
   }
   if (progress.kind === "distinct") {
+    const champions = championCoverageFromDistinct(progress);
     return (
       <div className="space-y-2">
         <div className="flex items-center justify-between gap-3">
@@ -30,12 +35,16 @@ export function ChallengeProgress(props: { progress: ChallengeProgressValue }) {
             {progress.current.toString()} / {progress.target.toString()}
           </Badge>
         </div>
-        {progress.missing.length > 0 ? (
-          <p className="text-sm text-scout-subtle">
-            Missing: {progress.missing.map((value) => value.label).join(", ")}
-          </p>
+        {champions === null ? (
+          progress.missing.length > 0 ? (
+            <p className="text-sm text-scout-subtle">
+              Missing: {progress.missing.map((value) => value.label).join(", ")}
+            </p>
+          ) : (
+            <p className="text-sm text-scout-success">Complete</p>
+          )
         ) : (
-          <p className="text-sm text-scout-success">Complete</p>
+          <ChallengeChampionCoverage entries={champions} />
         )}
       </div>
     );

--- a/packages/scout-for-lol/packages/app/src/components/challenge/player-challenge-runs.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/challenge/player-challenge-runs.tsx
@@ -28,7 +28,7 @@ function ChallengeRunSection(props: {
             >
               <span className="font-medium">{run.title}</span>
               <Badge variant="outline">
-                {run.recomputing ? "recomputing" : run.status}
+                {run.recomputing ? "Updating now..." : run.status}
               </Badge>
             </Link>
           </li>

--- a/packages/scout-for-lol/packages/app/src/routes/challenge-catalog.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/challenge-catalog.tsx
@@ -108,7 +108,7 @@ export function ChallengeCatalog() {
                 <span className="flex items-center justify-between gap-2">
                   <strong>{run.title}</strong>
                   <Badge variant="outline">
-                    {run.recomputing ? "recomputing" : run.status}
+                    {run.recomputing ? "Updating now..." : run.status}
                   </Badge>
                 </span>
                 <span className="mt-2 block text-sm text-scout-subtle">

--- a/packages/scout-for-lol/packages/app/src/routes/challenge-run.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/challenge-run.tsx
@@ -51,7 +51,7 @@ export function ChallengeRun() {
             {run.data.title}
           </h1>
           <Badge variant="outline">
-            {run.data.recomputing ? "recomputing" : run.data.status}
+            {run.data.recomputing ? "Updating now..." : run.data.status}
           </Badge>
         </div>
         <p className="text-scout-subtle">{run.data.summary}</p>
@@ -62,17 +62,13 @@ export function ChallengeRun() {
       <Card>
         <CardHeader>
           <CardTitle>Progress</CardTitle>
-          <CardDescription>
-            {run.data.recomputing
-              ? "Showing the last complete snapshot while revision work continues."
-              : "Deterministically evaluated from Scout's retained match evidence."}
-          </CardDescription>
+          {run.data.recomputing ? (
+            <CardDescription>Updating now...</CardDescription>
+          ) : null}
         </CardHeader>
         <CardContent>
           {snapshot === null ? (
-            <p className="text-sm text-scout-subtle">
-              The first snapshot is still building.
-            </p>
+            <p className="text-sm text-scout-subtle">Updating now...</p>
           ) : (
             <div className="space-y-4">
               <ChallengeProgress progress={snapshot.progress} />

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/how-to/run-community-challenge.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/how-to/run-community-challenge.md
@@ -44,16 +44,17 @@ partial history never looks complete by implication.
 
 The built-in **Win on every current champion A–Z** challenge freezes the current
 champion list when you start. A champion released later does not move that
-run's finish line.
+run's finish line. Champion coverage is shown as portraits: completed in color,
+remaining in grayscale.
 
 ## Change contributing accounts
 
 Open the run and change the selected linked accounts. Scout creates a new
 evaluation revision and recomputes from the run's original start date.
 
-While that work runs, the page keeps showing the last complete snapshot with a
-**Recomputing** marker. Scout replaces it atomically only after the new revision
-is complete.
+While that work runs, the page keeps showing the last complete snapshot with an
+**Updating now...** indicator. Scout replaces it atomically only after the new
+revision is complete.
 
 ## Restart or run something else
 


### PR DESCRIPTION
## Why

Distinct champion coverage was a comma-separated remaining-name list. That is hard to scan on an A–Z run.

## What

- Champion-shaped distinct progress renders a wrap grid of design-system square portraits: completed in color, remaining in grayscale.
- Roles and queues still list names. Unknown numeric IDs fail instead of degrading to a name list.
- Progress has no idle subtitle. Refreshing runs show **Updating now...**

## Verification

- `bunx turbo run test lint typecheck --filter=@scout-for-lol/app --filter=@scout-for-lol/docs-site`
- `bunx lefthook run pre-commit`
- Local `ChallengeProgress` screenshot of the frozen A–Z catalog (42 of 173 completed):

![challenge-progress.png](https://public.sjer.red/pr/assets/2796/challenge-progress.png)

- Live signed-in run page not opened
- Buildkite not yet run on this head