### PR TITLE
fix(macos-ai-subscription-tracker): stop the recurring Claude Keychain prompt

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/quotabar.md
+++ b/packages/docs/wiki/src/content/docs/explanation/quotabar.md
@@ -71,7 +71,11 @@ so reading the item with the Security framework turns a five-minute poll into a
 recurring password prompt. Brim reads it through `/usr/bin/security` instead:
 that tool is the trusted application each rewrite re-establishes, which keeps
 credential discovery silent without Brim ever writing another tool's
-credentials.
+credentials. That boundary is implemented by the
+[Keychain reader](https://github.com/shepherdjerred/monorepo/blob/8974ae3e5b14fbffebb67dea8c6d68be11f027d8/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Keychain.swift),
+which the
+[credential store](https://github.com/shepherdjerred/monorepo/blob/8974ae3e5b14fbffebb67dea8c6d68be11f027d8/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Credentials.swift)
+uses for Claude discovery.
 
 Google means Antigravity under the user's Google AI Pro subscription. Brim
 asks the already signed-in `agy` CLI for its zero-turn `/usage` result and

--- a/packages/docs/wiki/src/content/docs/explanation/quotabar.md
+++ b/packages/docs/wiki/src/content/docs/explanation/quotabar.md
@@ -63,6 +63,16 @@ The provider-specific behavior is isolated in the
 [Claude adapter](https://github.com/shepherdjerred/monorepo/blob/231bac375d228b685e12308a1d02d243cb3d1481/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/ClaudeCodeProvider.swift)
 and [Codex adapter](https://github.com/shepherdjerred/monorepo/blob/231bac375d228b685e12308a1d02d243cb3d1481/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/CodexProvider.swift).
 
+Claude Code owns its credential item and rewrites it with
+`security add-generic-password -U` on every token refresh, which resets that
+item's access-control list to the creating tool. A grant Brim earns from the
+system's "Always Allow" dialog therefore survives only until the next refresh,
+so reading the item with the Security framework turns a five-minute poll into a
+recurring password prompt. Brim reads it through `/usr/bin/security` instead:
+that tool is the trusted application each rewrite re-establishes, which keeps
+credential discovery silent without Brim ever writing another tool's
+credentials.
+
 Google means Antigravity under the user's Google AI Pro subscription. Brim
 asks the already signed-in `agy` CLI for its zero-turn `/usage` result and
 displays the Gemini and Claude/GPT five-hour and weekly pools. The CLI remains

--- a/packages/macos-ai-subscription-tracker/README.md
+++ b/packages/macos-ai-subscription-tracker/README.md
@@ -128,6 +128,14 @@ and writer of those OAuth token chains: Brim never rotates, refreshes, or
 rewrites OpenCode files or its credential database. An expired or rejected
 Kimi/Grok token instructs the user to refresh it through OpenCode.
 
+Claude Code keeps its credentials only in the macOS login Keychain and rewrites
+that item with `security add-generic-password -U` on every OAuth token refresh,
+which resets the item's access-control list to the tool that created it. Reading
+it with the Security framework therefore re-prompts for the login Keychain
+password after each refresh, however often "Always Allow" is granted. Brim reads
+it through `/usr/bin/security`, the trusted application every one of those
+rewrites re-establishes, so discovery stays silent.
+
 The Kimi and Grok subscription quota responses are private provider contracts,
 not stable public APIs. Their adapters validate responses and show an explicit
 unavailable/stale state when a provider changes shape. Claude and Codex use

--- a/packages/macos-ai-subscription-tracker/README.md
+++ b/packages/macos-ai-subscription-tracker/README.md
@@ -128,13 +128,10 @@ and writer of those OAuth token chains: Brim never rotates, refreshes, or
 rewrites OpenCode files or its credential database. An expired or rejected
 Kimi/Grok token instructs the user to refresh it through OpenCode.
 
-Claude Code keeps its credentials only in the macOS login Keychain and rewrites
-that item with `security add-generic-password -U` on every OAuth token refresh,
-which resets the item's access-control list to the tool that created it. Reading
-it with the Security framework therefore re-prompts for the login Keychain
-password after each refresh, however often "Always Allow" is granted. Brim reads
-it through `/usr/bin/security`, the trusted application every one of those
-rewrites re-establishes, so discovery stays silent.
+Claude credentials are read through `/usr/bin/security` rather than the Security
+framework. The
+[Brim explanation page](../docs/wiki/src/content/docs/explanation/quotabar.md)
+covers why.
 
 The Kimi and Grok subscription quota responses are private provider contracts,
 not stable public APIs. Their adapters validate responses and show an explicit

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/CommandRunning.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/CommandRunning.swift
@@ -48,6 +48,39 @@ public struct FoundationCommandRunner: CommandRunning, Sendable {
   }
 }
 
+/// Runs a short-lived command and blocks until it exits.
+///
+/// The credential stores read files, SQLite databases, and the keychain synchronously on the
+/// polling task, so a credential helper that spawns a process belongs on the same blocking path
+/// rather than forcing the whole `CredentialStore` API to become asynchronous.
+public protocol SynchronousCommandRunning: Sendable {
+  func run(executableURL: URL, arguments: [String]) throws -> CommandResult
+}
+
+public struct FoundationSynchronousCommandRunner: SynchronousCommandRunning, Sendable {
+  public init() {}
+
+  public func run(executableURL: URL, arguments: [String]) throws -> CommandResult {
+    let process = Process()
+    let output = Pipe()
+    process.executableURL = executableURL
+    process.arguments = arguments
+    process.standardOutput = output
+    process.standardError = FileHandle.nullDevice
+    process.standardInput = FileHandle.nullDevice
+    do {
+      try process.run()
+    } catch {
+      throw QuotaError.commandFailed(executableURL.lastPathComponent)
+    }
+    // Drain the pipe before waiting: a command whose output exceeds the pipe buffer blocks on
+    // write, and waiting first would deadlock against it.
+    let stdout = output.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    return CommandResult(stdout: stdout, terminationStatus: process.terminationStatus)
+  }
+}
+
 private final class ProcessControl: @unchecked Sendable {
   let process = Process()
   let output = Pipe()

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Credentials.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Credentials.swift
@@ -2,65 +2,6 @@ public import Foundation
 import SQLite3
 import Security
 
-public protocol KeychainClient: Sendable {
-  func read(service: String, account: String?) throws -> Data?
-  func write(_ data: Data, service: String, account: String) throws
-  func delete(service: String, account: String) throws
-}
-
-public struct SystemKeychainClient: KeychainClient, Sendable {
-  public init() {}
-
-  public func read(service: String, account: String?) throws -> Data? {
-    var query: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: service,
-      kSecReturnData as String: true,
-      kSecMatchLimit as String: kSecMatchLimitOne,
-    ]
-    if let account { query[kSecAttrAccount as String] = account }
-    var result: AnyObject?
-    let status = SecItemCopyMatching(query as CFDictionary, &result)
-    if status == errSecItemNotFound { return nil }
-    guard status == errSecSuccess else { throw QuotaError.keychain(status: status) }
-    guard let data = result as? Data else { throw QuotaError.keychain(status: errSecDecode) }
-    return data
-  }
-
-  public func write(_ data: Data, service: String, account: String) throws {
-    let query: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: service,
-      kSecAttrAccount as String: account,
-    ]
-    let attributes: [String: Any] = [
-      kSecValueData as String: data,
-      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-    ]
-    let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
-    if updateStatus == errSecSuccess { return }
-    guard updateStatus == errSecItemNotFound else {
-      throw QuotaError.keychain(status: updateStatus)
-    }
-    var item = query
-    for (key, value) in attributes { item[key] = value }
-    let addStatus = SecItemAdd(item as CFDictionary, nil)
-    guard addStatus == errSecSuccess else { throw QuotaError.keychain(status: addStatus) }
-  }
-
-  public func delete(service: String, account: String) throws {
-    let query: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: service,
-      kSecAttrAccount as String: account,
-    ]
-    let status = SecItemDelete(query as CFDictionary)
-    guard status == errSecSuccess || status == errSecItemNotFound else {
-      throw QuotaError.keychain(status: status)
-    }
-  }
-}
-
 public actor ManualCredentialStore: CredentialStore {
   public static let service = "com.sjerred.QuotaBar.credentials"
   private let keychain: any KeychainClient
@@ -111,7 +52,7 @@ public final class LocalCredentialStore: CredentialStore, @unchecked Sendable {
   private let homeDirectory: URL
   private let kimiCodeHome: URL?
   private let cursorStateDatabase: URL?
-  private let claudeKeychain: any KeychainClient
+  private let claudeKeychain: any KeychainReading
   private let selectionLock = NSLock()
   private var rejectedTokens: [ProviderID: Set<String>] = [:]
 
@@ -120,7 +61,7 @@ public final class LocalCredentialStore: CredentialStore, @unchecked Sendable {
     homeDirectory: URL? = nil,
     kimiCodeHome: URL? = nil,
     cursorStateDatabase: URL? = nil,
-    claudeKeychain: any KeychainClient = SystemKeychainClient()
+    claudeKeychain: any KeychainReading = SecurityToolKeychainClient()
   ) {
     self.fileManager = fileManager
     self.homeDirectory = homeDirectory ?? fileManager.homeDirectoryForCurrentUser

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Keychain.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Keychain.swift
@@ -75,10 +75,13 @@ public struct SystemKeychainClient: KeychainClient, Sendable {
 /// the trusted application that each of those rewrites re-establishes, so reading through it stays
 /// silent and keeps working across refreshes.
 public struct SecurityToolKeychainClient: KeychainReading, Sendable {
-  /// `security` exits 44 when no item matches the query and 36 when the keychain itself is
-  /// missing. Both mean the credential is absent, which is the normal state for a tool the user has
-  /// not signed into. Every other non-zero status is a genuine failure and must surface.
-  private static let absentStatuses: Set<Int32> = [36, 44]
+  /// `security` reports its `OSStatus` through the exit status' low byte, so
+  /// `errSecItemNotFound` (-25300) arrives as 44. That status alone means no credential has been
+  /// stored, which is the normal state for a tool the user has not signed into. Every other
+  /// status - including `errSecInteractionNotAllowed` (-25308, exit 36) from a locked Keychain -
+  /// describes a credential this Mac would not hand over, and must surface instead of reading as
+  /// missing.
+  private static let itemNotFoundStatus: Int32 = 44
   private static let executableURL = URL(fileURLWithPath: "/usr/bin/security")
 
   private let commandRunner: any SynchronousCommandRunning
@@ -95,7 +98,7 @@ public struct SecurityToolKeychainClient: KeychainReading, Sendable {
       arguments.append(contentsOf: ["-a", account])
     }
     let result = try commandRunner.run(executableURL: Self.executableURL, arguments: arguments)
-    guard !Self.absentStatuses.contains(result.terminationStatus) else { return nil }
+    guard result.terminationStatus != Self.itemNotFoundStatus else { return nil }
     guard result.terminationStatus == 0,
       let output = String(data: result.stdout, encoding: .utf8)
     else {

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Keychain.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Keychain.swift
@@ -1,0 +1,107 @@
+public import Foundation
+import Security
+
+/// The read-only half of keychain access. `LocalCredentialStore` only ever reads items another
+/// tool owns and must never write them, so it depends on this narrower protocol.
+public protocol KeychainReading: Sendable {
+  func read(service: String, account: String?) throws -> Data?
+}
+
+public protocol KeychainClient: KeychainReading {
+  func write(_ data: Data, service: String, account: String) throws
+  func delete(service: String, account: String) throws
+}
+
+public struct SystemKeychainClient: KeychainClient, Sendable {
+  public init() {}
+
+  public func read(service: String, account: String?) throws -> Data? {
+    var query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecReturnData as String: true,
+      kSecMatchLimit as String: kSecMatchLimitOne,
+    ]
+    if let account { query[kSecAttrAccount as String] = account }
+    var result: AnyObject?
+    let status = SecItemCopyMatching(query as CFDictionary, &result)
+    if status == errSecItemNotFound { return nil }
+    guard status == errSecSuccess else { throw QuotaError.keychain(status: status) }
+    guard let data = result as? Data else { throw QuotaError.keychain(status: errSecDecode) }
+    return data
+  }
+
+  public func write(_ data: Data, service: String, account: String) throws {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: account,
+    ]
+    let attributes: [String: Any] = [
+      kSecValueData as String: data,
+      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+    ]
+    let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+    if updateStatus == errSecSuccess { return }
+    guard updateStatus == errSecItemNotFound else {
+      throw QuotaError.keychain(status: updateStatus)
+    }
+    var item = query
+    for (key, value) in attributes { item[key] = value }
+    let addStatus = SecItemAdd(item as CFDictionary, nil)
+    guard addStatus == errSecSuccess else { throw QuotaError.keychain(status: addStatus) }
+  }
+
+  public func delete(service: String, account: String) throws {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: account,
+    ]
+    let status = SecItemDelete(query as CFDictionary)
+    guard status == errSecSuccess || status == errSecItemNotFound else {
+      throw QuotaError.keychain(status: status)
+    }
+  }
+}
+
+/// Reads a login-keychain item owned by another tool through `/usr/bin/security` instead of
+/// `SecItemCopyMatching`.
+///
+/// Claude Code stores its OAuth credentials with `security add-generic-password -U`, which
+/// re-creates the item and resets its access-control list to the creating tool. A grant Brim earns
+/// from the system's "Always Allow" dialog therefore survives only until the next token refresh,
+/// after which every poll prompts for the login keychain password again. `/usr/bin/security` is
+/// the trusted application that each of those rewrites re-establishes, so reading through it stays
+/// silent and keeps working across refreshes.
+public struct SecurityToolKeychainClient: KeychainReading, Sendable {
+  /// `security` exits 44 when no item matches the query and 36 when the keychain itself is
+  /// missing. Both mean the credential is absent, which is the normal state for a tool the user has
+  /// not signed into. Every other non-zero status is a genuine failure and must surface.
+  private static let absentStatuses: Set<Int32> = [36, 44]
+  private static let executableURL = URL(fileURLWithPath: "/usr/bin/security")
+
+  private let commandRunner: any SynchronousCommandRunning
+
+  public init(
+    commandRunner: any SynchronousCommandRunning = FoundationSynchronousCommandRunner()
+  ) {
+    self.commandRunner = commandRunner
+  }
+
+  public func read(service: String, account: String?) throws -> Data? {
+    var arguments = ["find-generic-password", "-w", "-s", service]
+    if let account {
+      arguments.append(contentsOf: ["-a", account])
+    }
+    let result = try commandRunner.run(executableURL: Self.executableURL, arguments: arguments)
+    guard !Self.absentStatuses.contains(result.terminationStatus) else { return nil }
+    guard result.terminationStatus == 0,
+      let output = String(data: result.stdout, encoding: .utf8)
+    else {
+      throw QuotaError.commandFailed("security")
+    }
+    let payload = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    return payload.isEmpty ? nil : Data(payload.utf8)
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/ClaudeCodeKeychainTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/ClaudeCodeKeychainTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import XCTest
+
+@testable import QuotaBarCore
+
+final class ClaudeCodeKeychainTests: XCTestCase {
+  func testReadsThroughTheSecurityToolTheKeychainAlreadyTrusts() throws {
+    let runner = StubCommandRunner(stdout: "token-payload\n", terminationStatus: 0)
+    let client = SecurityToolKeychainClient(commandRunner: runner)
+
+    let data = try client.read(service: "Claude Code-credentials", account: nil)
+
+    XCTAssertEqual(data.flatMap { String(bytes: $0, encoding: .utf8) }, "token-payload")
+    XCTAssertEqual(runner.invocation?.executableURL.path, "/usr/bin/security")
+    XCTAssertEqual(
+      runner.invocation?.arguments,
+      ["find-generic-password", "-w", "-s", "Claude Code-credentials"]
+    )
+  }
+
+  func testNarrowsTheQueryWhenAnAccountIsRequested() throws {
+    let runner = StubCommandRunner(stdout: "token-payload", terminationStatus: 0)
+    let client = SecurityToolKeychainClient(commandRunner: runner)
+
+    _ = try client.read(service: "Claude Code-credentials", account: "jerred")
+
+    XCTAssertEqual(
+      runner.invocation?.arguments,
+      ["find-generic-password", "-w", "-s", "Claude Code-credentials", "-a", "jerred"]
+    )
+  }
+
+  func testMissingItemStatusesReadAsAbsent() throws {
+    // 44 is "the specified item could not be found", 36 is "no such keychain".
+    for status in [Int32(36), Int32(44)] {
+      let client = SecurityToolKeychainClient(
+        commandRunner: StubCommandRunner(stdout: "", terminationStatus: status)
+      )
+      XCTAssertNil(try client.read(service: "Claude Code-credentials", account: nil))
+    }
+  }
+
+  func testUnexpectedStatusFailsLoudly() {
+    let client = SecurityToolKeychainClient(
+      commandRunner: StubCommandRunner(stdout: "", terminationStatus: 1)
+    )
+
+    XCTAssertThrowsError(try client.read(service: "Claude Code-credentials", account: nil)) {
+      XCTAssertEqual($0 as? QuotaError, .commandFailed("security"))
+    }
+  }
+
+  func testEmptyPayloadReadsAsAbsent() throws {
+    let client = SecurityToolKeychainClient(
+      commandRunner: StubCommandRunner(stdout: "\n", terminationStatus: 0)
+    )
+
+    XCTAssertNil(try client.read(service: "Claude Code-credentials", account: nil))
+  }
+
+  func testClaudeCredentialsResolveWithoutTouchingTheSecurityFramework() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let runner = StubCommandRunner(
+      stdout: #"{"claudeAiOauth":{"accessToken":"security-tool-token"}}"#,
+      terminationStatus: 0
+    )
+    let store = LocalCredentialStore(
+      homeDirectory: root,
+      claudeKeychain: SecurityToolKeychainClient(commandRunner: runner)
+    )
+
+    let credential = try store.credential(for: .claudeCode, rejecting: nil)
+
+    XCTAssertEqual(credential.accessToken, "security-tool-token")
+    XCTAssertEqual(runner.invocation?.executableURL.path, "/usr/bin/security")
+  }
+}
+
+private final class StubCommandRunner: SynchronousCommandRunning, @unchecked Sendable {
+  struct Invocation: Equatable {
+    let executableURL: URL
+    let arguments: [String]
+  }
+
+  private let lock = NSLock()
+  private let result: CommandResult
+  private var recorded: Invocation?
+
+  init(stdout: String, terminationStatus: Int32) {
+    result = CommandResult(stdout: Data(stdout.utf8), terminationStatus: terminationStatus)
+  }
+
+  var invocation: Invocation? { lock.withLock { recorded } }
+
+  func run(executableURL: URL, arguments: [String]) throws -> CommandResult {
+    lock.withLock {
+      recorded = Invocation(executableURL: executableURL, arguments: arguments)
+    }
+    return result
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/ClaudeCodeKeychainTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/ClaudeCodeKeychainTests.swift
@@ -30,13 +30,24 @@ final class ClaudeCodeKeychainTests: XCTestCase {
     )
   }
 
-  func testMissingItemStatusesReadAsAbsent() throws {
-    // 44 is "the specified item could not be found", 36 is "no such keychain".
-    for status in [Int32(36), Int32(44)] {
-      let client = SecurityToolKeychainClient(
-        commandRunner: StubCommandRunner(stdout: "", terminationStatus: status)
-      )
-      XCTAssertNil(try client.read(service: "Claude Code-credentials", account: nil))
+  func testOnlyItemNotFoundReadsAsAbsent() throws {
+    // 44 is `errSecItemNotFound` through the exit status' low byte.
+    let client = SecurityToolKeychainClient(
+      commandRunner: StubCommandRunner(stdout: "", terminationStatus: 44)
+    )
+
+    XCTAssertNil(try client.read(service: "Claude Code-credentials", account: nil))
+  }
+
+  func testLockedKeychainFailsInsteadOfReadingAsAbsent() {
+    // 36 is `errSecInteractionNotAllowed`: the credential exists but this Mac will not hand it
+    // over. Reading that as absent would report "no local credentials" for a locked Keychain.
+    let client = SecurityToolKeychainClient(
+      commandRunner: StubCommandRunner(stdout: "", terminationStatus: 36)
+    )
+
+    XCTAssertThrowsError(try client.read(service: "Claude Code-credentials", account: nil)) {
+      XCTAssertEqual($0 as? QuotaError, .commandFailed("security"))
     }
   }
 

--- a/packages/macos-ai-subscription-tracker/concurrency-escapes.json
+++ b/packages/macos-ai-subscription-tracker/concurrency-escapes.json
@@ -31,6 +31,11 @@
       "rationale": "FileManager lacks a Sendable conformance; this immutable store delegates file-system synchronization to Foundation."
     },
     {
+      "path": "Tests/QuotaBarCoreTests/ClaudeCodeKeychainTests.swift",
+      "count": 1,
+      "rationale": "The test double protects its recorded command invocation with NSLock."
+    },
+    {
       "path": "Tests/QuotaBarCoreTests/HistoryModelTests.swift",
       "count": 1,
       "rationale": "The test double protects its mutable snapshot map with NSLock."


### PR DESCRIPTION
## Why

Brim asked for the login Keychain password every few minutes:

> Brim wants to access key "Claude Code-credentials" in your keychain.

Three facts combine into an unbreakable loop:

1. `LocalCredentialStore.readClaude` prefers `~/.claude/.credentials.json` and
   falls back to the Keychain. Claude Code on macOS never writes that file — its
   plaintext store is gated to Claude Code's own remote hosts — so the fallback
   is the only path.
2. The credential poll runs every five minutes by default, so the fallback is
   taken constantly.
3. Claude Code writes the item with `security add-generic-password -U` on every
   OAuth token refresh. That rewrite resets the item's access-control list to
   the creating tool, discarding whatever "Always Allow" had granted Brim.

So each grant survives only until the next token refresh, and then the next poll
re-opens the dialog. No number of grants outlasts a writer that resets the ACL
on every write.

## What

Read the item through `/usr/bin/security` instead of `SecItemCopyMatching`.
That tool is the trusted application every one of Claude Code's rewrites
re-establishes, so the read stays silent across refreshes — it is the same
mechanism that lets `claude` itself read the item without ever prompting.

- `SecurityToolKeychainClient` runs
  `security find-generic-password -w -s <service>`, adding `-a <account>` only
  when a caller narrows the query.
- Statuses 36 and 44 mean the item is absent and read as `nil`. Every other
  non-zero status raises `commandFailed("security")` rather than falling back to
  the prompting path and re-arming the loop.
- Keychain access moves out of `Credentials.swift` into `Keychain.swift`, which
  splits the read-only `KeychainReading` half `LocalCredentialStore` needs away
  from the full `KeychainClient`. The store now cannot write another tool's
  credentials even by accident; `ManualCredentialStore` keeps the full client
  for Brim's own item, which Brim owns and is never prompted for.
- `FoundationSynchronousCommandRunner` is the blocking sibling of the existing
  async runner. Credential discovery already reads files, SQLite, and the
  Keychain synchronously on the polling task, so the helper stays on that path
  rather than turning the whole `CredentialStore` API asynchronous.

The README and the wiki explanation page carry the rationale, since "why not
just use the Security framework" is otherwise invisible.

## Verification

Source and focused local checks only:

- `bunx turbo run lint:swift test:macos --filter=@shepherdjerred/quotabar` —
  145 tests pass, 6 new, `swift build`/`swift test` under
  `-warnings-as-errors`, SwiftLint `--strict`, and the concurrency-escape
  inventory.
- `bun run format:check` (swift-format `--strict`).
- `bunx lefthook run pre-commit`.

New coverage asserts the executable is `/usr/bin/security` and the exact argv,
that 36/44 read as absent, that any other status fails loudly, and that
`LocalCredentialStore` resolves a Claude token end to end without the Security
framework.

**Not verified:** the live prompt-free read. That needs this branch built,
signed, and reinstalled over the running app; Buildkite is also unverified at
the time of writing.