### PR TITLE
feat(macos-ai-subscription-tracker): track API spend and Grok extra resets

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/quotabar.md
+++ b/packages/docs/wiki/src/content/docs/explanation/quotabar.md
@@ -52,7 +52,8 @@ and rendered by the
 
 The `API & routers` segment is separate from these subscription quotas.
 It reports billed API spend, not remaining subscription windows.
-OpenRouter, OpenAI, and Anthropic each use a read-only admin or management key.
+OpenRouter, OpenAI, and Anthropic each use a privileged admin or management key.
+Brim uses those keys only for read-only billing requests.
 Those keys never replace Claude, Codex, or ChatGPT subscription sign-ins.
 
 Claude and Codex use private authenticated subscription usage surfaces. Claude

--- a/packages/docs/wiki/src/content/docs/explanation/quotabar.md
+++ b/packages/docs/wiki/src/content/docs/explanation/quotabar.md
@@ -6,8 +6,8 @@ sidebar:
 ---
 
 Brim keeps subscription usage visible without turning provider-specific web
-usage pages into a dashboard. Claude Code, Codex, Google Antigravity, and Cursor
-are its standard providers; Kimi Code and Grok remain hidden legacy providers.
+usage pages into a dashboard. Claude Code, Codex, Google Antigravity, Cursor,
+Grok, and Kimi Code are its standard providers.
 The authenticated HTTP providers use
 [typed credential discovery](https://github.com/shepherdjerred/monorepo/blob/231bac375d228b685e12308a1d02d243cb3d1481/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Credentials.swift).
 Its [provider-independent model](https://github.com/shepherdjerred/monorepo/blob/231bac375d228b685e12308a1d02d243cb3d1481/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Domain.swift)
@@ -31,26 +31,29 @@ flowchart LR
 
 The subscription side of the app tracks quota only. It does not show provider
 API rate cards, notifications, or a full usage dashboard. Its separate API view
-reports configured OpenRouter usage, while local quota samples power the
-subscription History graph.
+reports configured OpenRouter, OpenAI, and Anthropic usage, while local quota
+samples power the subscription History graph.
 The popover includes a personal subscription-spend reminder: $200/month each
-for Claude Code and Codex plus $20/month each for Google AI Pro and Cursor Pro
-($440/month standard total). Hidden legacy providers add Kimi Code at $40/month
-and Grok at $30/month when enabled; these figures are reminders, not provider
-billing data.
+for Claude Code and Codex, $20/month each for Google AI Pro and Cursor Pro,
+$30/month for Grok, and $40/month for Kimi Code ($510/month total). These
+figures are reminders, not provider billing data.
 The reminder values live in the
 [subscription plan model](https://github.com/shepherdjerred/monorepo/blob/231bac375d228b685e12308a1d02d243cb3d1481/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Domain.swift).
 
 The subscription view surfaces the tightest actionable quota first and sorts
-provider sections by current remaining usage. Quota windows and Codex reset
+provider sections by current remaining usage. Quota windows and Codex/Grok reset
 expirations use compact rows; healthy values stay neutral while orange and red
 are reserved for pressure. Policy-only Fable data, stale snapshots, unknown
 percentages, and provider errors remain explicit without invented progress.
-The `API & routers` segment is separate from these subscription quotas.
 These choices are derived by the
 [quota overview model](https://github.com/shepherdjerred/monorepo/blob/231bac375d228b685e12308a1d02d243cb3d1481/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/QuotaOverview.swift)
 and rendered by the
 [menu-bar view](https://github.com/shepherdjerred/monorepo/blob/231bac375d228b685e12308a1d02d243cb3d1481/packages/macos-ai-subscription-tracker/Sources/QuotaBar/MenuBarView.swift).
+
+The `API & routers` segment is separate from these subscription quotas.
+It reports billed API spend, not remaining subscription windows.
+OpenRouter, OpenAI, and Anthropic each use a read-only admin or management key.
+Those keys never replace Claude, Codex, or ChatGPT subscription sign-ins.
 
 Claude and Codex use private authenticated subscription usage surfaces. Claude
 preserves additive model-scoped windows when the account returns them; Fable is
@@ -96,17 +99,32 @@ fabricated zero usage. Cursor team analytics and on-demand spend reporting stay
 out of scope; the two subscription pools are described in Cursor's
 [usage-limit guide](https://prod.cursor.com/help/models-and-usage/usage-limits).
 
-Kimi Code reads its local OAuth credential directory, including a relocated
-`KIMI_CODE_HOME`, and keeps Kimi Code separate from Moonshot Open Platform API
-keys. Kimi and Grok may also read typed OAuth entries owned by OpenCode.
-Brim never refreshes or rewrites OpenCode's credential chain; expired
-credentials must be refreshed through OpenCode. Grok reads subscription usage
-and credit surfaces, not xAI developer API limits. Kimi and Grok responses are
-private contracts: malformed or changed responses become unavailable/stale
-states and are covered by local fixtures.
+Grok means the SuperGrok subscription, not xAI developer API rate limits. Brim
+reads grok CLI `auth.json` or an optional Keychain override. It ignores OpenCode
+Grok and xAI tokens. It then requests Grok's identity, monthly billing, and
+credit surfaces, plus remaining unused reset tokens. SuperGrok unified-credit
+accounts have no included monthly dollar limit; Brim shows the weekly credit
+window instead of inventing one.
+Product and extra-credit rows inherit that same weekly reset.
+Banked extra resets are a separate list from that weekly countdown. Brim
+shows remaining unused packs with their expirations and never redeems one.
+Those responses are a private contract: malformed or changed
+shapes become unavailable or partial data rather than a fabricated zero. Brim
+never refreshes grok CLI credentials; `grok login` owns that session. xAI API
+keys and developer rate cards stay out of scope. The contract is implemented by
+the
+[Grok adapter](https://github.com/shepherdjerred/monorepo/blob/231bac375d228b685e12308a1d02d243cb3d1481/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/GrokProvider.swift)
+and read-only [credential store](https://github.com/shepherdjerred/monorepo/blob/231bac375d228b685e12308a1d02d243cb3d1481/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Credentials.swift).
+
+Kimi Code is a first-class subscription, kept separate from Moonshot Open
+Platform API keys. It reads its local OAuth credential directory, including a
+relocated `KIMI_CODE_HOME`, and may also read typed OAuth entries owned by
+OpenCode. Brim never refreshes or rewrites OpenCode's credential chain; expired
+credentials must be refreshed through OpenCode. Kimi responses are a private
+contract: malformed or changed responses become unavailable or stale states
+and are covered by local fixtures.
 Those boundaries are implemented by the
-[Kimi adapter](https://github.com/shepherdjerred/monorepo/blob/231bac375d228b685e12308a1d02d243cb3d1481/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/KimiProvider.swift),
-[Grok adapter](https://github.com/shepherdjerred/monorepo/blob/231bac375d228b685e12308a1d02d243cb3d1481/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/GrokProvider.swift),
+[Kimi adapter](https://github.com/shepherdjerred/monorepo/blob/231bac375d228b685e12308a1d02d243cb3d1481/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/KimiProvider.swift)
 and read-only [credential store](https://github.com/shepherdjerred/monorepo/blob/231bac375d228b685e12308a1d02d243cb3d1481/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Credentials.swift).
 
 ## Runtime behavior
@@ -129,8 +147,10 @@ launch at login, optional credentials for supported providers, and links to the
 provider usage pages. Optional overrides are stored in the macOS Keychain and
 are not included in the snapshot cache. Antigravity and Cursor cannot be
 overridden because their respective local applications own those sign-ins;
-Kimi Code and Grok fields are for subscription credentials, not their developer
-API keys. Launch at login reflects the
+Grok fields are for grok CLI subscription credentials, not xAI developer API
+keys. Kimi Code fields are for subscription credentials, not Moonshot developer
+API keys. API platform keys use a separate Keychain service and report billed
+spend, not subscription quota. Launch at login reflects the
 installed app's real `SMAppService` state and reports approval or registration
 failures instead of storing a hopeful boolean.
 The controls are defined by [SettingsView](https://github.com/shepherdjerred/monorepo/blob/231bac375d228b685e12308a1d02d243cb3d1481/packages/macos-ai-subscription-tracker/Sources/QuotaBar/SettingsView.swift)

--- a/packages/macos-ai-subscription-tracker/README.md
+++ b/packages/macos-ai-subscription-tracker/README.md
@@ -185,8 +185,9 @@ not redeem or consume them.
 
 ### API platform reporting
 
-The API view accepts a read-only key per platform, entered in Settings and
-stored in a dedicated login-Keychain account:
+The API view accepts a privileged admin or management key per platform, entered
+in Settings and stored in a dedicated login-Keychain account. Brim uses each
+key only for read-only billing requests:
 
 - OpenRouter Management API key: credits remaining and current-month API-key
   spend, including estimated BYOK, across every workspace.

--- a/packages/macos-ai-subscription-tracker/README.md
+++ b/packages/macos-ai-subscription-tracker/README.md
@@ -1,24 +1,23 @@
 # Brim
 
 Brim is a personal macOS menu-bar app for monitoring AI subscription
-quotas. It targets Claude Code, Codex, Google Antigravity, and Cursor by default.
-Kimi Code and Grok remain available only through the Advanced legacy-provider
-setting.
+quotas. It targets Claude Code, Codex, Google Antigravity, Cursor, Grok, and
+Kimi Code by default.
 
 Brim is the product name; QuotaBar is the Xcode target, bundle id
 (`com.sjerred.QuotaBar`), and workspace package id
 (`@shepherdjerred/quotabar`).
 
 The menu bar also shows the configured personal subscription spend: $200/month
-each for Claude Code and Codex, plus $20/month each for Google AI Pro and Cursor
-Pro ($440/month total). Enabling legacy providers adds Kimi Code ($40/month) and
-Grok ($30/month). This is a reminder, not provider billing data.
+each for Claude Code and Codex, $20/month each for Google AI Pro and Cursor
+Pro, $30/month for Grok, and $40/month for Kimi Code ($510/month total). This
+is a reminder, not provider billing data.
 
 The compact subscription view sorts providers by their tightest current quota,
 keeps each quota and reset on one line, and uses pressure colors only for low or
 critical remaining usage. Cached values remain visible but dimmed and stale.
-The `API & routers` segment currently reports OpenRouter credits and API-key
-spend across all workspaces.
+The `API & routers` segment reports OpenRouter credits plus OpenAI and Anthropic
+organization API spend for the current local month.
 
 ## Build and install
 
@@ -120,13 +119,15 @@ Brim does not log tokens or include them in its JSON usage cache. It stores only
 local historical quota samples (provider/window metadata, percentages, reset
 times, and timestamps) for up to 30 days so it can render the History graph.
 
-Claude and Codex use their typed local credential formats. When the legacy
-provider setting is enabled, Kimi Code reads its `KIMI_CODE_HOME` credential
-directory (default `~/.kimi-code`). Kimi and Grok
-can also read typed OAuth entries from OpenCode. OpenCode remains the sole owner
-and writer of those OAuth token chains: Brim never rotates, refreshes, or
+Claude and Codex use their typed local credential formats. Grok reads grok CLI
+`auth.json` (including a relocated `GROK_HOME`) plus an optional Keychain
+override. It does not read OpenCode Grok or xAI tokens. Kimi Code reads its
+`KIMI_CODE_HOME` credential directory (default `~/.kimi-code`) and can also
+read typed OAuth entries from OpenCode. OpenCode remains the sole owner and
+writer of those Kimi OAuth token chains: Brim never rotates, refreshes, or
 rewrites OpenCode files or its credential database. An expired or rejected
-Kimi/Grok token instructs the user to refresh it through OpenCode.
+Kimi token instructs the user to refresh it through OpenCode. An expired or
+rejected Grok token instructs the user to sign in again with `grok login`.
 
 Claude credentials are read through `/usr/bin/security` rather than the Security
 framework. The
@@ -138,8 +139,8 @@ not stable public APIs. Their adapters validate responses and show an explicit
 unavailable/stale state when a provider changes shape. Claude and Codex use
 their authenticated subscription usage surfaces; Kimi Code uses its coding
 subscription surface, not a Kimi Open Platform API key; Grok uses subscription
-usage and credits, not xAI developer API rate limits. Non-OpenRouter API billing
-cards and developer API rate limits remain outside the v1 scope.
+usage and credits, not xAI developer API rate limits. Other provider developer
+API rate limits remain outside this scope.
 
 Antigravity is invoked through the signed-in `agy` executable found on the
 current process `PATH` or in standard Homebrew, local, and mise locations. Brim
@@ -162,29 +163,49 @@ Brim never substitutes zero usage. Cursor team analytics and on-demand spend
 reporting are outside this integration. Cursor documents the two pools in its
 [usage-limit guide](https://prod.cursor.com/help/models-and-usage/usage-limits).
 
+Grok reads grok CLI `auth.json` (default `~/.grok`, or `GROK_HOME`), or an
+optional Keychain override. It does not read OpenCode Grok or xAI tokens.
+It requests Grok's identity, monthly billing, and credit surfaces, plus the
+remaining-reset RPC read-only. It displays subscription usage and credits, not
+xAI developer API rate limits. Banked extra resets are shown individually with
+their expiration dates; Brim never redeems or consumes them. This is a
+private provider contract: schema drift and authentication failures remain
+explicit, and Brim never substitutes zero usage. Brim never refreshes or
+rewrites grok CLI credentials; `grok login` remains the owner of that session.
+
+Kimi Code reads its local OAuth credential directory, including a relocated
+`KIMI_CODE_HOME`, and can also read typed OpenCode OAuth entries. It displays
+the coding subscription surface, not a Kimi Open Platform API key. This is a
+private provider contract: schema drift and authentication failures remain
+explicit, and Brim never substitutes zero usage.
+
 Codex also reads the authenticated reset-credit surface read-only. Available
 banked resets are shown individually with their expiration dates; Brim does
 not redeem or consume them.
 
-### OpenRouter API reporting
+### API platform reporting
 
-The API view requires an OpenRouter Management API key entered manually in
-Settings. Brim stores this key in a dedicated login-Keychain entry and only
-performs read-only requests for credits, workspaces, and API-key usage. Brim
-does not create, update, disable, or delete OpenRouter keys.
+The API view accepts a read-only key per platform, entered in Settings and
+stored in a dedicated login-Keychain account:
 
-The view shows credits remaining, monthly API-key spend, and a projected
-month-end spend. Monthly spend is the sum of OpenRouter's current-month
-usage_monthly and estimated byok_usage_monthly values across every workspace
-and API key, including disabled keys. The projection uses the current Mac-local
-calendar pace against OpenRouter's authoritative monthly usage period. Chatroom
-and Fusion activity is outside this first API-key reporting slice.
+- OpenRouter Management API key: credits remaining and current-month API-key
+  spend, including estimated BYOK, across every workspace.
+- OpenAI Admin API key: organization Costs API spend for the current local
+  calendar month. This is not ChatGPT subscription usage.
+- Anthropic Admin API key: organization Cost Report spend for the current
+  local calendar month. This is not Claude Pro or Claude Code subscription
+  usage.
+
+Brim only performs read-only requests. It does not create, update, disable, or
+delete provider keys. Each platform projects month-end spend from the current
+Mac-local calendar pace. Chatroom, Fusion, and other unlisted billing products
+stay out of this slice.
 
 Provider contracts are isolated in focused files under `Sources/QuotaBarCore`.
 Claude and Codex endpoints are authenticated subscription web surfaces;
 Antigravity uses its CLI contract; Cursor uses the unsupported personal-client
-contract described above. Legacy Kimi and Grok support uses private subscription
-quota surfaces and is disabled by default. Provider response changes produce an
+contract described above. Grok and Kimi use private subscription quota
+surfaces. Provider response changes produce an
 explicit unavailable, partial, or stale state rather than a fabricated zero.
 
 ## Development
@@ -200,7 +221,8 @@ bunx turbo run lint:swift --filter=@shepherdjerred/quotabar
 Provider fixtures are shape-preserving samples with synthetic account values.
 Passing fixtures proves decoder behavior, not current production correctness.
 Release acceptance still compares all displayed windows, percentages, reset
-times, and Codex reset expirations with each provider's own Usage screen.
+times, and Codex/Grok banked reset expirations with each provider's own Usage
+screen.
 
 The frozen `sandbox/archive/glance` app is reference material only; this app is
 implemented as a separate package so the archived tree remains unchanged.

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/APIPlatformViews.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/APIPlatformViews.swift
@@ -2,6 +2,7 @@ import QuotaBarCore
 import SwiftUI
 
 struct APIPlatformSummaryView: View {
+  let platform: APIPlatformID
   let state: APIPlatformDisplayState
   let date: Date
 
@@ -19,12 +20,9 @@ struct APIPlatformSummaryView: View {
       Image(systemName: "network")
         .foregroundStyle(.blue)
         .accessibilityHidden(true)
-      Text("OpenRouter")
+      Text(platform.displayName)
         .font(.subheadline.weight(.semibold))
       Spacer()
-      Text("All workspaces")
-        .font(.caption)
-        .foregroundStyle(.secondary)
     }
   }
 
@@ -43,7 +41,7 @@ struct APIPlatformSummaryView: View {
       snapshotContent(snapshot, staleReason: reason)
     case let .unauthenticated(message):
       statusRow(
-        "Management API key required",
+        "API key required",
         symbol: "key",
         help: message
       )
@@ -58,17 +56,21 @@ struct APIPlatformSummaryView: View {
   ) -> some View {
     VStack(alignment: .leading, spacing: 9) {
       HStack(spacing: 6) {
-        metric("Credits remaining", value: snapshot.creditsRemaining)
+        if let creditsRemaining = snapshot.creditsRemaining {
+          metric("Credits remaining", value: creditsRemaining)
+        }
         metric("Monthly API spend", value: snapshot.monthlySpend)
         metric("Projected spend", value: snapshot.projectedSpend)
       }
       .opacity(staleReason == nil ? 1 : 0.62)
 
-      Text(workspaceDetail(snapshot.workspaceNames))
-        .font(.caption2)
-        .foregroundStyle(.secondary)
-        .lineLimit(1)
-        .help(snapshot.workspaceNames.joined(separator: ", "))
+      if !snapshot.workspaceNames.isEmpty {
+        Text(workspaceDetail(snapshot.workspaceNames))
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .help(snapshot.workspaceNames.joined(separator: ", "))
+      }
 
       HStack(spacing: 5) {
         if let staleReason {
@@ -82,13 +84,10 @@ struct APIPlatformSummaryView: View {
       }
       .font(.caption2)
 
-      Text(
-        "Monthly spend is OpenRouter API-key usage and includes estimated BYOK spend. "
-          + "Projection uses the current local calendar pace."
-      )
-      .font(.caption2)
-      .foregroundStyle(.tertiary)
-      .fixedSize(horizontal: false, vertical: true)
+      Text(platform.spendFootnote)
+        .font(.caption2)
+        .foregroundStyle(.tertiary)
+        .fixedSize(horizontal: false, vertical: true)
     }
   }
 
@@ -124,11 +123,7 @@ struct APIPlatformSummaryView: View {
   }
 
   private func currency(_ value: Decimal) -> String {
-    let formatter = NumberFormatter()
-    formatter.numberStyle = .currency
-    formatter.currencyCode = "USD"
-    formatter.locale = .current
-    return value.formatted(.currency(code: "USD"))
+    value.formatted(.currency(code: "USD"))
   }
 
   private func statusRow(_ text: String, symbol: String, help: String) -> some View {

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/MenuBarView.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/MenuBarView.swift
@@ -61,7 +61,20 @@ struct MenuBarView: View {
       }
       navigationSegments
       Divider()
-      APIPlatformSummaryView(state: apiModel.state, date: date)
+      ScrollView {
+        VStack(spacing: 0) {
+          ForEach(APIPlatformID.allCases) { platform in
+            APIPlatformSummaryView(
+              platform: platform,
+              state: apiModel.state(for: platform),
+              date: date
+            )
+            if platform != APIPlatformID.allCases.last {
+              Divider()
+            }
+          }
+        }
+      }
       if let cacheError = apiModel.cacheErrorMessage {
         Divider()
         StatusMessage(symbol: "externaldrive.badge.exclamationmark", text: cacheError)
@@ -208,9 +221,7 @@ struct MenuBarView: View {
     .padding(.horizontal, 12)
     .padding(.vertical, 7)
     .help(
-      model.settings.showsLegacyProviders
-        ? "Claude Code $200, Codex $200, Google AI Pro $20, Cursor Pro $20, Kimi Code $40, Grok $30"
-        : "Claude Code $200, Codex $200, Google AI Pro $20, Cursor Pro $20"
+      "Claude Code $200, Codex $200, Google AI Pro $20, Cursor Pro $20, Grok $30, Kimi Code $40"
     )
   }
 
@@ -231,12 +242,7 @@ struct MenuBarView: View {
   }
 
   private var apiLastUpdatedAt: Date? {
-    switch apiModel.state {
-    case let .available(snapshot), let .stale(snapshot, _):
-      snapshot.sourceTimestamp
-    case .loading, .unavailable, .unauthenticated:
-      nil
-    }
+    apiModel.lastUpdatedAt
   }
 }
 

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/Previews.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/Previews.swift
@@ -22,6 +22,8 @@ import SwiftUI
       .codex: .available(PreviewData.shippingCodex),
       .antigravity: .available(PreviewData.shippingAntigravity),
       .cursor: .available(PreviewData.shippingCursor),
+      .grok: .available(PreviewData.shippingGrok),
+      .kimi: .available(PreviewData.snapshot(.kimi, remaining: 42)),
     ])
   )
 }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/QuotaBarApp.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/QuotaBarApp.swift
@@ -8,7 +8,7 @@ struct QuotaBarApp: App {
   @State private var apiModel: APIPlatformModel
   @State private var launchAtLogin: LaunchAtLoginController
   private let manualCredentials: ManualCredentialStore
-  private let openRouterCredentials: OpenRouterCredentialStore
+  private let apiCredentials: APIPlatformCredentialStore
   private let startupError: String?
 
   init() {
@@ -31,8 +31,8 @@ struct QuotaBarApp: App {
       startupError = "Brim could not configure its provider URLs."
     }
     self.manualCredentials = manualCredentials
-    let openRouterCredentials = OpenRouterCredentialStore()
-    self.openRouterCredentials = openRouterCredentials
+    let apiCredentials = APIPlatformCredentialStore()
+    self.apiCredentials = apiCredentials
     self.startupError = startupError
     let model = QuotaBarModel(
       providers: providers,
@@ -41,7 +41,7 @@ struct QuotaBarApp: App {
       historyStore: JSONUsageHistoryStore(),
       providerFactory: providerFactory
     )
-    let apiModel = APIPlatformModel(settings: settings, credentials: openRouterCredentials)
+    let apiModel = APIPlatformModel(settings: settings, credentials: apiCredentials)
     _model = State(initialValue: model)
     _apiModel = State(initialValue: apiModel)
     _launchAtLogin = State(initialValue: LaunchAtLoginController())
@@ -62,7 +62,7 @@ struct QuotaBarApp: App {
         model: model,
         apiModel: apiModel,
         manualCredentials: manualCredentials,
-        openRouterCredentials: openRouterCredentials,
+        apiCredentials: apiCredentials,
         launchAtLogin: launchAtLogin
       )
     }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/SettingsView.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/SettingsView.swift
@@ -6,26 +6,28 @@ struct SettingsView: View {
   @Bindable var model: QuotaBarModel
   @Bindable var apiModel: APIPlatformModel
   let manualCredentials: ManualCredentialStore
-  let openRouterCredentials: OpenRouterCredentialStore
+  let apiCredentials: APIPlatformCredentialStore
   @Bindable var launchAtLogin: LaunchAtLoginController
   @State private var drafts: [ProviderID: String] = [:]
   @State private var overriddenProviders: Set<ProviderID> = []
   @State private var credentialMessage: String?
-  @State private var openRouterDraft = ""
-  @State private var hasOpenRouterCredential = false
-  @State private var openRouterCredentialMessage: String?
+  @State private var apiDrafts: [APIPlatformID: String] = [:]
+  @State private var apiHasCredential: Set<APIPlatformID> = []
+  @State private var apiMessages: [APIPlatformID: String] = [:]
 
   var body: some View {
     Form {
       providerSection
-      advancedSection
+      if !ProviderID.legacy.isEmpty {
+        advancedSection
+      }
       refreshSection
       loginSection
       credentialSection
-      openRouterCredentialSection
+      apiCredentialSection
     }
     .formStyle(.grouped)
-    .frame(width: 520, height: 720)
+    .frame(width: 520, height: 780)
     .task { await loadCredentialStatus() }
     .onChange(of: model.settings.visibleProviderIDs) { _, _ in
       Task { await loadCredentialStatus() }
@@ -33,35 +35,39 @@ struct SettingsView: View {
     .onAppear { launchAtLogin.refresh() }
   }
 
-  private var openRouterCredentialSection: some View {
-    Section("API platform") {
+  private var apiCredentialSection: some View {
+    Section("API platforms") {
       Text(
-        "Enter an OpenRouter Management API key to read credits, workspaces, and API-key usage. "
-          + "Brim only sends read-only requests; the key remains in your login Keychain."
+        "Enter read-only admin or management keys to report API spend. Keys stay in your login Keychain. "
+          + "Brim never creates, rotates, or deletes provider keys."
       )
       .font(.caption)
       .foregroundStyle(.secondary)
-      if let url = URL(string: "https://openrouter.ai/settings/management-keys") {
-        Link("OpenRouter Management API keys", destination: url)
-      }
-      VStack(alignment: .leading, spacing: 5) {
-        HStack {
-          SecureField("OpenRouter Management API key", text: $openRouterDraft)
-          Button("Save") { saveOpenRouterCredential() }
-            .disabled(openRouterDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-          Button("Remove") { removeOpenRouterCredential() }
-            .disabled(!hasOpenRouterCredential)
+      ForEach(APIPlatformID.allCases) { platform in
+        VStack(alignment: .leading, spacing: 5) {
+          if let url = platform.credentialHelpURL {
+            Link("\(platform.displayName) keys", destination: url)
+          }
+          HStack {
+            SecureField(platform.credentialLabel, text: apiDraftBinding(platform))
+            Button("Save") { saveAPICredential(platform) }
+              .disabled(
+                apiDrafts[platform, default: ""].trimmingCharacters(in: .whitespacesAndNewlines)
+                  .isEmpty)
+            Button("Remove") { removeAPICredential(platform) }
+              .disabled(!apiHasCredential.contains(platform))
+          }
+          if apiHasCredential.contains(platform) {
+            Label("Key saved in Keychain", systemImage: "key.fill")
+              .font(.caption2)
+              .foregroundStyle(.secondary)
+          }
+          if let message = apiMessages[platform] {
+            Text(message)
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
         }
-        if hasOpenRouterCredential {
-          Label("Management API key saved in Keychain", systemImage: "key.fill")
-            .font(.caption2)
-            .foregroundStyle(.secondary)
-        }
-      }
-      if let openRouterCredentialMessage {
-        Text(openRouterCredentialMessage)
-          .font(.caption)
-          .foregroundStyle(.secondary)
       }
     }
   }
@@ -86,7 +92,7 @@ struct SettingsView: View {
     Section("Advanced") {
       Toggle("Show legacy providers", isOn: legacyProviderBinding)
       Text(
-        "Kimi Code and Grok use unsupported subscription surfaces. They remain off unless you opt in."
+        "These providers use unsupported subscription surfaces. They remain off unless you opt in."
       )
       .font(.caption)
       .foregroundStyle(.secondary)
@@ -189,6 +195,13 @@ struct SettingsView: View {
     )
   }
 
+  private func apiDraftBinding(_ platform: APIPlatformID) -> Binding<String> {
+    Binding(
+      get: { apiDrafts[platform, default: ""] },
+      set: { apiDrafts[platform] = $0 }
+    )
+  }
+
   private func saveCredential(_ provider: ProviderID) {
     let token = drafts[provider, default: ""]
     Task {
@@ -228,37 +241,41 @@ struct SettingsView: View {
         credentialMessage = "Keychain status unavailable."
       }
     }
-    do {
-      hasOpenRouterCredential = try await openRouterCredentials.token() != nil
-    } catch {
-      openRouterCredentialMessage = "OpenRouter Keychain status unavailable."
-    }
-  }
-
-  private func saveOpenRouterCredential() {
-    let token = openRouterDraft
-    Task {
+    for platform in APIPlatformID.allCases {
       do {
-        try await openRouterCredentials.save(token)
-        hasOpenRouterCredential = true
-        openRouterDraft = ""
-        openRouterCredentialMessage = "Saved OpenRouter Management API key."
-        await apiModel.handleCredentialChange()
+        if try await apiCredentials.token(for: platform) != nil {
+          apiHasCredential.insert(platform)
+        }
       } catch {
-        openRouterCredentialMessage = error.localizedDescription
+        apiMessages[platform] = "\(platform.displayName) Keychain status unavailable."
       }
     }
   }
 
-  private func removeOpenRouterCredential() {
+  private func saveAPICredential(_ platform: APIPlatformID) {
+    let token = apiDrafts[platform, default: ""]
     Task {
       do {
-        try await openRouterCredentials.remove()
-        hasOpenRouterCredential = false
-        openRouterCredentialMessage = "Removed OpenRouter Management API key."
-        await apiModel.handleCredentialChange()
+        try await apiCredentials.save(token, for: platform)
+        apiHasCredential.insert(platform)
+        apiDrafts[platform] = ""
+        apiMessages[platform] = "Saved \(platform.credentialLabel)."
+        await apiModel.handleCredentialChange(for: platform)
       } catch {
-        openRouterCredentialMessage = error.localizedDescription
+        apiMessages[platform] = error.localizedDescription
+      }
+    }
+  }
+
+  private func removeAPICredential(_ platform: APIPlatformID) {
+    Task {
+      do {
+        try await apiCredentials.remove(for: platform)
+        apiHasCredential.remove(platform)
+        apiMessages[platform] = "Removed \(platform.credentialLabel)."
+        await apiModel.handleCredentialChange(for: platform)
+      } catch {
+        apiMessages[platform] = error.localizedDescription
       }
     }
   }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/SettingsView.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/SettingsView.swift
@@ -38,8 +38,8 @@ struct SettingsView: View {
   private var apiCredentialSection: some View {
     Section("API platforms") {
       Text(
-        "Enter read-only admin or management keys to report API spend. Keys stay in your login Keychain. "
-          + "Brim never creates, rotates, or deletes provider keys."
+        "Enter a privileged admin or management key. Brim uses it only for read-only billing requests. "
+          + "Keys stay in your login Keychain. Brim never creates, rotates, or deletes provider keys."
       )
       .font(.caption)
       .foregroundStyle(.secondary)

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatform.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatform.swift
@@ -1,23 +1,71 @@
 public import Foundation
 
-public enum APIPlatformID: String, Codable, Equatable, Sendable {
+public enum APIPlatformID: String, CaseIterable, Codable, Equatable, Identifiable, Sendable {
   case openRouter = "openrouter"
+  case openAI = "openai"
+  case anthropic
 
-  public var displayName: String { "OpenRouter" }
+  public var id: String { rawValue }
+
+  public var displayName: String {
+    switch self {
+    case .openRouter: "OpenRouter"
+    case .openAI: "OpenAI"
+    case .anthropic: "Anthropic"
+    }
+  }
+
+  public var credentialAccount: String {
+    switch self {
+    case .openRouter: "openrouter-management"
+    case .openAI: "openai-admin"
+    case .anthropic: "anthropic-admin"
+    }
+  }
+
+  public var credentialLabel: String {
+    switch self {
+    case .openRouter: "OpenRouter Management API key"
+    case .openAI: "OpenAI Admin API key"
+    case .anthropic: "Anthropic Admin API key"
+    }
+  }
+
+  public var credentialHelpURL: URL? {
+    switch self {
+    case .openRouter: URL(string: "https://openrouter.ai/settings/management-keys")
+    case .openAI: URL(string: "https://developers.openai.com/api/docs/guides/admin-apis")
+    case .anthropic: URL(string: "https://platform.claude.com/settings/admin-keys")
+    }
+  }
+
+  public var spendFootnote: String {
+    switch self {
+    case .openRouter:
+      "Monthly spend is OpenRouter API-key usage and includes estimated BYOK spend. "
+        + "Projection uses the current local calendar pace."
+    case .openAI:
+      "Monthly spend is OpenAI organization API cost for the current local calendar month. "
+        + "This is not ChatGPT subscription usage."
+    case .anthropic:
+      "Monthly spend is Anthropic organization API cost for the current local calendar month. "
+        + "This is not Claude Pro or Claude Code subscription usage."
+    }
+  }
 }
 
 public struct APIPlatformSnapshot: Codable, Equatable, Sendable {
   public let platform: APIPlatformID
   public let workspaceNames: [String]
-  public let creditsRemaining: Decimal
+  public let creditsRemaining: Decimal?
   public let monthlySpend: Decimal
   public let projectedSpend: Decimal
   public let sourceTimestamp: Date
 
   public init(
-    platform: APIPlatformID = .openRouter,
+    platform: APIPlatformID,
     workspaceNames: [String],
-    creditsRemaining: Decimal,
+    creditsRemaining: Decimal?,
     monthlySpend: Decimal,
     projectedSpend: Decimal,
     sourceTimestamp: Date
@@ -39,46 +87,80 @@ public enum APIPlatformDisplayState: Equatable, Sendable {
   case unauthenticated(message: String)
 }
 
+public enum APIPlatformProjection {
+  public static func projectedSpend(
+    platform: APIPlatformID,
+    monthlySpend: Decimal,
+    now: Date,
+    timeZone: TimeZone
+  ) throws -> Decimal {
+    guard monthlySpend >= 0 else { throw APIPlatformError.malformedResponse(platform) }
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = timeZone
+    let elapsedDays = calendar.component(.day, from: now)
+    guard let range = calendar.range(of: .day, in: .month, for: now), elapsedDays > 0 else {
+      throw APIPlatformError.malformedResponse(platform)
+    }
+    return monthlySpend / Decimal(elapsedDays) * Decimal(range.count)
+  }
+
+  public static func monthStart(platform: APIPlatformID, now: Date, timeZone: TimeZone) throws
+    -> Date
+  {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = timeZone
+    var components = calendar.dateComponents([.year, .month], from: now)
+    components.day = 1
+    components.hour = 0
+    components.minute = 0
+    components.second = 0
+    guard let start = calendar.date(from: components) else {
+      throw APIPlatformError.malformedResponse(platform)
+    }
+    return start
+  }
+}
+
 public enum APIPlatformError: Error, Equatable, LocalizedError, Sendable {
-  case credentialsMissing
-  case credentialEmpty
-  case keychain(status: Int32)
-  case invalidURL
-  case unauthorized
-  case forbidden
-  case rateLimited
-  case requestTimedOut
-  case network
-  case malformedResponse
+  case credentialsMissing(APIPlatformID)
+  case credentialEmpty(APIPlatformID)
+  case keychain(APIPlatformID, status: Int32)
+  case invalidURL(APIPlatformID)
+  case unauthorized(APIPlatformID)
+  case forbidden(APIPlatformID)
+  case rateLimited(APIPlatformID)
+  case requestTimedOut(APIPlatformID)
+  case network(APIPlatformID)
+  case malformedResponse(APIPlatformID)
   case cacheCorrupt
   case cacheWriteFailed
 
   public var errorDescription: String? {
     switch self {
-    case .credentialsMissing:
-      "Add an OpenRouter Management API key in Brim Settings."
-    case .credentialEmpty:
-      "Enter an OpenRouter Management API key before saving."
-    case let .keychain(status):
-      "Unable to access the OpenRouter credential in Keychain (status \(status))."
-    case .invalidURL:
-      "The OpenRouter API URL is invalid."
-    case .unauthorized:
-      "OpenRouter rejected the Management API key. Check the key in Brim Settings."
-    case .forbidden:
-      "The OpenRouter key does not have permission to read account usage."
-    case .rateLimited:
-      "OpenRouter temporarily rate-limited Brim."
-    case .requestTimedOut:
-      "OpenRouter did not respond before the timeout."
-    case .network:
-      "Brim could not reach OpenRouter."
-    case .malformedResponse:
-      "OpenRouter returned malformed account data."
+    case let .credentialsMissing(platform):
+      "Add a \(platform.credentialLabel) in Brim Settings."
+    case let .credentialEmpty(platform):
+      "Enter a \(platform.credentialLabel) before saving."
+    case let .keychain(platform, status):
+      "Unable to access the \(platform.displayName) credential in Keychain (status \(status))."
+    case let .invalidURL(platform):
+      "The \(platform.displayName) API URL is invalid."
+    case let .unauthorized(platform):
+      "\(platform.displayName) rejected the API key. Check the key in Brim Settings."
+    case let .forbidden(platform):
+      "The \(platform.displayName) key does not have permission to read account usage."
+    case let .rateLimited(platform):
+      "\(platform.displayName) temporarily rate-limited Brim."
+    case let .requestTimedOut(platform):
+      "\(platform.displayName) did not respond before the timeout."
+    case let .network(platform):
+      "Brim could not reach \(platform.displayName)."
+    case let .malformedResponse(platform):
+      "\(platform.displayName) returned malformed account data."
     case .cacheCorrupt:
-      "The saved OpenRouter cache is corrupt."
+      "The saved API platform cache is corrupt."
     case .cacheWriteFailed:
-      "Brim could not save the latest OpenRouter data."
+      "Brim could not save the latest API platform data."
     }
   }
 
@@ -88,6 +170,24 @@ public enum APIPlatformError: Error, Equatable, LocalizedError, Sendable {
       true
     default:
       false
+    }
+  }
+
+  public var platform: APIPlatformID? {
+    switch self {
+    case let .credentialsMissing(platform),
+      let .credentialEmpty(platform),
+      let .keychain(platform, _),
+      let .invalidURL(platform),
+      let .unauthorized(platform),
+      let .forbidden(platform),
+      let .rateLimited(platform),
+      let .requestTimedOut(platform),
+      let .network(platform),
+      let .malformedResponse(platform):
+      platform
+    case .cacheCorrupt, .cacheWriteFailed:
+      nil
     }
   }
 }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformCredentials.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformCredentials.swift
@@ -1,9 +1,8 @@
 import Foundation
 import Security
 
-public actor OpenRouterCredentialStore {
+public actor APIPlatformCredentialStore {
   public static let service = "com.sjerred.QuotaBar.api-platform"
-  public static let account = "openrouter-management"
 
   private let keychain: any KeychainClient
 
@@ -11,47 +10,49 @@ public actor OpenRouterCredentialStore {
     self.keychain = keychain
   }
 
-  public func token() throws -> String? {
+  public func token(for platform: APIPlatformID) throws -> String? {
     do {
-      guard let data = try keychain.read(service: Self.service, account: Self.account) else {
+      guard
+        let data = try keychain.read(service: Self.service, account: platform.credentialAccount)
+      else {
         return nil
       }
       guard let token = String(data: data, encoding: .utf8) else {
-        throw APIPlatformError.keychain(status: errSecDecode)
+        throw APIPlatformError.keychain(platform, status: errSecDecode)
       }
       let normalized = token.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !normalized.isEmpty else { throw APIPlatformError.credentialEmpty }
+      guard !normalized.isEmpty else { throw APIPlatformError.credentialEmpty(platform) }
       return normalized
     } catch let error as APIPlatformError {
       throw error
     } catch let error as QuotaError {
       if case let .keychain(status) = error {
-        throw APIPlatformError.keychain(status: status)
+        throw APIPlatformError.keychain(platform, status: status)
       }
       throw error
     }
   }
 
-  public func save(_ token: String) throws {
+  public func save(_ token: String, for platform: APIPlatformID) throws {
     let normalized = token.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !normalized.isEmpty else { throw APIPlatformError.credentialEmpty }
+    guard !normalized.isEmpty else { throw APIPlatformError.credentialEmpty(platform) }
     do {
       try keychain.write(
-        Data(normalized.utf8), service: Self.service, account: Self.account)
+        Data(normalized.utf8), service: Self.service, account: platform.credentialAccount)
     } catch let error as QuotaError {
       if case let .keychain(status) = error {
-        throw APIPlatformError.keychain(status: status)
+        throw APIPlatformError.keychain(platform, status: status)
       }
       throw error
     }
   }
 
-  public func remove() throws {
+  public func remove(for platform: APIPlatformID) throws {
     do {
-      try keychain.delete(service: Self.service, account: Self.account)
+      try keychain.delete(service: Self.service, account: platform.credentialAccount)
     } catch let error as QuotaError {
       if case let .keychain(status) = error {
-        throw APIPlatformError.keychain(status: status)
+        throw APIPlatformError.keychain(platform, status: status)
       }
       throw error
     }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformEndpoints.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformEndpoints.swift
@@ -1,0 +1,107 @@
+public import Foundation
+
+public struct OpenAIEndpoints: Sendable {
+  public let baseURL: URL
+
+  public init(baseURL: URL) {
+    guard baseURL.scheme?.lowercased() == "https", baseURL.host != nil else {
+      preconditionFailure("OpenAI endpoint must use an HTTPS URL with a host.")
+    }
+    self.baseURL = baseURL
+  }
+
+  public static func live() -> OpenAIEndpoints {
+    OpenAIEndpoints(baseURL: liveOpenAIBaseURL)
+  }
+
+  public func costs(startTime: Int, endTime: Int, page: String?) -> URL {
+    var items = [
+      URLQueryItem(name: "start_time", value: String(startTime)),
+      URLQueryItem(name: "end_time", value: String(endTime)),
+      URLQueryItem(name: "bucket_width", value: "1d"),
+      URLQueryItem(name: "limit", value: "31"),
+    ]
+    if let page {
+      items.append(URLQueryItem(name: "page", value: page))
+    }
+    return url(path: "v1/organization/costs", queryItems: items)
+  }
+
+  private func url(path: String, queryItems: [URLQueryItem]) -> URL {
+    var components = URLComponents()
+    components.scheme = baseURL.scheme
+    components.host = baseURL.host
+    components.port = baseURL.port
+    components.path = joinedPath(path)
+    components.queryItems = queryItems
+    guard let url = components.url else {
+      preconditionFailure("The OpenAI endpoint URL could not be constructed.")
+    }
+    return url
+  }
+
+  private func joinedPath(_ path: String) -> String {
+    let prefix = baseURL.path.hasSuffix("/") ? String(baseURL.path.dropLast()) : baseURL.path
+    return prefix + "/" + path
+  }
+}
+
+public struct AnthropicEndpoints: Sendable {
+  public let baseURL: URL
+
+  public init(baseURL: URL) {
+    guard baseURL.scheme?.lowercased() == "https", baseURL.host != nil else {
+      preconditionFailure("Anthropic endpoint must use an HTTPS URL with a host.")
+    }
+    self.baseURL = baseURL
+  }
+
+  public static func live() -> AnthropicEndpoints {
+    AnthropicEndpoints(baseURL: liveAnthropicBaseURL)
+  }
+
+  public func costReport(startingAt: String, endingAt: String, page: String?) -> URL {
+    var items = [
+      URLQueryItem(name: "starting_at", value: startingAt),
+      URLQueryItem(name: "ending_at", value: endingAt),
+      URLQueryItem(name: "bucket_width", value: "1d"),
+      URLQueryItem(name: "limit", value: "31"),
+    ]
+    if let page {
+      items.append(URLQueryItem(name: "page", value: page))
+    }
+    return url(path: "v1/organizations/cost_report", queryItems: items)
+  }
+
+  private func url(path: String, queryItems: [URLQueryItem]) -> URL {
+    var components = URLComponents()
+    components.scheme = baseURL.scheme
+    components.host = baseURL.host
+    components.port = baseURL.port
+    components.path = joinedPath(path)
+    components.queryItems = queryItems
+    guard let url = components.url else {
+      preconditionFailure("The Anthropic endpoint URL could not be constructed.")
+    }
+    return url
+  }
+
+  private func joinedPath(_ path: String) -> String {
+    let prefix = baseURL.path.hasSuffix("/") ? String(baseURL.path.dropLast()) : baseURL.path
+    return prefix + "/" + path
+  }
+}
+
+private let liveOpenAIBaseURL: URL = {
+  guard let url = URL(string: "https://api.openai.com") else {
+    preconditionFailure("The OpenAI default URL is invalid.")
+  }
+  return url
+}()
+
+private let liveAnthropicBaseURL: URL = {
+  guard let url = URL(string: "https://api.anthropic.com") else {
+    preconditionFailure("The Anthropic default URL is invalid.")
+  }
+  return url
+}()

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformEndpoints.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformEndpoints.swift
@@ -11,7 +11,7 @@ public struct OpenAIEndpoints: Sendable {
   }
 
   public static func live() -> OpenAIEndpoints {
-    OpenAIEndpoints(baseURL: liveOpenAIBaseURL)
+    OpenAIEndpoints(baseURL: liveBaseURL(from: liveOpenAICostsURL, name: "OpenAI"))
   }
 
   public func costs(startTime: Int, endTime: Int, page: String?) -> URL {
@@ -57,7 +57,7 @@ public struct AnthropicEndpoints: Sendable {
   }
 
   public static func live() -> AnthropicEndpoints {
-    AnthropicEndpoints(baseURL: liveAnthropicBaseURL)
+    AnthropicEndpoints(baseURL: liveBaseURL(from: liveAnthropicCostReportURL, name: "Anthropic"))
   }
 
   public func costReport(startingAt: String, endingAt: String, page: String?) -> URL {
@@ -92,16 +92,22 @@ public struct AnthropicEndpoints: Sendable {
   }
 }
 
-private let liveOpenAIBaseURL: URL = {
-  guard let url = URL(string: "https://api.openai.com") else {
-    preconditionFailure("The OpenAI default URL is invalid.")
-  }
-  return url
-}()
+private let liveOpenAICostsURL = "https://api.openai.com/v1/organization/costs"
+private let liveAnthropicCostReportURL = "https://api.anthropic.com/v1/organizations/cost_report"
 
-private let liveAnthropicBaseURL: URL = {
-  guard let url = URL(string: "https://api.anthropic.com") else {
-    preconditionFailure("The Anthropic default URL is invalid.")
+private func liveBaseURL(from endpoint: String, name: String) -> URL {
+  guard let endpointURL = URL(string: endpoint),
+    let scheme = endpointURL.scheme,
+    let host = endpointURL.host
+  else {
+    preconditionFailure("The \(name) endpoint URL is invalid.")
+  }
+  var components = URLComponents()
+  components.scheme = scheme
+  components.host = host
+  components.port = endpointURL.port
+  guard let url = components.url else {
+    preconditionFailure("The \(name) default URL is invalid.")
   }
   return url
-}()
+}

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformHTTP.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformHTTP.swift
@@ -1,0 +1,125 @@
+public import Foundation
+
+public enum APIHTTPMethod: String, Equatable, Sendable {
+  case get = "GET"
+}
+
+public struct APIPlatformRequest: Equatable, Sendable, CustomStringConvertible {
+  public let platform: APIPlatformID
+  public let method: APIHTTPMethod
+  public let url: URL
+  public let headers: [String: String]
+  public let timeout: TimeInterval
+
+  public init(
+    platform: APIPlatformID,
+    method: APIHTTPMethod = .get,
+    url: URL,
+    headers: [String: String],
+    timeout: TimeInterval = 20
+  ) {
+    self.platform = platform
+    self.method = method
+    self.url = url
+    self.headers = headers
+    self.timeout = timeout
+  }
+
+  public var description: String {
+    "APIPlatformRequest(platform: \(platform.rawValue), method: \(method.rawValue), "
+      + "url: \(url.absoluteString), headers: <redacted>)"
+  }
+}
+
+public struct APIPlatformResponse: Equatable, Sendable {
+  public let statusCode: Int
+  public let data: Data
+
+  public init(statusCode: Int, data: Data) {
+    self.statusCode = statusCode
+    self.data = data
+  }
+}
+
+public protocol APIPlatformTransport: Sendable {
+  func send(_ request: APIPlatformRequest) async throws -> APIPlatformResponse
+}
+
+public final class URLSessionAPIPlatformTransport: APIPlatformTransport, Sendable {
+  private let session: URLSession
+
+  public init(session: URLSession? = nil) {
+    if let session {
+      self.session = session
+    } else {
+      let configuration = URLSessionConfiguration.ephemeral
+      configuration.timeoutIntervalForRequest = 20
+      configuration.timeoutIntervalForResource = 30
+      self.session = URLSession(configuration: configuration)
+    }
+  }
+
+  public func send(_ request: APIPlatformRequest) async throws -> APIPlatformResponse {
+    var urlRequest = URLRequest(url: request.url, timeoutInterval: request.timeout)
+    urlRequest.httpMethod = request.method.rawValue
+    for (name, value) in request.headers {
+      urlRequest.setValue(value, forHTTPHeaderField: name)
+    }
+
+    do {
+      let (data, response) = try await session.data(for: urlRequest)
+      guard let response = response as? HTTPURLResponse else {
+        throw APIPlatformError.network(request.platform)
+      }
+      return APIPlatformResponse(statusCode: response.statusCode, data: data)
+    } catch let error as APIPlatformError {
+      throw error
+    } catch let error as URLError where error.code == .timedOut {
+      throw APIPlatformError.requestTimedOut(request.platform)
+    } catch {
+      throw APIPlatformError.network(request.platform)
+    }
+  }
+}
+
+public enum APIPlatformHTTP {
+  public static func bearerHeaders(token: String) -> [String: String] {
+    [
+      "Authorization": "Bearer \(token)",
+      "Accept": "application/json",
+    ]
+  }
+
+  public static func anthropicHeaders(token: String) -> [String: String] {
+    [
+      "x-api-key": token,
+      "anthropic-version": "2023-06-01",
+      "Accept": "application/json",
+    ]
+  }
+
+  public static func decode<Value: Decodable>(
+    _ type: Value.Type,
+    from response: APIPlatformResponse,
+    platform: APIPlatformID
+  ) throws -> Value {
+    switch response.statusCode {
+    case 200..<300:
+      do {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(Value.self, from: response.data)
+      } catch {
+        throw APIPlatformError.malformedResponse(platform)
+      }
+    case 401:
+      throw APIPlatformError.unauthorized(platform)
+    case 403:
+      throw APIPlatformError.forbidden(platform)
+    case 429:
+      throw APIPlatformError.rateLimited(platform)
+    default:
+      throw APIPlatformError.network(platform)
+    }
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformModel.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformModel.swift
@@ -4,38 +4,65 @@ public import Observation
 @MainActor @Observable
 public final class APIPlatformModel {
   public let settings: AppSettings
-  public private(set) var state: APIPlatformDisplayState = .loading
+  public private(set) var states: [APIPlatformID: APIPlatformDisplayState]
   public private(set) var isRefreshing = false
   public private(set) var cacheErrorMessage: String?
 
-  private let client: OpenRouterAPIClient
-  private let credentials: OpenRouterCredentialStore
+  private let openRouter: OpenRouterAPIClient
+  private let openAI: OpenAIAPIClient
+  private let anthropic: AnthropicAPIClient
+  private let credentials: APIPlatformCredentialStore
   private let store: any APIPlatformSnapshotPersisting
   private let providerTimeout: Duration
-  private var lastSuccessful: APIPlatformSnapshot?
+  private var lastSuccessful: [APIPlatformID: APIPlatformSnapshot] = [:]
   private var pollingTask: Task<Void, Never>?
   private var activeRefresh: Task<Void, Never>?
 
   public init(
     settings: AppSettings,
-    client: OpenRouterAPIClient = OpenRouterAPIClient(),
-    credentials: OpenRouterCredentialStore = OpenRouterCredentialStore(),
+    openRouter: OpenRouterAPIClient = OpenRouterAPIClient(),
+    openAI: OpenAIAPIClient = OpenAIAPIClient(),
+    anthropic: AnthropicAPIClient = AnthropicAPIClient(),
+    credentials: APIPlatformCredentialStore = APIPlatformCredentialStore(),
     store: any APIPlatformSnapshotPersisting = JSONAPIPlatformSnapshotStore(),
     providerTimeout: Duration = .seconds(25)
   ) {
     self.settings = settings
-    self.client = client
+    self.openRouter = openRouter
+    self.openAI = openAI
+    self.anthropic = anthropic
     self.credentials = credentials
     self.store = store
     self.providerTimeout = providerTimeout
+    var states = Dictionary(
+      uniqueKeysWithValues: APIPlatformID.allCases.map { ($0, APIPlatformDisplayState.loading) }
+    )
     do {
-      if let snapshot = try store.load() {
-        lastSuccessful = snapshot
-        state = .stale(snapshot, reason: "Cached data; waiting for an OpenRouter refresh.")
+      let loaded = try store.load()
+      lastSuccessful = loaded
+      for (platform, snapshot) in loaded {
+        states[platform] = .stale(
+          snapshot, reason: "Cached data; waiting for a \(platform.displayName) refresh.")
       }
     } catch {
       cacheErrorMessage = APIPlatformError.cacheCorrupt.localizedDescription
     }
+    self.states = states
+  }
+
+  public func state(for platform: APIPlatformID) -> APIPlatformDisplayState {
+    states[platform] ?? .loading
+  }
+
+  public var lastUpdatedAt: Date? {
+    states.values.compactMap { state -> Date? in
+      switch state {
+      case let .available(snapshot), let .stale(snapshot, _):
+        snapshot.sourceTimestamp
+      case .loading, .unavailable, .unauthenticated:
+        nil
+      }
+    }.max()
   }
 
   public func startPolling() {
@@ -75,85 +102,148 @@ public final class APIPlatformModel {
     }
     let task = Task { [weak self] in
       guard let self else { return }
-      await self.performRefresh()
+      await self.performRefresh(platforms: Array(APIPlatformID.allCases))
     }
     activeRefresh = task
     await task.value
     activeRefresh = nil
   }
 
-  public func handleCredentialChange() async {
-    lastSuccessful = nil
-    state = .loading
+  public func handleCredentialChange(for platform: APIPlatformID) async {
+    lastSuccessful[platform] = nil
+    states[platform] = .loading
+    var remaining = lastSuccessful
+    remaining[platform] = nil
     do {
-      try store.remove()
+      try store.save(remaining)
       cacheErrorMessage = nil
     } catch {
       cacheErrorMessage = APIPlatformError.cacheWriteFailed.localizedDescription
     }
-    await refresh()
+    await performRefresh(platforms: [platform])
   }
 
-  private func performRefresh() async {
+  private func performRefresh(platforms: [APIPlatformID]) async {
     isRefreshing = true
     defer { isRefreshing = false }
 
+    await withTaskGroup(of: APIPlatformFetchResult.self) { group in
+      for platform in platforms {
+        group.addTask { [weak self] in
+          guard let self else {
+            return APIPlatformFetchResult(
+              platform: platform,
+              state: .unavailable(message: "Cancelled"),
+              snapshot: nil
+            )
+          }
+          return await self.fetchState(for: platform)
+        }
+      }
+      for await result in group {
+        states[result.platform] = result.state
+        if let snapshot = result.snapshot {
+          lastSuccessful[result.platform] = snapshot
+        }
+      }
+    }
+
     do {
-      guard let token = try await credentials.token() else {
-        state = .unauthenticated(message: APIPlatformError.credentialsMissing.localizedDescription)
-        return
+      try store.save(lastSuccessful)
+      cacheErrorMessage = nil
+    } catch {
+      cacheErrorMessage = APIPlatformError.cacheWriteFailed.localizedDescription
+    }
+  }
+
+  private func fetchState(for platform: APIPlatformID) async -> APIPlatformFetchResult {
+    do {
+      guard let token = try await credentials.token(for: platform) else {
+        return APIPlatformFetchResult(
+          platform: platform,
+          state: .unauthenticated(
+            message: APIPlatformError.credentialsMissing(platform).localizedDescription),
+          snapshot: nil
+        )
       }
       let snapshot = try await Self.fetch(
-        client: client,
-        managementKey: token,
+        platform: platform,
+        openRouter: openRouter,
+        openAI: openAI,
+        anthropic: anthropic,
+        token: token,
         timeout: providerTimeout
       )
-      lastSuccessful = snapshot
-      state = .available(snapshot)
-      do {
-        try store.save(snapshot)
-        cacheErrorMessage = nil
-      } catch {
-        cacheErrorMessage = APIPlatformError.cacheWriteFailed.localizedDescription
-      }
+      return APIPlatformFetchResult(
+        platform: platform, state: .available(snapshot), snapshot: snapshot)
     } catch {
-      let apiError = Self.classify(error: error)
-      if let lastSuccessful {
-        state = .stale(lastSuccessful, reason: apiError.localizedDescription)
-      } else if apiError.isAuthenticationError {
-        state = .unauthenticated(message: apiError.localizedDescription)
-      } else {
-        state = .unavailable(message: apiError.localizedDescription)
+      let apiError = Self.classify(error: error, platform: platform)
+      if let cached = lastSuccessful[platform] {
+        return APIPlatformFetchResult(
+          platform: platform,
+          state: .stale(cached, reason: apiError.localizedDescription),
+          snapshot: nil
+        )
       }
+      if apiError.isAuthenticationError {
+        return APIPlatformFetchResult(
+          platform: platform,
+          state: .unauthenticated(message: apiError.localizedDescription),
+          snapshot: nil
+        )
+      }
+      return APIPlatformFetchResult(
+        platform: platform,
+        state: .unavailable(message: apiError.localizedDescription),
+        snapshot: nil
+      )
     }
   }
 
   nonisolated private static func fetch(
-    client: OpenRouterAPIClient,
-    managementKey: String,
+    platform: APIPlatformID,
+    openRouter: OpenRouterAPIClient,
+    openAI: OpenAIAPIClient,
+    anthropic: AnthropicAPIClient,
+    token: String,
     timeout: Duration
   ) async throws -> APIPlatformSnapshot {
     try await withThrowingTaskGroup(of: APIPlatformSnapshot.self) { group in
       group.addTask {
-        try await client.fetchSnapshot(managementKey: managementKey)
+        switch platform {
+        case .openRouter:
+          try await openRouter.fetchSnapshot(token: token)
+        case .openAI:
+          try await openAI.fetchSnapshot(token: token)
+        case .anthropic:
+          try await anthropic.fetchSnapshot(token: token)
+        }
       }
       group.addTask {
         try await Task.sleep(for: timeout)
-        throw APIPlatformError.requestTimedOut
+        throw APIPlatformError.requestTimedOut(platform)
       }
       defer { group.cancelAll() }
       guard let result = try await group.next() else {
-        throw APIPlatformError.requestTimedOut
+        throw APIPlatformError.requestTimedOut(platform)
       }
       return result
     }
   }
 
-  nonisolated private static func classify(error: any Error) -> APIPlatformError {
+  nonisolated private static func classify(error: any Error, platform: APIPlatformID)
+    -> APIPlatformError
+  {
     if let apiError = error as? APIPlatformError { return apiError }
     if let quotaError = error as? QuotaError, case let .keychain(status) = quotaError {
-      return .keychain(status: status)
+      return .keychain(platform, status: status)
     }
-    return .network
+    return .network(platform)
   }
+}
+
+private struct APIPlatformFetchResult: Sendable {
+  let platform: APIPlatformID
+  let state: APIPlatformDisplayState
+  let snapshot: APIPlatformSnapshot?
 }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformModel.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformModel.swift
@@ -16,7 +16,8 @@ public final class APIPlatformModel {
   private let providerTimeout: Duration
   private var lastSuccessful: [APIPlatformID: APIPlatformSnapshot] = [:]
   private var pollingTask: Task<Void, Never>?
-  private var activeRefresh: Task<Void, Never>?
+  private var activeRefresh: ActiveRefresh?
+  private var nextRefreshID = 0
 
   public init(
     settings: AppSettings,
@@ -97,30 +98,54 @@ public final class APIPlatformModel {
 
   public func refresh() async {
     if let activeRefresh {
-      await activeRefresh.value
+      await activeRefresh.task.value
+      clearRefresh(id: activeRefresh.id)
       return
     }
-    let task = Task { [weak self] in
-      guard let self else { return }
-      await self.performRefresh(platforms: Array(APIPlatformID.allCases))
-    }
-    activeRefresh = task
-    await task.value
-    activeRefresh = nil
+    await beginRefresh(platforms: Array(APIPlatformID.allCases))
   }
 
   public func handleCredentialChange(for platform: APIPlatformID) async {
+    let inFlight = activeRefresh
+    clearCachedSnapshot(for: platform)
+    if let inFlight {
+      await inFlight.task.value
+      clearRefresh(id: inFlight.id)
+      clearCachedSnapshot(for: platform)
+    }
+    await beginRefresh(platforms: [platform])
+  }
+
+  private func beginRefresh(platforms: [APIPlatformID]) async {
+    nextRefreshID += 1
+    let refreshID = nextRefreshID
+    let task = Task { [weak self] in
+      guard let self else { return }
+      await self.performRefresh(platforms: platforms)
+    }
+    activeRefresh = ActiveRefresh(id: refreshID, task: task)
+    await task.value
+    clearRefresh(id: refreshID)
+  }
+
+  private func clearRefresh(id: Int) {
+    guard activeRefresh?.id == id else { return }
+    activeRefresh = nil
+  }
+
+  private func clearCachedSnapshot(for platform: APIPlatformID) {
     lastSuccessful[platform] = nil
     states[platform] = .loading
-    var remaining = lastSuccessful
-    remaining[platform] = nil
+    persistLastSuccessful()
+  }
+
+  private func persistLastSuccessful() {
     do {
-      try store.save(remaining)
+      try store.save(lastSuccessful)
       cacheErrorMessage = nil
     } catch {
       cacheErrorMessage = APIPlatformError.cacheWriteFailed.localizedDescription
     }
-    await performRefresh(platforms: [platform])
   }
 
   private func performRefresh(platforms: [APIPlatformID]) async {
@@ -148,12 +173,7 @@ public final class APIPlatformModel {
       }
     }
 
-    do {
-      try store.save(lastSuccessful)
-      cacheErrorMessage = nil
-    } catch {
-      cacheErrorMessage = APIPlatformError.cacheWriteFailed.localizedDescription
-    }
+    persistLastSuccessful()
   }
 
   private func fetchState(for platform: APIPlatformID) async -> APIPlatformFetchResult {
@@ -246,4 +266,9 @@ private struct APIPlatformFetchResult: Sendable {
   let platform: APIPlatformID
   let state: APIPlatformDisplayState
   let snapshot: APIPlatformSnapshot?
+}
+
+private struct ActiveRefresh {
+  let id: Int
+  let task: Task<Void, Never>
 }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformPersistence.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformPersistence.swift
@@ -1,8 +1,8 @@
 public import Foundation
 
 public protocol APIPlatformSnapshotPersisting: Sendable {
-  func load() throws -> APIPlatformSnapshot?
-  func save(_ snapshot: APIPlatformSnapshot) throws
+  func load() throws -> [APIPlatformID: APIPlatformSnapshot]
+  func save(_ snapshots: [APIPlatformID: APIPlatformSnapshot]) throws
   func remove() throws
 }
 
@@ -27,20 +27,30 @@ public final class JSONAPIPlatformSnapshotStore: APIPlatformSnapshotPersisting, 
     )
   }
 
-  public func load() throws -> APIPlatformSnapshot? {
-    guard fileManager.fileExists(atPath: url.path) else { return nil }
+  public func load() throws -> [APIPlatformID: APIPlatformSnapshot] {
+    guard fileManager.fileExists(atPath: url.path) else { return [:] }
+    let data: Data
     do {
-      return try JSONDecoder().decode(APIPlatformSnapshot.self, from: Data(contentsOf: url))
+      data = try Data(contentsOf: url)
     } catch {
       throw APIPlatformError.cacheCorrupt
     }
+    if let cache = try? JSONDecoder().decode(APIPlatformCacheFile.self, from: data) {
+      return try dictionary(from: cache.snapshots)
+    }
+    if let snapshot = try? JSONDecoder().decode(APIPlatformSnapshot.self, from: data) {
+      return [snapshot.platform: snapshot]
+    }
+    throw APIPlatformError.cacheCorrupt
   }
 
-  public func save(_ snapshot: APIPlatformSnapshot) throws {
+  public func save(_ snapshots: [APIPlatformID: APIPlatformSnapshot]) throws {
     do {
       try fileManager.createDirectory(
         at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-      try JSONEncoder().encode(snapshot).write(to: url, options: .atomic)
+      let cache = APIPlatformCacheFile(
+        snapshots: snapshots.values.sorted { $0.platform.rawValue < $1.platform.rawValue })
+      try JSONEncoder().encode(cache).write(to: url, options: .atomic)
     } catch {
       throw APIPlatformError.cacheWriteFailed
     }
@@ -54,4 +64,19 @@ public final class JSONAPIPlatformSnapshotStore: APIPlatformSnapshotPersisting, 
       throw APIPlatformError.cacheWriteFailed
     }
   }
+
+  private func dictionary(from snapshots: [APIPlatformSnapshot]) throws -> [APIPlatformID:
+    APIPlatformSnapshot]
+  {
+    var result: [APIPlatformID: APIPlatformSnapshot] = [:]
+    for snapshot in snapshots {
+      if result[snapshot.platform] != nil { throw APIPlatformError.cacheCorrupt }
+      result[snapshot.platform] = snapshot
+    }
+    return result
+  }
+}
+
+private struct APIPlatformCacheFile: Codable {
+  let snapshots: [APIPlatformSnapshot]
 }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/AnthropicAPI.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/AnthropicAPI.swift
@@ -63,13 +63,22 @@ public struct AnthropicAPIClient: Sendable {
         guard result.currency.lowercased() == "usd" else {
           throw APIPlatformError.malformedResponse(id)
         }
-        guard let cents = Decimal(string: result.amount), cents >= 0 else {
-          throw APIPlatformError.malformedResponse(id)
-        }
+        let cents = try posixDecimal(result.amount)
+        guard cents >= 0 else { throw APIPlatformError.malformedResponse(id) }
         total += cents / 100
       }
     }
     return total
+  }
+
+  private func posixDecimal(_ value: String) throws -> Decimal {
+    let scanner = Scanner(string: value)
+    scanner.locale = Locale(identifier: "en_US_POSIX")
+    scanner.charactersToBeSkipped = nil
+    guard let parsed = scanner.scanDecimal(), scanner.isAtEnd else {
+      throw APIPlatformError.malformedResponse(id)
+    }
+    return parsed
   }
 
   private static func rfc3339(_ date: Date) -> String {

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/AnthropicAPI.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/AnthropicAPI.swift
@@ -1,0 +1,106 @@
+public import Foundation
+
+public struct AnthropicAPIClient: Sendable {
+  public let id = APIPlatformID.anthropic
+  private let transport: any APIPlatformTransport
+  private let endpoints: AnthropicEndpoints
+
+  public init(
+    transport: any APIPlatformTransport = URLSessionAPIPlatformTransport(),
+    endpoints: AnthropicEndpoints = AnthropicEndpoints.live()
+  ) {
+    self.transport = transport
+    self.endpoints = endpoints
+  }
+
+  public func fetchSnapshot(
+    token: String,
+    now: Date = .now,
+    timeZone: TimeZone = .autoupdatingCurrent
+  ) async throws -> APIPlatformSnapshot {
+    let start = try APIPlatformProjection.monthStart(platform: id, now: now, timeZone: timeZone)
+    let startingAt = Self.rfc3339(start)
+    let endingAt = Self.rfc3339(now)
+
+    var monthlySpend = Decimal.zero
+    var page: String?
+    var seenPages: Set<String> = []
+    repeat {
+      if let page, !seenPages.insert(page).inserted {
+        throw APIPlatformError.malformedResponse(id)
+      }
+      let envelope: CostReport = try await get(
+        path: endpoints.costReport(startingAt: startingAt, endingAt: endingAt, page: page),
+        token: token
+      )
+      monthlySpend += try totalUSD(envelope.data)
+      if envelope.hasMore {
+        guard let nextPage = envelope.nextPage, !nextPage.isEmpty else {
+          throw APIPlatformError.malformedResponse(id)
+        }
+        page = nextPage
+      } else {
+        page = nil
+      }
+    } while page != nil
+
+    let projectedSpend = try APIPlatformProjection.projectedSpend(
+      platform: id, monthlySpend: monthlySpend, now: now, timeZone: timeZone)
+    return APIPlatformSnapshot(
+      platform: id,
+      workspaceNames: [],
+      creditsRemaining: nil,
+      monthlySpend: monthlySpend,
+      projectedSpend: projectedSpend,
+      sourceTimestamp: now
+    )
+  }
+
+  private func totalUSD(_ buckets: [CostBucket]) throws -> Decimal {
+    var total = Decimal.zero
+    for bucket in buckets {
+      for result in bucket.results {
+        guard result.currency.lowercased() == "usd" else {
+          throw APIPlatformError.malformedResponse(id)
+        }
+        guard let cents = Decimal(string: result.amount), cents >= 0 else {
+          throw APIPlatformError.malformedResponse(id)
+        }
+        total += cents / 100
+      }
+    }
+    return total
+  }
+
+  private static func rfc3339(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter.string(from: date)
+  }
+
+  private func get<Value: Decodable>(path: URL, token: String) async throws -> Value {
+    let response = try await transport.send(
+      APIPlatformRequest(
+        platform: id,
+        url: path,
+        headers: APIPlatformHTTP.anthropicHeaders(token: token)
+      )
+    )
+    return try APIPlatformHTTP.decode(Value.self, from: response, platform: id)
+  }
+}
+
+private struct CostReport: Decodable {
+  let data: [CostBucket]
+  let hasMore: Bool
+  let nextPage: String?
+}
+
+private struct CostBucket: Decodable {
+  let results: [CostResult]
+}
+
+private struct CostResult: Decodable {
+  let amount: String
+  let currency: String
+}

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/CompositeCredentials.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/CompositeCredentials.swift
@@ -1,0 +1,41 @@
+public actor CompositeCredentialStore: CredentialStore {
+  private let manual: ManualCredentialStore
+  private let local: any CredentialStore
+  private var rejectedManualTokens: [ProviderID: Set<String>] = [:]
+
+  public init(manual: ManualCredentialStore, local: any CredentialStore) {
+    self.manual = manual
+    self.local = local
+  }
+
+  public func credential(
+    for provider: ProviderID,
+    rejecting rejectedCredential: ProviderCredential?
+  ) async throws -> ProviderCredential {
+    guard provider.supportsManualCredentialOverride else {
+      return try await local.credential(for: provider, rejecting: rejectedCredential)
+    }
+    // Remember every manual token rejected during the current replacement sequence, not just
+    // the one passed to this call — a caller (e.g. GrokProvider/CodexProvider) that restarts a
+    // whole fetch across several 401s only ever excludes its most recent credential, so without
+    // this history an already-rejected manual token would be handed out again once a later
+    // local token is rejected, oscillating between the two forever instead of exhausting.
+    //
+    // `rejecting: nil` only happens at the start of a fresh top-level fetch (never mid-restart,
+    // which always excludes the credential that just failed), so it marks a new replacement
+    // sequence and resets the history. Without this, one rejected manual token would suppress
+    // the saved override for the app's entire lifetime, surviving a transient failure or even
+    // the user removing and re-saving the same credential.
+    var rejected = rejectedCredential == nil ? [] : (rejectedManualTokens[provider] ?? [])
+    if let rejectedCredential {
+      rejected.insert(rejectedCredential.accessToken)
+    }
+    rejectedManualTokens[provider] = rejected
+    if let manualCredential = try await manual.credentialIfPresent(for: provider),
+      !rejected.contains(manualCredential.accessToken)
+    {
+      return manualCredential
+    }
+    return try await local.credential(for: provider, rejecting: rejectedCredential)
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/CredentialFormats.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/CredentialFormats.swift
@@ -108,29 +108,23 @@ struct KimiOAuth: Decodable {
 struct OpenCodeAuthFile: Decodable {
   let kimiForCodingOAuth: OpenCodeOAuthCredential?
   let kimi: OpenCodeOAuthCredential?
-  let xai: OpenCodeOAuthCredential?
-  let grok: OpenCodeOAuthCredential?
 
   enum CodingKeys: String, CodingKey {
     case kimiForCodingOAuth = "kimi-for-coding-oauth"
     case kimi
-    case xai
-    case grok
   }
 
   func credentials(for provider: ProviderID) -> [TokenValue] {
     switch provider {
     case .kimi: [kimiForCodingOAuth, kimi].compactMap { $0?.value }
-    case .grok: [xai, grok].compactMap { $0?.value }
-    case .claudeCode, .codex, .antigravity, .cursor: []
+    case .claudeCode, .codex, .antigravity, .cursor, .grok: []
     }
   }
 
   static func labels(for provider: ProviderID) -> Set<String> {
     switch provider {
     case .kimi: ["kimi-for-coding-oauth", "kimi"]
-    case .grok: ["xai", "grok"]
-    case .claudeCode, .codex, .antigravity, .cursor: []
+    case .claudeCode, .codex, .antigravity, .cursor, .grok: []
     }
   }
 }
@@ -141,6 +135,87 @@ struct OpenCodeOAuthCredential: Decodable {
 
   var value: TokenValue {
     TokenValue(accessToken: access, expiresAt: normalizedDate(expires))
+  }
+}
+
+struct GrokCLIAuthFile: Decodable {
+  let sessions: [String: GrokCLISession]
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    self.sessions = try container.decode([String: GrokCLISession].self)
+  }
+
+  func tokenValues() throws -> [TokenValue] {
+    var values: [TokenValue] = []
+    for key in sessions.keys.sorted() {
+      guard let session = sessions[key], let token = session.token else { continue }
+      let expiresAt: Date?
+      if let raw = session.expiresAt {
+        guard let date = ISO8601.parse(raw) else {
+          throw QuotaError.malformedResponse(.grok)
+        }
+        expiresAt = date
+      } else {
+        expiresAt = nil
+      }
+      values.append(TokenValue(accessToken: token, expiresAt: expiresAt))
+    }
+    return values
+  }
+}
+
+enum GrokCLICredentialDiscovery {
+  static func read(
+    grokHome: URL?,
+    homeDirectory: URL,
+    fileManager: FileManager,
+    excluding excludedTokens: Set<String>
+  ) throws -> ProviderCredential? {
+    let root = grokHome ?? homeDirectory.appendingPathComponent(".grok")
+    let path = root.appendingPathComponent("auth.json")
+    guard fileManager.fileExists(atPath: path.path) else { return nil }
+    let file: GrokCLIAuthFile
+    do {
+      file = try JSONDecoder().decode(GrokCLIAuthFile.self, from: Data(contentsOf: path))
+    } catch let error as QuotaError {
+      throw error
+    } catch {
+      throw QuotaError.malformedResponse(.grok)
+    }
+    var expiredCredential: ProviderCredential?
+    for value in try file.tokenValues() {
+      let credential = try ProviderCredential(
+        accessToken: value.accessToken,
+        expiresAt: value.expiresAt,
+        source: path.path
+      )
+      guard !excludedTokens.contains(credential.accessToken) else { continue }
+      do {
+        return try credential.requireCurrent(for: .grok)
+      } catch QuotaError.credentialsExpired {
+        if expiredCredential == nil { expiredCredential = credential }
+      }
+    }
+    return expiredCredential
+  }
+}
+
+struct GrokCLISession: Decodable {
+  let key: String?
+  let accessTokenSnake: String?
+  let expiresAt: String?
+
+  enum CodingKeys: String, CodingKey {
+    case key
+    case accessTokenSnake = "access_token"
+    case expiresAt = "expires_at"
+  }
+
+  var token: String? {
+    let raw = (key ?? accessTokenSnake)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let raw, !raw.isEmpty else { return nil }
+    return raw
   }
 }
 

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Credentials.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Credentials.swift
@@ -51,6 +51,7 @@ public final class LocalCredentialStore: CredentialStore, @unchecked Sendable {
   private let fileManager: FileManager
   private let homeDirectory: URL
   private let kimiCodeHome: URL?
+  private let grokHome: URL?
   private let cursorStateDatabase: URL?
   private let claudeKeychain: any KeychainReading
   private let selectionLock = NSLock()
@@ -60,22 +61,23 @@ public final class LocalCredentialStore: CredentialStore, @unchecked Sendable {
     fileManager: FileManager = .default,
     homeDirectory: URL? = nil,
     kimiCodeHome: URL? = nil,
+    grokHome: URL? = nil,
     cursorStateDatabase: URL? = nil,
     claudeKeychain: any KeychainReading = SecurityToolKeychainClient()
   ) {
     self.fileManager = fileManager
     self.homeDirectory = homeDirectory ?? fileManager.homeDirectoryForCurrentUser
-    if let kimiCodeHome {
-      self.kimiCodeHome = kimiCodeHome
-    } else if let configured = ProcessInfo.processInfo.environment["KIMI_CODE_HOME"],
-      !configured.isEmpty
-    {
-      self.kimiCodeHome = URL(fileURLWithPath: configured, isDirectory: true)
-    } else {
-      self.kimiCodeHome = nil
-    }
+    self.kimiCodeHome = Self.configuredHome(kimiCodeHome, environmentKey: "KIMI_CODE_HOME")
+    self.grokHome = Self.configuredHome(grokHome, environmentKey: "GROK_HOME")
     self.cursorStateDatabase = cursorStateDatabase
     self.claudeKeychain = claudeKeychain
+  }
+
+  private static func configuredHome(_ explicit: URL?, environmentKey: String) -> URL? {
+    if let explicit { return explicit }
+    guard let configured = ProcessInfo.processInfo.environment[environmentKey], !configured.isEmpty
+    else { return nil }
+    return URL(fileURLWithPath: configured, isDirectory: true)
   }
 
   public func credential(
@@ -93,7 +95,13 @@ public final class LocalCredentialStore: CredentialStore, @unchecked Sendable {
     case .antigravity: credential = nil
     case .cursor: credential = try readCursor(excluding: excludedTokens)
     case .kimi: credential = try readCurrentKimiCredential(excluding: excludedTokens)
-    case .grok: credential = try readOpenCode(provider: provider, excluding: excludedTokens)
+    case .grok:
+      credential = try GrokCLICredentialDiscovery.read(
+        grokHome: grokHome,
+        homeDirectory: homeDirectory,
+        fileManager: fileManager,
+        excluding: excludedTokens
+      )
     }
     guard let credential else { throw QuotaError.credentialsMissing(provider) }
     return try credential.requireCurrent(for: provider)
@@ -393,47 +401,5 @@ public final class LocalCredentialStore: CredentialStore, @unchecked Sendable {
       throw QuotaError.commandFailed("SQLite")
     }
     return value
-  }
-}
-
-public actor CompositeCredentialStore: CredentialStore {
-  private let manual: ManualCredentialStore
-  private let local: any CredentialStore
-  private var rejectedManualTokens: [ProviderID: Set<String>] = [:]
-
-  public init(manual: ManualCredentialStore, local: any CredentialStore) {
-    self.manual = manual
-    self.local = local
-  }
-
-  public func credential(
-    for provider: ProviderID,
-    rejecting rejectedCredential: ProviderCredential?
-  ) async throws -> ProviderCredential {
-    guard provider.supportsManualCredentialOverride else {
-      return try await local.credential(for: provider, rejecting: rejectedCredential)
-    }
-    // Remember every manual token rejected during the current replacement sequence, not just
-    // the one passed to this call — a caller (e.g. GrokProvider/CodexProvider) that restarts a
-    // whole fetch across several 401s only ever excludes its most recent credential, so without
-    // this history an already-rejected manual token would be handed out again once a later
-    // local token is rejected, oscillating between the two forever instead of exhausting.
-    //
-    // `rejecting: nil` only happens at the start of a fresh top-level fetch (never mid-restart,
-    // which always excludes the credential that just failed), so it marks a new replacement
-    // sequence and resets the history. Without this, one rejected manual token would suppress
-    // the saved override for the app's entire lifetime, surviving a transient failure or even
-    // the user removing and re-saving the same credential.
-    var rejected = rejectedCredential == nil ? [] : (rejectedManualTokens[provider] ?? [])
-    if let rejectedCredential {
-      rejected.insert(rejectedCredential.accessToken)
-    }
-    rejectedManualTokens[provider] = rejected
-    if let manualCredential = try await manual.credentialIfPresent(for: provider),
-      !rejected.contains(manualCredential.accessToken)
-    {
-      return manualCredential
-    }
-    return try await local.credential(for: provider, rejecting: rejectedCredential)
   }
 }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Domain.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Domain.swift
@@ -5,11 +5,13 @@ public enum ProviderID: String, CaseIterable, Codable, Identifiable, Sendable {
   case codex
   case antigravity
   case cursor
-  case kimi
   case grok
+  case kimi
 
-  public static let standard: Set<ProviderID> = [.claudeCode, .codex, .antigravity, .cursor]
-  public static let legacy: Set<ProviderID> = [.kimi, .grok]
+  public static let standard: Set<ProviderID> = [
+    .claudeCode, .codex, .antigravity, .cursor, .grok, .kimi,
+  ]
+  public static let legacy: Set<ProviderID> = []
 
   public var id: String { rawValue }
 
@@ -19,8 +21,8 @@ public enum ProviderID: String, CaseIterable, Codable, Identifiable, Sendable {
     case .codex: "Codex"
     case .antigravity: "Google Antigravity"
     case .cursor: "Cursor"
-    case .kimi: "Kimi Code"
     case .grok: "Grok"
+    case .kimi: "Kimi Code"
     }
   }
 
@@ -30,15 +32,22 @@ public enum ProviderID: String, CaseIterable, Codable, Identifiable, Sendable {
     case .codex: URL(string: "https://chatgpt.com/codex/settings/usage")
     case .antigravity: URL(string: "https://antigravity.google/docs/cli/commands/usage")
     case .cursor: URL(string: "https://prod.cursor.com/help/models-and-usage/usage-limits")
-    case .kimi: URL(string: "https://www.kimi.com/code/console")
     case .grok: URL(string: "https://grok.com/settings/usage?_s=usage")
+    case .kimi: URL(string: "https://www.kimi.com/code/console")
     }
   }
 
   public var supportsManualCredentialOverride: Bool {
     switch self {
-    case .claudeCode, .codex, .kimi, .grok: true
+    case .claudeCode, .codex, .grok, .kimi: true
     case .antigravity, .cursor: false
+    }
+  }
+
+  public var tracksBankedResets: Bool {
+    switch self {
+    case .codex, .grok: true
+    case .claudeCode, .antigravity, .cursor, .kimi: false
     }
   }
 }
@@ -53,12 +62,11 @@ public struct SubscriptionPlan: Identifiable, Equatable, Sendable {
     SubscriptionPlan(provider: .codex, monthlyCostUSD: 200),
     SubscriptionPlan(provider: .antigravity, monthlyCostUSD: 20),
     SubscriptionPlan(provider: .cursor, monthlyCostUSD: 20),
+    SubscriptionPlan(provider: .grok, monthlyCostUSD: 30),
+    SubscriptionPlan(provider: .kimi, monthlyCostUSD: 40),
   ]
 
-  public static let legacy: [SubscriptionPlan] = [
-    SubscriptionPlan(provider: .kimi, monthlyCostUSD: 40),
-    SubscriptionPlan(provider: .grok, monthlyCostUSD: 30),
-  ]
+  public static let legacy: [SubscriptionPlan] = []
 
   public static func plans(includingLegacy: Bool) -> [SubscriptionPlan] {
     standard + (includingLegacy ? legacy : [])

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Errors.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Errors.swift
@@ -27,12 +27,16 @@ public enum QuotaError: Error, Equatable, LocalizedError, Sendable {
         "No signed-in Antigravity CLI was found. Install and sign in to agy."
       case .cursor:
         "No local Cursor sign-in was found. Sign in through Cursor."
+      case .grok:
+        "No local Grok credentials found. Sign in with grok login."
       default:
         "No local credentials found for \(provider.displayName)."
       }
     case let .credentialsExpired(provider):
-      if provider == .kimi || provider == .grok {
+      if provider == .kimi {
         "\(provider.displayName) credentials expired. Refresh them through OpenCode."
+      } else if provider == .grok {
+        "Grok credentials expired. Sign in again with grok login."
       } else if provider == .cursor {
         "Cursor credentials expired. Sign in again through Cursor."
       } else {
@@ -45,9 +49,11 @@ public enum QuotaError: Error, Equatable, LocalizedError, Sendable {
     case let .invalidURL(provider):
       "The configured \(provider.displayName) usage URL is invalid."
     case let .unauthorized(provider):
-      if provider == .kimi || provider == .grok {
+      if provider == .kimi {
         "\(provider.displayName) rejected the local credential. "
           + "Refresh it through OpenCode or update the Brim override."
+      } else if provider == .grok {
+        "Grok rejected the local credential. Sign in again with grok or update the Brim override."
       } else if provider == .cursor {
         "Cursor rejected its local session. Sign in again through Cursor."
       } else {

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/GrokResetCodec.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/GrokResetCodec.swift
@@ -1,0 +1,202 @@
+import Foundation
+
+/// gRPC-web framing for Grok's remaining-reset RPC. Brim only reads remaining
+/// `ResetToken`s; it never calls `RedeemReset`.
+enum GrokResetCodec {
+  static let emptyUnaryRequest = Data([0x00, 0x00, 0x00, 0x00, 0x00])
+
+  static let requestHeaders: [String: String] = [
+    "Content-Type": "application/grpc-web+proto",
+    "X-Grpc-Web": "1",
+  ]
+
+  static func parseTokens(from data: Data, now: Date) throws -> [Reset] {
+    let message = try unaryMessage(from: data)
+    return try decodeTokens(from: message, now: now)
+  }
+
+  private static func unaryMessage(from data: Data) throws -> Data {
+    var offset = 0
+    var payloads: [Data] = []
+    var status: Int?
+    while offset < data.count {
+      guard offset + 5 <= data.count else { throw QuotaError.malformedResponse(.grok) }
+      let flag = data[offset]
+      let length =
+        Int(data[offset + 1]) << 24
+        | Int(data[offset + 2]) << 16
+        | Int(data[offset + 3]) << 8
+        | Int(data[offset + 4])
+      offset += 5
+      guard offset + length <= data.count else {
+        throw QuotaError.malformedResponse(.grok)
+      }
+      let frame = data.subdata(in: offset..<(offset + length))
+      offset += length
+      if flag & 0x80 != 0 {
+        if flag & 0x01 != 0 { throw QuotaError.malformedResponse(.grok) }
+        status = try grpcStatus(from: frame)
+        continue
+      }
+      if flag & 0x01 != 0 { throw QuotaError.malformedResponse(.grok) }
+      payloads.append(frame)
+    }
+    guard payloads.count <= 1, let status else { throw QuotaError.malformedResponse(.grok) }
+    if status == 16 { throw QuotaError.unauthorized(.grok) }
+    if status != 0 { throw QuotaError.network(.grok) }
+    return payloads.first ?? Data()
+  }
+
+  private static func grpcStatus(from trailer: Data) throws -> Int {
+    guard let text = String(data: trailer, encoding: .utf8) else {
+      throw QuotaError.malformedResponse(.grok)
+    }
+    let normalized = text.replacingOccurrences(of: "\r\n", with: "\n")
+    for line in normalized.split(separator: "\n", omittingEmptySubsequences: true) {
+      let parts = line.split(separator: ":", maxSplits: 1)
+      guard parts.count == 2 else { continue }
+      let name = parts[0].trimmingCharacters(in: .whitespaces).lowercased()
+      guard name == "grpc-status" else { continue }
+      let value = parts[1].trimmingCharacters(in: .whitespaces)
+      guard let status = Int(value) else { throw QuotaError.malformedResponse(.grok) }
+      return status
+    }
+    throw QuotaError.malformedResponse(.grok)
+  }
+
+  private static func decodeTokens(from message: Data, now: Date) throws -> [Reset] {
+    var reader = ProtobufReader(data: message)
+    var resets: [Reset] = []
+    while let field = try reader.nextField() {
+      guard field.number == 1 else { continue }
+      guard field.wire == .lengthDelimited else { throw QuotaError.malformedResponse(.grok) }
+      guard let reset = try decodeToken(field.payload, now: now) else { continue }
+      resets.append(reset)
+    }
+    return resets.sorted { $0.exp < $1.exp }
+  }
+
+  private static func decodeToken(_ data: Data, now: Date) throws -> Reset? {
+    var reader = ProtobufReader(data: data)
+    var tokenID: String?
+    var validityEnd: Date?
+    while let field = try reader.nextField() {
+      switch field.number {
+      case 1:
+        guard field.wire == .lengthDelimited,
+          let value = String(data: field.payload, encoding: .utf8)
+        else {
+          throw QuotaError.malformedResponse(.grok)
+        }
+        tokenID = value
+      case 2:
+        guard field.wire == .lengthDelimited else { throw QuotaError.malformedResponse(.grok) }
+        _ = try decodeTimestamp(field.payload)
+      case 3:
+        guard field.wire == .lengthDelimited else { throw QuotaError.malformedResponse(.grok) }
+        validityEnd = try decodeTimestamp(field.payload)
+      default:
+        continue
+      }
+    }
+    guard let tokenID, !tokenID.isEmpty, let validityEnd, validityEnd > now else { return nil }
+    return Reset(exp: validityEnd)
+  }
+
+  private static func decodeTimestamp(_ data: Data) throws -> Date {
+    var reader = ProtobufReader(data: data)
+    var seconds: Int64 = 0
+    var nanos: Int32 = 0
+    while let field = try reader.nextField() {
+      switch field.number {
+      case 1:
+        guard field.wire == .varint else { throw QuotaError.malformedResponse(.grok) }
+        seconds = Int64(bitPattern: field.varint)
+      case 2:
+        guard field.wire == .varint else { throw QuotaError.malformedResponse(.grok) }
+        let value = field.varint
+        guard value <= UInt64(Int32.max) else { throw QuotaError.malformedResponse(.grok) }
+        nanos = Int32(value)
+      default:
+        continue
+      }
+    }
+    guard nanos >= 0, nanos < 1_000_000_000 else { throw QuotaError.malformedResponse(.grok) }
+    let value = Double(seconds) + Double(nanos) / 1_000_000_000
+    guard value.isFinite, abs(value) < 1e13 else { throw QuotaError.malformedResponse(.grok) }
+    return Date(timeIntervalSince1970: value)
+  }
+}
+
+private struct ProtobufReader {
+  enum Wire: UInt8 {
+    case varint = 0
+    case bits64 = 1
+    case lengthDelimited = 2
+    case bits32 = 5
+  }
+
+  struct Field {
+    let number: UInt32
+    let wire: Wire
+    let payload: Data
+    let varint: UInt64
+  }
+
+  private let data: Data
+  private var offset = 0
+
+  init(data: Data) {
+    self.data = data
+  }
+
+  mutating func nextField() throws -> Field? {
+    guard offset < data.count else { return nil }
+    let tag = try readVarint()
+    let number = UInt32(tag >> 3)
+    guard number != 0, let wire = Wire(rawValue: UInt8(tag & 0x07)) else {
+      throw QuotaError.malformedResponse(.grok)
+    }
+    switch wire {
+    case .varint:
+      let value = try readVarint()
+      return Field(number: number, wire: wire, payload: Data(), varint: value)
+    case .lengthDelimited:
+      let length = try readVarint()
+      guard length <= UInt64(data.count - offset) else {
+        throw QuotaError.malformedResponse(.grok)
+      }
+      let payload = data.subdata(in: offset..<(offset + Int(length)))
+      offset += Int(length)
+      return Field(number: number, wire: wire, payload: payload, varint: 0)
+    case .bits64:
+      let payload = try readExact(8)
+      return Field(number: number, wire: wire, payload: payload, varint: 0)
+    case .bits32:
+      let payload = try readExact(4)
+      return Field(number: number, wire: wire, payload: payload, varint: 0)
+    }
+  }
+
+  private mutating func readVarint() throws -> UInt64 {
+    var result: UInt64 = 0
+    var shift = 0
+    while true {
+      guard offset < data.count, shift <= 63 else { throw QuotaError.malformedResponse(.grok) }
+      let byte = data[offset]
+      offset += 1
+      let bits = UInt64(byte & 0x7F)
+      if shift == 63, bits > 1 { throw QuotaError.malformedResponse(.grok) }
+      result |= bits << shift
+      if byte & 0x80 == 0 { return result }
+      shift += 7
+    }
+  }
+
+  private mutating func readExact(_ count: Int) throws -> Data {
+    guard offset + count <= data.count else { throw QuotaError.malformedResponse(.grok) }
+    let payload = data.subdata(in: offset..<(offset + count))
+    offset += count
+    return payload
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Networking.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Networking.swift
@@ -240,6 +240,26 @@ public struct ProviderHTTPClient: Sendable {
     return try validate(response, provider: provider)
   }
 
+  public func post(
+    provider: ProviderID,
+    url: URL,
+    body: Data,
+    credential: ProviderCredential,
+    headers: [String: String] = [:],
+    timeout: TimeInterval = 20
+  ) async throws -> Data {
+    let request = ProviderRequestTemplate(
+      method: .post,
+      provider: provider,
+      url: url,
+      body: body,
+      headers: headers,
+      timeout: timeout
+    )
+    let response = try await send(request, credential: credential)
+    return try validate(response, provider: provider)
+  }
+
   private func send(
     _ request: ProviderRequestTemplate,
     credential: ProviderCredential

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/OpenAIAPI.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/OpenAIAPI.swift
@@ -1,0 +1,103 @@
+public import Foundation
+
+public struct OpenAIAPIClient: Sendable {
+  public let id = APIPlatformID.openAI
+  private let transport: any APIPlatformTransport
+  private let endpoints: OpenAIEndpoints
+
+  public init(
+    transport: any APIPlatformTransport = URLSessionAPIPlatformTransport(),
+    endpoints: OpenAIEndpoints = OpenAIEndpoints.live()
+  ) {
+    self.transport = transport
+    self.endpoints = endpoints
+  }
+
+  public func fetchSnapshot(
+    token: String,
+    now: Date = .now,
+    timeZone: TimeZone = .autoupdatingCurrent
+  ) async throws -> APIPlatformSnapshot {
+    let start = try APIPlatformProjection.monthStart(platform: id, now: now, timeZone: timeZone)
+    let startTime = Int(start.timeIntervalSince1970)
+    let endTime = Int(now.timeIntervalSince1970)
+    guard endTime >= startTime else { throw APIPlatformError.malformedResponse(id) }
+
+    var monthlySpend = Decimal.zero
+    var page: String?
+    var seenPages: Set<String> = []
+    repeat {
+      if let page, !seenPages.insert(page).inserted {
+        throw APIPlatformError.malformedResponse(id)
+      }
+      let envelope: CostsPage = try await get(
+        path: endpoints.costs(startTime: startTime, endTime: endTime, page: page),
+        token: token
+      )
+      monthlySpend += try totalUSD(envelope.data)
+      if envelope.hasMore {
+        guard let nextPage = envelope.nextPage, !nextPage.isEmpty else {
+          throw APIPlatformError.malformedResponse(id)
+        }
+        page = nextPage
+      } else {
+        page = nil
+      }
+    } while page != nil
+
+    let projectedSpend = try APIPlatformProjection.projectedSpend(
+      platform: id, monthlySpend: monthlySpend, now: now, timeZone: timeZone)
+    return APIPlatformSnapshot(
+      platform: id,
+      workspaceNames: [],
+      creditsRemaining: nil,
+      monthlySpend: monthlySpend,
+      projectedSpend: projectedSpend,
+      sourceTimestamp: now
+    )
+  }
+
+  private func totalUSD(_ buckets: [CostBucket]) throws -> Decimal {
+    var total = Decimal.zero
+    for bucket in buckets {
+      for result in bucket.results {
+        guard result.amount.currency.lowercased() == "usd" else {
+          throw APIPlatformError.malformedResponse(id)
+        }
+        guard result.amount.value >= 0 else { throw APIPlatformError.malformedResponse(id) }
+        total += result.amount.value
+      }
+    }
+    return total
+  }
+
+  private func get<Value: Decodable>(path: URL, token: String) async throws -> Value {
+    let response = try await transport.send(
+      APIPlatformRequest(
+        platform: id,
+        url: path,
+        headers: APIPlatformHTTP.bearerHeaders(token: token)
+      )
+    )
+    return try APIPlatformHTTP.decode(Value.self, from: response, platform: id)
+  }
+}
+
+private struct CostsPage: Decodable {
+  let data: [CostBucket]
+  let hasMore: Bool
+  let nextPage: String?
+}
+
+private struct CostBucket: Decodable {
+  let results: [CostResult]
+}
+
+private struct CostResult: Decodable {
+  let amount: CostAmount
+}
+
+private struct CostAmount: Decodable {
+  let value: Decimal
+  let currency: String
+}

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers/GrokProvider.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers/GrokProvider.swift
@@ -6,17 +6,20 @@ public struct GrokProvider: UsageProvider {
   private let userEndpoint: URL
   private let billingEndpoint: URL
   private let creditsEndpoint: URL
+  private let resetEndpoint: URL
 
   public init(
     client: ProviderHTTPClient,
     userEndpoint: URL,
     billingEndpoint: URL,
-    creditsEndpoint: URL
+    creditsEndpoint: URL,
+    resetEndpoint: URL
   ) {
     self.client = client
     self.userEndpoint = userEndpoint
     self.billingEndpoint = billingEndpoint
     self.creditsEndpoint = creditsEndpoint
+    self.resetEndpoint = resetEndpoint
   }
 
   public func fetch() async throws -> UsageSnapshot {
@@ -24,10 +27,11 @@ public struct GrokProvider: UsageProvider {
     return try await fetch(usingCredential: credential)
   }
 
-  /// Pins the identity, billing, and credits requests to one credential so a 401 on any single
-  /// surface cannot leave the published snapshot combining an account label from one credential
-  /// with usage data from another; a 401 on any surface restarts the complete fetch (identity
-  /// included) with a replacement credential instead of letting each surface reload on its own.
+  /// Pins the identity, billing, credits, and remaining-reset requests to one credential so a
+  /// 401 on any single surface cannot leave the published snapshot combining an account label from
+  /// one credential with usage or banked resets from another; a 401 on any surface restarts the
+  /// complete fetch (identity included) with a replacement credential instead of letting each
+  /// surface reload on its own.
   private func fetch(usingCredential credential: ProviderCredential) async throws -> UsageSnapshot {
     let identityData: Data
     do {
@@ -38,6 +42,7 @@ public struct GrokProvider: UsageProvider {
     }
     let identity = try Self.parseIdentity(data: identityData)
     let surfaceHeaders = Self.headers(userID: identity.userID)
+    let resetHeaders = Self.resetHeaders(userID: identity.userID)
     async let billingOutcome = captureAuthAwareSurface {
       try await client.get(
         provider: id, url: billingEndpoint, credential: credential, headers: surfaceHeaders)
@@ -46,15 +51,61 @@ public struct GrokProvider: UsageProvider {
       try await client.get(
         provider: id, url: creditsEndpoint, credential: credential, headers: surfaceHeaders)
     }
+    async let resetRequest = captureAuthAwareSurface {
+      try await client.post(
+        provider: id,
+        url: resetEndpoint,
+        body: GrokResetCodec.emptyUnaryRequest,
+        credential: credential,
+        headers: resetHeaders
+      )
+    }
     let billing = await billingOutcome
     let credits = await creditsOutcome
+    let resetOutcome = await resetRequest
     if case .unauthorized = billing { return try await restartFetch(excluding: credential) }
     if case .unauthorized = credits { return try await restartFetch(excluding: credential) }
-    return try Self.parse(
-      billing: billing.surfaceResult,
-      credits: credits.surfaceResult,
-      accountLabel: identity.accountLabel
-    )
+    switch try Self.decodeResetSurface(resetOutcome) {
+    case let .decoded(resets, errorMessage):
+      return try Self.parse(
+        billing: billing.surfaceResult,
+        credits: credits.surfaceResult,
+        resets: resets,
+        resetErrorMessage: errorMessage,
+        accountLabel: identity.accountLabel
+      )
+    case .unauthorized:
+      return try await restartFetch(excluding: credential)
+    }
+  }
+
+  private enum ResetSurface {
+    case decoded(resets: [Reset], errorMessage: String?)
+    case unauthorized
+  }
+
+  private static func decodeResetSurface(_ outcome: AuthAwareSurfaceOutcome) throws -> ResetSurface
+  {
+    switch outcome {
+    case let .success(data):
+      do {
+        return .decoded(resets: try parseResets(data: data), errorMessage: nil)
+      } catch QuotaError.unauthorized {
+        return .unauthorized
+      } catch QuotaError.malformedResponse {
+        throw QuotaError.malformedResponse(.grok)
+      } catch let error as QuotaError {
+        return .decoded(resets: [], errorMessage: error.localizedDescription)
+      }
+    case let .failure(message):
+      return .decoded(resets: [], errorMessage: message)
+    case .unauthorized:
+      return .unauthorized
+    }
+  }
+
+  public static func parseResets(data: Data, now: Date = .now) throws -> [Reset] {
+    try GrokResetCodec.parseTokens(from: data, now: now)
   }
 
   private func restartFetch(excluding credential: ProviderCredential) async throws -> UsageSnapshot
@@ -83,6 +134,12 @@ public struct GrokProvider: UsageProvider {
       }
       throw QuotaError.unsupportedResponse(.grok)
     }
+    // SuperGrok unified-credit accounts report a zero included monthly dollar limit. That is
+    // not a monthly quota window; spend lives on the credits surface instead.
+    if limit == 0 {
+      guard used.isFinite, used >= 0 else { throw QuotaValidationError.invalidPairedFields }
+      return []
+    }
     guard limit > 0, 0...limit ~= used else { throw QuotaValidationError.invalidPairedFields }
     return [
       try UsageWindow.validated(
@@ -99,6 +156,7 @@ public struct GrokProvider: UsageProvider {
   public static func parseCredits(data: Data, now: Date = .now) throws -> [UsageWindow] {
     let response = try ProviderDecoder.decode(GrokCredits.self, from: data, provider: .grok)
     var windows = try sharedCreditWindows(config: response.config, now: now)
+    let inheritedReset = response.config.currentPeriod?.end ?? response.config.billingPeriodEnd
     var productIDs: Set<String> = []
     for (name, metric) in response.config.productUsage.sorted(by: { $0.key < $1.key }) {
       let id = "grok-product-\(slug(name))"
@@ -111,7 +169,7 @@ public struct GrokProvider: UsageProvider {
           label: title(name),
           kind: .modelScoped(model: title(name)),
           usedPercent: try metric.calculatedPercentage(),
-          resetAt: metric.resetAt,
+          resetAt: metric.resetAt ?? inheritedReset,
           sourceTimestamp: now
         )
       )
@@ -123,7 +181,7 @@ public struct GrokProvider: UsageProvider {
           label: "Extra credits",
           kind: .credits,
           usedPercent: try extra.calculatedPercentage(),
-          resetAt: extra.resetAt,
+          resetAt: extra.resetAt ?? inheritedReset,
           sourceTimestamp: now
         )
       )
@@ -138,14 +196,14 @@ public struct GrokProvider: UsageProvider {
   ) throws -> [UsageWindow] {
     guard config.creditUsagePercent != nil || config.currentPeriod != nil else { return [] }
     let period = config.currentPeriod
-    let isWeekly = period?.kind == .weekly
+    let isWeekly = period?.kind.isWeekly == true
     return [
       try UsageWindow.validated(
         id: "grok-shared-credits",
         label: isWeekly ? "Weekly" : "Shared credits",
         kind: isWeekly ? .weekly : .credits,
         usedPercent: config.creditUsagePercent,
-        resetAt: period?.end,
+        resetAt: period?.end ?? config.billingPeriodEnd,
         sourceTimestamp: now
       )
     ]
@@ -154,6 +212,8 @@ public struct GrokProvider: UsageProvider {
   static func parse(
     billing: SurfaceResult,
     credits: SurfaceResult,
+    resets: [Reset] = [],
+    resetErrorMessage: String? = nil,
     accountLabel: String?,
     now: Date = .now
   ) throws -> UsageSnapshot {
@@ -174,6 +234,8 @@ public struct GrokProvider: UsageProvider {
       provider: .grok,
       accountLabel: accountLabel,
       windows: windows,
+      resets: resets.filter { $0.exp > now }.sorted { $0.exp < $1.exp },
+      resetErrorMessage: resetErrorMessage,
       notes: warnings,
       sourceTimestamp: now
     )
@@ -182,10 +244,17 @@ public struct GrokProvider: UsageProvider {
   private static func headers(userID: String? = nil) -> [String: String] {
     var headers = [
       "X-XAI-Token-Auth": "xai-grok-cli",
-      "x-grok-client-version": "3.12.0",
+      "x-grok-client-version": "1.0.13",
       "x-grok-client-mode": "headless",
+      "User-Agent": "grok-cli/1.0.13",
     ]
     if let userID { headers["x-userid"] = userID }
+    return headers
+  }
+
+  private static func resetHeaders(userID: String) -> [String: String] {
+    var headers = headers(userID: userID)
+    for (name, value) in GrokResetCodec.requestHeaders { headers[name] = value }
     return headers
   }
 }
@@ -232,12 +301,14 @@ private struct GrokCredits: Decodable {
 private struct GrokCreditsConfig: Decodable {
   let creditUsagePercent: Double?
   let currentPeriod: GrokPeriod?
+  let billingPeriodEnd: Date?
   let productUsage: [String: GrokMetric]
   let extraCredits: GrokMetric?
 
   enum CodingKeys: String, CodingKey {
     case creditUsagePercent
     case currentPeriod
+    case billingPeriodEnd
     case productUsage
     case productBreakdown
     case extraCredits
@@ -249,14 +320,15 @@ private struct GrokCreditsConfig: Decodable {
       ProviderDecoder.number(in: container, forKey: .creditUsagePercent)
     )
     self.currentPeriod = try container.decodeIfPresent(GrokPeriod.self, forKey: .currentPeriod)
+    self.billingPeriodEnd = try ProviderDecoder.date(in: container, forKey: .billingPeriodEnd)
     let productUsage = try container.decodeIfPresent(
-      [String: GrokMetric].self,
+      GrokProductUsageMap.self,
       forKey: .productUsage
-    )
+    )?.metrics
     let productBreakdown = try container.decodeIfPresent(
-      [String: GrokMetric].self,
+      GrokProductUsageMap.self,
       forKey: .productBreakdown
-    )
+    )?.metrics
     if let productUsage, let productBreakdown, productUsage != productBreakdown {
       throw QuotaValidationError.invalidPairedFields
     }
@@ -286,6 +358,49 @@ private struct GrokPeriod: Decodable {
 
 private enum GrokPeriodKind: String, Decodable {
   case weekly
+  case usagePeriodWeekly = "USAGE_PERIOD_TYPE_WEEKLY"
+
+  var isWeekly: Bool {
+    switch self {
+    case .weekly, .usagePeriodWeekly: true
+    }
+  }
+}
+
+private struct GrokProductUsageMap: Decodable {
+  let metrics: [String: GrokMetric]
+
+  init(from decoder: any Decoder) throws {
+    if var unkeyed = try? decoder.unkeyedContainer() {
+      var metrics: [String: GrokMetric] = [:]
+      while !unkeyed.isAtEnd {
+        let row = try unkeyed.decode(GrokProductUsageRow.self)
+        let name = row.product.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty, metrics[name] == nil else {
+          throw QuotaValidationError.emptyIdentifier
+        }
+        metrics[name] = row.metric
+      }
+      self.metrics = metrics
+      return
+    }
+    metrics = try decoder.singleValueContainer().decode([String: GrokMetric].self)
+  }
+}
+
+private struct GrokProductUsageRow: Decodable {
+  let product: String
+  let metric: GrokMetric
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    product = try container.decode(String.self, forKey: .product)
+    metric = try GrokMetric(from: decoder)
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case product
+  }
 }
 
 private struct GrokMetric: Decodable, Equatable {
@@ -300,6 +415,7 @@ private struct GrokMetric: Decodable, Equatable {
     case used
     case remaining
     case creditUsagePercent
+    case usagePercent
     case resetAt
   }
 
@@ -308,9 +424,12 @@ private struct GrokMetric: Decodable, Equatable {
     self.limit = try ProviderDecoder.number(in: container, forKey: .limit)
     self.used = try ProviderDecoder.number(in: container, forKey: .used)
     self.remaining = try ProviderDecoder.number(in: container, forKey: .remaining)
-    self.explicitPercentage = try ProviderDecoder.percentage(
-      ProviderDecoder.number(in: container, forKey: .creditUsagePercent)
-    )
+    let creditUsagePercent = try ProviderDecoder.number(in: container, forKey: .creditUsagePercent)
+    let usagePercent = try ProviderDecoder.number(in: container, forKey: .usagePercent)
+    if let creditUsagePercent, let usagePercent, abs(creditUsagePercent - usagePercent) > 0.01 {
+      throw QuotaValidationError.invalidPairedFields
+    }
+    self.explicitPercentage = try ProviderDecoder.percentage(creditUsagePercent ?? usagePercent)
     self.resetAt = try ProviderDecoder.date(in: container, forKey: .resetAt)
   }
 

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers/OpenRouterAPI.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers/OpenRouterAPI.swift
@@ -1,82 +1,5 @@
 public import Foundation
 
-public enum APIHTTPMethod: String, Equatable, Sendable {
-  case get = "GET"
-}
-
-public struct OpenRouterRequest: Equatable, Sendable, CustomStringConvertible {
-  public let method: APIHTTPMethod
-  public let url: URL
-  public let bearerToken: String
-  public let timeout: TimeInterval
-
-  public init(
-    method: APIHTTPMethod = .get,
-    url: URL,
-    bearerToken: String,
-    timeout: TimeInterval = 20
-  ) {
-    self.method = method
-    self.url = url
-    self.bearerToken = bearerToken
-    self.timeout = timeout
-  }
-
-  public var description: String {
-    "OpenRouterRequest(method: \(method.rawValue), url: \(url.absoluteString), bearerToken: <redacted>)"
-  }
-}
-
-public struct OpenRouterResponse: Equatable, Sendable {
-  public let statusCode: Int
-  public let data: Data
-
-  public init(statusCode: Int, data: Data) {
-    self.statusCode = statusCode
-    self.data = data
-  }
-}
-
-public protocol OpenRouterTransport: Sendable {
-  func send(_ request: OpenRouterRequest) async throws -> OpenRouterResponse
-}
-
-public final class URLSessionOpenRouterTransport: OpenRouterTransport, Sendable {
-  private let session: URLSession
-
-  public init(session: URLSession? = nil) {
-    if let session {
-      self.session = session
-    } else {
-      let configuration = URLSessionConfiguration.ephemeral
-      configuration.timeoutIntervalForRequest = 20
-      configuration.timeoutIntervalForResource = 30
-      self.session = URLSession(configuration: configuration)
-    }
-  }
-
-  public func send(_ request: OpenRouterRequest) async throws -> OpenRouterResponse {
-    var urlRequest = URLRequest(url: request.url, timeoutInterval: request.timeout)
-    urlRequest.httpMethod = request.method.rawValue
-    urlRequest.setValue("Bearer \(request.bearerToken)", forHTTPHeaderField: "Authorization")
-    urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-
-    do {
-      let (data, response) = try await session.data(for: urlRequest)
-      guard let response = response as? HTTPURLResponse else {
-        throw APIPlatformError.network
-      }
-      return OpenRouterResponse(statusCode: response.statusCode, data: data)
-    } catch let error as APIPlatformError {
-      throw error
-    } catch let error as URLError where error.code == .timedOut {
-      throw APIPlatformError.requestTimedOut
-    } catch {
-      throw APIPlatformError.network
-    }
-  }
-}
-
 public struct OpenRouterEndpoints: Sendable {
   public let baseURL: URL
 
@@ -134,12 +57,13 @@ public struct OpenRouterEndpoints: Sendable {
 }
 
 public struct OpenRouterAPIClient: Sendable {
-  private let transport: any OpenRouterTransport
+  public let id = APIPlatformID.openRouter
+  private let transport: any APIPlatformTransport
   private let endpoints: OpenRouterEndpoints
   private let pageSize = 100
 
   public init(
-    transport: any OpenRouterTransport = URLSessionOpenRouterTransport(),
+    transport: any APIPlatformTransport = URLSessionAPIPlatformTransport(),
     endpoints: OpenRouterEndpoints = OpenRouterEndpoints()
   ) {
     self.transport = transport
@@ -147,31 +71,24 @@ public struct OpenRouterAPIClient: Sendable {
   }
 
   public func fetchSnapshot(
-    managementKey: String,
+    token: String,
     now: Date = .now,
     timeZone: TimeZone = .autoupdatingCurrent
   ) async throws -> APIPlatformSnapshot {
-    let credits: CreditsEnvelope = try await get(path: endpoints.credits(), token: managementKey)
-    let workspaces = try await fetchAllWorkspaces(token: managementKey)
-    let keys = try await fetchAllKeys(workspaces: workspaces, token: managementKey)
+    let credits: CreditsEnvelope = try await get(path: endpoints.credits(), token: token)
+    let workspaces = try await fetchAllWorkspaces(token: token)
+    let keys = try await fetchAllKeys(workspaces: workspaces, token: token)
     let creditsRemaining = credits.data.totalCredits - credits.data.totalUsage
-    guard creditsRemaining >= 0 else { throw APIPlatformError.malformedResponse }
+    guard creditsRemaining >= 0 else { throw APIPlatformError.malformedResponse(id) }
 
     let monthlySpend = keys.reduce(Decimal.zero) { total, key in
       total + key.usageMonthly + key.byokUsageMonthly
     }
-    guard monthlySpend >= 0 else { throw APIPlatformError.malformedResponse }
-
-    var calendar = Calendar(identifier: .gregorian)
-    calendar.timeZone = timeZone
-    let elapsedDays = calendar.component(.day, from: now)
-    guard let range = calendar.range(of: .day, in: .month, for: now), elapsedDays > 0 else {
-      throw APIPlatformError.malformedResponse
-    }
-    let daysInMonth = range.count
-    let projectedSpend = monthlySpend / Decimal(elapsedDays) * Decimal(daysInMonth)
+    let projectedSpend = try APIPlatformProjection.projectedSpend(
+      platform: id, monthlySpend: monthlySpend, now: now, timeZone: timeZone)
 
     return APIPlatformSnapshot(
+      platform: id,
       workspaceNames: workspaces.map(\.name).sorted(),
       creditsRemaining: creditsRemaining,
       monthlySpend: monthlySpend,
@@ -186,7 +103,7 @@ public struct OpenRouterAPIClient: Sendable {
     while true {
       let page: WorkspacePage = try await get(
         path: endpoints.workspaces(offset: offset, limit: pageSize), token: token)
-      guard page.data.count <= pageSize else { throw APIPlatformError.malformedResponse }
+      guard page.data.count <= pageSize else { throw APIPlatformError.malformedResponse(id) }
       result.append(contentsOf: page.data)
       if result.count >= page.totalCount || page.data.isEmpty { return result }
       offset += page.data.count
@@ -200,7 +117,7 @@ public struct OpenRouterAPIClient: Sendable {
       while true {
         let page: APIKeyPage = try await get(
           path: endpoints.keys(workspaceID: workspace.id, offset: offset), token: token)
-        guard page.data.count <= pageSize else { throw APIPlatformError.malformedResponse }
+        guard page.data.count <= pageSize else { throw APIPlatformError.malformedResponse(id) }
         result.append(contentsOf: page.data)
         if page.data.isEmpty || page.data.count < pageSize { break }
         offset += page.data.count
@@ -211,26 +128,13 @@ public struct OpenRouterAPIClient: Sendable {
 
   private func get<Value: Decodable>(path: URL, token: String) async throws -> Value {
     let response = try await transport.send(
-      OpenRouterRequest(url: path, bearerToken: token)
+      APIPlatformRequest(
+        platform: id,
+        url: path,
+        headers: APIPlatformHTTP.bearerHeaders(token: token)
+      )
     )
-    switch response.statusCode {
-    case 200..<300:
-      do {
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return try decoder.decode(Value.self, from: response.data)
-      } catch {
-        throw APIPlatformError.malformedResponse
-      }
-    case 401:
-      throw APIPlatformError.unauthorized
-    case 403:
-      throw APIPlatformError.forbidden
-    case 429:
-      throw APIPlatformError.rateLimited
-    default:
-      throw APIPlatformError.network
-    }
+    return try APIPlatformHTTP.decode(Value.self, from: response, platform: id)
   }
 }
 

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers/ProviderDecoding.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers/ProviderDecoding.swift
@@ -106,8 +106,8 @@ func captureSurface(_ operation: @Sendable () async throws -> Data) async -> Sur
 }
 
 /// Like `SurfaceResult`, but distinguishes an unauthorized response so a caller pinning several
-/// requests to one credential (Codex's usage/reset surfaces, Grok's identity/billing/credits
-/// surfaces) can restart the whole batch instead of quietly degrading that one surface to a
+/// requests to one credential (Codex's usage/reset surfaces, Grok's identity/billing/credits/
+/// reset surfaces) can restart the whole batch instead of quietly degrading that one surface to a
 /// warning and leaving the published snapshot combining data from two different credentials.
 enum AuthAwareSurfaceOutcome: Sendable {
   case success(Data)

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers/ProviderEndpoints.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers/ProviderEndpoints.swift
@@ -9,6 +9,7 @@ public struct ProviderEndpoints: Sendable {
   public let grokUser: URL
   public let grokBilling: URL
   public let grokCredits: URL
+  public let grokResets: URL
 
   public init(
     claudeUsage: URL,
@@ -18,7 +19,8 @@ public struct ProviderEndpoints: Sendable {
     kimiUsage: URL,
     grokUser: URL,
     grokBilling: URL,
-    grokCredits: URL
+    grokCredits: URL,
+    grokResets: URL
   ) {
     self.claudeUsage = claudeUsage
     self.codexUsage = codexUsage
@@ -28,6 +30,7 @@ public struct ProviderEndpoints: Sendable {
     self.grokUser = grokUser
     self.grokBilling = grokBilling
     self.grokCredits = grokCredits
+    self.grokResets = grokResets
   }
 
   public static func live() throws -> ProviderEndpoints {
@@ -74,6 +77,10 @@ public struct ProviderEndpoints: Sendable {
       grokBilling: url("https://cli-chat-proxy.grok.com/v1/billing", provider: .grok),
       grokCredits: url(
         "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+        provider: .grok
+      ),
+      grokResets: url(
+        "https://grok.com/grok_api_v2.GrokBuildBilling/GetRemainingResets",
         provider: .grok
       )
     )

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers/Providers.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers/Providers.swift
@@ -36,7 +36,8 @@ public enum Providers {
           client: client,
           userEndpoint: endpoints.grokUser,
           billingEndpoint: endpoints.grokBilling,
-          creditsEndpoint: endpoints.grokCredits
+          creditsEndpoint: endpoints.grokCredits,
+          resetEndpoint: endpoints.grokResets
         )
       }
     }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/QuotaOverview.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/QuotaOverview.swift
@@ -198,7 +198,7 @@ public struct ProviderOverview: Identifiable, Equatable, Sendable {
         )
       )
     }
-    guard provider == .codex, snapshot.freshness == .current, let resetOverview else {
+    guard provider.tracksBankedResets, snapshot.freshness == .current, let resetOverview else {
       return badges
     }
     switch resetOverview {
@@ -217,7 +217,7 @@ public struct ProviderOverview: Identifiable, Equatable, Sendable {
     state: ProviderDisplayState,
     at date: Date
   ) -> ResetOverview? {
-    guard provider == .codex, case let .available(snapshot) = state else { return nil }
+    guard provider.tracksBankedResets, case let .available(snapshot) = state else { return nil }
     if let message = snapshot.resetErrorMessage { return .unavailable(message: message) }
     let resets = snapshot.activeResets(at: date)
     return resets.isEmpty ? ResetOverview.none : .available(resets)

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Settings.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Settings.swift
@@ -13,7 +13,7 @@ public protocol SettingsPersisting: Sendable {
 }
 
 public final class UserDefaultsSettingsStore: SettingsPersisting, @unchecked Sendable {
-  private static let standardProvidersVersion = 1
+  private static let standardProvidersVersion = 3
   private let defaults: UserDefaults
 
   public init(defaults: UserDefaults = .standard) {
@@ -31,8 +31,16 @@ public final class UserDefaultsSettingsStore: SettingsPersisting, @unchecked Sen
       providers.insert(provider)
     }
     let storedVersion = defaults.integer(forKey: "standardProvidersVersion")
-    if storedVersion < Self.standardProvidersVersion {
+    if storedVersion < 1 {
       providers.formUnion([.antigravity, .cursor])
+    }
+    if storedVersion < 2 {
+      providers.insert(.grok)
+    }
+    if storedVersion < 3 {
+      providers.insert(.kimi)
+    }
+    if storedVersion < Self.standardProvidersVersion {
       defaults.set(providers.map(\.rawValue).sorted(), forKey: "enabledProviders")
       defaults.set(Self.standardProvidersVersion, forKey: "standardProvidersVersion")
     }

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/CredentialTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/CredentialTests.swift
@@ -172,16 +172,15 @@ final class CredentialTests: XCTestCase {
     )
   }
 
-  func testReloadAdvancesAcrossOpenCodeStores() throws {
+  func testReloadAdvancesAcrossGrokCLISessions() throws {
     let root = try temporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }
     try write(
-      #"{"xai":{"access":"first-current-token","expires":9999999999999}}"#,
-      to: root.appendingPathComponent(".local/share/opencode/auth.json")
-    )
-    try write(
-      #"{"grok":{"access":"fallback-token","expires":9999999999999}}"#,
-      to: root.appendingPathComponent(".config/opencode/auth.json")
+      grokCLIAuth(
+        firstToken: "first-current-token",
+        secondToken: "fallback-token"
+      ),
+      to: root.appendingPathComponent(".grok/auth.json")
     )
     let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
 
@@ -197,12 +196,11 @@ final class CredentialTests: XCTestCase {
     let root = try temporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }
     try write(
-      #"{"xai":{"access":"rejected-token","expires":9999999999999}}"#,
-      to: root.appendingPathComponent(".local/share/opencode/auth.json")
-    )
-    try write(
-      #"{"grok":{"access":"accepted-token","expires":9999999999999}}"#,
-      to: root.appendingPathComponent(".config/opencode/auth.json")
+      grokCLIAuth(
+        firstToken: "rejected-token",
+        secondToken: "accepted-token"
+      ),
+      to: root.appendingPathComponent(".grok/auth.json")
     )
     let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
     let firstRequest = try store.credential(for: .grok, rejecting: nil)
@@ -226,12 +224,11 @@ final class CredentialTests: XCTestCase {
     let root = try temporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }
     try write(
-      #"{"xai":{"access":"rejected-token","expires":9999999999999}}"#,
-      to: root.appendingPathComponent(".local/share/opencode/auth.json")
-    )
-    try write(
-      #"{"grok":{"access":"accepted-token","expires":9999999999999}}"#,
-      to: root.appendingPathComponent(".config/opencode/auth.json")
+      grokCLIAuth(
+        firstToken: "rejected-token",
+        secondToken: "accepted-token"
+      ),
+      to: root.appendingPathComponent(".grok/auth.json")
     )
     let transport = StubTransport([
       .success(ProviderResponse(statusCode: 401, data: Data())),
@@ -257,24 +254,24 @@ final class CredentialTests: XCTestCase {
     let database = root.appendingPathComponent(".local/share/opencode/opencode.db")
     try createOpenCodeDatabase(
       at: database,
-      label: "xai",
+      label: "kimi-for-coding-oauth",
       value: #"{"access":"database-token","expires":9999999999999}"#
     )
     let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
 
-    let credential = try store.credential(for: .grok, rejecting: nil)
+    let credential = try store.credential(for: .kimi, rejecting: nil)
 
     XCTAssertEqual(credential.accessToken, "database-token")
   }
 
-  func testOpenCodeKimiAndGrokFilesRemainUnchanged() throws {
+  func testOpenCodeKimiFileRemainsUnchanged() throws {
     let root = try temporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }
     let authURL = root.appendingPathComponent(".local/share/opencode/auth.json")
     let kimiEntry =
-      #"{"kimi-for-coding-oauth":{"access":"kimi-opencode","refresh":"never-write","expires":9999999999999},"#
-    let grokEntry = #""xai":{"access":"grok-opencode","expires":9999999999999}}"#
-    let original = Data((kimiEntry + grokEntry).utf8)
+      #"{"kimi-for-coding-oauth":{"access":"kimi-token","refresh":"never-write","expires":9999999999999},"#
+    let ignoredGrokEntry = #""xai":{"access":"ignored","expires":9999999999999}}"#
+    let original = Data((kimiEntry + ignoredGrokEntry).utf8)
     try FileManager.default.createDirectory(
       at: authURL.deletingLastPathComponent(),
       withIntermediateDirectories: true
@@ -282,43 +279,30 @@ final class CredentialTests: XCTestCase {
     try original.write(to: authURL)
     let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
     let kimi = try store.credential(for: .kimi, rejecting: nil)
-    let grok = try store.credential(for: .grok, rejecting: nil)
-    XCTAssertEqual(kimi.accessToken, "kimi-opencode")
-    XCTAssertEqual(grok.accessToken, "grok-opencode")
-    XCTAssertEqual(try Data(contentsOf: authURL), original)
-  }
-
-  func testExpiredOpenCodeCredentialRequiresOpenCodeRefresh() throws {
-    let root = try temporaryDirectory()
-    defer { try? FileManager.default.removeItem(at: root) }
-    try write(
-      #"{"xai":{"access":"expired-grok","expires":1}}"#,
-      to: root.appendingPathComponent(".config/opencode/auth.json")
-    )
-    let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
+    XCTAssertEqual(kimi.accessToken, "kimi-token")
     do {
       _ = try store.credential(for: .grok, rejecting: nil)
-      XCTFail("Expected expiry")
+      XCTFail("Expected Grok to ignore OpenCode tokens")
     } catch {
-      XCTAssertEqual(error as? QuotaError, .credentialsExpired(.grok))
-      XCTAssertTrue(error.localizedDescription.contains("OpenCode"))
+      XCTAssertEqual(error as? QuotaError, .credentialsMissing(.grok))
     }
+    XCTAssertEqual(try Data(contentsOf: authURL), original)
   }
 
   func testExpiredOpenCodeCandidateDoesNotMaskLaterCurrentCredential() throws {
     let root = try temporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }
     try write(
-      #"{"xai":{"access":"expired-first-token","expires":1}}"#,
+      #"{"kimi-for-coding-oauth":{"access":"expired-first-token","expires":1}}"#,
       to: root.appendingPathComponent(".local/share/opencode/auth.json")
     )
     try write(
-      #"{"grok":{"access":"current-later-token","expires":9999999999999}}"#,
+      #"{"kimi":{"access":"current-later-token","expires":9999999999999}}"#,
       to: root.appendingPathComponent(".config/opencode/auth.json")
     )
     let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
 
-    let credential = try store.credential(for: .grok, rejecting: nil)
+    let credential = try store.credential(for: .kimi, rejecting: nil)
 
     XCTAssertEqual(credential.accessToken, "current-later-token")
   }
@@ -328,17 +312,17 @@ final class CredentialTests: XCTestCase {
     defer { try? FileManager.default.removeItem(at: root) }
     try createOpenCodeDatabase(
       at: root.appendingPathComponent(".local/share/opencode/opencode.db"),
-      label: "xai",
+      label: "kimi-for-coding-oauth",
       value: #"{"access":"expired-database-token","expires":1}"#
     )
     try createOpenCodeDatabase(
       at: root.appendingPathComponent("Library/Application Support/opencode/opencode.db"),
-      label: "grok",
+      label: "kimi",
       value: #"{"access":"current-database-token","expires":9999999999999}"#
     )
     let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
 
-    let credential = try store.credential(for: .grok, rejecting: nil)
+    let credential = try store.credential(for: .kimi, rejecting: nil)
 
     XCTAssertEqual(credential.accessToken, "current-database-token")
   }

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/DomainTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/DomainTests.swift
@@ -149,9 +149,12 @@ final class DomainTests: XCTestCase {
   }
 
   func testSubscriptionPlansAndProviderMetadata() {
-    XCTAssertEqual(SubscriptionPlan.totalMonthlyCostUSD(), 440)
+    XCTAssertEqual(SubscriptionPlan.totalMonthlyCostUSD(), 510)
     XCTAssertEqual(SubscriptionPlan.totalMonthlyCostUSD(includingLegacy: true), 510)
-    XCTAssertEqual(SubscriptionPlan.standard.count, 4)
+    XCTAssertEqual(SubscriptionPlan.standard.count, 6)
+    XCTAssertTrue(SubscriptionPlan.legacy.isEmpty)
+    XCTAssertTrue(ProviderID.legacy.isEmpty)
+    XCTAssertEqual(ProviderID.standard, Set(ProviderID.allCases))
     XCTAssertEqual(SubscriptionPlan.plan(for: .claudeCode).monthlyCostUSD, 200)
     XCTAssertEqual(SubscriptionPlan.plan(for: .codex).monthlyCostUSD, 200)
     XCTAssertEqual(SubscriptionPlan.plan(for: .antigravity).monthlyCostUSD, 20)
@@ -164,10 +167,13 @@ final class DomainTests: XCTestCase {
     )
     XCTAssertEqual(
       ProviderID.allCases,
-      [.claudeCode, .codex, .antigravity, .cursor, .kimi, .grok]
+      [.claudeCode, .codex, .antigravity, .cursor, .grok, .kimi]
     )
     XCTAssertFalse(ProviderID.antigravity.supportsManualCredentialOverride)
     XCTAssertFalse(ProviderID.cursor.supportsManualCredentialOverride)
+    XCTAssertTrue(ProviderID.codex.tracksBankedResets)
+    XCTAssertTrue(ProviderID.grok.tracksBankedResets)
+    XCTAssertFalse(ProviderID.claudeCode.tracksBankedResets)
     for provider in ProviderID.allCases {
       XCTAssertFalse(provider.displayName.isEmpty)
       XCTAssertNotNil(provider.usageURL)
@@ -180,7 +186,9 @@ final class DomainTests: XCTestCase {
     XCTAssertTrue(QuotaError.unauthorized(.codex).isAuthenticationError)
     XCTAssertFalse(QuotaError.rateLimited(.codex).isAuthenticationError)
     XCTAssertTrue(QuotaError.credentialsExpired(.kimi).localizedDescription.contains("OpenCode"))
-    XCTAssertTrue(QuotaError.unauthorized(.grok).localizedDescription.contains("OpenCode"))
+    XCTAssertTrue(QuotaError.credentialsExpired(.grok).localizedDescription.contains("grok login"))
+    XCTAssertTrue(QuotaError.unauthorized(.grok).localizedDescription.contains("grok"))
+    XCTAssertFalse(QuotaError.unauthorized(.grok).localizedDescription.contains("OpenCode"))
     XCTAssertFalse(QuotaError.network(.grok).localizedDescription.isEmpty)
   }
 

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/anthropic-cost-report-eur.json
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/anthropic-cost-report-eur.json
@@ -1,0 +1,11 @@
+{
+  "data": [
+    {
+      "starting_at": "2026-09-01T00:00:00Z",
+      "ending_at": "2026-09-02T00:00:00Z",
+      "results": [{ "amount": "350.00", "currency": "EUR" }]
+    }
+  ],
+  "has_more": false,
+  "next_page": null
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/anthropic-cost-report.json
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/anthropic-cost-report.json
@@ -1,0 +1,16 @@
+{
+  "data": [
+    {
+      "starting_at": "2026-09-01T00:00:00Z",
+      "ending_at": "2026-09-02T00:00:00Z",
+      "results": [{ "amount": "350.00", "currency": "USD" }]
+    },
+    {
+      "starting_at": "2026-09-02T00:00:00Z",
+      "ending_at": "2026-09-03T00:00:00Z",
+      "results": [{ "amount": "500.00", "currency": "USD" }]
+    }
+  ],
+  "has_more": false,
+  "next_page": null
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/claude-success.json
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/claude-success.json
@@ -24,5 +24,10 @@
     "percent": 0,
     "enabled": false
   },
-  "member_dashboard_available": false
+  "member_dashboard_available": false,
+  "seven_day_breakdown": {
+    "as_of": "2026-08-09T00:00:00Z",
+    "window_started_at": "2026-08-07T00:00:00Z",
+    "rows": []
+  }
 }

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/grok-billing-zero-limit.json
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/grok-billing-zero-limit.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "monthlyLimit": { "val": 0 },
+    "used": { "val": 36 },
+    "billingPeriodEnd": "2026-10-01T00:00:00Z"
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/grok-credits-unified.json
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/grok-credits-unified.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "creditUsagePercent": 9,
+    "currentPeriod": {
+      "type": "USAGE_PERIOD_TYPE_WEEKLY",
+      "start": "2026-09-06T21:23:49.187637+00:00",
+      "end": "2026-09-13T21:23:49.187637+00:00"
+    },
+    "productUsage": [
+      {
+        "product": "chat",
+        "usagePercent": 9
+      }
+    ]
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openai-costs-eur.json
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openai-costs-eur.json
@@ -1,0 +1,12 @@
+{
+  "object": "page",
+  "data": [
+    {
+      "start_time": 1756684800,
+      "end_time": 1756771200,
+      "results": [{ "amount": { "value": 4.25, "currency": "eur" } }]
+    }
+  ],
+  "has_more": false,
+  "next_page": null
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openai-costs.json
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openai-costs.json
@@ -1,0 +1,17 @@
+{
+  "object": "page",
+  "data": [
+    {
+      "start_time": 1756684800,
+      "end_time": 1756771200,
+      "results": [{ "amount": { "value": 4.25, "currency": "usd" } }]
+    },
+    {
+      "start_time": 1756771200,
+      "end_time": 1756857600,
+      "results": [{ "amount": { "value": 8.25, "currency": "usd" } }]
+    }
+  ],
+  "has_more": false,
+  "next_page": null
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/GrokDiscoveryTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/GrokDiscoveryTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import XCTest
+
+@testable import QuotaBarCore
+
+final class GrokDiscoveryTests: XCTestCase {
+  func testGrokCLICredentialIsUsedWhenOpenCodeAlsoHasAToken() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    try write(
+      grokCLIAuth(token: "grok-cli-token", expiresAt: "2099-01-01T00:00:00Z"),
+      to: root.appendingPathComponent(".grok/auth.json")
+    )
+    try write(
+      #"{"xai":{"access":"opencode-token","expires":9999999999999}}"#,
+      to: root.appendingPathComponent(".local/share/opencode/auth.json")
+    )
+    let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
+    let credential = try store.credential(for: .grok, rejecting: nil)
+    XCTAssertEqual(credential.accessToken, "grok-cli-token")
+  }
+
+  func testOpenCodeGrokTokenIsIgnoredWhenGrokCLIIsMissing() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    try write(
+      #"{"xai":{"access":"opencode-token","expires":9999999999999}}"#,
+      to: root.appendingPathComponent(".local/share/opencode/auth.json")
+    )
+    let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
+    do {
+      _ = try store.credential(for: .grok, rejecting: nil)
+      XCTFail("Expected missing credentials when only OpenCode Grok tokens exist")
+    } catch {
+      XCTAssertEqual(error as? QuotaError, .credentialsMissing(.grok))
+    }
+  }
+
+  func testExpiredGrokCLICredentialDoesNotFallBackToOpenCode() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    try write(
+      grokCLIAuth(token: "expired-cli-token", expiresAt: "1970-01-01T00:00:01Z"),
+      to: root.appendingPathComponent(".grok/auth.json")
+    )
+    try write(
+      #"{"xai":{"access":"fresh-opencode-token","expires":9999999999999}}"#,
+      to: root.appendingPathComponent(".local/share/opencode/auth.json")
+    )
+    let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
+    do {
+      _ = try store.credential(for: .grok, rejecting: nil)
+      XCTFail("Expected expiry from grok CLI, not an OpenCode fallback")
+    } catch {
+      XCTAssertEqual(error as? QuotaError, .credentialsExpired(.grok))
+      XCTAssertTrue(error.localizedDescription.contains("grok login"))
+    }
+  }
+
+  func testExpiredGrokCLISessionDoesNotMaskLaterCurrentSession() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let auth = """
+      {
+        "https://auth.x.ai::aaa": {
+          "key": "expired-first-token",
+          "expires_at": "1970-01-01T00:00:01Z"
+        },
+        "https://auth.x.ai::bbb": {
+          "key": "current-later-token",
+          "expires_at": "2099-01-01T00:00:00Z"
+        }
+      }
+      """
+    try write(auth, to: root.appendingPathComponent(".grok/auth.json"))
+    let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
+    let credential = try store.credential(for: .grok, rejecting: nil)
+    XCTAssertEqual(credential.accessToken, "current-later-token")
+  }
+
+  func testGrokCLIAuthFileRemainsUnchanged() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let authURL = root.appendingPathComponent(".grok/auth.json")
+    let original = Data(
+      grokCLIAuth(token: "grok-cli-token", expiresAt: "2099-01-01T00:00:00.544286Z").utf8)
+    try FileManager.default.createDirectory(
+      at: authURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try original.write(to: authURL)
+    let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
+    let credential = try store.credential(for: .grok, rejecting: nil)
+    XCTAssertEqual(credential.accessToken, "grok-cli-token")
+    XCTAssertEqual(try Data(contentsOf: authURL), original)
+  }
+
+  func testGrokHomeRelocation() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let relocated = root.appendingPathComponent("custom-grok")
+    try write(
+      grokCLIAuth(token: "relocated-cli-token", expiresAt: "2099-01-01T00:00:00Z"),
+      to: relocated.appendingPathComponent("auth.json")
+    )
+    try write(
+      grokCLIAuth(token: "default-home-token", expiresAt: "2099-01-01T00:00:00Z"),
+      to: root.appendingPathComponent(".grok/auth.json")
+    )
+    let store = LocalCredentialStore(
+      homeDirectory: root,
+      grokHome: relocated,
+      claudeKeychain: FakeKeychain()
+    )
+    let credential = try store.credential(for: .grok, rejecting: nil)
+    XCTAssertEqual(credential.accessToken, "relocated-cli-token")
+  }
+
+  func testMalformedGrokCLIAuthPropagates() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    try write("truncated { not valid json", to: root.appendingPathComponent(".grok/auth.json"))
+    let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
+    do {
+      _ = try store.credential(for: .grok, rejecting: nil)
+      XCTFail("Expected malformedResponse for a corrupted grok CLI auth file")
+    } catch {
+      XCTAssertEqual(error as? QuotaError, .malformedResponse(.grok))
+    }
+  }
+
+  func testRejectedGrokCLICredentialDoesNotFallBackToOpenCode() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    try write(
+      grokCLIAuth(token: "cli-token", expiresAt: "2099-01-01T00:00:00Z"),
+      to: root.appendingPathComponent(".grok/auth.json")
+    )
+    try write(
+      #"{"xai":{"access":"opencode-token","expires":9999999999999}}"#,
+      to: root.appendingPathComponent(".local/share/opencode/auth.json")
+    )
+    let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
+    let first = try store.credential(for: .grok, rejecting: nil)
+    XCTAssertEqual(first.accessToken, "cli-token")
+    do {
+      _ = try store.credential(for: .grok, rejecting: first)
+      XCTFail("Expected missing credentials rather than an OpenCode fallback")
+    } catch {
+      XCTAssertEqual(error as? QuotaError, .credentialsMissing(.grok))
+    }
+  }
+
+  func testRejectedGrokCLISessionAdvancesToLaterCurrentSession() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    try write(
+      """
+      {
+        "https://auth.x.ai::aaa": {
+          "key": "first-current-token",
+          "expires_at": "2099-01-01T00:00:00Z"
+        },
+        "https://auth.x.ai::bbb": {
+          "key": "fallback-token",
+          "expires_at": "2099-01-01T00:00:00Z"
+        }
+      }
+      """,
+      to: root.appendingPathComponent(".grok/auth.json")
+    )
+    let store = LocalCredentialStore(homeDirectory: root, claudeKeychain: FakeKeychain())
+    let first = try store.credential(for: .grok, rejecting: nil)
+    XCTAssertEqual(first.accessToken, "first-current-token")
+    XCTAssertEqual(
+      try store.credential(for: .grok, rejecting: first).accessToken,
+      "fallback-token"
+    )
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/GrokNetworkingTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/GrokNetworkingTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import XCTest
+
+@testable import QuotaBarCore
+
+final class GrokNetworkingTests: XCTestCase {
+  func testGrokUnauthorizedSurfaceRestartsCompleteFetchOnOneCredential() async throws {
+    let endpoints = try ProviderEndpoints.live(environment: [:])
+    let transport = TokenRoutingTransport(routes: [
+      endpoints.grokUser.absoluteString: (
+        rejectedToken: nil,
+        response: .success(ProviderResponse(statusCode: 200, data: fixture("grok-user")))
+      ),
+      endpoints.grokBilling.absoluteString: (
+        rejectedToken: "token-a",
+        response: .success(ProviderResponse(statusCode: 200, data: fixture("grok-billing")))
+      ),
+      endpoints.grokCredits.absoluteString: (
+        rejectedToken: "token-a",
+        response: .success(ProviderResponse(statusCode: 200, data: fixture("grok-credits")))
+      ),
+      endpoints.grokResets.absoluteString: (
+        rejectedToken: "token-a",
+        response: .success(ProviderResponse(statusCode: 200, data: grokEmptyResets))
+      ),
+    ])
+    let client = ProviderHTTPClient(
+      transport: transport,
+      credentials: StubCredentialStore(tokens: ["token-a", "token-b"])
+    )
+
+    let grok = try await GrokProvider(
+      client: client,
+      userEndpoint: endpoints.grokUser,
+      billingEndpoint: endpoints.grokBilling,
+      creditsEndpoint: endpoints.grokCredits,
+      resetEndpoint: endpoints.grokResets
+    ).fetch()
+
+    XCTAssertTrue(grok.windows.map(\.label).contains("Monthly"))
+    let requests = await transport.requests
+    XCTAssertEqual(
+      requests.filter { $0.url == endpoints.grokUser }.map(\.bearerToken),
+      ["token-a", "token-b"]
+    )
+    XCTAssertEqual(
+      requests.filter { $0.url == endpoints.grokBilling }.map(\.bearerToken),
+      ["token-a", "token-b"]
+    )
+    XCTAssertEqual(
+      requests.filter { $0.url == endpoints.grokCredits }.map(\.bearerToken),
+      ["token-a", "token-b"]
+    )
+    XCTAssertEqual(
+      requests.filter { $0.url == endpoints.grokResets }.map(\.bearerToken),
+      ["token-a", "token-b"]
+    )
+  }
+
+  func testGrokPropagatesMalformedResetShapeInsteadOfMaskingIt() async throws {
+    let endpoints = try ProviderEndpoints.live(environment: [:])
+    let transport = RoutingTransport(routes: [
+      endpoints.grokUser.absoluteString: .success(
+        ProviderResponse(statusCode: 200, data: fixture("grok-user"))
+      ),
+      endpoints.grokBilling.absoluteString: .success(
+        ProviderResponse(statusCode: 200, data: fixture("grok-billing"))
+      ),
+      endpoints.grokCredits.absoluteString: .success(
+        ProviderResponse(statusCode: 200, data: fixture("grok-credits"))
+      ),
+      endpoints.grokResets.absoluteString: .success(
+        ProviderResponse(statusCode: 200, data: Data("not-grpc-web".utf8))
+      ),
+    ])
+    let provider = GrokProvider(
+      client: ProviderHTTPClient(
+        transport: transport,
+        credentials: StubCredentialStore(tokens: ["token"])
+      ),
+      userEndpoint: endpoints.grokUser,
+      billingEndpoint: endpoints.grokBilling,
+      creditsEndpoint: endpoints.grokCredits,
+      resetEndpoint: endpoints.grokResets
+    )
+
+    do {
+      _ = try await provider.fetch()
+      XCTFail("Expected malformedResponse for an unrecognized reset frame")
+    } catch {
+      XCTAssertEqual(error as? QuotaError, .malformedResponse(.grok))
+    }
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/GrokParsingTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/GrokParsingTests.swift
@@ -1,0 +1,231 @@
+import Foundation
+import XCTest
+
+@testable import QuotaBarCore
+
+final class GrokParsingTests: XCTestCase {
+  private let now = date("2026-08-09T00:00:00Z")
+
+  func testGrokSurfacesDecodeIndependently() throws {
+    let identity = try GrokProvider.parseIdentity(data: fixture("grok-user"))
+    XCTAssertEqual(identity.userID, "user_quotabar_fixture")
+    XCTAssertEqual(identity.accountLabel, "fixture@example.com")
+    XCTAssertEqual(
+      try GrokProvider.parseBilling(data: fixture("grok-billing"), now: now).first?
+        .remainingPercent, 65)
+    let credits = try GrokProvider.parseCredits(data: fixture("grok-credits"), now: now)
+    XCTAssertEqual(credits.map(\.remainingPercent), [58, 82, 55, 90])
+    XCTAssertEqual(
+      credits.map(\.resetAt),
+      [
+        date("2026-08-16T00:00:00Z"),
+        date("2026-08-16T00:00:00Z"),
+        date("2026-08-16T00:00:00Z"),
+        date("2026-08-16T00:00:00Z"),
+      ]
+    )
+  }
+
+  func testGrokProductResetAtWinsOverSharedPeriodEnd() throws {
+    let credits = try GrokProvider.parseCredits(
+      data: Data(
+        #"""
+        {
+          "config": {
+            "currentPeriod": {"type": "weekly", "end": "2026-08-16T00:00:00Z"},
+            "productUsage": {
+              "chat": {"creditUsagePercent": 20, "resetAt": "2026-08-20T00:00:00Z"}
+            }
+          }
+        }
+        """#.utf8
+      ),
+      now: now
+    )
+    XCTAssertEqual(credits.map(\.id), ["grok-shared-credits", "grok-product-chat"])
+    XCTAssertEqual(
+      credits.map(\.resetAt),
+      [date("2026-08-16T00:00:00Z"), date("2026-08-20T00:00:00Z")]
+    )
+  }
+
+  func testGrokProductAliasesMustBeUnambiguous() throws {
+    let identicalAliases = try GrokProvider.parseCredits(
+      data: Data(
+        #"""
+        {
+          "config": {
+            "productUsage": {"chat": {"creditUsagePercent": 20}},
+            "productBreakdown": {"chat": {"creditUsagePercent": 20}}
+          }
+        }
+        """#.utf8
+      ),
+      now: now
+    )
+    XCTAssertEqual(identicalAliases.first?.remainingPercent, 80)
+
+    XCTAssertThrowsError(
+      try GrokProvider.parseCredits(
+        data: Data(
+          #"""
+          {
+            "config": {
+              "productUsage": {},
+              "productBreakdown": {"chat": {"creditUsagePercent": 20}}
+            }
+          }
+          """#.utf8
+        ),
+        now: now
+      )
+    )
+    XCTAssertThrowsError(
+      try GrokProvider.parseCredits(
+        data: Data(
+          #"{"config":{"productUsage":{"grok-3":{"creditUsagePercent":20},"grok_3":{"creditUsagePercent":30}}}}"#
+            .utf8
+        ),
+        now: now
+      )
+    )
+  }
+
+  func testGrokUnknownUsageIsNotZeroAndPartialDataSurvives() throws {
+    let unknown = try GrokProvider.parseCredits(data: fixture("grok-credits-unknown"), now: now)
+    XCTAssertNil(unknown.first?.usedPercent)
+    let snapshot = try GrokProvider.parse(
+      billing: .success(fixture("grok-billing")),
+      credits: .failure("offline"),
+      accountLabel: "fixture@example.com",
+      now: now
+    )
+    XCTAssertEqual(snapshot.windows.count, 1)
+    XCTAssertTrue(snapshot.notes.first?.contains("offline") == true)
+  }
+
+  func testGrokUnifiedCreditBillingHasNoMonthlyDollarWindow() throws {
+    XCTAssertEqual(
+      try GrokProvider.parseBilling(data: fixture("grok-billing-zero-limit"), now: now),
+      []
+    )
+    let credits = try GrokProvider.parseCredits(data: fixture("grok-credits-unified"), now: now)
+    XCTAssertEqual(credits.map(\.id), ["grok-shared-credits", "grok-product-chat"])
+    XCTAssertEqual(credits.map(\.kind), [.weekly, .modelScoped(model: "Chat")])
+    XCTAssertEqual(credits.map(\.remainingPercent), [91, 91])
+    XCTAssertEqual(Set(credits.compactMap(\.resetAt)).count, 1)
+    XCTAssertNotNil(credits[0].resetAt)
+    let snapshot = try GrokProvider.parse(
+      billing: .success(fixture("grok-billing-zero-limit")),
+      credits: .success(fixture("grok-credits-unified")),
+      accountLabel: "fixture@example.com",
+      now: now
+    )
+    XCTAssertEqual(snapshot.windows.map(\.id), ["grok-shared-credits", "grok-product-chat"])
+    XCTAssertEqual(snapshot.notes, [])
+  }
+
+  func testGrokRemainingResetsDecodeGrpcWebTokens() throws {
+    XCTAssertEqual(
+      try GrokProvider.parseResets(data: grokEmptyResets, now: now),
+      []
+    )
+    let resets = try GrokProvider.parseResets(data: grokAvailableResets, now: now)
+    XCTAssertEqual(
+      resets.map(\.exp),
+      [date("2026-08-15T00:00:00Z"), date("2026-08-20T00:00:00Z")]
+    )
+    let snapshot = try GrokProvider.parse(
+      billing: .success(fixture("grok-billing-zero-limit")),
+      credits: .success(fixture("grok-credits-unified")),
+      resets: resets,
+      accountLabel: "fixture@example.com",
+      now: now
+    )
+    XCTAssertEqual(snapshot.resets, resets)
+    XCTAssertNil(snapshot.resetErrorMessage)
+  }
+
+  func testGrokRemainingResetsRejectMalformedFramesAndMapRpcFailures() {
+    XCTAssertThrowsError(
+      try GrokProvider.parseResets(data: Data("not-grpc".utf8), now: now)
+    ) { error in
+      XCTAssertEqual(error as? QuotaError, .malformedResponse(.grok))
+    }
+    XCTAssertThrowsError(
+      try GrokProvider.parseResets(
+        data: data(hex: "00000000008000000010677270632d7374617475733a31330d0a"),
+        now: now
+      )
+    ) { error in
+      XCTAssertEqual(error as? QuotaError, .network(.grok))
+    }
+    XCTAssertThrowsError(
+      try GrokProvider.parseResets(
+        data: data(hex: "00000000008000000010677270632d7374617475733a31360d0a"),
+        now: now
+      )
+    ) { error in
+      XCTAssertEqual(error as? QuotaError, .unauthorized(.grok))
+    }
+  }
+
+  func testGrokRejectsInvalidSurfaceShapes() {
+    XCTAssertThrowsError(
+      try GrokProvider.parseBilling(data: fixture("grok-invalid-monthly"), now: now))
+    XCTAssertThrowsError(
+      try GrokProvider.parseCredits(data: Data(#"{"config":{}}"#.utf8), now: now))
+    XCTAssertThrowsError(try GrokProvider.parseIdentity(data: Data(#"{"userId":""}"#.utf8)))
+    XCTAssertThrowsError(
+      try GrokProvider.parse(
+        billing: .failure("offline"),
+        credits: .failure("offline"),
+        accountLabel: nil,
+        now: now
+      )
+    )
+    XCTAssertThrowsError(
+      try GrokProvider.parse(
+        billing: .success(fixture("grok-invalid-monthly")),
+        credits: .success(fixture("grok-credits")),
+        accountLabel: nil,
+        now: now
+      )
+    )
+    XCTAssertThrowsError(
+      try GrokProvider.parse(
+        billing: .success(fixture("grok-billing")),
+        credits: .success(Data(#"{"config":{}}"#.utf8)),
+        accountLabel: nil,
+        now: now
+      )
+    )
+    XCTAssertThrowsError(
+      try GrokProvider.parseCredits(
+        data: Data(
+          #"{"config":{"productUsage":{"chat":{"limit":100,"used":20,"remaining":10}}}}"#
+            .utf8
+        ),
+        now: now
+      )
+    )
+    XCTAssertThrowsError(
+      try GrokProvider.parseCredits(
+        data: Data(
+          #"{"config":{"productUsage":{"chat":{"limit":100,"used":20,"creditUsagePercent":30}}}}"#
+            .utf8
+        ),
+        now: now
+      )
+    )
+    XCTAssertThrowsError(
+      try GrokProvider.parseCredits(
+        data: Data(
+          #"{"config":{"creditUsagePercent":20,"currentPeriod":{"type":"biweekly","end":"2026-08-16T00:00:00Z"}}}"#
+            .utf8
+        ),
+        now: now
+      )
+    )
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/NetworkingTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/NetworkingTests.swift
@@ -140,6 +140,8 @@ final class NetworkingTests: XCTestCase {
       ),
       endpoints.grokCredits.absoluteString: .success(
         ProviderResponse(statusCode: 500, data: Data())),
+      endpoints.grokResets.absoluteString: .success(
+        ProviderResponse(statusCode: 429, data: Data())),
     ])
     let client = ProviderHTTPClient(
       transport: transport,
@@ -158,60 +160,23 @@ final class NetworkingTests: XCTestCase {
       client: client,
       userEndpoint: endpoints.grokUser,
       billingEndpoint: endpoints.grokBilling,
-      creditsEndpoint: endpoints.grokCredits
+      creditsEndpoint: endpoints.grokCredits,
+      resetEndpoint: endpoints.grokResets
     ).fetch()
     XCTAssertEqual(grok.windows.map(\.label), ["Monthly"])
     XCTAssertFalse(grok.notes.isEmpty)
+    XCTAssertNotNil(grok.resetErrorMessage)
     let requests = await transport.requests
-    XCTAssertEqual(requests.filter { $0.provider == .grok }.count, 3)
+    XCTAssertEqual(requests.filter { $0.provider == .grok }.count, 4)
     XCTAssertTrue(requests.contains { $0.headers["x-userid"] == "user_quotabar_fixture" })
-  }
-
-  func testGrokUnauthorizedSurfaceRestartsCompleteFetchOnOneCredential() async throws {
-    let endpoints = try ProviderEndpoints.live(environment: [:])
-    let transport = TokenRoutingTransport(routes: [
-      endpoints.grokUser.absoluteString: (
-        rejectedToken: nil,
-        response: .success(ProviderResponse(statusCode: 200, data: fixture("grok-user")))
-      ),
-      endpoints.grokBilling.absoluteString: (
-        rejectedToken: "token-a",
-        response: .success(ProviderResponse(statusCode: 200, data: fixture("grok-billing")))
-      ),
-      endpoints.grokCredits.absoluteString: (
-        rejectedToken: "token-a",
-        response: .success(ProviderResponse(statusCode: 200, data: fixture("grok-credits")))
-      ),
-    ])
-    let client = ProviderHTTPClient(
-      transport: transport,
-      credentials: StubCredentialStore(tokens: ["token-a", "token-b"])
+    XCTAssertEqual(
+      requests.first { $0.url == endpoints.grokResets }?.method,
+      .post
     )
-
-    let grok = try await GrokProvider(
-      client: client,
-      userEndpoint: endpoints.grokUser,
-      billingEndpoint: endpoints.grokBilling,
-      creditsEndpoint: endpoints.grokCredits
-    ).fetch()
-
-    XCTAssertTrue(grok.windows.map(\.label).contains("Monthly"))
-    let requests = await transport.requests
     XCTAssertEqual(
-      requests.filter { $0.url == endpoints.grokUser }.map(\.bearerToken),
-      [
-        "token-a", "token-b",
-      ])
-    XCTAssertEqual(
-      requests.filter { $0.url == endpoints.grokBilling }.map(\.bearerToken),
-      [
-        "token-a", "token-b",
-      ])
-    XCTAssertEqual(
-      requests.filter { $0.url == endpoints.grokCredits }.map(\.bearerToken),
-      [
-        "token-a", "token-b",
-      ])
+      requests.first { $0.url == endpoints.grokResets }?.headers["Content-Type"],
+      "application/grpc-web+proto"
+    )
   }
 
   func testCodexUnauthorizedSurfaceRestartsCompleteFetchOnOneCredential() async throws {
@@ -354,7 +319,7 @@ final class NetworkingTests: XCTestCase {
     let credentials = StubCredentialStore(tokens: ["token"])
     XCTAssertEqual(
       try Providers.live(credentials: credentials).map(\.id),
-      [.claudeCode, .codex, .antigravity, .cursor]
+      ProviderID.allCases
     )
     XCTAssertEqual(
       try Providers.live(credentials: credentials, providerIDs: Set(ProviderID.allCases)).map(\.id),

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/OpenAIAnthropicTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/OpenAIAnthropicTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import XCTest
+
+@testable import QuotaBarCore
+
+final class OpenAIAnthropicAPITests: XCTestCase {
+  func testOpenAISumsCurrentMonthCostsAndProjects() async throws {
+    let endpoints = testOpenAIEndpoints()
+    let now = date("2026-09-07T12:00:00Z")
+    let start = try APIPlatformProjection.monthStart(
+      platform: .openAI, now: now, timeZone: utcTimeZone())
+    let transport = APIPlatformRoutingTransport(
+      routes: [
+        endpoints.costs(
+          startTime: Int(start.timeIntervalSince1970),
+          endTime: Int(now.timeIntervalSince1970),
+          page: nil
+        ).absoluteString: response(fixture("openai-costs"))
+      ]
+    )
+    let client = OpenAIAPIClient(transport: transport, endpoints: endpoints)
+    let snapshot = try await client.fetchSnapshot(
+      token: "openai-admin",
+      now: now,
+      timeZone: utcTimeZone()
+    )
+
+    XCTAssertEqual(snapshot.platform, .openAI)
+    XCTAssertNil(snapshot.creditsRemaining)
+    XCTAssertEqual(snapshot.monthlySpend, decimal("12.5"))
+    XCTAssertEqual(snapshot.projectedSpend, decimal("12.5") / Decimal(7) * Decimal(30))
+    let requests = await transport.requests
+    XCTAssertEqual(requests.count, 1)
+    XCTAssertTrue(requests.allSatisfy { !$0.description.contains("openai-admin") })
+  }
+
+  func testOpenAIPaginatesCostBuckets() async throws {
+    let endpoints = testOpenAIEndpoints()
+    let now = date("2026-09-07T12:00:00Z")
+    let start = try APIPlatformProjection.monthStart(
+      platform: .openAI, now: now, timeZone: utcTimeZone())
+    let startTime = Int(start.timeIntervalSince1970)
+    let endTime = Int(now.timeIntervalSince1970)
+    let firstPage = endpoints.costs(startTime: startTime, endTime: endTime, page: nil)
+    let secondPage = endpoints.costs(startTime: startTime, endTime: endTime, page: "page-2")
+    let transport = APIPlatformRoutingTransport(
+      routes: [
+        firstPage.absoluteString: response(
+          Data(
+            #"""
+            {
+              "object": "page",
+              "data": [{ "results": [{ "amount": { "value": 4.25, "currency": "usd" } }] }],
+              "has_more": true,
+              "next_page": "page-2"
+            }
+            """#.utf8)
+        ),
+        secondPage.absoluteString: response(
+          Data(
+            #"""
+            {
+              "object": "page",
+              "data": [{ "results": [{ "amount": { "value": 8.25, "currency": "usd" } }] }],
+              "has_more": false,
+              "next_page": null
+            }
+            """#.utf8)
+        ),
+      ]
+    )
+    let snapshot = try await OpenAIAPIClient(transport: transport, endpoints: endpoints)
+      .fetchSnapshot(token: "secret", now: now, timeZone: utcTimeZone())
+    XCTAssertEqual(snapshot.monthlySpend, decimal("12.5"))
+    let requests = await transport.requests
+    XCTAssertEqual(
+      requests.map(\.url.absoluteString),
+      [
+        firstPage.absoluteString, secondPage.absoluteString,
+      ])
+  }
+
+  func testOpenAIRejectsNonUSDAndUnauthorized() async throws {
+    let endpoints = testOpenAIEndpoints()
+    let now = date("2026-09-07T12:00:00Z")
+    let start = try APIPlatformProjection.monthStart(
+      platform: .openAI, now: now, timeZone: utcTimeZone())
+    let costsURL = endpoints.costs(
+      startTime: Int(start.timeIntervalSince1970),
+      endTime: Int(now.timeIntervalSince1970),
+      page: nil
+    ).absoluteString
+
+    let nonUSD = OpenAIAPIClient(
+      transport: APIPlatformRoutingTransport(
+        routes: [costsURL: response(fixture("openai-costs-eur"))]
+      ),
+      endpoints: endpoints
+    )
+    do {
+      _ = try await nonUSD.fetchSnapshot(token: "secret", now: now, timeZone: utcTimeZone())
+      XCTFail("Expected malformed non-USD response")
+    } catch let error as APIPlatformError {
+      XCTAssertEqual(error, .malformedResponse(.openAI))
+    }
+
+    let unauthorized = OpenAIAPIClient(
+      transport: APIPlatformRoutingTransport(
+        routes: [costsURL: APIPlatformResponse(statusCode: 401, data: Data())]
+      ),
+      endpoints: endpoints
+    )
+    do {
+      _ = try await unauthorized.fetchSnapshot(token: "secret", now: now, timeZone: utcTimeZone())
+      XCTFail("Expected unauthorized")
+    } catch let error as APIPlatformError {
+      XCTAssertEqual(error, .unauthorized(.openAI))
+    }
+  }
+
+  func testAnthropicConvertsCentsAndProjects() async throws {
+    let endpoints = testAnthropicEndpoints()
+    let now = date("2026-09-07T12:00:00Z")
+    let start = try APIPlatformProjection.monthStart(
+      platform: .anthropic, now: now, timeZone: utcTimeZone())
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    let reportURL = endpoints.costReport(
+      startingAt: formatter.string(from: start),
+      endingAt: formatter.string(from: now),
+      page: nil
+    ).absoluteString
+    let transport = APIPlatformRoutingTransport(
+      routes: [reportURL: response(fixture("anthropic-cost-report"))]
+    )
+    let client = AnthropicAPIClient(transport: transport, endpoints: endpoints)
+    let snapshot = try await client.fetchSnapshot(
+      token: "sk-ant-admin",
+      now: now,
+      timeZone: utcTimeZone()
+    )
+
+    XCTAssertEqual(snapshot.platform, .anthropic)
+    XCTAssertNil(snapshot.creditsRemaining)
+    XCTAssertEqual(snapshot.monthlySpend, decimal("8.5"))
+    XCTAssertEqual(snapshot.projectedSpend, decimal("8.5") / Decimal(7) * Decimal(30))
+    let requests = await transport.requests
+    XCTAssertEqual(requests.count, 1)
+    XCTAssertTrue(requests[0].headers["x-api-key"] == "sk-ant-admin")
+    XCTAssertTrue(requests.allSatisfy { !$0.description.contains("sk-ant-admin") })
+  }
+
+  func testAnthropicRejectsNonUSDAndMalformedAmounts() async throws {
+    let endpoints = testAnthropicEndpoints()
+    let now = date("2026-09-07T12:00:00Z")
+    let start = try APIPlatformProjection.monthStart(
+      platform: .anthropic, now: now, timeZone: utcTimeZone())
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    let reportURL = endpoints.costReport(
+      startingAt: formatter.string(from: start),
+      endingAt: formatter.string(from: now),
+      page: nil
+    ).absoluteString
+    let client = AnthropicAPIClient(
+      transport: APIPlatformRoutingTransport(
+        routes: [reportURL: response(fixture("anthropic-cost-report-eur"))]
+      ),
+      endpoints: endpoints
+    )
+    do {
+      _ = try await client.fetchSnapshot(token: "secret", now: now, timeZone: utcTimeZone())
+      XCTFail("Expected malformed non-USD response")
+    } catch let error as APIPlatformError {
+      XCTAssertEqual(error, .malformedResponse(.anthropic))
+    }
+
+    let leftover = AnthropicAPIClient(
+      transport: APIPlatformRoutingTransport(
+        routes: [
+          reportURL: response(
+            Data(
+              #"""
+              {
+                "data": [{
+                  "starting_at": "2026-09-01T00:00:00Z",
+                  "ending_at": "2026-09-02T00:00:00Z",
+                  "results": [{ "amount": "12.34extra", "currency": "USD" }]
+                }],
+                "has_more": false,
+                "next_page": null
+              }
+              """#.utf8)
+          )
+        ]
+      ),
+      endpoints: endpoints
+    )
+    do {
+      _ = try await leftover.fetchSnapshot(token: "secret", now: now, timeZone: utcTimeZone())
+      XCTFail("Expected leftover decimal digits to fail")
+    } catch let error as APIPlatformError {
+      XCTAssertEqual(error, .malformedResponse(.anthropic))
+    }
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/OpenRouterTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/OpenRouterTests.swift
@@ -5,8 +5,8 @@ import XCTest
 
 final class OpenRouterTests: XCTestCase {
   func testFetchSnapshotAggregatesAllWorkspacesAndKeys() async throws {
-    let endpoints = testEndpoints()
-    let transport = OpenRouterRoutingTransport(
+    let endpoints = testOpenRouterEndpoints()
+    let transport = APIPlatformRoutingTransport(
       routes: [
         endpoints.credits().absoluteString: response(fixture("openrouter-credits")),
         endpoints.workspaces(offset: 0, limit: 100).absoluteString:
@@ -21,11 +21,12 @@ final class OpenRouterTests: XCTestCase {
     let client = OpenRouterAPIClient(transport: transport, endpoints: endpoints)
 
     let snapshot = try await client.fetchSnapshot(
-      managementKey: "management-secret",
+      token: "management-secret",
       now: date("2026-08-16T12:00:00Z"),
       timeZone: utcTimeZone()
     )
 
+    XCTAssertEqual(snapshot.platform, .openRouter)
     XCTAssertEqual(snapshot.workspaceNames, ["Development", "Production"])
     XCTAssertEqual(snapshot.creditsRemaining, Decimal(string: "60"))
     XCTAssertEqual(snapshot.monthlySpend, Decimal(string: "4.5"))
@@ -44,8 +45,8 @@ final class OpenRouterTests: XCTestCase {
   }
 
   func testProjectionUsesLocalCalendarMonthLength() async throws {
-    let endpoints = testEndpoints()
-    let transport = OpenRouterRoutingTransport(
+    let endpoints = testOpenRouterEndpoints()
+    let transport = APIPlatformRoutingTransport(
       routes: [
         endpoints.credits().absoluteString: response(
           Data(#"{ "data": { "total_credits": 20, "total_usage": 0 } }"#.utf8)
@@ -59,7 +60,7 @@ final class OpenRouterTests: XCTestCase {
       ])
     let client = OpenRouterAPIClient(transport: transport, endpoints: endpoints)
     let snapshot = try await client.fetchSnapshot(
-      managementKey: "secret",
+      token: "secret",
       now: date("2026-02-28T12:00:00Z"),
       timeZone: utcTimeZone()
     )
@@ -69,49 +70,54 @@ final class OpenRouterTests: XCTestCase {
   }
 
   func testHTTPStatusesAndMalformedResponsesAreExplicit() async throws {
-    let endpoints = testEndpoints()
+    let endpoints = testOpenRouterEndpoints()
     let unauthorized = OpenRouterAPIClient(
-      transport: OpenRouterRoutingTransport(
+      transport: APIPlatformRoutingTransport(
         routes: [
-          endpoints.credits().absoluteString: OpenRouterResponse(statusCode: 401, data: Data())
+          endpoints.credits().absoluteString: APIPlatformResponse(statusCode: 401, data: Data())
         ]
       ),
       endpoints: endpoints
     )
     do {
-      _ = try await unauthorized.fetchSnapshot(managementKey: "secret")
+      _ = try await unauthorized.fetchSnapshot(token: "secret")
       XCTFail("Expected unauthorized error")
     } catch let error as APIPlatformError {
-      XCTAssertEqual(error, .unauthorized)
+      XCTAssertEqual(error, .unauthorized(.openRouter))
     }
 
     let malformed = OpenRouterAPIClient(
-      transport: OpenRouterRoutingTransport(
+      transport: APIPlatformRoutingTransport(
         routes: [endpoints.credits().absoluteString: response(fixture("openrouter-malformed"))]
       ),
       endpoints: endpoints
     )
     do {
-      _ = try await malformed.fetchSnapshot(managementKey: "secret")
-      XCTFail("Expected malformed response error")
+      _ = try await malformed.fetchSnapshot(token: "secret")
+      XCTFail("Expected malformed response")
     } catch let error as APIPlatformError {
-      XCTAssertEqual(error, .malformedResponse)
+      XCTAssertEqual(error, .malformedResponse(.openRouter))
     }
   }
 
-  func testOpenRouterCredentialUsesDedicatedKeychainEntry() async throws {
+  func testAPIPlatformCredentialsUseIsolatedKeychainAccounts() async throws {
     let keychain = FakeKeychain()
-    let store = OpenRouterCredentialStore(keychain: keychain)
+    let store = APIPlatformCredentialStore(keychain: keychain)
 
-    let initialToken = try await store.token()
-    XCTAssertNil(initialToken)
-    try await store.save("  management-secret  ")
-    let savedToken = try await store.token()
-    XCTAssertEqual(savedToken, "management-secret")
-    try await store.remove()
-    let removedToken = try await store.token()
-    XCTAssertNil(removedToken)
+    try await store.save("  openrouter-secret  ", for: .openRouter)
+    try await store.save("openai-secret", for: .openAI)
+    let openRouterToken = try await store.token(for: .openRouter)
+    let openAIToken = try await store.token(for: .openAI)
+    let anthropicToken = try await store.token(for: .anthropic)
+    XCTAssertEqual(openRouterToken, "openrouter-secret")
+    XCTAssertEqual(openAIToken, "openai-secret")
+    XCTAssertNil(anthropicToken)
 
+    try await store.remove(for: .openRouter)
+    let removedOpenRouter = try await store.token(for: .openRouter)
+    let remainingOpenAI = try await store.token(for: .openAI)
+    XCTAssertNil(removedOpenRouter)
+    XCTAssertEqual(remainingOpenAI, "openai-secret")
     XCTAssertNil(
       try keychain.read(
         service: ManualCredentialStore.service,
@@ -120,26 +126,29 @@ final class OpenRouterTests: XCTestCase {
     )
   }
 
-  func testAPIPlatformCacheContainsNoCredential() throws {
+  func testAPIPlatformCacheMigratesLegacySingleSnapshotAndOmitsSecrets() throws {
     let root = try temporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }
     let url = root.appendingPathComponent("api-platform-snapshot.json")
     let store = JSONAPIPlatformSnapshotStore(url: url)
     let snapshot = APIPlatformSnapshot(
+      platform: .openRouter,
       workspaceNames: ["Default"],
       creditsRemaining: decimal("10"),
       monthlySpend: decimal("2.5"),
       projectedSpend: decimal("5"),
       sourceTimestamp: date("2026-08-16T12:00:00Z")
     )
+    try JSONEncoder().encode(snapshot).write(to: url)
 
-    try store.save(snapshot)
+    XCTAssertEqual(try store.load(), [.openRouter: snapshot])
 
+    try store.save([.openRouter: snapshot])
     let cached = try Data(contentsOf: url)
     XCTAssertFalse(String(data: cached, encoding: .utf8)?.contains("management-secret") == true)
-    XCTAssertEqual(try store.load(), snapshot)
+    XCTAssertEqual(try store.load(), [.openRouter: snapshot])
     try store.remove()
-    XCTAssertNil(try store.load())
+    XCTAssertEqual(try store.load(), [:])
   }
 
   @MainActor
@@ -147,39 +156,48 @@ final class OpenRouterTests: XCTestCase {
     let settings = AppSettings(store: APISettingsStore())
     let model = APIPlatformModel(
       settings: settings,
-      credentials: OpenRouterCredentialStore(keychain: FakeKeychain()),
+      credentials: APIPlatformCredentialStore(keychain: FakeKeychain()),
       store: MemoryAPIPlatformStore()
     )
 
     await model.refresh()
 
-    guard case let .unauthenticated(message) = model.state else {
+    guard case let .unauthenticated(message) = model.state(for: .openRouter) else {
       XCTFail("Expected missing-key state")
       return
     }
-    XCTAssertEqual(message, APIPlatformError.credentialsMissing.localizedDescription)
+    XCTAssertEqual(message, APIPlatformError.credentialsMissing(.openRouter).localizedDescription)
+    guard case .unauthenticated = model.state(for: .openAI) else {
+      XCTFail("Expected OpenAI missing-key state")
+      return
+    }
+    guard case .unauthenticated = model.state(for: .anthropic) else {
+      XCTFail("Expected Anthropic missing-key state")
+      return
+    }
   }
 
   @MainActor
   func testAPIPlatformModelRetainsCachedSnapshotAsStale() async throws {
-    let endpoints = testEndpoints()
+    let endpoints = testOpenRouterEndpoints()
     let keychain = FakeKeychain()
-    let credentials = OpenRouterCredentialStore(keychain: keychain)
-    try await credentials.save("secret")
+    let credentials = APIPlatformCredentialStore(keychain: keychain)
+    try await credentials.save("secret", for: .openRouter)
     let cached = APIPlatformSnapshot(
+      platform: .openRouter,
       workspaceNames: ["Default"],
       creditsRemaining: decimal("10"),
       monthlySpend: decimal("2"),
       projectedSpend: decimal("4"),
       sourceTimestamp: date("2026-08-16T11:00:00Z")
     )
-    let store = MemoryAPIPlatformStore(loaded: cached)
+    let store = MemoryAPIPlatformStore(loaded: [.openRouter: cached])
     let model = APIPlatformModel(
       settings: AppSettings(store: APISettingsStore()),
-      client: OpenRouterAPIClient(
-        transport: OpenRouterRoutingTransport(
+      openRouter: OpenRouterAPIClient(
+        transport: APIPlatformRoutingTransport(
           routes: [
-            endpoints.credits().absoluteString: OpenRouterResponse(statusCode: 401, data: Data())
+            endpoints.credits().absoluteString: APIPlatformResponse(statusCode: 401, data: Data())
           ]
         ),
         endpoints: endpoints
@@ -190,24 +208,212 @@ final class OpenRouterTests: XCTestCase {
 
     await model.refresh()
 
-    guard case let .stale(snapshot, reason) = model.state else {
+    guard case let .stale(snapshot, reason) = model.state(for: .openRouter) else {
       XCTFail("Expected stale cached state")
       return
     }
     XCTAssertEqual(snapshot, cached)
-    XCTAssertEqual(reason, APIPlatformError.unauthorized.localizedDescription)
-  }
-
-  private func response(_ data: Data) -> OpenRouterResponse {
-    OpenRouterResponse(statusCode: 200, data: data)
+    XCTAssertEqual(reason, APIPlatformError.unauthorized(.openRouter).localizedDescription)
   }
 }
 
-private func testEndpoints() -> OpenRouterEndpoints {
+final class OpenAIAnthropicAPITests: XCTestCase {
+  func testOpenAISumsCurrentMonthCostsAndProjects() async throws {
+    let endpoints = testOpenAIEndpoints()
+    let now = date("2026-09-07T12:00:00Z")
+    let start = try APIPlatformProjection.monthStart(
+      platform: .openAI, now: now, timeZone: utcTimeZone())
+    let transport = APIPlatformRoutingTransport(
+      routes: [
+        endpoints.costs(
+          startTime: Int(start.timeIntervalSince1970),
+          endTime: Int(now.timeIntervalSince1970),
+          page: nil
+        ).absoluteString: response(fixture("openai-costs"))
+      ]
+    )
+    let client = OpenAIAPIClient(transport: transport, endpoints: endpoints)
+    let snapshot = try await client.fetchSnapshot(
+      token: "openai-admin",
+      now: now,
+      timeZone: utcTimeZone()
+    )
+
+    XCTAssertEqual(snapshot.platform, .openAI)
+    XCTAssertNil(snapshot.creditsRemaining)
+    XCTAssertEqual(snapshot.monthlySpend, decimal("12.5"))
+    XCTAssertEqual(snapshot.projectedSpend, decimal("12.5") / Decimal(7) * Decimal(30))
+    let requests = await transport.requests
+    XCTAssertEqual(requests.count, 1)
+    XCTAssertTrue(requests.allSatisfy { !$0.description.contains("openai-admin") })
+  }
+
+  func testOpenAIPaginatesCostBuckets() async throws {
+    let endpoints = testOpenAIEndpoints()
+    let now = date("2026-09-07T12:00:00Z")
+    let start = try APIPlatformProjection.monthStart(
+      platform: .openAI, now: now, timeZone: utcTimeZone())
+    let startTime = Int(start.timeIntervalSince1970)
+    let endTime = Int(now.timeIntervalSince1970)
+    let firstPage = endpoints.costs(startTime: startTime, endTime: endTime, page: nil)
+    let secondPage = endpoints.costs(startTime: startTime, endTime: endTime, page: "page-2")
+    let transport = APIPlatformRoutingTransport(
+      routes: [
+        firstPage.absoluteString: response(
+          Data(
+            #"""
+            {
+              "object": "page",
+              "data": [{ "results": [{ "amount": { "value": 4.25, "currency": "usd" } }] }],
+              "has_more": true,
+              "next_page": "page-2"
+            }
+            """#.utf8)
+        ),
+        secondPage.absoluteString: response(
+          Data(
+            #"""
+            {
+              "object": "page",
+              "data": [{ "results": [{ "amount": { "value": 8.25, "currency": "usd" } }] }],
+              "has_more": false,
+              "next_page": null
+            }
+            """#.utf8)
+        ),
+      ]
+    )
+    let snapshot = try await OpenAIAPIClient(transport: transport, endpoints: endpoints)
+      .fetchSnapshot(token: "secret", now: now, timeZone: utcTimeZone())
+    XCTAssertEqual(snapshot.monthlySpend, decimal("12.5"))
+    let requests = await transport.requests
+    XCTAssertEqual(
+      requests.map(\.url.absoluteString),
+      [
+        firstPage.absoluteString, secondPage.absoluteString,
+      ])
+  }
+
+  func testOpenAIRejectsNonUSDAndUnauthorized() async throws {
+    let endpoints = testOpenAIEndpoints()
+    let now = date("2026-09-07T12:00:00Z")
+    let start = try APIPlatformProjection.monthStart(
+      platform: .openAI, now: now, timeZone: utcTimeZone())
+    let costsURL = endpoints.costs(
+      startTime: Int(start.timeIntervalSince1970),
+      endTime: Int(now.timeIntervalSince1970),
+      page: nil
+    ).absoluteString
+
+    let nonUSD = OpenAIAPIClient(
+      transport: APIPlatformRoutingTransport(
+        routes: [costsURL: response(fixture("openai-costs-eur"))]
+      ),
+      endpoints: endpoints
+    )
+    do {
+      _ = try await nonUSD.fetchSnapshot(token: "secret", now: now, timeZone: utcTimeZone())
+      XCTFail("Expected malformed non-USD response")
+    } catch let error as APIPlatformError {
+      XCTAssertEqual(error, .malformedResponse(.openAI))
+    }
+
+    let unauthorized = OpenAIAPIClient(
+      transport: APIPlatformRoutingTransport(
+        routes: [costsURL: APIPlatformResponse(statusCode: 401, data: Data())]
+      ),
+      endpoints: endpoints
+    )
+    do {
+      _ = try await unauthorized.fetchSnapshot(token: "secret", now: now, timeZone: utcTimeZone())
+      XCTFail("Expected unauthorized")
+    } catch let error as APIPlatformError {
+      XCTAssertEqual(error, .unauthorized(.openAI))
+    }
+  }
+
+  func testAnthropicConvertsCentsAndProjects() async throws {
+    let endpoints = testAnthropicEndpoints()
+    let now = date("2026-09-07T12:00:00Z")
+    let start = try APIPlatformProjection.monthStart(
+      platform: .anthropic, now: now, timeZone: utcTimeZone())
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    let reportURL = endpoints.costReport(
+      startingAt: formatter.string(from: start),
+      endingAt: formatter.string(from: now),
+      page: nil
+    ).absoluteString
+    let transport = APIPlatformRoutingTransport(
+      routes: [reportURL: response(fixture("anthropic-cost-report"))]
+    )
+    let client = AnthropicAPIClient(transport: transport, endpoints: endpoints)
+    let snapshot = try await client.fetchSnapshot(
+      token: "sk-ant-admin",
+      now: now,
+      timeZone: utcTimeZone()
+    )
+
+    XCTAssertEqual(snapshot.platform, .anthropic)
+    XCTAssertNil(snapshot.creditsRemaining)
+    XCTAssertEqual(snapshot.monthlySpend, decimal("8.5"))
+    XCTAssertEqual(snapshot.projectedSpend, decimal("8.5") / Decimal(7) * Decimal(30))
+    let requests = await transport.requests
+    XCTAssertEqual(requests.count, 1)
+    XCTAssertTrue(requests[0].headers["x-api-key"] == "sk-ant-admin")
+    XCTAssertTrue(requests.allSatisfy { !$0.description.contains("sk-ant-admin") })
+  }
+
+  func testAnthropicRejectsNonUSD() async throws {
+    let endpoints = testAnthropicEndpoints()
+    let now = date("2026-09-07T12:00:00Z")
+    let start = try APIPlatformProjection.monthStart(
+      platform: .anthropic, now: now, timeZone: utcTimeZone())
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    let reportURL = endpoints.costReport(
+      startingAt: formatter.string(from: start),
+      endingAt: formatter.string(from: now),
+      page: nil
+    ).absoluteString
+    let client = AnthropicAPIClient(
+      transport: APIPlatformRoutingTransport(
+        routes: [reportURL: response(fixture("anthropic-cost-report-eur"))]
+      ),
+      endpoints: endpoints
+    )
+    do {
+      _ = try await client.fetchSnapshot(token: "secret", now: now, timeZone: utcTimeZone())
+      XCTFail("Expected malformed non-USD response")
+    } catch let error as APIPlatformError {
+      XCTAssertEqual(error, .malformedResponse(.anthropic))
+    }
+  }
+}
+
+private func response(_ data: Data) -> APIPlatformResponse {
+  APIPlatformResponse(statusCode: 200, data: data)
+}
+
+private func testOpenRouterEndpoints() -> OpenRouterEndpoints {
   guard let url = URL(string: "https://openrouter.test") else {
     preconditionFailure("Invalid test endpoint")
   }
   return OpenRouterEndpoints(baseURL: url)
+}
+
+private func testOpenAIEndpoints() -> OpenAIEndpoints {
+  guard let url = URL(string: "https://openai.test") else {
+    preconditionFailure("Invalid test endpoint")
+  }
+  return OpenAIEndpoints(baseURL: url)
+}
+
+private func testAnthropicEndpoints() -> AnthropicEndpoints {
+  guard let url = URL(string: "https://anthropic.test") else {
+    preconditionFailure("Invalid test endpoint")
+  }
+  return AnthropicEndpoints(baseURL: url)
 }
 
 private func utcTimeZone() -> TimeZone {
@@ -237,37 +443,37 @@ private final class APISettingsStore: SettingsPersisting, Sendable {
 
 private final class MemoryAPIPlatformStore: APIPlatformSnapshotPersisting, @unchecked Sendable {
   private let lock = NSLock()
-  private var snapshot: APIPlatformSnapshot?
+  private var snapshots: [APIPlatformID: APIPlatformSnapshot]
 
-  init(loaded: APIPlatformSnapshot? = nil) {
-    snapshot = loaded
+  init(loaded: [APIPlatformID: APIPlatformSnapshot] = [:]) {
+    snapshots = loaded
   }
 
-  func load() throws -> APIPlatformSnapshot? {
-    lock.withLock { snapshot }
+  func load() throws -> [APIPlatformID: APIPlatformSnapshot] {
+    lock.withLock { snapshots }
   }
 
-  func save(_ snapshot: APIPlatformSnapshot) throws {
-    lock.withLock { self.snapshot = snapshot }
+  func save(_ snapshots: [APIPlatformID: APIPlatformSnapshot]) throws {
+    lock.withLock { self.snapshots = snapshots }
   }
 
   func remove() throws {
-    lock.withLock { snapshot = nil }
+    lock.withLock { snapshots = [:] }
   }
 }
 
-private actor OpenRouterRoutingTransport: OpenRouterTransport {
-  private let routes: [String: OpenRouterResponse]
-  private(set) var requests: [OpenRouterRequest] = []
+private actor APIPlatformRoutingTransport: APIPlatformTransport {
+  private let routes: [String: APIPlatformResponse]
+  private(set) var requests: [APIPlatformRequest] = []
 
-  init(routes: [String: OpenRouterResponse]) {
+  init(routes: [String: APIPlatformResponse]) {
     self.routes = routes
   }
 
-  func send(_ request: OpenRouterRequest) throws -> OpenRouterResponse {
+  func send(_ request: APIPlatformRequest) throws -> APIPlatformResponse {
     requests.append(request)
     guard let response = routes[request.url.absoluteString] else {
-      throw APIPlatformError.network
+      throw APIPlatformError.network(request.platform)
     }
     return response
   }

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/OpenRouterTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/OpenRouterTests.swift
@@ -215,184 +215,46 @@ final class OpenRouterTests: XCTestCase {
     XCTAssertEqual(snapshot, cached)
     XCTAssertEqual(reason, APIPlatformError.unauthorized(.openRouter).localizedDescription)
   }
-}
 
-final class OpenAIAnthropicAPITests: XCTestCase {
-  func testOpenAISumsCurrentMonthCostsAndProjects() async throws {
-    let endpoints = testOpenAIEndpoints()
-    let now = date("2026-09-07T12:00:00Z")
-    let start = try APIPlatformProjection.monthStart(
-      platform: .openAI, now: now, timeZone: utcTimeZone())
+  @MainActor
+  func testAPIPlatformCredentialChangeDiscardsActiveRefresh() async throws {
+    let endpoints = testOpenRouterEndpoints()
+    let keychain = FakeKeychain()
+    let credentials = APIPlatformCredentialStore(keychain: keychain)
+    try await credentials.save("secret", for: .openRouter)
     let transport = APIPlatformRoutingTransport(
       routes: [
-        endpoints.costs(
-          startTime: Int(start.timeIntervalSince1970),
-          endTime: Int(now.timeIntervalSince1970),
-          page: nil
-        ).absoluteString: response(fixture("openai-costs"))
-      ]
-    )
-    let client = OpenAIAPIClient(transport: transport, endpoints: endpoints)
-    let snapshot = try await client.fetchSnapshot(
-      token: "openai-admin",
-      now: now,
-      timeZone: utcTimeZone()
-    )
-
-    XCTAssertEqual(snapshot.platform, .openAI)
-    XCTAssertNil(snapshot.creditsRemaining)
-    XCTAssertEqual(snapshot.monthlySpend, decimal("12.5"))
-    XCTAssertEqual(snapshot.projectedSpend, decimal("12.5") / Decimal(7) * Decimal(30))
-    let requests = await transport.requests
-    XCTAssertEqual(requests.count, 1)
-    XCTAssertTrue(requests.allSatisfy { !$0.description.contains("openai-admin") })
-  }
-
-  func testOpenAIPaginatesCostBuckets() async throws {
-    let endpoints = testOpenAIEndpoints()
-    let now = date("2026-09-07T12:00:00Z")
-    let start = try APIPlatformProjection.monthStart(
-      platform: .openAI, now: now, timeZone: utcTimeZone())
-    let startTime = Int(start.timeIntervalSince1970)
-    let endTime = Int(now.timeIntervalSince1970)
-    let firstPage = endpoints.costs(startTime: startTime, endTime: endTime, page: nil)
-    let secondPage = endpoints.costs(startTime: startTime, endTime: endTime, page: "page-2")
-    let transport = APIPlatformRoutingTransport(
-      routes: [
-        firstPage.absoluteString: response(
-          Data(
-            #"""
-            {
-              "object": "page",
-              "data": [{ "results": [{ "amount": { "value": 4.25, "currency": "usd" } }] }],
-              "has_more": true,
-              "next_page": "page-2"
-            }
-            """#.utf8)
+        endpoints.credits().absoluteString: response(fixture("openrouter-credits")),
+        endpoints.workspaces(offset: 0, limit: 100).absoluteString: response(
+          Data(#"{ "data": [], "total_count": 0 }"#.utf8)
         ),
-        secondPage.absoluteString: response(
-          Data(
-            #"""
-            {
-              "object": "page",
-              "data": [{ "results": [{ "amount": { "value": 8.25, "currency": "usd" } }] }],
-              "has_more": false,
-              "next_page": null
-            }
-            """#.utf8)
-        ),
-      ]
+      ],
+      delay: .milliseconds(80)
     )
-    let snapshot = try await OpenAIAPIClient(transport: transport, endpoints: endpoints)
-      .fetchSnapshot(token: "secret", now: now, timeZone: utcTimeZone())
-    XCTAssertEqual(snapshot.monthlySpend, decimal("12.5"))
-    let requests = await transport.requests
-    XCTAssertEqual(
-      requests.map(\.url.absoluteString),
-      [
-        firstPage.absoluteString, secondPage.absoluteString,
-      ])
-  }
-
-  func testOpenAIRejectsNonUSDAndUnauthorized() async throws {
-    let endpoints = testOpenAIEndpoints()
-    let now = date("2026-09-07T12:00:00Z")
-    let start = try APIPlatformProjection.monthStart(
-      platform: .openAI, now: now, timeZone: utcTimeZone())
-    let costsURL = endpoints.costs(
-      startTime: Int(start.timeIntervalSince1970),
-      endTime: Int(now.timeIntervalSince1970),
-      page: nil
-    ).absoluteString
-
-    let nonUSD = OpenAIAPIClient(
-      transport: APIPlatformRoutingTransport(
-        routes: [costsURL: response(fixture("openai-costs-eur"))]
-      ),
-      endpoints: endpoints
+    let store = MemoryAPIPlatformStore()
+    let model = APIPlatformModel(
+      settings: AppSettings(store: APISettingsStore()),
+      openRouter: OpenRouterAPIClient(transport: transport, endpoints: endpoints),
+      credentials: credentials,
+      store: store
     )
-    do {
-      _ = try await nonUSD.fetchSnapshot(token: "secret", now: now, timeZone: utcTimeZone())
-      XCTFail("Expected malformed non-USD response")
-    } catch let error as APIPlatformError {
-      XCTAssertEqual(error, .malformedResponse(.openAI))
+
+    let activeRefresh = Task { await model.refresh() }
+    for _ in 0..<50 {
+      if await transport.requests.count >= 1 { break }
+      try? await Task.sleep(for: .milliseconds(10))
     }
+    try await credentials.remove(for: .openRouter)
+    await model.handleCredentialChange(for: .openRouter)
+    await activeRefresh.value
 
-    let unauthorized = OpenAIAPIClient(
-      transport: APIPlatformRoutingTransport(
-        routes: [costsURL: APIPlatformResponse(statusCode: 401, data: Data())]
-      ),
-      endpoints: endpoints
-    )
-    do {
-      _ = try await unauthorized.fetchSnapshot(token: "secret", now: now, timeZone: utcTimeZone())
-      XCTFail("Expected unauthorized")
-    } catch let error as APIPlatformError {
-      XCTAssertEqual(error, .unauthorized(.openAI))
+    guard case .unauthenticated = model.state(for: .openRouter) else {
+      XCTFail("Expected the in-flight snapshot to be discarded")
+      return
     }
+    XCTAssertNil(try store.load()[.openRouter])
+    XCTAssertFalse(model.isRefreshing)
   }
-
-  func testAnthropicConvertsCentsAndProjects() async throws {
-    let endpoints = testAnthropicEndpoints()
-    let now = date("2026-09-07T12:00:00Z")
-    let start = try APIPlatformProjection.monthStart(
-      platform: .anthropic, now: now, timeZone: utcTimeZone())
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime]
-    let reportURL = endpoints.costReport(
-      startingAt: formatter.string(from: start),
-      endingAt: formatter.string(from: now),
-      page: nil
-    ).absoluteString
-    let transport = APIPlatformRoutingTransport(
-      routes: [reportURL: response(fixture("anthropic-cost-report"))]
-    )
-    let client = AnthropicAPIClient(transport: transport, endpoints: endpoints)
-    let snapshot = try await client.fetchSnapshot(
-      token: "sk-ant-admin",
-      now: now,
-      timeZone: utcTimeZone()
-    )
-
-    XCTAssertEqual(snapshot.platform, .anthropic)
-    XCTAssertNil(snapshot.creditsRemaining)
-    XCTAssertEqual(snapshot.monthlySpend, decimal("8.5"))
-    XCTAssertEqual(snapshot.projectedSpend, decimal("8.5") / Decimal(7) * Decimal(30))
-    let requests = await transport.requests
-    XCTAssertEqual(requests.count, 1)
-    XCTAssertTrue(requests[0].headers["x-api-key"] == "sk-ant-admin")
-    XCTAssertTrue(requests.allSatisfy { !$0.description.contains("sk-ant-admin") })
-  }
-
-  func testAnthropicRejectsNonUSD() async throws {
-    let endpoints = testAnthropicEndpoints()
-    let now = date("2026-09-07T12:00:00Z")
-    let start = try APIPlatformProjection.monthStart(
-      platform: .anthropic, now: now, timeZone: utcTimeZone())
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime]
-    let reportURL = endpoints.costReport(
-      startingAt: formatter.string(from: start),
-      endingAt: formatter.string(from: now),
-      page: nil
-    ).absoluteString
-    let client = AnthropicAPIClient(
-      transport: APIPlatformRoutingTransport(
-        routes: [reportURL: response(fixture("anthropic-cost-report-eur"))]
-      ),
-      endpoints: endpoints
-    )
-    do {
-      _ = try await client.fetchSnapshot(token: "secret", now: now, timeZone: utcTimeZone())
-      XCTFail("Expected malformed non-USD response")
-    } catch let error as APIPlatformError {
-      XCTAssertEqual(error, .malformedResponse(.anthropic))
-    }
-  }
-}
-
-private func response(_ data: Data) -> APIPlatformResponse {
-  APIPlatformResponse(statusCode: 200, data: data)
 }
 
 private func testOpenRouterEndpoints() -> OpenRouterEndpoints {
@@ -400,34 +262,6 @@ private func testOpenRouterEndpoints() -> OpenRouterEndpoints {
     preconditionFailure("Invalid test endpoint")
   }
   return OpenRouterEndpoints(baseURL: url)
-}
-
-private func testOpenAIEndpoints() -> OpenAIEndpoints {
-  guard let url = URL(string: "https://openai.test") else {
-    preconditionFailure("Invalid test endpoint")
-  }
-  return OpenAIEndpoints(baseURL: url)
-}
-
-private func testAnthropicEndpoints() -> AnthropicEndpoints {
-  guard let url = URL(string: "https://anthropic.test") else {
-    preconditionFailure("Invalid test endpoint")
-  }
-  return AnthropicEndpoints(baseURL: url)
-}
-
-private func utcTimeZone() -> TimeZone {
-  guard let timeZone = TimeZone(secondsFromGMT: 0) else {
-    preconditionFailure("Invalid UTC test time zone")
-  }
-  return timeZone
-}
-
-private func decimal(_ value: String) -> Decimal {
-  guard let result = Decimal(string: value) else {
-    preconditionFailure("Invalid test decimal")
-  }
-  return result
 }
 
 private final class APISettingsStore: SettingsPersisting, Sendable {
@@ -459,22 +293,5 @@ private final class MemoryAPIPlatformStore: APIPlatformSnapshotPersisting, @unch
 
   func remove() throws {
     lock.withLock { snapshots = [:] }
-  }
-}
-
-private actor APIPlatformRoutingTransport: APIPlatformTransport {
-  private let routes: [String: APIPlatformResponse]
-  private(set) var requests: [APIPlatformRequest] = []
-
-  init(routes: [String: APIPlatformResponse]) {
-    self.routes = routes
-  }
-
-  func send(_ request: APIPlatformRequest) throws -> APIPlatformResponse {
-    requests.append(request)
-    guard let response = routes[request.url.absoluteString] else {
-      throw APIPlatformError.network(request.platform)
-    }
-    return response
   }
 }

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/PersistenceSettingsTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/PersistenceSettingsTests.swift
@@ -55,18 +55,14 @@ final class PersistenceSettingsTests: XCTestCase {
   }
 
   @MainActor
-  func testLegacyProvidersAreHiddenByDefaultAndRestoredOnOptIn() {
+  func testAllProvidersAreVisibleByDefault() {
     let store = MemorySettingsStore(enabled: nil, showsLegacy: nil, interval: nil)
     let settings = AppSettings(store: store)
 
-    XCTAssertEqual(settings.visibleProviderIDs, ProviderID.standard)
-    XCTAssertFalse(settings.showsLegacyProviders)
-
-    settings.setShowsLegacyProviders(true)
-
     XCTAssertEqual(settings.visibleProviderIDs, Set(ProviderID.allCases))
-    XCTAssertTrue(settings.enabledProviders.isSuperset(of: ProviderID.legacy))
-    XCTAssertTrue(store.savedShowsLegacy)
+    XCTAssertEqual(settings.visibleProviderIDs, ProviderID.standard)
+    XCTAssertTrue(ProviderID.legacy.isEmpty)
+    XCTAssertFalse(settings.showsLegacyProviders)
   }
 
   @MainActor
@@ -80,11 +76,55 @@ final class PersistenceSettingsTests: XCTestCase {
     defaults.set([ProviderID.codex.rawValue], forKey: "enabledProviders")
 
     let migrated = AppSettings(store: UserDefaultsSettingsStore(defaults: defaults))
-    XCTAssertEqual(migrated.enabledProviders, [.codex, .antigravity, .cursor])
+    XCTAssertEqual(migrated.enabledProviders, [.codex, .antigravity, .cursor, .grok, .kimi])
     migrated.setProvider(.cursor, enabled: false)
 
     let reloaded = AppSettings(store: UserDefaultsSettingsStore(defaults: defaults))
-    XCTAssertEqual(reloaded.enabledProviders, [.codex, .antigravity])
+    XCTAssertEqual(reloaded.enabledProviders, [.codex, .antigravity, .grok, .kimi])
+  }
+
+  @MainActor
+  func testVersionOneInstallsGainGrokWithoutReenablingDisabledStandardProviders() throws {
+    let suiteName = "QuotaBarTests.\(UUID().uuidString)"
+    guard let defaults = UserDefaults(suiteName: suiteName) else {
+      XCTFail("Expected isolated defaults")
+      return
+    }
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    defaults.set(
+      [ProviderID.codex.rawValue, ProviderID.antigravity.rawValue],
+      forKey: "enabledProviders"
+    )
+    defaults.set(1, forKey: "standardProvidersVersion")
+
+    let migrated = AppSettings(store: UserDefaultsSettingsStore(defaults: defaults))
+    XCTAssertEqual(migrated.enabledProviders, [.codex, .antigravity, .grok, .kimi])
+    XCTAssertFalse(migrated.enabledProviders.contains(.cursor))
+    XCTAssertEqual(defaults.integer(forKey: "standardProvidersVersion"), 3)
+  }
+
+  @MainActor
+  func testVersionTwoInstallsGainKimiWithoutReenablingDisabledStandardProviders() throws {
+    let suiteName = "QuotaBarTests.\(UUID().uuidString)"
+    guard let defaults = UserDefaults(suiteName: suiteName) else {
+      XCTFail("Expected isolated defaults")
+      return
+    }
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    defaults.set(
+      [
+        ProviderID.codex.rawValue,
+        ProviderID.antigravity.rawValue,
+        ProviderID.grok.rawValue,
+      ],
+      forKey: "enabledProviders"
+    )
+    defaults.set(2, forKey: "standardProvidersVersion")
+
+    let migrated = AppSettings(store: UserDefaultsSettingsStore(defaults: defaults))
+    XCTAssertEqual(migrated.enabledProviders, [.codex, .antigravity, .grok, .kimi])
+    XCTAssertFalse(migrated.enabledProviders.contains(.cursor))
+    XCTAssertEqual(defaults.integer(forKey: "standardProvidersVersion"), 3)
   }
 
   @MainActor

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/ProviderParsingTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/ProviderParsingTests.swift
@@ -27,6 +27,26 @@ final class ProviderParsingTests: XCTestCase {
     XCTAssertNil(snapshot.windows.first(where: { $0.id.contains("breakdown") }))
   }
 
+  func testClaudeIgnoresUnrecognizedBreakdownMetadata() throws {
+    XCTAssertThrowsError(
+      try ClaudeCodeProvider.parse(
+        data: Data(
+          #"""
+          {
+            "five_hour": {"utilization": 10, "resets_at": "2026-08-09T22:00:00Z"},
+            "seven_day": {"utilization": 20, "resets_at": "2026-08-14T00:00:00Z"},
+            "unrecognized_breakdown": {
+              "as_of": "2026-08-09T00:00:00Z",
+              "rows": []
+            }
+          }
+          """#.utf8
+        ),
+        now: now
+      )
+    )
+  }
+
   func testClaudeLimitsPreserveModelAndPolicy() throws {
     let snapshot = try ClaudeCodeProvider.parse(data: fixture("claude-limits"), now: now)
     XCTAssertFalse(snapshot.windows.contains { $0.label.contains("Nimbus Quil") })
@@ -229,131 +249,6 @@ final class ProviderParsingTests: XCTestCase {
     XCTAssertThrowsError(
       try KimiProvider.parse(
         data: Data(#"{"usage":{"used_percent":20,"usage_percent":30}}"#.utf8),
-        now: now
-      )
-    )
-  }
-
-  func testGrokSurfacesDecodeIndependently() throws {
-    let identity = try GrokProvider.parseIdentity(data: fixture("grok-user"))
-    XCTAssertEqual(identity.userID, "user_quotabar_fixture")
-    XCTAssertEqual(identity.accountLabel, "fixture@example.com")
-    XCTAssertEqual(
-      try GrokProvider.parseBilling(data: fixture("grok-billing"), now: now).first?
-        .remainingPercent, 65)
-    let credits = try GrokProvider.parseCredits(data: fixture("grok-credits"), now: now)
-    XCTAssertEqual(credits.map(\.remainingPercent), [58, 82, 55, 90])
-  }
-
-  func testGrokProductAliasesMustBeUnambiguous() throws {
-    let identicalAliases = try GrokProvider.parseCredits(
-      data: Data(
-        #"""
-        {
-          "config": {
-            "productUsage": {"chat": {"creditUsagePercent": 20}},
-            "productBreakdown": {"chat": {"creditUsagePercent": 20}}
-          }
-        }
-        """#.utf8
-      ),
-      now: now
-    )
-    XCTAssertEqual(identicalAliases.first?.remainingPercent, 80)
-
-    XCTAssertThrowsError(
-      try GrokProvider.parseCredits(
-        data: Data(
-          #"""
-          {
-            "config": {
-              "productUsage": {},
-              "productBreakdown": {"chat": {"creditUsagePercent": 20}}
-            }
-          }
-          """#.utf8
-        ),
-        now: now
-      )
-    )
-    XCTAssertThrowsError(
-      try GrokProvider.parseCredits(
-        data: Data(
-          #"{"config":{"productUsage":{"grok-3":{"creditUsagePercent":20},"grok_3":{"creditUsagePercent":30}}}}"#
-            .utf8
-        ),
-        now: now
-      )
-    )
-  }
-
-  func testGrokUnknownUsageIsNotZeroAndPartialDataSurvives() throws {
-    let unknown = try GrokProvider.parseCredits(data: fixture("grok-credits-unknown"), now: now)
-    XCTAssertNil(unknown.first?.usedPercent)
-    let snapshot = try GrokProvider.parse(
-      billing: .success(fixture("grok-billing")),
-      credits: .failure("offline"),
-      accountLabel: "fixture@example.com",
-      now: now
-    )
-    XCTAssertEqual(snapshot.windows.count, 1)
-    XCTAssertTrue(snapshot.notes.first?.contains("offline") == true)
-  }
-
-  func testGrokRejectsInvalidSurfaceShapes() {
-    XCTAssertThrowsError(
-      try GrokProvider.parseBilling(data: fixture("grok-invalid-monthly"), now: now))
-    XCTAssertThrowsError(
-      try GrokProvider.parseCredits(data: Data(#"{"config":{}}"#.utf8), now: now))
-    XCTAssertThrowsError(try GrokProvider.parseIdentity(data: Data(#"{"userId":""}"#.utf8)))
-    XCTAssertThrowsError(
-      try GrokProvider.parse(
-        billing: .failure("offline"),
-        credits: .failure("offline"),
-        accountLabel: nil,
-        now: now
-      )
-    )
-    XCTAssertThrowsError(
-      try GrokProvider.parse(
-        billing: .success(fixture("grok-invalid-monthly")),
-        credits: .success(fixture("grok-credits")),
-        accountLabel: nil,
-        now: now
-      )
-    )
-    XCTAssertThrowsError(
-      try GrokProvider.parse(
-        billing: .success(fixture("grok-billing")),
-        credits: .success(Data(#"{"config":{}}"#.utf8)),
-        accountLabel: nil,
-        now: now
-      )
-    )
-    XCTAssertThrowsError(
-      try GrokProvider.parseCredits(
-        data: Data(
-          #"{"config":{"productUsage":{"chat":{"limit":100,"used":20,"remaining":10}}}}"#
-            .utf8
-        ),
-        now: now
-      )
-    )
-    XCTAssertThrowsError(
-      try GrokProvider.parseCredits(
-        data: Data(
-          #"{"config":{"productUsage":{"chat":{"limit":100,"used":20,"creditUsagePercent":30}}}}"#
-            .utf8
-        ),
-        now: now
-      )
-    )
-    XCTAssertThrowsError(
-      try GrokProvider.parseCredits(
-        data: Data(
-          #"{"config":{"creditUsagePercent":20,"currentPeriod":{"type":"biweekly","end":"2026-08-16T00:00:00Z"}}}"#
-            .utf8
-        ),
         now: now
       )
     )

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/QuotaOverviewTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/QuotaOverviewTests.swift
@@ -46,7 +46,7 @@ final class QuotaOverviewTests: XCTestCase {
       overview.providers.map(\.provider),
       [.codex, .claudeCode, .grok, .antigravity, .cursor, .kimi]
     )
-    XCTAssertEqual(overview.providers[2].badges.map(\.kind), [.partial])
+    XCTAssertEqual(overview.providers[2].badges.map(\.kind), [.partial, .noResets])
   }
 
   func testProviderBadgesDescribeFreshnessAndResetDetails() throws {
@@ -91,7 +91,7 @@ final class QuotaOverviewTests: XCTestCase {
     XCTAssertTrue(kimi.dimsContent)
 
     let grok = try XCTUnwrap(overview.providers.first { $0.provider == .grok })
-    XCTAssertEqual(grok.badges.map(\.kind), [.partial])
+    XCTAssertEqual(grok.badges.map(\.kind), [.partial, .noResets])
     XCTAssertEqual(grok.badges.first?.age, "4D")
     XCTAssertEqual(grok.badges.first?.detail, "Monthly usage is unavailable.")
     XCTAssertFalse(grok.dimsContent)
@@ -108,6 +108,59 @@ final class QuotaOverviewTests: XCTestCase {
     let codex = try XCTUnwrap(overview.providers.first { $0.provider == .codex })
     XCTAssertEqual(codex.badges.map(\.kind), [.noResets])
     XCTAssertEqual(codex.badges.first?.detail, "No reset windows are currently available.")
+  }
+
+  func testGrokResetBadgesMatchCodexBankedResetContract() throws {
+    let resetDate = referenceDate.addingTimeInterval(4_000)
+    let available = QuotaOverview(
+      states: allStates([
+        .grok: .available(
+          UsageSnapshot(
+            provider: .grok,
+            windows: [window(remaining: 44)],
+            resets: [Reset(exp: resetDate)],
+            sourceTimestamp: referenceDate
+          )
+        )
+      ]),
+      at: referenceDate
+    )
+    let grok = try XCTUnwrap(available.providers.first { $0.provider == .grok })
+    XCTAssertEqual(grok.badges.map(\.kind), [.resets])
+    XCTAssertEqual(grok.badges.first?.expirations, [resetDate])
+    XCTAssertEqual(
+      grok.resetOverview,
+      .available([Reset(exp: resetDate)])
+    )
+
+    let none = QuotaOverview(
+      states: allStates([
+        .grok: .available(snapshot(provider: .grok, remaining: 44))
+      ]),
+      at: referenceDate
+    )
+    XCTAssertEqual(
+      none.providers.first { $0.provider == .grok }?.badges.map(\.kind),
+      [.noResets]
+    )
+
+    let resetError = QuotaOverview(
+      states: allStates([
+        .grok: .available(
+          UsageSnapshot(
+            provider: .grok,
+            windows: [window(remaining: 44)],
+            resetErrorMessage: "Reset surface unavailable",
+            sourceTimestamp: referenceDate
+          )
+        )
+      ]),
+      at: referenceDate
+    )
+    XCTAssertEqual(
+      resetError.providers.first { $0.provider == .grok }?.resetOverview,
+      .unavailable(message: "Reset surface unavailable")
+    )
   }
 
   func testCriticalQuotaTakesPrecedenceOverStaleProvider() {

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/TestSupport.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/TestSupport.swift
@@ -238,3 +238,57 @@ final class FakeKeychain: KeychainClient, @unchecked Sendable {
     "\(service)::\(account ?? "")"
   }
 }
+
+func response(_ data: Data) -> APIPlatformResponse {
+  APIPlatformResponse(statusCode: 200, data: data)
+}
+
+func utcTimeZone() -> TimeZone {
+  guard let timeZone = TimeZone(secondsFromGMT: 0) else {
+    preconditionFailure("Invalid UTC test time zone")
+  }
+  return timeZone
+}
+
+func decimal(_ value: String) -> Decimal {
+  guard let result = Decimal(string: value) else {
+    preconditionFailure("Invalid test decimal")
+  }
+  return result
+}
+
+func testOpenAIEndpoints() -> OpenAIEndpoints {
+  guard let url = URL(string: "https://openai.test") else {
+    preconditionFailure("Invalid test endpoint")
+  }
+  return OpenAIEndpoints(baseURL: url)
+}
+
+func testAnthropicEndpoints() -> AnthropicEndpoints {
+  guard let url = URL(string: "https://anthropic.test") else {
+    preconditionFailure("Invalid test endpoint")
+  }
+  return AnthropicEndpoints(baseURL: url)
+}
+
+actor APIPlatformRoutingTransport: APIPlatformTransport {
+  private let routes: [String: APIPlatformResponse]
+  private let delay: Duration
+  private(set) var requests: [APIPlatformRequest] = []
+
+  init(routes: [String: APIPlatformResponse], delay: Duration = .zero) {
+    self.routes = routes
+    self.delay = delay
+  }
+
+  func send(_ request: APIPlatformRequest) async throws -> APIPlatformResponse {
+    if delay > .zero {
+      try await Task.sleep(for: delay)
+    }
+    requests.append(request)
+    guard let response = routes[request.url.absoluteString] else {
+      throw APIPlatformError.network(request.platform)
+    }
+    return response
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/TestSupport.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/TestSupport.swift
@@ -56,6 +56,61 @@ func write(_ value: String, to url: URL) throws {
   try Data(value.utf8).write(to: url)
 }
 
+func grokCLIAuth(token: String, expiresAt: String) -> String {
+  """
+  {
+    "https://auth.x.ai::session": {
+      "key": "\(token)",
+      "expires_at": "\(expiresAt)"
+    }
+  }
+  """
+}
+
+func grokCLIAuth(firstToken: String, secondToken: String) -> String {
+  """
+  {
+    "https://auth.x.ai::aaa": {
+      "key": "\(firstToken)",
+      "expires_at": "2099-01-01T00:00:00Z"
+    },
+    "https://auth.x.ai::bbb": {
+      "key": "\(secondToken)",
+      "expires_at": "2099-01-01T00:00:00Z"
+    }
+  }
+  """
+}
+
+/// Live GetRemainingResets unary frame: empty protobuf message and grpc-status 0.
+let grokEmptyResets = data(hex: "0000000000800000000f677270632d7374617475733a300d0a")
+
+/// Two remaining packs plus expired, empty-id, and missing-end tokens that must be ignored.
+let grokAvailableResets = data(
+  hex: "000000004a"
+    + "0a100a067061636b2d611a060880d8fed306"
+    + "0a100a067061636b2d621a0608808799d406"
+    + "0a0e0a04757365641a060880eeb4d306"
+    + "0a0a0a001a060880d8fed306"
+    + "0a080a066e6f2d656e64"
+    + "800000000f677270632d7374617475733a300d0a"
+)
+
+func data(hex: String) -> Data {
+  precondition(hex.count.isMultiple(of: 2), "Hex strings must have even length")
+  var data = Data()
+  var index = hex.startIndex
+  while index < hex.endIndex {
+    let next = hex.index(index, offsetBy: 2)
+    guard let byte = UInt8(hex[index..<next], radix: 16) else {
+      preconditionFailure("Invalid hex")
+    }
+    data.append(byte)
+    index = next
+  }
+  return data
+}
+
 actor StubCredentialStore: CredentialStore {
   private var credentials: [ProviderCredential]
   private(set) var rejectionRequests: [Bool] = []

--- a/scripts/checks/check-ai-architecture.test.ts
+++ b/scripts/checks/check-ai-architecture.test.ts
@@ -93,6 +93,11 @@ describe("AI architecture guard", () => {
           contents:
             'let usage = URL(string: "https://api.anthropic.com/api/oauth/usage")',
         },
+        {
+          path: "packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformEndpoints.swift",
+          contents:
+            'const openai = "https://api.openai.com/v1/organization/costs";\nconst anthropic = "https://api.anthropic.com/v1/organizations/cost_report";',
+        },
       ]),
     ).toEqual([]);
   });
@@ -155,6 +160,23 @@ describe("AI architecture guard", () => {
       "provider-api-key",
       "direct-provider-endpoint",
     ]);
+  });
+
+  test("allows Brim billing endpoints only in APIPlatformEndpoints.swift", () => {
+    expect(
+      findAiArchitectureViolations([
+        {
+          path: "packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/OpenAIAPI.swift",
+          contents:
+            'const costs = "https://api.openai.com/v1/organization/costs";',
+        },
+        {
+          path: "packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/AnthropicAPI.swift",
+          contents:
+            'const report = "https://api.anthropic.com/v1/organizations/cost_report";',
+        },
+      ]).map(({ rule }) => rule),
+    ).toEqual(["direct-provider-endpoint", "direct-provider-endpoint"]);
   });
 
   test("allows only the official OpenAI billing reconciliation endpoint", () => {

--- a/scripts/checks/check-ai-architecture.test.ts
+++ b/scripts/checks/check-ai-architecture.test.ts
@@ -179,6 +179,18 @@ describe("AI architecture guard", () => {
     ).toEqual(["direct-provider-endpoint", "direct-provider-endpoint"]);
   });
 
+  test("rejects unapproved provider URLs inside APIPlatformEndpoints.swift", () => {
+    expect(
+      findAiArchitectureViolations([
+        {
+          path: "packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformEndpoints.swift",
+          contents:
+            'const completions = "https://api.openai.com/v1/chat/completions";',
+        },
+      ]).map(({ rule }) => rule),
+    ).toEqual(["direct-provider-endpoint"]);
+  });
+
   test("allows only the official OpenAI billing reconciliation endpoint", () => {
     expect(
       findAiArchitectureViolations([

--- a/scripts/checks/check-ai-architecture.ts
+++ b/scripts/checks/check-ai-architecture.ts
@@ -135,6 +135,12 @@ const SUBSCRIPTION_QUOTA_ENDPOINTS =
 // authorities. This is not an inference path.
 const BRIM_API_BILLING_ENDPOINTS =
   "packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformEndpoints.swift";
+const BRIM_API_BILLING_ALLOWED_URLS = new Set([
+  "https://api.openai.com/v1/organization/costs",
+  "https://api.anthropic.com/v1/organizations/cost_report",
+]);
+const DIRECT_PROVIDER_URL =
+  /https:\/\/(?:api\.(?:anthropic|groq|openai|x\.ai)\.com|generativelanguage\.googleapis\.com)[^"'\\\s]*/g;
 // The billing monitor uses OpenAI's official organization Usage and Costs APIs
 // as the payment authority; this is not an inference path.
 const OPENAI_BILLING_RECONCILIATION_PATH =
@@ -152,7 +158,21 @@ function isTestOrFixture(filePath: string): boolean {
   );
 }
 
-function isAllowedViolation(rule: ArchitectureRule, filePath: string): boolean {
+function brimBillingLineIsAllowed(source: string): boolean {
+  const urls = source.match(DIRECT_PROVIDER_URL) ?? [];
+  return (
+    urls.length > 0 &&
+    urls.every((url) =>
+      BRIM_API_BILLING_ALLOWED_URLS.has(url.replace(/\/$/, "")),
+    )
+  );
+}
+
+function isAllowedViolation(
+  rule: ArchitectureRule,
+  filePath: string,
+  source: string,
+): boolean {
   if (CHECK_IMPLEMENTATION_PATHS.has(filePath)) return true;
 
   if (rule.id === "provider-api-key") {
@@ -178,10 +198,12 @@ function isAllowedViolation(rule: ArchitectureRule, filePath: string): boolean {
   }
 
   if (rule.id === "direct-provider-endpoint") {
+    if (filePath === BRIM_API_BILLING_ENDPOINTS) {
+      return brimBillingLineIsAllowed(source);
+    }
     return (
       filePath === WHISPER_TRANSCRIPTION_ADAPTER ||
       filePath === SUBSCRIPTION_QUOTA_ENDPOINTS ||
-      filePath === BRIM_API_BILLING_ENDPOINTS ||
       filePath === OPENAI_BILLING_RECONCILIATION_PATH
     );
   }
@@ -201,7 +223,10 @@ export function findAiArchitectureViolations(
     const lines = file.contents.split("\n");
     for (const [lineIndex, source] of lines.entries()) {
       for (const rule of RULES) {
-        if (rule.pattern.test(source) && !isAllowedViolation(rule, file.path)) {
+        if (
+          rule.pattern.test(source) &&
+          !isAllowedViolation(rule, file.path, source)
+        ) {
           violations.push({
             rule: rule.id,
             description: rule.description,

--- a/scripts/checks/check-ai-architecture.ts
+++ b/scripts/checks/check-ai-architecture.ts
@@ -131,6 +131,10 @@ const STREAMBOT_VOICE_TTS_PATHS = new Set([
 ]);
 const SUBSCRIPTION_QUOTA_ENDPOINTS =
   "packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers/ProviderEndpoints.swift";
+// Brim's API view reads OpenAI Costs and Anthropic Cost Report as billing
+// authorities. This is not an inference path.
+const BRIM_API_BILLING_ENDPOINTS =
+  "packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformEndpoints.swift";
 // The billing monitor uses OpenAI's official organization Usage and Costs APIs
 // as the payment authority; this is not an inference path.
 const OPENAI_BILLING_RECONCILIATION_PATH =
@@ -177,6 +181,7 @@ function isAllowedViolation(rule: ArchitectureRule, filePath: string): boolean {
     return (
       filePath === WHISPER_TRANSCRIPTION_ADAPTER ||
       filePath === SUBSCRIPTION_QUOTA_ENDPOINTS ||
+      filePath === BRIM_API_BILLING_ENDPOINTS ||
       filePath === OPENAI_BILLING_RECONCILIATION_PATH
     );
   }


### PR DESCRIPTION
## Why

Brim only reported OpenRouter API spend, and Grok extra resets were missing from the menu-bar badge. SuperGrok now uses unified weekly credits plus banked extra-reset tokens, Claude started sending `seven_day_breakdown` metadata that grayed the section, and OpenAI and Anthropic API keys had no spend surface.

## What

- Generalize API platforms to OpenRouter, OpenAI, and Anthropic with a shared transport and Keychain namespace.
- Fetch Grok from grok CLI plus Keychain; decode SuperGrok unified weekly credits and `GetRemainingResets` as Codex-style banked extra resets. Brim never redeems a reset.
- Skip Claude `seven_day_breakdown` metadata so the section stays current instead of stale.
- Allow OpenAI Costs and Anthropic Cost Report URLs only in `APIPlatformEndpoints.swift`.

## Verification

- `cd packages/macos-ai-subscription-tracker && bun run format && bun run lint:swift && bun run test:macos`
- 161 Swift tests passed after restacking onto main
- `bun run bundle:macos && bun run install:macos` (pre-restack local install)
- Live: Grok `GetRemainingResets` HTTP 200 (empty tokens on this account); Claude `oauth/usage` HTTP 200 after the decoder fix; Brim restarted from `/Applications/Brim.app`
- Not run: Buildkite, wiki typecheck/e2e, GitOps (not a hosted workload)

## Rollout notes

OpenAI and Anthropic admin keys, like OpenRouter Management keys, can have broad account authority. Brim only issues the documented read-only billing requests. Grok extra-reset tokens are listed, never redeemed.