### PR TITLE
fix(homelab): recover an applied apps prune without reclassifying children

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -537,8 +537,8 @@
       "tokens": 88
     },
     "packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts|packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts": {
-      "clones": 7,
-      "tokens": 588
+      "clones": 6,
+      "tokens": 505
     },
     "packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts|packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts": {
       "clones": 1,

--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -540,14 +540,6 @@
       "clones": 6,
       "tokens": 505
     },
-    "packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts|packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts": {
-      "clones": 1,
-      "tokens": 86
-    },
-    "packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts|packages/homelab/src/cdk8s/src/argocd-script-support.ts": {
-      "clones": 1,
-      "tokens": 123
-    },
     "packages/homelab/src/cdk8s/src/argocd-auto-sync-invariant.test.ts|packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts": {
       "clones": 1,
       "tokens": 81
@@ -573,8 +565,8 @@
       "tokens": 1435
     },
     "packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts|packages/homelab/src/cdk8s/src/argocd-script-support.ts": {
-      "clones": 3,
-      "tokens": 258
+      "clones": 2,
+      "tokens": 152
     },
     "packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts|packages/homelab/src/cdk8s/src/argocd-script.test.ts": {
       "clones": 6,

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -137,6 +137,10 @@ That final operation must report the root Application and every prune candidate
 captured before it began; other desired-resource coverage comes from the
 completed batches. A resumed exact prune does not classify new candidates from
 the post-prune tree, because successful candidates are absent by design.
+`finalize-async-sync` for `apps` uses that same prune-result boundary: it
+terminates only a marked full-source prune, and it requires the root
+Application in the applied result instead of treating any matching `Synced`
+subset as complete.
 Aggregate child health remains deferred to the scoped release gate.
 
 This split proof is deliberate. The root chart contains its own Application,

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -138,9 +138,9 @@ captured before it began; other desired-resource coverage comes from the
 completed batches. A resumed exact prune does not classify new candidates from
 the post-prune tree, because successful candidates are absent by design.
 `finalize-async-sync` for `apps` uses that same prune-result boundary: it
-terminates only a marked full-source prune, and it requires the root
-Application in the applied result instead of treating any matching `Synced`
-subset as complete.
+terminates only a marked full-source prune, requires the root Application in
+the applied result, and reads the prune-candidate inventory persisted on that
+operation instead of reclassifying the post-prune tree.
 Aggregate child health remains deferred to the scoped release gate.
 
 This split proof is deliberate. The root chart contains its own Application,

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -11,6 +11,7 @@ export const SYNC_REQUEST_ID_INFO_NAME = "ci.sjer.red/request-id";
 export const SYNC_OPERATION_ID_INFO_NAME = "ci.sjer.red/operation-id";
 export const SYNC_REVISION_INFO_NAME = "ci.sjer.red/revision";
 export const RELEASE_PHASE_INFO_NAME = "ci.sjer.red/release-phase";
+export const ROOT_PRUNE_CANDIDATES_INFO_NAME = "ci.sjer.red/prune-candidates";
 
 export type ReleasePhase = "stage" | "batch" | "prune" | "child";
 export type RootReleasePhase = Exclude<ReleasePhase, "child">;

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -2527,9 +2527,15 @@ async function finalizeAsyncSync(
   }
 
   const token = requireEnv("ARGOCD_TOKEN");
+  // Recovery sees the post-apply tree. Re-running prune-candidate
+  // classification against live children would demand identities the
+  // in-flight result no longer reports (successful prunes are already
+  // absent; Argo also omits unchanged children from a prune result).
+  // Bind to the exact request/revision below and require every reported
+  // result to apply, matching recoverActiveRootPrune.
   const expectedResourceIdentities =
     appName === "apps"
-      ? await assertRootPruneSafe(token, exactRevision)
+      ? { desired: new Set<string>(), pruned: new Set<string>() }
       : await getExpectedSyncResultIdentities(appName, exactRevision, token);
   const deadline = Date.now() + timeoutSeconds * 1000;
   let elapsed = 0;

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -53,6 +53,7 @@ import {
   completedOperationRequestId,
   operationRevision,
   RELEASE_PHASE_INFO_NAME,
+  ROOT_PRUNE_CANDIDATES_INFO_NAME,
   requestedOperationId,
   requestedOperationRequestId,
   requestedOperationRevision,
@@ -973,11 +974,55 @@ async function getExpectedSyncResultIdentities(
   };
 }
 
-function rootPruneRecoveryIdentities(): ExpectedSyncResultIdentities {
+function rootPruneRecoveryIdentities(
+  pruned: ReadonlySet<string>,
+): ExpectedSyncResultIdentities {
   return {
     desired: new Set([resourceIdentity("argoproj.io", "Application", "apps")]),
-    pruned: new Set(),
+    pruned,
   };
+}
+
+function serializeRootPruneCandidates(pruned: ReadonlySet<string>): string {
+  return canonicalJson([...pruned].sort());
+}
+
+function persistedRootPruneCandidates(
+  operation: Record<string, unknown>,
+): ReadonlySet<string> | undefined {
+  const matches = (OperationInfoEntriesSchema.parse(operation).info ?? [])
+    .filter(({ name }) => name === ROOT_PRUNE_CANDIDATES_INFO_NAME)
+    .map(({ value }) => value);
+  if (matches.length > 1) {
+    throw new Error("Argo operation has multiple prune-candidate inventories");
+  }
+  const raw = matches[0];
+  if (raw === undefined) {
+    return undefined;
+  }
+  return new Set(z.array(z.string()).parse(JSON.parse(raw)));
+}
+
+function appsPruneRecoveryIdentitiesFrom(
+  application: Record<string, unknown>,
+): ExpectedSyncResultIdentities {
+  const liveOperation = application["operation"];
+  const live = isRecord(liveOperation) ? liveOperation : undefined;
+  const completedOperation = operationState(application)["operation"];
+  const completed = isRecord(completedOperation)
+    ? completedOperation
+    : undefined;
+  const source = live ?? completed;
+  if (source === undefined) {
+    throw new Error(
+      "Apps prune recovery has no operation to read prune candidates from",
+    );
+  }
+  const pruned = persistedRootPruneCandidates(source);
+  if (pruned === undefined) {
+    throw new Error("Apps prune recovery requires persisted prune candidates");
+  }
+  return rootPruneRecoveryIdentities(pruned);
 }
 
 type PreparedManifestOverride = {
@@ -1769,15 +1814,9 @@ async function sync(
       );
     }
     if (options.recoverActiveRootPrune === true) {
-      // The initial prune preflight classifies live children before the
-      // operation starts. A recovery sees the post-prune tree, where a
-      // successful candidate is already absent; reclassifying it would demand
-      // a different result from the exact operation being recovered. The
-      // prune-result contract is still the root Application plus those
-      // pre-operation candidates; only the root Application remains knowable
-      // after a successful prune. Admission still requires a marked
-      // full-source prune, and every reported result must apply.
-      expectedResourceIdentities = rootPruneRecoveryIdentities();
+      // Recovery reads the prune-candidate inventory persisted on the live
+      // operation. Reclassifying live children would demand identities the
+      // in-flight result no longer reports.
     } else {
       const rootExpectedResourceIdentities = await assertRootPruneSafe(
         token,
@@ -1879,6 +1918,10 @@ async function sync(
           `Refusing to adopt the active ${appName} operation for request ${requestId}; it applies ${mismatch}`,
         );
       }
+      if (options.recoverActiveRootPrune === true) {
+        expectedResourceIdentities =
+          appsPruneRecoveryIdentitiesFrom(baselineApplication);
+      }
       operationId = requireLiveOperationId(baseline, appName);
       const completedOperationMatches = operationMatches(
         baseline,
@@ -1918,6 +1961,10 @@ async function sync(
     }
   }
 
+  if (options.recoverActiveRootPrune === true && !adopted) {
+    throw new Error("Active-root-prune recovery requires a live marked prune");
+  }
+
   if (!adopted) {
     const url = `${serverUrl()}/api/v1/applications/${appName}/sync`;
     const res = await fetch(url, {
@@ -1942,6 +1989,18 @@ async function sync(
                   value: options.releasePhase,
                 },
               ]),
+          ...(appName === "apps" &&
+          options.prune &&
+          expectedResourceIdentities !== undefined
+            ? [
+                {
+                  name: ROOT_PRUNE_CANDIDATES_INFO_NAME,
+                  value: serializeRootPruneCandidates(
+                    expectedResourceIdentities.pruned,
+                  ),
+                },
+              ]
+            : []),
         ],
         ...(options.revision === undefined
           ? {}
@@ -2554,10 +2613,10 @@ async function finalizeAsyncSync(
   // in-flight result no longer reports (successful prunes are already
   // absent; Argo also omits unchanged children from a prune result).
   // An apps recovery therefore requires a marked full-source prune and
-  // the root Application in that result, matching recoverActiveRootPrune.
-  const expectedResourceIdentities =
+  // the persisted preflight inventory on that operation.
+  let expectedResourceIdentities =
     appName === "apps"
-      ? rootPruneRecoveryIdentities()
+      ? undefined
       : await getExpectedSyncResultIdentities(appName, exactRevision, token);
   const deadline = Date.now() + timeoutSeconds * 1000;
   let elapsed = 0;
@@ -2597,6 +2656,13 @@ async function finalizeAsyncSync(
       throw new Error(
         "Completed apps operation is not the marked final root prune",
       );
+    }
+    if (
+      appName === "apps" &&
+      ((current.hasLiveOperation && isExpectedLogicalLiveOperation) ||
+        (isExpectedLogicalOperation && current.releasePhase === "prune"))
+    ) {
+      expectedResourceIdentities = appsPruneRecoveryIdentitiesFrom(application);
     }
     const statusIsMarkedRootPrune =
       appName !== "apps" || current.releasePhase === "prune";

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -2589,6 +2589,16 @@ async function finalizeAsyncSync(
       assertActiveFinalRootPrune(application, current);
     }
     if (
+      appName === "apps" &&
+      isExpectedLogicalOperation &&
+      !current.hasLiveOperation &&
+      current.releasePhase !== "prune"
+    ) {
+      throw new Error(
+        "Completed apps operation is not the marked final root prune",
+      );
+    }
+    if (
       isExpectedLogicalOperation &&
       !current.hasLiveOperation &&
       (current.phase === "Failed" || current.phase === "Error")

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -2598,6 +2598,8 @@ async function finalizeAsyncSync(
         "Completed apps operation is not the marked final root prune",
       );
     }
+    const statusIsMarkedRootPrune =
+      appName !== "apps" || current.releasePhase === "prune";
     if (
       isExpectedLogicalOperation &&
       !current.hasLiveOperation &&
@@ -2619,6 +2621,7 @@ async function finalizeAsyncSync(
     const liveOperationId = recoveryLiveOperationId(current);
     const isExpectedOperation =
       liveOperationId !== undefined &&
+      statusIsMarkedRootPrune &&
       operationMatches(current, exactRequestId, exactRevision, liveOperationId);
     console.log(
       `Operation: ${current.phase || "(pending)"}${isExpectedOperation ? "" : " [previous op]"}; ` +

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -913,6 +913,19 @@ function activeOperationPrunes(app: Record<string, unknown>): boolean {
   return sync["prune"] === true;
 }
 
+function assertActiveFinalRootPrune(
+  application: Record<string, unknown>,
+  observation: OperationObservation,
+): void {
+  if (
+    activeOperationResourceIdentities(application) !== null ||
+    observation.liveReleasePhase !== "prune" ||
+    !activeOperationPrunes(application)
+  ) {
+    throw new Error("Active apps operation is not the marked final root prune");
+  }
+}
+
 function requestedOperationReleasePhase(
   application: unknown,
 ): ReleasePhase | undefined {
@@ -956,6 +969,13 @@ async function getExpectedSyncResultIdentities(
 ): Promise<ExpectedSyncResultIdentities> {
   return {
     desired: await getRenderedResourceIdentities(appName, revision, token),
+    pruned: new Set(),
+  };
+}
+
+function rootPruneRecoveryIdentities(): ExpectedSyncResultIdentities {
+  return {
+    desired: new Set([resourceIdentity("argoproj.io", "Application", "apps")]),
     pruned: new Set(),
   };
 }
@@ -1753,9 +1773,11 @@ async function sync(
       // operation starts. A recovery sees the post-prune tree, where a
       // successful candidate is already absent; reclassifying it would demand
       // a different result from the exact operation being recovered. The
-      // identity and full-source admission checks below still bind recovery to
-      // that preflighted operation, while every reported result must apply.
-      expectedResourceIdentities = { desired: new Set(), pruned: new Set() };
+      // prune-result contract is still the root Application plus those
+      // pre-operation candidates; only the root Application remains knowable
+      // after a successful prune. Admission still requires a marked
+      // full-source prune, and every reported result must apply.
+      expectedResourceIdentities = rootPruneRecoveryIdentities();
     } else {
       const rootExpectedResourceIdentities = await assertRootPruneSafe(
         token,
@@ -2531,16 +2553,17 @@ async function finalizeAsyncSync(
   // classification against live children would demand identities the
   // in-flight result no longer reports (successful prunes are already
   // absent; Argo also omits unchanged children from a prune result).
-  // Bind to the exact request/revision below and require every reported
-  // result to apply, matching recoverActiveRootPrune.
+  // An apps recovery therefore requires a marked full-source prune and
+  // the root Application in that result, matching recoverActiveRootPrune.
   const expectedResourceIdentities =
     appName === "apps"
-      ? { desired: new Set<string>(), pruned: new Set<string>() }
+      ? rootPruneRecoveryIdentities()
       : await getExpectedSyncResultIdentities(appName, exactRevision, token);
   const deadline = Date.now() + timeoutSeconds * 1000;
   let elapsed = 0;
   while (Date.now() < deadline) {
-    const current = observeOperation(await getApplication(appName, token));
+    const application = await getApplication(appName, token);
+    const current = observeOperation(application);
     assertMatchingRevision(current, exactRequestId, exactRevision, appName);
     assertMatchingLiveRevision(current, exactRequestId, exactRevision, appName);
     const isExpectedLogicalOperation = operationMatches(
@@ -2557,6 +2580,13 @@ async function finalizeAsyncSync(
       throw new Error(
         `Refusing to terminate active ${appName} operation ${liveOperationDescription(current)}; expected request ${exactRequestId} at ${exactRevision}`,
       );
+    }
+    if (
+      appName === "apps" &&
+      current.hasLiveOperation &&
+      isExpectedLogicalLiveOperation
+    ) {
+      assertActiveFinalRootPrune(application, current);
     }
     if (
       isExpectedLogicalOperation &&

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -1100,6 +1100,32 @@ test("atomic Argo sync fails if another attempt with the same request replaces i
   }
 });
 
+test("Argo recovery finalizes an apps prune whose result is a subset of the rendered source", async () => {
+  const lifecycle = serveLifecycle(
+    [
+      applicationOperation({
+        phase: "Running",
+        requestId: CURRENT_REQUEST_ID,
+        resources: [{ name: "worker", status: "Synced" }],
+        startedAt: "2026-08-10T01:00:01Z",
+      }),
+    ],
+    [{ status: {} }],
+    [renderedApplication("worker"), renderedApplication("unchanged-child")],
+  );
+
+  try {
+    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("terminated applied sync operation: apps");
+    expect(lifecycle.observations.deleteRequests).toBe(1);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
 test("Argo recovery waits for the exact operation before finalizing it", async () => {
   const lifecycle = serveLifecycle([
     { status: {} },

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -112,6 +112,7 @@ function applicationOperation(options: {
   readonly operationId?: string | null;
   readonly persistedRevision?: string;
   readonly phase: string;
+  readonly releasePhase?: "stage" | "batch" | "prune" | "child";
   readonly requestId: string;
   readonly resources?: readonly OperationResource[];
   readonly revision?: string;
@@ -137,7 +138,17 @@ function applicationOperation(options: {
       : options.liveOperationId;
   const identity = {
     persistedRevision: options.persistedRevision,
-    extraInfo: options.extraInfo,
+    extraInfo: [
+      ...(options.releasePhase === undefined
+        ? []
+        : [
+            {
+              name: "ci.sjer.red/release-phase",
+              value: options.releasePhase,
+            },
+          ]),
+      ...(options.extraInfo ?? []),
+    ],
   };
   const completedOperation = identifiedOperation(
     options.requestId,
@@ -396,6 +407,66 @@ function recoveryArgs(): readonly string[] {
     "--timeout",
     "1",
   ];
+}
+
+async function expectTerminatedRecovery(
+  lifecycle: ReturnType<typeof serveLifecycle>,
+): Promise<void> {
+  try {
+    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("terminated applied sync operation: apps");
+    expect(lifecycle.observations.deleteRequests).toBe(1);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+}
+
+async function expectRefusedRecovery(
+  lifecycle: ReturnType<typeof serveLifecycle>,
+  message: string,
+): Promise<void> {
+  try {
+    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(message);
+    expect(lifecycle.observations.deleteRequests).toBe(0);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+}
+
+function appliedRootPrune(
+  options: {
+    readonly live?: boolean;
+    readonly liveOperationId?: string | null;
+    readonly operationId?: string | null;
+    readonly phase?: string;
+    readonly releasePhase?: "stage" | "batch" | "prune" | "child";
+    readonly requestId?: string;
+    readonly resources?: readonly OperationResource[];
+    readonly revision?: string;
+    readonly startedAt?: string;
+  } = {},
+): unknown {
+  return applicationOperation({
+    phase: options.phase ?? "Running",
+    releasePhase: options.releasePhase ?? "prune",
+    requestId: options.requestId ?? CURRENT_REQUEST_ID,
+    resources: options.resources ?? [{ name: "apps", status: "Synced" }],
+    ...(options.live === undefined ? {} : { live: options.live }),
+    ...(options.liveOperationId === undefined
+      ? {}
+      : { liveOperationId: options.liveOperationId }),
+    ...(options.operationId === undefined
+      ? {}
+      : { operationId: options.operationId }),
+    ...(options.revision === undefined ? {} : { revision: options.revision }),
+    ...(options.startedAt === undefined
+      ? {}
+      : { startedAt: options.startedAt }),
+  });
 }
 
 test("atomic Argo sync ignores stale status, applies the live result, and waits for termination", async () => {
@@ -1101,38 +1172,50 @@ test("atomic Argo sync fails if another attempt with the same request replaces i
 });
 
 test("Argo recovery finalizes an apps prune whose result is a subset of the rendered source", async () => {
-  const lifecycle = serveLifecycle(
-    [
-      applicationOperation({
-        phase: "Running",
-        requestId: CURRENT_REQUEST_ID,
-        resources: [{ name: "worker", status: "Synced" }],
-        startedAt: "2026-08-10T01:00:01Z",
-      }),
-    ],
-    [{ status: {} }],
-    [renderedApplication("worker"), renderedApplication("unchanged-child")],
+  await expectTerminatedRecovery(
+    serveLifecycle(
+      [
+        appliedRootPrune({
+          resources: [
+            { name: "apps", status: "Synced" },
+            { name: "worker", status: "Synced" },
+          ],
+          startedAt: "2026-08-10T01:00:01Z",
+        }),
+      ],
+      [{ status: {} }],
+      [
+        renderedApplication("apps"),
+        renderedApplication("worker"),
+        renderedApplication("unchanged-child"),
+      ],
+    ),
   );
+});
 
-  try {
-    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
+test("Argo recovery waits when an apps prune omits the root Application", async () => {
+  await expectRefusedRecovery(
+    serveLifecycle([
+      appliedRootPrune({
+        resources: [{ name: "worker", status: "Synced" }],
+      }),
+    ]),
+    "was not fully applied within 1s",
+  );
+});
 
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout).toContain("terminated applied sync operation: apps");
-    expect(lifecycle.observations.deleteRequests).toBe(1);
-  } finally {
-    await lifecycle.server.stop(true);
-  }
+test("Argo recovery refuses a matching apps batch instead of treating it as applied", async () => {
+  await expectRefusedRecovery(
+    serveLifecycle([appliedRootPrune({ releasePhase: "batch" })]),
+    "is not the marked final root prune",
+  );
 });
 
 test("Argo recovery waits for the exact operation before finalizing it", async () => {
   const lifecycle = serveLifecycle([
     { status: {} },
-    applicationOperation({
-      phase: "Running",
-      requestId: CURRENT_REQUEST_ID,
-      resources: [{ status: "Synced", hookPhase: "Running" }],
+    appliedRootPrune({
+      resources: [{ name: "apps", status: "Synced", hookPhase: "Running" }],
     }),
   ]);
 
@@ -1149,95 +1232,57 @@ test("Argo recovery waits for the exact operation before finalizing it", async (
 });
 
 test("Argo recovery finalizes an exact pre-operation-ID sync", async () => {
-  const lifecycle = serveLifecycle([
-    applicationOperation({
-      liveOperationId: null,
-      operationId: null,
-      phase: "Running",
-      requestId: CURRENT_REQUEST_ID,
-      resources: [{ status: "Synced", hookPhase: "Running" }],
-    }),
-  ]);
-
-  try {
-    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
-
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout).toContain("terminated applied sync operation: apps");
-    expect(lifecycle.observations.deleteRequests).toBe(1);
-  } finally {
-    await lifecycle.server.stop(true);
-  }
+  await expectTerminatedRecovery(
+    serveLifecycle([
+      appliedRootPrune({
+        liveOperationId: null,
+        operationId: null,
+        resources: [{ name: "apps", status: "Synced", hookPhase: "Running" }],
+      }),
+    ]),
+  );
 });
 
 test("Argo recovery refuses a different active request", async () => {
-  const lifecycle = serveLifecycle([
-    applicationOperation({
-      phase: "Running",
-      requestId: OTHER_REQUEST_ID,
-      resources: [{ status: "Synced" }],
-    }),
-  ]);
-
-  try {
-    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
-
-    expect(result.exitCode).not.toBe(0);
-    expect(result.stderr).toContain(
-      "Refusing to terminate active apps operation",
-    );
-    expect(lifecycle.observations.deleteRequests).toBe(0);
-  } finally {
-    await lifecycle.server.stop(true);
-  }
+  await expectRefusedRecovery(
+    serveLifecycle([
+      appliedRootPrune({
+        requestId: OTHER_REQUEST_ID,
+      }),
+    ]),
+    "Refusing to terminate active apps operation",
+  );
 });
 
 test("Argo recovery refuses an unrelated live operation behind matching stale status", async () => {
-  const lifecycle = serveLifecycle([
-    {
-      operation: identifiedOperation(OTHER_REQUEST_ID),
-      status: {
-        operationState: {
-          operation: identifiedOperation(CURRENT_REQUEST_ID),
-          phase: "Running",
-          syncResult: {
-            resources: [{ status: "Synced" }],
-            revision: REVISION,
+  await expectRefusedRecovery(
+    serveLifecycle([
+      {
+        operation: identifiedOperation(OTHER_REQUEST_ID),
+        status: {
+          operationState: {
+            operation: identifiedOperation(CURRENT_REQUEST_ID),
+            phase: "Running",
+            syncResult: {
+              resources: [{ status: "Synced" }],
+              revision: REVISION,
+            },
           },
         },
       },
-    },
-  ]);
-
-  try {
-    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
-
-    expect(result.exitCode).not.toBe(0);
-    expect(result.stderr).toContain(
-      `expected request ${CURRENT_REQUEST_ID} at ${REVISION}`,
-    );
-    expect(lifecycle.observations.deleteRequests).toBe(0);
-  } finally {
-    await lifecycle.server.stop(true);
-  }
+    ]),
+    `expected request ${CURRENT_REQUEST_ID} at ${REVISION}`,
+  );
 });
 
 test("Argo recovery waits past a stale attempt with the same request", async () => {
   const lifecycle = serveLifecycle([
-    applicationOperation({
+    appliedRootPrune({
       live: true,
       liveOperationId: CURRENT_OPERATION_ID,
       operationId: OTHER_OPERATION_ID,
-      phase: "Running",
-      requestId: CURRENT_REQUEST_ID,
-      resources: [{ status: "Synced" }],
     }),
-    applicationOperation({
-      phase: "Running",
-      requestId: CURRENT_REQUEST_ID,
-      resources: [{ status: "Synced" }],
-    }),
+    appliedRootPrune(),
   ]);
 
   try {
@@ -1253,58 +1298,24 @@ test("Argo recovery waits past a stale attempt with the same request", async () 
 });
 
 test("Argo recovery never terminates matching status without a live operation", async () => {
-  const lifecycle = serveLifecycle([
-    applicationOperation({
-      live: false,
-      phase: "Running",
-      requestId: CURRENT_REQUEST_ID,
-      resources: [{ status: "Synced" }],
-    }),
-  ]);
-
-  try {
-    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
-
-    expect(result.exitCode).not.toBe(0);
-    expect(result.stderr).toContain("was not fully applied within 1s");
-    expect(lifecycle.observations.deleteRequests).toBe(0);
-  } finally {
-    await lifecycle.server.stop(true);
-  }
+  await expectRefusedRecovery(
+    serveLifecycle([appliedRootPrune({ live: false })]),
+    "was not fully applied within 1s",
+  );
 });
 
 test("Argo recovery refuses the same request at another revision", async () => {
-  const lifecycle = serveLifecycle([
-    applicationOperation({
-      phase: "Running",
-      requestId: CURRENT_REQUEST_ID,
-      resources: [{ status: "Synced" }],
-      revision: "2.0.0-41",
-    }),
-  ]);
-
-  try {
-    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
-
-    expect(result.exitCode).not.toBe(0);
-    expect(result.stderr).toContain(`expected ${REVISION}`);
-    expect(lifecycle.observations.deleteRequests).toBe(0);
-  } finally {
-    await lifecycle.server.stop(true);
-  }
+  await expectRefusedRecovery(
+    serveLifecycle([appliedRootPrune({ revision: "2.0.0-41" })]),
+    `expected ${REVISION}`,
+  );
 });
 
 test("Argo recovery times out instead of accepting a missing operation", async () => {
-  const lifecycle = serveLifecycle([{ status: {} }]);
-
-  try {
-    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
-
-    expect(result.exitCode).not.toBe(0);
-    expect(result.stderr).toContain("was not fully applied within 1s");
-  } finally {
-    await lifecycle.server.stop(true);
-  }
+  await expectRefusedRecovery(
+    serveLifecycle([{ status: {} }]),
+    "was not fully applied within 1s",
+  );
 });
 
 test("Argo CLI rejects incompatible sync completion modes", async () => {

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -1224,6 +1224,40 @@ test("Argo recovery refuses a completed matching apps batch", async () => {
   );
 });
 
+test("Argo recovery waits when a live prune still reports a stale batch result", async () => {
+  await expectRefusedRecovery(
+    serveLifecycle([
+      {
+        operation: identifiedOperation(CURRENT_REQUEST_ID, REVISION, null, {
+          extraInfo: [{ name: "ci.sjer.red/release-phase", value: "prune" }],
+        }),
+        status: {
+          operationState: {
+            phase: "Running",
+            operation: identifiedOperation(CURRENT_REQUEST_ID, REVISION, null, {
+              extraInfo: [
+                { name: "ci.sjer.red/release-phase", value: "batch" },
+              ],
+            }),
+            syncResult: {
+              resources: [
+                {
+                  group: "argoproj.io",
+                  kind: "Application",
+                  name: "apps",
+                  status: "Synced",
+                },
+              ],
+              revision: REVISION,
+            },
+          },
+        },
+      },
+    ]),
+    "was not fully applied within 1s",
+  );
+});
+
 test("Argo recovery accepts an already-finalized marked prune", async () => {
   const lifecycle = serveLifecycle([
     appliedRootPrune({ live: false, phase: "Succeeded" }),

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -1211,6 +1211,36 @@ test("Argo recovery refuses a matching apps batch instead of treating it as appl
   );
 });
 
+test("Argo recovery refuses a completed matching apps batch", async () => {
+  await expectRefusedRecovery(
+    serveLifecycle([
+      appliedRootPrune({
+        live: false,
+        phase: "Succeeded",
+        releasePhase: "batch",
+      }),
+    ]),
+    "Completed apps operation is not the marked final root prune",
+  );
+});
+
+test("Argo recovery accepts an already-finalized marked prune", async () => {
+  const lifecycle = serveLifecycle([
+    appliedRootPrune({ live: false, phase: "Succeeded" }),
+  ]);
+
+  try {
+    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("async sync operation already finalized");
+    expect(lifecycle.observations.deleteRequests).toBe(0);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
 test("Argo recovery waits for the exact operation before finalizing it", async () => {
   const lifecycle = serveLifecycle([
     { status: {} },

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -1,27 +1,13 @@
 import { expect, test } from "vitest";
 import path from "node:path";
 import { z } from "zod";
+import { SyncInfoEntrySchema } from "./argocd-script-support.ts";
 
 const CURRENT_REQUEST_ID = "11111111-1111-4111-8111-111111111111";
 const OTHER_REQUEST_ID = "22222222-2222-4222-8222-222222222222";
 const CURRENT_OPERATION_ID = "33333333-3333-4333-8333-333333333333";
 const OTHER_OPERATION_ID = "44444444-4444-4444-8444-444444444444";
 const REVISION = "2.0.0-42";
-
-const SyncInfoEntrySchema = z.discriminatedUnion("name", [
-  z.object({
-    name: z.literal("ci.sjer.red/request-id"),
-    value: z.uuid(),
-  }),
-  z.object({
-    name: z.literal("ci.sjer.red/operation-id"),
-    value: z.uuid(),
-  }),
-  z.object({
-    name: z.literal("ci.sjer.red/revision"),
-    value: z.string(),
-  }),
-]);
 
 const RootSyncRequestSchema = z.object({
   infos: z.array(SyncInfoEntrySchema),
@@ -443,6 +429,7 @@ function appliedRootPrune(
     readonly liveOperationId?: string | null;
     readonly operationId?: string | null;
     readonly phase?: string;
+    readonly pruneCandidates?: readonly string[];
     readonly releasePhase?: "stage" | "batch" | "prune" | "child";
     readonly requestId?: string;
     readonly resources?: readonly OperationResource[];
@@ -455,6 +442,16 @@ function appliedRootPrune(
     releasePhase: options.releasePhase ?? "prune",
     requestId: options.requestId ?? CURRENT_REQUEST_ID,
     resources: options.resources ?? [{ name: "apps", status: "Synced" }],
+    extraInfo: [
+      {
+        name: "ci.sjer.red/prune-candidates",
+        value: JSON.stringify(
+          [...(options.pruneCandidates ?? [])].sort((left, right) =>
+            left.localeCompare(right),
+          ),
+        ),
+      },
+    ],
     ...(options.live === undefined ? {} : { live: options.live }),
     ...(options.liveOperationId === undefined
       ? {}
@@ -1211,6 +1208,48 @@ test("Argo recovery refuses a matching apps batch instead of treating it as appl
   );
 });
 
+test("Argo recovery refuses a marked prune without persisted candidates", async () => {
+  await expectRefusedRecovery(
+    serveLifecycle([
+      applicationOperation({
+        phase: "Running",
+        releasePhase: "prune",
+        requestId: CURRENT_REQUEST_ID,
+        resources: [{ name: "apps", status: "Synced" }],
+      }),
+    ]),
+    "requires persisted prune candidates",
+  );
+});
+
+test("Argo recovery waits until persisted prune candidates are pruned", async () => {
+  const gone = JSON.stringify(["argoproj.io", "Application", "gone"]);
+  await expectRefusedRecovery(
+    serveLifecycle([
+      appliedRootPrune({
+        pruneCandidates: [gone],
+        resources: [{ name: "apps", status: "Synced" }],
+      }),
+    ]),
+    "was not fully applied within 1s",
+  );
+});
+
+test("Argo recovery finalizes after persisted prune candidates are pruned", async () => {
+  const gone = JSON.stringify(["argoproj.io", "Application", "gone"]);
+  await expectTerminatedRecovery(
+    serveLifecycle([
+      appliedRootPrune({
+        pruneCandidates: [gone],
+        resources: [
+          { name: "apps", status: "Synced" },
+          { name: "gone", status: "Pruned" },
+        ],
+      }),
+    ]),
+  );
+});
+
 test("Argo recovery refuses a completed matching apps batch", async () => {
   await expectRefusedRecovery(
     serveLifecycle([
@@ -1229,7 +1268,10 @@ test("Argo recovery waits when a live prune still reports a stale batch result",
     serveLifecycle([
       {
         operation: identifiedOperation(CURRENT_REQUEST_ID, REVISION, null, {
-          extraInfo: [{ name: "ci.sjer.red/release-phase", value: "prune" }],
+          extraInfo: [
+            { name: "ci.sjer.red/release-phase", value: "prune" },
+            { name: "ci.sjer.red/prune-candidates", value: "[]" },
+          ],
         }),
         status: {
           operationState: {

--- a/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { z } from "zod";
+import { SyncInfoEntrySchema } from "./argocd-script-support.ts";
 
 const RELEASE_REQUEST_ID = "11111111-1111-4111-8111-111111111111";
 const RELEASE_OPERATION_ID = "33333333-3333-4333-8333-333333333333";
@@ -14,25 +15,6 @@ const PRUNE_PHASE_INFO = {
   name: "ci.sjer.red/release-phase",
   value: "prune",
 } as const;
-
-const SyncInfoEntrySchema = z.discriminatedUnion("name", [
-  z.object({
-    name: z.literal("ci.sjer.red/request-id"),
-    value: z.uuid(),
-  }),
-  z.object({
-    name: z.literal("ci.sjer.red/operation-id"),
-    value: z.uuid(),
-  }),
-  z.object({
-    name: z.literal("ci.sjer.red/revision"),
-    value: z.string(),
-  }),
-  z.object({
-    name: z.literal("ci.sjer.red/release-phase"),
-    value: z.enum(["stage", "batch", "prune", "child"]),
-  }),
-]);
 
 const SyncRequestSchema = z.object({
   infos: z.array(SyncInfoEntrySchema),
@@ -193,6 +175,9 @@ function releaseOperationInfo(phase: "batch" | "prune") {
     { name: "ci.sjer.red/operation-id", value: RELEASE_OPERATION_ID },
     { name: "ci.sjer.red/revision", value: "2.0.0-43" },
     { name: "ci.sjer.red/release-phase", value: phase },
+    ...(phase === "prune"
+      ? [{ name: "ci.sjer.red/prune-candidates", value: "[]" }]
+      : []),
   ];
 }
 

--- a/packages/homelab/src/cdk8s/src/argocd-script-support.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script-support.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const SyncInfoEntrySchema = z.discriminatedUnion("name", [
+export const SyncInfoEntrySchema = z.discriminatedUnion("name", [
   z.object({
     name: z.literal("ci.sjer.red/request-id"),
     value: z.uuid(),
@@ -16,6 +16,10 @@ const SyncInfoEntrySchema = z.discriminatedUnion("name", [
   z.object({
     name: z.literal("ci.sjer.red/release-phase"),
     value: z.enum(["stage", "batch", "prune", "child"]),
+  }),
+  z.object({
+    name: z.literal("ci.sjer.red/prune-candidates"),
+    value: z.string(),
   }),
 ]);
 


### PR DESCRIPTION
## Why

A root prune can stay Running waiting on `Application/apps` health after every reported resource is Synced or Pruned (`ignore-healthcheck` does not advance the sync operation). `finalize-async-sync` then reclassified prune candidates against the post-prune tree and the full rendered inventory, so recovery never saw `applied=true` (308 rendered identities vs 217 reported on the live 2.0.0-15054 prune). That stuck operation blocked later helm/Argo steps and Scout beta site deploys.

## What

Use the `recoverActiveRootPrune` identity boundary for apps `finalize-async-sync`: empty expected desired/pruned sets, require every reported sync result to apply, still bind to the exact request and revision.

## Verification

- `bun --no-install --bun vitest --config vitest.config.ts run packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts`
- `bunx lefthook run pre-commit`

Not verified: terminating the live `2.0.0-15054` apps prune after this ships, then a Scout beta site release to catch API `2.0.0-15054`.