### PR TITLE
chore(root): tighten the directory file-count target to 25

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,13 +63,14 @@ or in-process timers.
   fail.
 - After roughly two failed attempts at the same workaround, step back and
   reconsider the design instead of layering more exceptions.
-- No directory may exceed 50 code files, counted per directory with source and
-  colocated tests holding separate budgets
-  (`scripts/checks/check-directory-file-counts.ts`). Split the directory into
-  sub-domains rather than raising `CEILING`, which has no allowlist to add to.
-  `CEILING` is a ratchet lowered by each reorganization PR toward the
-  permanent `TARGET` of 50; until it reaches `TARGET`, some directories may
-  still legally sit above 50 and below the current `CEILING`.
+- No authored directory may exceed 25 code files, counted per directory with
+  source and colocated tests holding separate budgets
+  (`scripts/checks/check-directory-file-counts.ts`). Generated directories and
+  `sandbox/` do not count. Split into sub-domains rather than raising
+  `CEILING`, which has no allowlist to add to. `CEILING` is a ratchet lowered
+  by each reorganization PR toward the permanent `TARGET` of 25; until it
+  reaches `TARGET`, some directories may still legally sit above 25 and below
+  the current `CEILING`.
 
 Automation under `scripts/`, `.buildkite/`, and deploy/build scripts must not
 hide failures or credentials. In particular, do not add `|| true`,

--- a/scripts/checks/check-directory-file-counts.test.ts
+++ b/scripts/checks/check-directory-file-counts.test.ts
@@ -69,6 +69,20 @@ describe("isCountedPath", () => {
     expect(isCountedPath("packages/x/sandbox/a.ts")).toBe(true);
   });
 
+  test("excludes generated trees, which are machine output", () => {
+    expect(
+      isCountedPath("packages/homelab/src/cdk8s/generated/helm/loki.types.ts"),
+    ).toBe(false);
+    expect(isCountedPath("packages/x/generated/client.ts")).toBe(false);
+    expect(isCountedPath("generated/root.ts")).toBe(false);
+  });
+
+  test("still counts authored files whose name contains generated", () => {
+    expect(
+      isCountedPath("packages/homelab/src/cdk8s/src/version-map.generated.ts"),
+    ).toBe(true);
+  });
+
   test("is not fooled by an extension appearing mid-path", () => {
     expect(isCountedPath("packages/x.ts/notes.md")).toBe(false);
   });
@@ -97,7 +111,7 @@ describe("budgetOf", () => {
   /**
    * The budget split only means anything if a test is recognised as a test in
    * the language it is written in. Charging these to the source budget would
-   * make a directory of 30 modules and their 30 tests fail a 50-module limit it
+   * make a directory of 20 modules and their 20 tests fail a 25-module limit it
    * never exceeded.
    */
   test("recognises Go's convention", () => {

--- a/scripts/checks/check-directory-file-counts.ts
+++ b/scripts/checks/check-directory-file-counts.ts
@@ -1,29 +1,33 @@
 /**
  * Directory file-count governance.
  *
- * A flat directory stops being a domain and becomes a dumping ground somewhere
- * past fifty modules. This check draws that line mechanically.
+ * A flat authored directory stops being a domain and becomes a dumping ground
+ * somewhere past twenty-five modules. This check draws that line mechanically.
  *
  * Two budgets per directory, counted independently: source files and colocated
  * test files. A `foo.test.ts` is not a new concept, so it must not consume the
- * module budget — a directory may hold fifty modules and their fifty tests.
+ * module budget — a directory may hold twenty-five modules and their
+ * twenty-five tests.
  *
- * There is no allowlist and no exempt path. While the repository is being
- * reorganized, `CEILING` sits above `TARGET` and is lowered by each
- * reorganization PR; it is a single global number, so no directory is ever
- * individually excused, and nothing new may exceed today's worst case.
+ * Authored directories have no allowlist. Generated trees and `sandbox/` are
+ * not authored domains: generated output is machine-written, and
+ * `sandbox/archive` is do-not-modify, so a rule that could block either is a
+ * rule that cannot be obeyed. While the repository is being reorganized,
+ * `CEILING` sits above `TARGET` and is lowered by each reorganization PR; it
+ * is a single global number, so no authored directory is ever individually
+ * excused, and nothing new may exceed today's worst case.
  */
 
 import { trackedExistingFiles } from "../lib/tracked-files.ts";
 
 /** Lowered by each reorganization PR until it reaches `TARGET`. */
-export const CEILING = 69;
+export const CEILING = 58;
 
 /** The permanent limit. When `CEILING` reaches this, the workstream is done. */
-export const TARGET = 50;
+export const TARGET = 25;
 
 /** Advisory only — never affects the exit code. */
-export const WARN_THRESHOLD = 25;
+export const WARN_THRESHOLD = 20;
 
 const CODE_EXTENSIONS = new Set([
   "astro",
@@ -46,13 +50,16 @@ const CODE_EXTENSIONS = new Set([
  */
 const EXCLUDED_PREFIX = "sandbox/";
 
+/** Path segment for machine-written trees (Helm types, Prisma client, tokens). */
+const GENERATED_SEGMENT = "generated";
+
 /**
  * Test-file conventions, one per in-scope language.
  *
  * The budget split only means anything if a test is recognised as a test in
  * whatever language it is written in. Charging `foo_test.go` or `FooTests.swift`
- * to the source budget would make a directory of 30 modules and their 30
- * conventionally named tests fail a 50-module limit it never actually exceeded.
+ * to the source budget would make a directory of 20 modules and their 20
+ * conventionally named tests fail a 25-module limit it never actually exceeded.
  *
  * Each pattern is anchored on its own extension, so no language's convention
  * can classify another language's files.
@@ -95,6 +102,7 @@ export type Violation = {
 /** Whether a path counts toward either budget. */
 export function isCountedPath(path: string): boolean {
   if (path.startsWith(EXCLUDED_PREFIX)) return false;
+  if (path.split("/").includes(GENERATED_SEGMENT)) return false;
   const extension = path.slice(path.lastIndexOf(".") + 1);
   return CODE_EXTENSIONS.has(extension);
 }

--- a/scripts/script-migrations.json
+++ b/scripts/script-migrations.json
@@ -303,6 +303,11 @@
       "reason": "Terraform and jq helper is intentionally distributed as a shell script for use from initialized Terraform directories"
     },
     {
+      "source": "packages/dotfiles/herdr-stage-plugin/mark-stage.sh",
+      "disposition": "retain",
+      "reason": "Herdr plugin command is invoked as sh from the plugin directory without a Bun runtime"
+    },
+    {
       "source": "packages/dotfiles/install.sh",
       "disposition": "retain",
       "reason": "Bootstrap installs the toolchain including Bun"


### PR DESCRIPTION
## Why

Fifty modules in one folder is already a dumping ground. The ceiling still had slack above today's authored maximum (58), and generated trees are machine output rather than domains that can be split.

This is PR 1 of 4 in the Linear project [Directory file-count ratchet to 25](https://linear.app/sjerred/project/directory-file-count-ratchet-to-25-98af8346ddbf) ([SJ-197](https://linear.app/sjerred/issue/SJ-197)).

## What

- `TARGET` 50 → 25, `WARN_THRESHOLD` 25 → 20, `CEILING` 69 → 58 (today's authored max: `app/src/lib`)
- Exclude any path with a `generated` directory segment, matching the existing quality-gate rule
- Update `AGENTS.md` for the new target and generated exclusion

Follow-ups: [SJ-198](https://linear.app/sjerred/issue/SJ-198) Scout splits, [SJ-199](https://linear.app/sjerred/issue/SJ-199) Homelab/Temporal, [SJ-200](https://linear.app/sjerred/issue/SJ-200) remainder.

## Verification

- `bunx vitest run scripts/checks/check-directory-file-counts.test.ts` — 38 pass
- `bun scripts/checks/check-directory-file-counts.ts` — exit 0 (`generated/helm` no longer counted)
- `bun scripts/checks/check-agent-guidance.ts` — valid
- `bunx turbo run typecheck lint --filter=@shepherdjerred/root-scripts` — clean
- `bunx lefthook run pre-commit` — pass

Not run: Buildkite CI, deployment (source-only check change).