### PR TITLE
fix(root): tighten the jscpd baseline to the current clone count

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -538,7 +538,7 @@
     },
     "packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts|packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts": {
       "clones": 7,
-      "tokens": 589
+      "tokens": 588
     },
     "packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts|packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts": {
       "clones": 1,


### PR DESCRIPTION
## Why

`main` is red and has been since `d55c1b1fba`. The `:turborepo: verify` step
fails on the jscpd baseline ratchet:

```
FAIL: packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts|…same file… has
588 duplicated tokens but 589 allowed — run `bun run jscpd --update` to tighten
the baseline
```

Duplication in that file went *down* by one token and the baseline was not
followed down. The ratchet is working exactly as designed — it only accepts
monotonic improvement — but the result is that every open PR inherits a red
`verify`. Main build 15077 and PR builds 15089 and 15090 all fail on the
identical task hash `19e5834e30806386`.

## What

Lower that one pair's allowance from 589 to 588.

`bun run jscpd --update` produces the right value but also reorders ~20
unrelated keys, which would make this look like a 42-line change to a
quality-gate file. The value is edited in place instead, so the diff is one
line and reviewable at a glance.

I verified the update semantically rather than by eye. Comparing the generated
baseline against `HEAD` as parsed maps:

| | |
|---|---|
| pairs before / after | 411 / 411 |
| pairs added | 0 |
| pairs removed | 0 |
| entries **tightened** | 1 (`argocd-atomic-sync.test.ts` self-pair, 589 → 588) |
| entries **loosened** | **0** |

Nothing is being suppressed or given more room — the single allowance moves
down to meet reality.

## Verification

- `bun run jscpd` — "jscpd baseline ratchet passed".
- `bunx lefthook run pre-commit`.
- Buildkite confirmed as the source of the red: main 15077 fails this check on
  `main` itself, so this is not introduced by any open branch.

Unblocks #2811 and #2816, which are otherwise green on their own package tasks.