### PR TITLE
fix(macos-ai-subscription-tracker): keep Claude usage fresh across the new breakdown key

### DIFF
--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers/ClaudeCodeProvider.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers/ClaudeCodeProvider.swift
@@ -160,11 +160,16 @@ private struct ClaudeUsageResponse: Decodable {
     let container = try decoder.container(keyedBy: DynamicCodingKey.self)
     let limitsKey = DynamicCodingKey("limits")
     self.limits = try container.decodeIfPresent([ClaudeLimit].self, forKey: limitsKey) ?? []
+    // Every other top-level key is read as a usage window, so a new sibling object that is not
+    // one must be listed here. `seven_day_breakdown` reports the weekly split per model as
+    // `rows`, carrying neither a utilization nor a reset date, and the account surfaces the same
+    // per-model figures through `seven_day_<model>` and `limits`.
     let metadataKeys = Set([
       "extra_usage",
       "limits",
       "member_dashboard_available",
       "nimbus_quill",
+      "seven_day_breakdown",
       "spend",
     ])
     var windows: [String: ClaudeWindow] = [:]

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/claude-seven-day-breakdown.json
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/claude-seven-day-breakdown.json
@@ -1,0 +1,23 @@
+{
+  "five_hour": {
+    "utilization": 28,
+    "resets_at": "2026-08-09T22:00:00Z"
+  },
+  "seven_day": {
+    "utilization": 52,
+    "resets_at": "2026-08-14T00:00:00Z"
+  },
+  "seven_day_fable": {
+    "utilization": 16,
+    "resets_at": "2026-08-14T00:00:00Z"
+  },
+  "seven_day_breakdown": {
+    "as_of": "2026-08-09T00:00:00Z",
+    "window_started_at": "2026-08-07T00:00:00Z",
+    "rows": [
+      { "key": "opus", "display_name": "Opus", "percent": 31 },
+      { "key": "sonnet", "display_name": "Sonnet", "percent": 12 }
+    ]
+  },
+  "member_dashboard_available": false
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/ProviderParsingTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/ProviderParsingTests.swift
@@ -15,6 +15,18 @@ final class ProviderParsingTests: XCTestCase {
     XCTAssertTrue(snapshot.notes.isEmpty)
   }
 
+  func testClaudeSevenDayBreakdownIsMetadataNotAWindow() throws {
+    // `seven_day_breakdown` reports the weekly split as `rows`, with no utilization and no reset
+    // date. Reading it as a window made the whole response unsupported, which took the row stale
+    // even though the account and every real window still parsed.
+    let snapshot = try ClaudeCodeProvider.parse(
+      data: fixture("claude-seven-day-breakdown"), now: now)
+
+    XCTAssertEqual(
+      snapshot.windows.map(\.id).sorted(), ["five-hour", "weekly", "weekly-fable"])
+    XCTAssertNil(snapshot.windows.first(where: { $0.id.contains("breakdown") }))
+  }
+
   func testClaudeLimitsPreserveModelAndPolicy() throws {
     let snapshot = try ClaudeCodeProvider.parse(data: fixture("claude-limits"), now: now)
     XCTAssertFalse(snapshot.windows.contains { $0.label.contains("Nimbus Quil") })


### PR DESCRIPTION
## Why

The Claude Code row went stale at 19:14 PDT today and stayed stale for 32
minutes, showing:

> Claude Code changed its unsupported quota response.

The account's OAuth usage endpoint started returning a new top-level key:

```json
"seven_day_breakdown": {
  "as_of": "...",
  "window_started_at": "...",
  "rows": [{ "key": "opus", "display_name": "Opus", "percent": 31 }]
}
```

`ClaudeUsageResponse` reads every top-level key that is not listed as metadata
as a usage window. `ClaudeWindow` requires a utilization or a reset date and
throws `unsupportedResponse` when it finds neither — which this object does not
have. One unrecognized sibling therefore failed the *entire* response, taking
down the five-hour and weekly windows that still parsed perfectly.

This was diagnosed against the live endpoint. The credential read and the HTTP
request were both healthy (`security` exit 0, `HTTP 200`); only the parse
failed.

## What

List `seven_day_breakdown` with the other metadata keys. Its `rows` carry the
weekly split per model, which the account already exposes through
`seven_day_<model>` keys and through `limits` entries with kind
`weekly_scoped`, so no window data is lost by skipping it.

The fail-loud design is deliberate and stays intact — an unrecognized *window*
shape should still take the row stale rather than invent usage. This only
teaches the decoder that one new sibling is not a window, which is the same
treatment `nimbus_quill`, `extra_usage`, and `spend` already get.

A fixture mirroring the new response shape (with fabricated numbers) locks in
that the breakdown never becomes a window and that the three real windows still
resolve.

Not taken here: consuming `rows` as a richer per-model source. It is redundant
with the existing model-scoped windows, and widening the adapter is a separate
change.

## Verification

- `bunx turbo run lint:swift test:macos --filter=@shepherdjerred/quotabar` —
  147 tests, 1 new.
- `bun run format:check`.
- Reproduced end to end: the live payload threw `unsupportedResponse` before the
  change and parses to `five-hour`, `weekly`, `weekly-fable` after it.
- Installed locally at 19:41 — the Claude row recovered on the next poll
  (frozen at 19:09:28, fetched 19:41:52) and has stayed fresh alongside every
  other provider.

**Unrelated and still open:** the Grok row is frozen at 19:09:29 with its own
cause, not addressed here.