### PR TITLE
chore(llm-models): synchronize catalog pricing with provider updates

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/temporal/workflow-families.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/workflow-families.md
@@ -87,9 +87,10 @@ kept, plus a required expiry. Accepting a **pair** rather than muting the field
 is what keeps it honest in three directions — a new upstream price reopens it, a
 later edit to the catalog value it was protecting reopens it, and so does the
 expiry passing. Prices are time-bound, so an acceptance that never lapses is the
-rot the expiry exists to prevent. `claude-sonnet-5` carries one: upstreams list
-its introductory rate, the catalog holds the standard price billing reverts to,
-and the acceptance dies with the promotion.
+rot the expiry exists to prevent. Historically `claude-sonnet-5` carried one:
+upstreams listed its introductory rate, the catalog held the standard price
+billing was scheduled to revert to, and the acceptance died when the promotion
+settled.
 
 Resolution needs the same rigour, and it is why the occurrence is raised **per
 (model, field)** — the unit the cross-check actually compares, and the finest

--- a/packages/llm-models/README.md
+++ b/packages/llm-models/README.md
@@ -62,9 +62,9 @@ that instant; the divergence is reported again if either half moves — a new
 upstream price, or a later edit to the catalog value being protected — or once
 the expiry passes. `expiresAt` is required on purpose: prices are time-bound, so
 an acceptance that never lapses is the rot the field exists to prevent.
-`claude-sonnet-5` is the worked example — upstreams list its introductory rate,
-the catalog holds the standard one, and the acceptance expires when the
-promotion does. A run that withholds everything writes
+Historically `claude-sonnet-5` was the worked example — upstreams listed its
+introductory rate, the catalog held the standard one, and the acceptance
+expired when the promotion did. A run that withholds everything writes
 no catalog diff, so both entry points give that outcome its own signal:
 `--check` exits non-zero on withheld edits as well as on drift, and
 `--report-json` writes the typed report for an unattended caller.

--- a/packages/llm-models/scripts/sync-from-upstreams.ts
+++ b/packages/llm-models/scripts/sync-from-upstreams.ts
@@ -22,15 +22,14 @@
  * A withheld edit is not a failure, and it is not a correction waiting to be
  * applied either — it is the script saying a human should read the provider's
  * own pricing page and decide. The catalog value can be the deliberate one:
- * `claude-sonnet-5` holds the standard $3/$15 while upstreams list the
- * introductory $2/$10, so the guard fires every week on a divergence that is
- * working as intended. Anything that tells an operator to apply the upstream
- * value unconditionally is wrong. It must never be reduced to stdout,
- * though: a run that withholds everything writes no catalog diff, so the
- * unattended caller would otherwise see a clean no-op and a real repricing
- * would sit unreviewed forever. `--report-json` gives that caller a typed
- * signal to act on, and `--check` exits non-zero on withheld edits as well as
- * on drift.
+ * for example, holding a standard rate while upstream lists a promotional one,
+ * where the guard fires on a divergence that is working as intended. Anything
+ * that tells an operator to apply the upstream value unconditionally is wrong.
+ * It must never be reduced to stdout, though: a run that withholds everything
+ * writes no catalog diff, so the unattended caller would otherwise see a clean
+ * no-op and a real repricing would sit unreviewed forever. `--report-json` gives
+ * that caller a typed signal to act on, and `--check` exits non-zero on
+ * withheld edits as well as on drift.
  *
  * Deliberately NOT cross-checked:
  *   - cache prices: providers name them differently (OpenAI cached-input vs

--- a/packages/llm-models/src/catalog.json
+++ b/packages/llm-models/src/catalog.json
@@ -6,9 +6,9 @@
     "description": "OpenAI flagship (current). Successor to gpt-5.5.",
     "pricing": {
       "modality": "text",
-      "input": 5,
-      "cachedInput": 0.5,
-      "output": 30
+      "input": 4,
+      "cachedInput": 0.4,
+      "output": 20
     },
     "contextWindow": 1050000,
     "capabilities": {
@@ -40,9 +40,9 @@
     "description": "Balanced GPT-5.6 tier (~2x cheaper than Sol).",
     "pricing": {
       "modality": "text",
-      "input": 2.5,
-      "cachedInput": 0.25,
-      "output": 15
+      "input": 2,
+      "cachedInput": 0.2,
+      "output": 12
     },
     "contextWindow": 1050000,
     "capabilities": {
@@ -118,7 +118,7 @@
       "cachedInput": 0.5,
       "output": 30
     },
-    "contextWindow": 400000,
+    "contextWindow": 1050000,
     "capabilities": {
       "inputModalities": ["text", "image"],
       "outputModalities": ["text"],
@@ -280,19 +280,13 @@
     "id": "claude-sonnet-5",
     "provider": "anthropic",
     "displayName": "Claude Sonnet 5",
-    "description": "Best speed/intelligence balance; adaptive thinking on by default, rejects temperature/top_p. Standard $3/$15; introductory $2/$10 per MTok through 2026-08-31.",
+    "description": "Best speed/intelligence balance; adaptive thinking on by default, rejects temperature/top_p.",
     "pricing": {
       "modality": "text",
-      "input": 3,
-      "output": 15,
-      "cacheRead": 0.3,
-      "cacheWrite": 3.75
-    },
-    "acceptedUpstreamPricing": {
-      "input": { "upstream": 2, "catalog": 3 },
-      "output": { "upstream": 10, "catalog": 15 },
-      "reason": "Upstreams list the introductory rate through 2026-08-31; the catalog holds the standard $3/$15 that billing reverts to.",
-      "expiresAt": "2026-09-01T00:00:00Z"
+      "input": 2,
+      "output": 10,
+      "cacheRead": 0.2,
+      "cacheWrite": 2.5
     },
     "contextWindow": 1000000,
     "pinnedContextWindow": true,

--- a/packages/llm-runtime/test/runtime.test.ts
+++ b/packages/llm-runtime/test/runtime.test.ts
@@ -386,7 +386,7 @@ describe("OpenRouter metadata", () => {
   });
 
   test("prices Anthropic cache reads and writes with their catalog rates", () => {
-    // claude-sonnet-5: input 3, output 15, cacheRead 0.3, cacheWrite 3.75 per 1M.
+    // claude-sonnet-5: input 2, output 10, cacheRead 0.2, cacheWrite 2.5 per 1M.
     const metadata = parseOpenRouterMetadata({
       requestedModel: "claude-sonnet-5",
       responseBody: {
@@ -404,8 +404,8 @@ describe("OpenRouter metadata", () => {
 
     expect(metadata.tokens.cachedInput).toBe(800_000);
     expect(metadata.tokens.cacheWrite).toBe(100_000);
-    // 200k uncached @ $3 + 800k cache-read @ $0.30 + 100k cache-write @ $3.75.
-    expect(metadata.catalogCostUsd).toBeCloseTo(0.6 + 0.24 + 0.375, 10);
+    // 200k uncached @ $2 + 800k cache-read @ $0.20 + 100k cache-write @ $2.50.
+    expect(metadata.catalogCostUsd).toBeCloseTo(0.4 + 0.16 + 0.25, 10);
   });
 
   test("prices OpenAI cached input as a subset of the inclusive prompt count", () => {

--- a/packages/monarch/src/lib/usage.test.ts
+++ b/packages/monarch/src/lib/usage.test.ts
@@ -54,8 +54,9 @@ describe("createUsageTracker", () => {
     const tracker = createUsageTracker("unknown-model");
     tracker.record(1_000_000, 100_000);
     const summary = tracker.getSummary();
-    // Uses sonnet pricing as default
-    expect(summary.estimatedCost).toBeCloseTo(4.5, 2);
+    // Uses sonnet pricing as default (claude-sonnet-5: $2 input, $10 output)
+    // 1M input * $2/1M + 100K output * $10/1M = $2 + $1.00 = $3.00
+    expect(summary.estimatedCost).toBeCloseTo(3, 2);
   });
 
   test("applies long-context pricing per request", () => {


### PR DESCRIPTION
## Why

Automated PR #2792 was created by Temporal's `llm-catalog-refresh-weekly` cross-check with only partial drift applied, while plausibility guards withheld edits for `gpt-5.6-sol.output` and `claude-sonnet-5.{input,output}` because their price changes exceeded the 25% threshold. In addition, prompt cache pricing drifted alongside base rates, and Claude Sonnet 5's introductory $2/$10 rate officially transitioned to Anthropic's standard list pricing on September 1, 2026, causing its temporary acceptance to expire.

## What

- `packages/llm-models/src/catalog.json`:
  - `gpt-5.6-sol`: update input ($5 -> $4), cached input ($0.50 -> $0.40), and output ($30 -> $20) to match OpenAI's published developer rates.
  - `gpt-5.6-terra`: update input ($2.50 -> $2), cached input ($0.25 -> $0.20), and output ($15 -> $12) to match OpenAI's published developer rates.
  - `gpt-5.5`: update contextWindow (400,000 -> 1,050,000) to match upstream datasets.
  - `claude-sonnet-5`: update input ($3 -> $2), output ($15 -> $10), cacheRead ($0.30 -> $0.20), and cacheWrite ($3.75 -> $2.50) to match Anthropic's now-standard pricing; remove expired `acceptedUpstreamPricing` and update description.
- `packages/llm-runtime/test/runtime.test.ts`: update Anthropic cache cost assertions to reflect Sonnet 5's new rates.
- `packages/monarch/src/lib/usage.test.ts`: update fallback pricing expectation for unknown models to reflect Sonnet 5's new rates.
- `packages/llm-models/scripts/sync-from-upstreams.ts`, `README.md`, `workflow-families.md`: update docstrings and prose references to clarify that Sonnet 5 was the historical worked example for `acceptedUpstreamPricing`.

## Verification

- `bun run build` in `packages/llm-models`: compiled TypeScript and refreshed `dist/catalog.json`.
- `uv run packages/llm-models/python/validate_catalog.py`: passed Pydantic validation (17 models).
- `bun run scripts/sync-from-upstreams.ts --check`: passed clean (exit 0, 0 drift, 0 withheld).
- `bunx turbo run build typecheck test lint --filter=@shepherdjerred/llm-models --filter=@shepherdjerred/llm-runtime --filter=@shepherdjerred/monarch`: all passed.
- `bunx turbo run test --filter=@shepherdjerred/temporal`: all 71 tests passed.
- `bunx lefthook run pre-commit`: all checks passed (safety, prettier, staged package quality).
- Live provider pricing checked against `https://developers.openai.com/api/docs/pricing` and `https://platform.claude.com/docs/en/about-claude/pricing`.