### PR TITLE
refactor(scout-for-lol): remove the web backend's Gateway-cache dependency

### DIFF
--- a/packages/scout-for-lol/packages/backend/README.md
+++ b/packages/scout-for-lol/packages/backend/README.md
@@ -124,6 +124,38 @@ Manual end-to-end probe (macOS, trained assets + `OPENAI_API_KEY` required, no
 Discord): `bun scripts/smoke/voice-probe.ts --list-devices`, then
 `bun scripts/smoke/voice-probe.ts --device <index> --assets-dir <path>`.
 
+## How web requests read Discord
+
+No HTTP, tRPC, or Discord Activity request reads the gateway client's guild
+cache. That cache cannot answer honestly on a request path — an unconnected or
+still-backfilling client looks exactly like "Scout is not installed there" —
+so web-serving code goes through two application ports instead, and a pod that
+never connects a gateway serves the same answers as one that did:
+
+- `lib/discord/installed-guilds.ts` answers "is Scout installed here?" from
+  `GuildInstall` rows with `removedAt: null`. This makes `GuildInstall` an
+  authorization source, not just an analytics table: its writers
+  (`discord/events/guild-create.ts`, `guild-delete.ts`,
+  `analytics/guild-lifecycle.ts`) are load-bearing for access control. Because a
+  missing row is not proof of absence, a negative from the table is confirmed
+  against Discord before it is believed.
+- `lib/discord/bot-rest.ts` performs the authoritative bot-token REST reads the
+  web needs — guild channels, roles, a single member, member search, user
+  profiles — behind bounded per-guild TTL caches. Channel permission filtering
+  is recomputed from roles and overwrites in `lib/discord/channel-permissions.ts`
+  rather than read from a cached `GuildMember`.
+
+Three outcomes stay distinct on every path: Discord unreachable
+(`SERVICE_UNAVAILABLE`, or 503 on the Activity surface), Scout not installed
+(`NOT_FOUND` / 403), and the caller not authorized (`FORBIDDEN`). Failing to
+reach Discord must never be reported as either of the other two;
+`trpc/discord-upstream.ts` and `customs/activity-auth.ts` enforce that.
+
+Gateway events still _write_ installation state, and background jobs (outreach,
+cleanup, reconciliation, weekly leaderboards, report dispatch, the voice
+assistant) still read the gateway cache — they run only in a process that has
+one.
+
 ## Configuration
 
 Environment variables are validated with `env-var`/Zod at startup. Discord and

--- a/packages/scout-for-lol/packages/backend/src/customs/activity/activity-actor.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/activity/activity-actor.test.ts
@@ -29,7 +29,15 @@ const state: {
   channel: DiscordChannel | null;
   unavailable: boolean;
   adminRole: boolean;
-} = { member: null, channel: null, unavailable: false, adminRole: false };
+  ownerId: string;
+} = {
+  member: null,
+  channel: null,
+  unavailable: false,
+  adminRole: false,
+  // Somebody else owns the server unless a test says otherwise.
+  ownerId: "000",
+};
 
 function guard<T>(produce: () => T): Promise<T> {
   if (state.unavailable) {
@@ -45,6 +53,8 @@ function unused(): never {
 }
 
 const fakeRest: BotRestReader = {
+  guild: () =>
+    guard(() => ({ id: GUILD, name: "Server", owner_id: state.ownerId })),
   guildExists: () => guard(() => true),
   guildChannels: unused,
   guildRoles: () =>
@@ -123,6 +133,7 @@ function reset(): void {
   state.channel = voiceChannel();
   state.unavailable = false;
   state.adminRole = false;
+  state.ownerId = "000";
 }
 
 describe("customActivityActor", () => {
@@ -142,6 +153,25 @@ describe("customActivityActor", () => {
     state.adminRole = true;
     await expect(customActivityActor(claims)).resolves.toMatchObject({
       administrator: true,
+    });
+  });
+
+  test("the guild owner is Administrator with no admin role", async () => {
+    // Discord grants the owner everything implicitly, so a roles-only answer
+    // would deny the one person who can do anything in their own server.
+    reset();
+    state.ownerId = ACTOR;
+    await expect(customActivityActor(claims)).resolves.toMatchObject({
+      administrator: true,
+    });
+  });
+
+  test("a non-owner without an admin role is not Administrator", async () => {
+    reset();
+    state.member = member([ADMIN_ROLE]);
+    state.adminRole = false;
+    await expect(customActivityActor(claims)).resolves.toMatchObject({
+      administrator: false,
     });
   });
 

--- a/packages/scout-for-lol/packages/backend/src/customs/activity/activity-actor.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/activity/activity-actor.test.ts
@@ -70,6 +70,7 @@ const fakeRest: BotRestReader = {
     ]),
   botMember: unused,
   guildMember: () => guard(() => state.member),
+  freshGuildMember: () => guard(() => state.member),
   searchGuildMembers: unused,
   user: unused,
   channel: () => guard(() => state.channel),

--- a/packages/scout-for-lol/packages/backend/src/customs/activity/activity-actor.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/activity/activity-actor.test.ts
@@ -1,0 +1,204 @@
+/**
+ * The Activity's actor resolution reads Discord over REST, so it must work with
+ * no gateway — and must keep "Discord is unreachable" (503) distinct from "you
+ * are not in this server" (403).
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import { ChannelType, PermissionFlagsBits } from "discord.js";
+import type { CustomActivityClaims } from "@scout-for-lol/data";
+import { DiscordUpstreamError } from "#src/lib/discord-rest.ts";
+import type { BotRestReader } from "#src/lib/discord/bot-rest.ts";
+import type {
+  DiscordChannel,
+  DiscordGuildMember,
+} from "#src/lib/discord/bot-rest-schemas.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+} from "#src/testing/test-ids.ts";
+
+const GUILD = testGuildId("851");
+const CHANNEL = testChannelId("852");
+const ACTOR = testAccountId("853");
+const ADMIN_ROLE = "854";
+
+const state: {
+  member: DiscordGuildMember | null;
+  channel: DiscordChannel | null;
+  unavailable: boolean;
+  adminRole: boolean;
+} = { member: null, channel: null, unavailable: false, adminRole: false };
+
+function guard<T>(produce: () => T): Promise<T> {
+  if (state.unavailable) {
+    return Promise.reject(
+      new DiscordUpstreamError("fetch_error", "Discord is unreachable"),
+    );
+  }
+  return Promise.resolve(produce());
+}
+
+function unused(): never {
+  throw new Error("not used by the Activity actor");
+}
+
+const fakeRest: BotRestReader = {
+  guildExists: () => guard(() => true),
+  guildChannels: unused,
+  guildRoles: () =>
+    guard(() => [
+      { id: GUILD, name: "@everyone", permissions: "0" },
+      {
+        id: ADMIN_ROLE,
+        name: "Admins",
+        permissions: state.adminRole
+          ? PermissionFlagsBits.Administrator.toString()
+          : "0",
+      },
+    ]),
+  botMember: unused,
+  guildMember: () => guard(() => state.member),
+  searchGuildMembers: unused,
+  user: unused,
+  channel: () => guard(() => state.channel),
+  clearCaches: () => {
+    /* the fake holds no cache */
+  },
+};
+
+const activityAuth = await import("#src/customs/activity/activity-auth.ts");
+const botRestModule = await import("#src/lib/discord/bot-rest.ts");
+
+vi.doMock("#src/lib/discord/bot-rest.ts", () => ({
+  ...botRestModule,
+  botRest: () => fakeRest,
+}));
+vi.doMock("#src/lib/discord/installed-guilds.ts", () => ({
+  installedGuildName: () => Promise.resolve("Recorded Server"),
+  isScoutInstalledInGuild: () => Promise.resolve(true),
+  installedGuildIdsAmong: () => Promise.resolve(new Set<string>()),
+}));
+vi.doMock("#src/customs/activity/activity-auth.ts", () => ({
+  ...activityAuth,
+  assertCustomActivityPolicy: () => Promise.resolve(),
+}));
+
+const { assertCustomLaunchChannel, customActivityActor } =
+  await import("#src/customs/activity/activity-actor.ts");
+
+const claims: CustomActivityClaims = {
+  sub: ACTOR,
+  guildId: GUILD,
+  channelId: CHANNEL,
+  instanceId: "instance",
+  applicationId: "application",
+  type: "customs_activity",
+};
+
+function member(roles: string[]): DiscordGuildMember {
+  return {
+    user: { id: ACTOR, username: "player", global_name: "Player" },
+    nick: "Nick",
+    avatar: null,
+    roles,
+  };
+}
+
+function voiceChannel(overrides: Partial<DiscordChannel> = {}): DiscordChannel {
+  return {
+    id: CHANNEL,
+    name: "lobby",
+    type: ChannelType.GuildVoice,
+    parent_id: null,
+    permission_overwrites: [],
+    guild_id: GUILD,
+    ...overrides,
+  };
+}
+
+function reset(): void {
+  state.member = member([]);
+  state.channel = voiceChannel();
+  state.unavailable = false;
+  state.adminRole = false;
+}
+
+describe("customActivityActor", () => {
+  test("names the guild from the recorded install, not a gateway cache", async () => {
+    reset();
+    const actor = await customActivityActor(claims);
+    expect(actor).toMatchObject({
+      guildName: "Recorded Server",
+      displayName: "Nick",
+      administrator: false,
+    });
+  });
+
+  test("derives Administrator by joining the member's roles against the guild's", async () => {
+    reset();
+    state.member = member([ADMIN_ROLE]);
+    state.adminRole = true;
+    await expect(customActivityActor(claims)).resolves.toMatchObject({
+      administrator: true,
+    });
+  });
+
+  test("a non-member is 403", async () => {
+    reset();
+    state.member = null;
+    await expect(customActivityActor(claims)).rejects.toMatchObject({
+      status: 403,
+    });
+  });
+
+  test("an unreachable Discord is 503, not 403", async () => {
+    reset();
+    state.unavailable = true;
+    await expect(customActivityActor(claims)).rejects.toMatchObject({
+      status: 503,
+    });
+  });
+});
+
+describe("assertCustomLaunchChannel", () => {
+  const actor = {
+    discordId: ACTOR,
+    guildId: GUILD,
+    channelId: CHANNEL,
+    guildName: "Recorded Server",
+    displayName: "Nick",
+    avatarUrl: undefined,
+    administrator: false,
+  };
+
+  test("accepts a voice channel of the claimed guild", async () => {
+    reset();
+    await expect(assertCustomLaunchChannel(actor)).resolves.toBeUndefined();
+  });
+
+  test("rejects a text channel", async () => {
+    reset();
+    state.channel = voiceChannel({ type: ChannelType.GuildText });
+    await expect(assertCustomLaunchChannel(actor)).rejects.toThrow(
+      "guild voice channel",
+    );
+  });
+
+  test("rejects a voice channel belonging to another guild", async () => {
+    reset();
+    state.channel = voiceChannel({ guild_id: testGuildId("999") });
+    await expect(assertCustomLaunchChannel(actor)).rejects.toThrow(
+      "guild voice channel",
+    );
+  });
+
+  test("an unreachable Discord is 503, never a launch rejection", async () => {
+    reset();
+    state.unavailable = true;
+    await expect(assertCustomLaunchChannel(actor)).rejects.toMatchObject({
+      status: 503,
+    });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/customs/activity/activity-actor.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/activity/activity-actor.ts
@@ -49,19 +49,29 @@ export type CustomActivityActor = {
  *
  * The gateway used to hand this over as `member.permissions`; over REST the
  * member payload carries role ids only, so the roles have to be joined against
- * the guild's role list.
+ * the guild's role list — and against the guild's `owner_id`, because Discord
+ * grants the owner every permission without any role saying so. Plenty of
+ * servers are run by an owner who never gave themselves an Administrator role,
+ * and a roles-only answer denies exactly the person who can do anything.
  */
 async function hasGuildAdministrator(
   guildId: DiscordGuildId,
   member: DiscordGuildMember,
 ): Promise<boolean> {
-  const roles = await customsDiscordRead(
-    () => botRest().guildRoles(guildId),
-    "Scout could not read this server's roles right now",
-  );
+  const [guild, roles] = await Promise.all([
+    customsDiscordRead(
+      () => botRest().guild(guildId),
+      "Scout could not read this server right now",
+    ),
+    customsDiscordRead(
+      () => botRest().guildRoles(guildId),
+      "Scout could not read this server's roles right now",
+    ),
+  ]);
   if (roles === null) return false;
   const permissions = computeChannelPermissions({
     guildId,
+    guildOwnerId: guild?.owner_id ?? null,
     memberId: member.user.id,
     memberRoleIds: member.roles,
     rolePermissions: new Map(roles.map((role) => [role.id, role.permissions])),

--- a/packages/scout-for-lol/packages/backend/src/customs/activity/activity-actor.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/activity/activity-actor.ts
@@ -1,4 +1,13 @@
-import { PermissionFlagsBits, type GuildMember } from "discord.js";
+/**
+ * Who is acting inside a Scout Customs Activity, resolved for an HTTP request.
+ *
+ * Every Discord fact here comes from the bot REST ports rather than the gateway
+ * guild cache, so the Activity's API answers identically on a pod with no
+ * gateway connection. `customsDiscordRead` keeps "Discord is unreachable" (503)
+ * apart from "you are not in this server" (403).
+ */
+
+import { ChannelType, PermissionFlagsBits } from "discord.js";
 import {
   DiscordAccountIdSchema,
   DiscordChannelIdSchema,
@@ -8,8 +17,22 @@ import {
   type DiscordChannelId,
   type DiscordGuildId,
 } from "@scout-for-lol/data";
-import { client as discordClient } from "#src/discord/client.ts";
-import { assertCustomActivityPolicy } from "#src/customs/activity/activity-auth.ts";
+import {
+  CustomAuthHttpError,
+  assertCustomActivityPolicy,
+  customsDiscordRead,
+} from "#src/customs/activity/activity-auth.ts";
+import {
+  botRest,
+  memberAvatarUrl,
+  memberDisplayName,
+} from "#src/lib/discord/bot-rest.ts";
+import { installedGuildName } from "#src/lib/discord/installed-guilds.ts";
+import {
+  computeChannelPermissions,
+  hasPermission,
+} from "#src/lib/discord/channel-permissions.ts";
+import type { DiscordGuildMember } from "#src/lib/discord/bot-rest-schemas.ts";
 
 export type CustomActivityActor = {
   readonly discordId: DiscordAccountId;
@@ -21,31 +44,62 @@ export type CustomActivityActor = {
   readonly administrator: boolean;
 };
 
-function actorForMember(
-  member: GuildMember,
-  claims: CustomActivityClaims,
-): CustomActivityActor {
-  return {
-    discordId: DiscordAccountIdSchema.parse(claims.sub),
-    guildId: DiscordGuildIdSchema.parse(claims.guildId),
-    channelId: DiscordChannelIdSchema.parse(claims.channelId),
-    guildName: member.guild.name,
-    displayName: member.displayName,
-    avatarUrl: member.displayAvatarURL() || undefined,
-    administrator: member.permissions.has(PermissionFlagsBits.Administrator),
-  };
+/**
+ * Whether the member holds Administrator guild-wide.
+ *
+ * The gateway used to hand this over as `member.permissions`; over REST the
+ * member payload carries role ids only, so the roles have to be joined against
+ * the guild's role list.
+ */
+async function hasGuildAdministrator(
+  guildId: DiscordGuildId,
+  member: DiscordGuildMember,
+): Promise<boolean> {
+  const roles = await customsDiscordRead(
+    () => botRest().guildRoles(guildId),
+    "Scout could not read this server's roles right now",
+  );
+  if (roles === null) return false;
+  const permissions = computeChannelPermissions({
+    guildId,
+    memberId: member.user.id,
+    memberRoleIds: member.roles,
+    rolePermissions: new Map(roles.map((role) => [role.id, role.permissions])),
+    // No channel context: this is the guild-wide answer.
+    overwrites: [],
+  });
+  return hasPermission(permissions, PermissionFlagsBits.Administrator);
+}
+
+async function requireGuildMember(
+  guildId: DiscordGuildId,
+  discordId: string,
+): Promise<DiscordGuildMember> {
+  const member = await customsDiscordRead(
+    () => botRest().guildMember(guildId, discordId),
+    "Scout could not verify this server's members right now",
+  );
+  if (member === null) {
+    throw new CustomAuthHttpError(403, "Activity guild membership required");
+  }
+  return member;
 }
 
 export async function customActivityActor(
   claims: CustomActivityClaims,
 ): Promise<CustomActivityActor> {
   await assertCustomActivityPolicy(claims);
-  const guild = discordClient.guilds.cache.get(claims.guildId);
-  if (guild === undefined) {
-    throw new Error("Scout is not installed in the Activity guild");
-  }
-  const member = await guild.members.fetch(claims.sub);
-  return actorForMember(member, claims);
+  const guildId = DiscordGuildIdSchema.parse(claims.guildId);
+  const member = await requireGuildMember(guildId, claims.sub);
+  return {
+    discordId: DiscordAccountIdSchema.parse(claims.sub),
+    guildId,
+    channelId: DiscordChannelIdSchema.parse(claims.channelId),
+    guildName: (await installedGuildName(guildId)) ?? guildId,
+    displayName: memberDisplayName(member),
+    avatarUrl: memberAvatarUrl(member, guildId),
+    administrator: await hasGuildAdministrator(guildId, member),
+  };
 }
 
 export async function customGuildMemberIdentity(
@@ -56,27 +110,41 @@ export async function customGuildMemberIdentity(
   displayName: string;
   avatarUrl: string | undefined;
 }> {
-  const guild = discordClient.guilds.cache.get(actor.guildId);
-  if (guild === undefined) {
-    throw new Error("Scout is not installed in the Activity guild");
-  }
-  const member = await guild.members.fetch(discordId);
+  const member = await requireGuildMember(actor.guildId, discordId);
   return {
-    discordId: DiscordAccountIdSchema.parse(member.id),
-    displayName: member.displayName,
-    avatarUrl: member.displayAvatarURL() || undefined,
+    discordId: DiscordAccountIdSchema.parse(member.user.id),
+    displayName: memberDisplayName(member),
+    avatarUrl: memberAvatarUrl(member, actor.guildId),
   };
 }
 
+/** Voice-shaped channel kinds an Activity may legitimately launch from. */
+const LAUNCHABLE_CHANNEL_TYPES = new Set<number>([
+  ChannelType.GuildVoice,
+  ChannelType.GuildStageVoice,
+]);
+
+/**
+ * The channel the Activity was launched from must be a voice channel of the
+ * claimed guild.
+ *
+ * Read by id and uncached: the id comes from Discord's Activity SDK, not from a
+ * list Scout offered, and people routinely create a voice channel and launch
+ * Customs in it moments later — a cached channel list would reject a channel
+ * that provably exists. `guild_id` is checked here because the by-id route is
+ * not guild-scoped.
+ */
 export async function assertCustomLaunchChannel(
   actor: CustomActivityActor,
 ): Promise<void> {
-  const guild = discordClient.guilds.cache.get(actor.guildId);
-  if (guild === undefined) {
-    throw new Error("Scout is not installed in the Activity guild");
-  }
-  const channel = await guild.channels.fetch(actor.channelId);
-  if (channel?.isVoiceBased() !== true) {
+  const channel = await customsDiscordRead(
+    () => botRest().channel(actor.channelId),
+    "Scout could not read that channel right now",
+  );
+  if (
+    channel?.guild_id !== actor.guildId ||
+    !LAUNCHABLE_CHANNEL_TYPES.has(channel.type)
+  ) {
     throw new Error(
       "Scout Customs must be launched from a guild voice channel",
     );

--- a/packages/scout-for-lol/packages/backend/src/customs/activity/activity-auth.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/activity/activity-auth.ts
@@ -11,7 +11,9 @@ import {
 } from "@scout-for-lol/data";
 import configuration from "#src/configuration.ts";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
-import { client as discordClient } from "#src/discord/client.ts";
+import { DiscordUpstreamError } from "#src/lib/discord-rest.ts";
+import { botRest } from "#src/lib/discord/bot-rest.ts";
+import { isScoutInstalledInGuild } from "#src/lib/discord/installed-guilds.ts";
 
 const DISCORD_API_BASE = "https://discord.com/api/v10";
 const DISCORD_REQUEST_TIMEOUT_MS = 10_000;
@@ -47,6 +49,36 @@ export class CustomAuthHttpError extends Error {
     super(message, options);
     this.status = status;
   }
+}
+
+/**
+ * Run a bot-token Discord read for an Activity request.
+ *
+ * `lib/discord/bot-rest.ts` throws {@link DiscordUpstreamError} when it could
+ * not get an answer at all. The Activity's HTTP surface must report that as 503
+ * — the same rule `trpc/discord-upstream.ts` enforces for the dashboard — so an
+ * outage never reaches a player as "you are not in this server".
+ */
+export async function customsDiscordRead<T>(
+  operation: () => Promise<T>,
+  message: string,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof DiscordUpstreamError) {
+      throw new CustomAuthHttpError(503, message, { cause: error });
+    }
+    throw error;
+  }
+}
+
+/** Whether Scout is installed, with an unreachable Discord surfaced as 503. */
+export async function customsGuildInstalled(guildId: string): Promise<boolean> {
+  return await customsDiscordRead(
+    () => isScoutInstalledInGuild(guildId),
+    "Scout could not verify this server right now",
+  );
 }
 
 const DiscordTokenSchema = z.strictObject({
@@ -96,22 +128,28 @@ function requireSigningKey(): Uint8Array {
   return new TextEncoder().encode(secret);
 }
 
+/**
+ * Three outcomes, kept apart on purpose (the Activity is served over HTTP and
+ * must behave with no gateway connection): Discord unreachable ⇒ 503, Scout not
+ * installed ⇒ 403, the player is not in the guild ⇒ 403. Collapsing the first
+ * into either 403 would tell a player they lack access during an outage.
+ */
 export async function assertCustomGuildMember(
   claims: CustomActivityClaims,
 ): Promise<void> {
   if (claims.applicationId !== configuration.applicationId) {
     throw new CustomAuthHttpError(401, "Activity application mismatch");
   }
-  const guild = discordClient.guilds.cache.get(claims.guildId);
-  if (guild === undefined) {
+  const installed = await customsGuildInstalled(claims.guildId);
+  if (!installed) {
     throw new CustomAuthHttpError(403, "Scout is not installed in this guild");
   }
-  try {
-    await guild.members.fetch(claims.sub);
-  } catch (error) {
-    throw new CustomAuthHttpError(403, "Activity guild membership required", {
-      cause: error,
-    });
+  const member = await customsDiscordRead(
+    () => botRest().guildMember(claims.guildId, claims.sub),
+    "Activity guild membership could not be verified",
+  );
+  if (member === null) {
+    throw new CustomAuthHttpError(403, "Activity guild membership required");
   }
 }
 

--- a/packages/scout-for-lol/packages/backend/src/customs/voice-service.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/voice-service.ts
@@ -86,9 +86,17 @@ async function customGuild(actor: CustomActivityActor): Promise<Guild> {
   return customGuildById(actor.guildId);
 }
 
+/**
+ * The guild, always fetched rather than read from the gateway cache.
+ *
+ * The cache read made this path's behaviour depend on whether a gateway
+ * connection had backfilled yet — an HTTP request from the Activity would work
+ * or not based on shard state. `guilds.fetch` is a REST call and answers the
+ * same way either way. (Everything this module then does with the Guild —
+ * creating, editing and deleting channels, moving members — is REST too.)
+ */
 async function customGuildById(guildId: string): Promise<Guild> {
-  const cached = discordClient.guilds.cache.get(guildId);
-  return cached ?? discordClient.guilds.fetch(guildId);
+  return await discordClient.guilds.fetch(guildId);
 }
 
 async function voiceChannel(

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/capability.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/capability.test.ts
@@ -77,7 +77,7 @@ function countedAccess(
         counters.permission += 1;
         return await permissions(guildId);
       },
-      guildName: (guildId) => `Guild ${guildId}`,
+      guildName: (guildId) => Promise.resolve(`Guild ${guildId}`),
     });
 }
 
@@ -140,7 +140,7 @@ describe("creation tool registration", () => {
         resolveAccess: countedAccess(counters, () =>
           Promise.resolve(rootPermissions()),
         ),
-        listChannels: () => [],
+        listChannels: () => Promise.resolve([]),
       },
     });
 
@@ -169,7 +169,7 @@ describe("creation tool registration", () => {
         resolveAccess: countedAccess(counters, () =>
           Promise.resolve(createPermissionSet([])),
         ),
-        listChannels: () => [],
+        listChannels: () => Promise.resolve([]),
       },
     });
     expect(Object.keys(tools).toSorted()).toEqual([
@@ -196,7 +196,7 @@ describe("creation tool registration", () => {
         resolveAccess: countedAccess(counters, () =>
           Promise.resolve(createPermissionSet([])),
         ),
-        listChannels: () => [],
+        listChannels: () => Promise.resolve([]),
       },
     });
     expect(counters).toEqual({ oauth: 0, permission: 0 });

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/capability.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/capability.ts
@@ -34,7 +34,7 @@ import {
 import type { User } from "#generated/prisma/client/index.js";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
 import { prisma } from "#src/database/index.ts";
-import { client as discordClient } from "#src/discord/client.ts";
+import { installedGuildName } from "#src/lib/discord/installed-guilds.ts";
 import type { ExploreSurface } from "#src/explore/surface.ts";
 import type { PartialGuild } from "#src/lib/discord-rest.ts";
 import { fetchUserGuildsForRequest } from "#src/trpc/discord-upstream.ts";
@@ -69,7 +69,7 @@ export async function resolveCreationCapability(input: {
 /** One guild the asker may actually act in, with the permissions they hold. */
 export type CreationGuildAccess = {
   guildId: DiscordGuildId;
-  /** Display name from the bot's guild cache, for the model to name servers. */
+  /** Display name recorded at install time, for the model to name servers. */
   name: string;
   permissions: PermissionSet;
 };
@@ -93,18 +93,21 @@ type CreationAccessDependencies = {
     user: User,
     guildId: DiscordGuildId,
   ) => Promise<PermissionSet>;
-  guildName: (guildId: DiscordGuildId) => string;
+  guildName: (guildId: DiscordGuildId) => Promise<string>;
 };
 
 /**
- * The bot's cached display name for a guild.
+ * The guild's recorded display name.
  *
- * `resolveGuildPermissions` has already proved Scout is installed by the time
- * this is read, so a miss only happens for a dev guild override, where the id
- * is the most honest label available.
+ * Read from the `GuildInstall` row that `guildCreate` refreshes on every
+ * install, rather than the bot's gateway cache, so an Explore turn served by a
+ * gatewayless pod names servers the same way. `resolveGuildPermissions` has
+ * already proved Scout is installed by the time this is read, so a miss only
+ * happens for a dev guild override, where the id is the most honest label
+ * available.
  */
-function cachedGuildName(guildId: DiscordGuildId): string {
-  return discordClient.guilds.cache.get(guildId)?.name ?? guildId;
+async function recordedGuildName(guildId: DiscordGuildId): Promise<string> {
+  return (await installedGuildName(guildId)) ?? guildId;
 }
 
 const defaultCreationAccessDependencies: CreationAccessDependencies = {
@@ -116,7 +119,7 @@ const defaultCreationAccessDependencies: CreationAccessDependencies = {
     prisma.user.findUniqueOrThrow({ where: { discordId } }),
   fetchUserGuilds: fetchUserGuildsForRequest,
   resolvePermissions: resolveGuildPermissions,
-  guildName: cachedGuildName,
+  guildName: recordedGuildName,
 };
 
 /**
@@ -179,7 +182,7 @@ export async function resolveCreationAccess(
       const permissions = await dependencies.resolvePermissions(user, guildId);
       guilds.push({
         guildId,
-        name: dependencies.guildName(guildId),
+        name: await dependencies.guildName(guildId),
         permissions,
       });
     } catch (error) {

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/context.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/context.ts
@@ -24,6 +24,7 @@ import {
   type CreationPrepareResult,
 } from "#src/explore/creation/schemas.ts";
 import { createConfirmationIntent } from "#src/lib/confirmation-intent/create.ts";
+import { DiscordUpstreamError } from "#src/lib/discord-rest.ts";
 import type { PostableChannel } from "#src/lib/discord/postable-channels.ts";
 import type { resolveSubscriptionPuuid } from "#src/lib/subscription/add.ts";
 import type { ToolTracker } from "#src/reports/ai/scoutql-tools.ts";
@@ -99,13 +100,58 @@ export async function lookupGuildAccess(
   return { kind: "ok", guild };
 }
 
+/**
+ * What the model is told when Discord could not be reached for the channel
+ * list. Deliberately not a permission or validity claim: the tools must never
+ * say "Scout cannot post there" when the truth is that Scout could not ask.
+ */
+export const CREATION_CHANNELS_UNAVAILABLE_MESSAGE =
+  "Scout could not reach Discord to list that server's channels. Tell the user Scout could not check their channels right now and to try again shortly. Do not tell them the channel is invalid or that Scout lacks permission.";
+
+export type PostableChannelLookup =
+  | { kind: "ok"; channels: PostableChannel[] }
+  | { kind: "unavailable"; message: string };
+
+/**
+ * The guild's postable channels, with a failure to reach Discord converted into
+ * a value the creation protocol can express.
+ *
+ * `listPostableChannels` raises {@link DiscordUpstreamError} on an unreachable
+ * Discord — correct for tRPC, where it becomes SERVICE_UNAVAILABLE, but inside
+ * an Explore turn an escaping exception surfaces as a generic tool crash. The
+ * model then has no typed refusal to relay and is liable to invent a reason,
+ * which is exactly the "an outage is never a denial" rule this feature is built
+ * around. Every channel read in the creation tools goes through here.
+ */
+export async function lookupPostableChannels(
+  context: CreationToolContext,
+  guildId: DiscordGuildId,
+): Promise<PostableChannelLookup> {
+  try {
+    return { kind: "ok", channels: await context.listChannels(guildId) };
+  } catch (error) {
+    if (error instanceof DiscordUpstreamError) {
+      return {
+        kind: "unavailable",
+        message: CREATION_CHANNELS_UNAVAILABLE_MESSAGE,
+      };
+    }
+    throw error;
+  }
+}
+
 /** The channel must be one Scout can actually post the entity's output into. */
 export async function requirePostableChannel(
   context: CreationToolContext,
   input: { guildId: DiscordGuildId; channelId: string },
 ): Promise<CreationPrepareResult | null> {
-  const channels = await context.listChannels(input.guildId);
-  if (channels.some((channel) => channel.id === input.channelId)) return null;
+  const lookup = await lookupPostableChannels(context, input.guildId);
+  if (lookup.kind === "unavailable") {
+    return creationRefusal("verification_unavailable", lookup.message);
+  }
+  if (lookup.channels.some((channel) => channel.id === input.channelId)) {
+    return null;
+  }
   return creationRefusal(
     "invalid",
     "Scout cannot post in that channel. Call list_guild_channels and ask the user to pick one of the channels it returns.",
@@ -115,16 +161,22 @@ export async function requirePostableChannel(
 /**
  * The channel's display name, for a summary a person will read.
  *
- * Every caller has already proved the channel is postable, so a miss is
- * unreachable; the id is the honest label if it ever happens.
+ * Every caller has already proved the channel is postable through
+ * {@link requirePostableChannel}, so this re-read hits the same TTL cache and a
+ * miss is unreachable; the id is the honest label if it ever happens. An outage
+ * between the two reads degrades the label rather than failing a prepare that
+ * has already passed every real check.
  */
 export async function postableChannelName(
   context: CreationToolContext,
   guildId: DiscordGuildId,
   channelId: string,
 ): Promise<string> {
-  const channels = await context.listChannels(guildId);
-  const channel = channels.find((candidate) => candidate.id === channelId);
+  const lookup = await lookupPostableChannels(context, guildId);
+  if (lookup.kind === "unavailable") return channelId;
+  const channel = lookup.channels.find(
+    (candidate) => candidate.id === channelId,
+  );
   return channel?.name ?? channelId;
 }
 

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/context.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/context.ts
@@ -42,7 +42,7 @@ export type CreationToolContext = {
   db: ExtendedPrismaClient;
   /** Memoized for the turn; see the module docblock. */
   access: () => Promise<CreationAccess>;
-  listChannels: (guildId: DiscordGuildId) => PostableChannel[];
+  listChannels: (guildId: DiscordGuildId) => Promise<PostableChannel[]>;
   resolvePuuid: typeof resolveSubscriptionPuuid;
   now: () => Date;
   /**
@@ -100,11 +100,11 @@ export async function lookupGuildAccess(
 }
 
 /** The channel must be one Scout can actually post the entity's output into. */
-export function requirePostableChannel(
+export async function requirePostableChannel(
   context: CreationToolContext,
   input: { guildId: DiscordGuildId; channelId: string },
-): CreationPrepareResult | null {
-  const channels = context.listChannels(input.guildId);
+): Promise<CreationPrepareResult | null> {
+  const channels = await context.listChannels(input.guildId);
   if (channels.some((channel) => channel.id === input.channelId)) return null;
   return creationRefusal(
     "invalid",
@@ -118,14 +118,13 @@ export function requirePostableChannel(
  * Every caller has already proved the channel is postable, so a miss is
  * unreachable; the id is the honest label if it ever happens.
  */
-export function postableChannelName(
+export async function postableChannelName(
   context: CreationToolContext,
   guildId: DiscordGuildId,
   channelId: string,
-): string {
-  const channel = context
-    .listChannels(guildId)
-    .find((candidate) => candidate.id === channelId);
+): Promise<string> {
+  const channels = await context.listChannels(guildId);
+  const channel = channels.find((candidate) => candidate.id === channelId);
   return channel?.name ?? channelId;
 }
 

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/prepare-competition.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/prepare-competition.ts
@@ -82,7 +82,7 @@ export async function prepareCompetitionCreation(
     );
   }
 
-  const channelRefusal = requirePostableChannel(context, {
+  const channelRefusal = await requirePostableChannel(context, {
     guildId: parsed.guildId,
     channelId: parsed.channelId,
   });
@@ -127,7 +127,7 @@ export async function prepareCompetitionCreation(
   return await mintCreationIntent(context, {
     payload,
     guildId: parsed.guildId,
-    summary: `${write.visibility === "SERVER_WIDE" ? "Server-wide" : "Invite-only"} competition "${write.title}" in ${lookup.guild.name}, scored by ${write.criteria.type}, posting to #${postableChannelName(context, parsed.guildId, parsed.channelId)}, ${describeWindow(dates)}.`,
+    summary: `${write.visibility === "SERVER_WIDE" ? "Server-wide" : "Invite-only"} competition "${write.title}" in ${lookup.guild.name}, scored by ${write.criteria.type}, posting to #${await postableChannelName(context, parsed.guildId, parsed.channelId)}, ${describeWindow(dates)}.`,
   });
 }
 

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/prepare-report.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/prepare-report.ts
@@ -39,7 +39,7 @@ export async function prepareReportCreation(
     );
   }
 
-  const channelRefusal = requirePostableChannel(context, {
+  const channelRefusal = await requirePostableChannel(context, {
     guildId: parsed.guildId,
     channelId: parsed.channelId,
   });
@@ -65,6 +65,6 @@ export async function prepareReportCreation(
   return await mintCreationIntent(context, {
     payload,
     guildId: parsed.guildId,
-    summary: `Report "${parsed.title}" in ${lookup.guild.name}, posting to #${postableChannelName(context, parsed.guildId, parsed.channelId)} on cron ${parsed.cronExpression} (${parsed.scheduleTimezone}), ${parsed.isEnabled ? "enabled" : "disabled"}.`,
+    summary: `Report "${parsed.title}" in ${lookup.guild.name}, posting to #${await postableChannelName(context, parsed.guildId, parsed.channelId)} on cron ${parsed.cronExpression} (${parsed.scheduleTimezone}), ${parsed.isEnabled ? "enabled" : "disabled"}.`,
   });
 }

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/prepare-subscription.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/prepare-subscription.ts
@@ -90,7 +90,7 @@ export async function prepareSubscriptionCreation(
     );
   }
 
-  const channelRefusal = requirePostableChannel(context, {
+  const channelRefusal = await requirePostableChannel(context, {
     guildId: parsed.guildId,
     channelId: parsed.channelId,
   });
@@ -122,7 +122,7 @@ export async function prepareSubscriptionCreation(
   return await mintCreationIntent(context, {
     payload: subscriptionPayload(parsed, resolved),
     guildId: parsed.guildId,
-    summary: `Track ${resolved.gameName}#${resolved.tagLine} (${parsed.region}) as "${parsed.alias}" in ${lookup.guild.name}, posting to #${postableChannelName(context, parsed.guildId, parsed.channelId)}.`,
+    summary: `Track ${resolved.gameName}#${resolved.tagLine} (${parsed.region}) as "${parsed.alias}" in ${lookup.guild.name}, posting to #${await postableChannelName(context, parsed.guildId, parsed.channelId)}.`,
   });
 }
 

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/targets.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/targets.ts
@@ -13,7 +13,10 @@ import {
   type Permission,
 } from "@scout-for-lol/data";
 import type { CreationGuildAccess } from "#src/explore/creation/capability.ts";
-import type { CreationToolContext } from "#src/explore/creation/context.ts";
+import {
+  lookupPostableChannels,
+  type CreationToolContext,
+} from "#src/explore/creation/context.ts";
 import {
   previewCompetitionLimit,
   previewReportLimit,
@@ -73,38 +76,59 @@ async function limitFor(
   });
 }
 
+type BoundedChannels =
+  | { kind: "ok"; channels: { id: string; name: string }[] }
+  | { kind: "unavailable"; message: string };
+
 async function boundedChannels(
   context: CreationToolContext,
   guildId: DiscordGuildId,
-): Promise<{ id: string; name: string }[]> {
-  const channels = await context.listChannels(guildId);
-  return channels
-    .slice(0, CREATION_MAX_CHANNELS)
-    .map((channel) => ({ id: channel.id, name: channel.name }));
+): Promise<BoundedChannels> {
+  const lookup = await lookupPostableChannels(context, guildId);
+  if (lookup.kind === "unavailable") return lookup;
+  return {
+    kind: "ok",
+    channels: lookup.channels
+      .slice(0, CREATION_MAX_CHANNELS)
+      .map((channel) => ({ id: channel.id, name: channel.name })),
+  };
 }
+
+type DescribedTarget = {
+  target: unknown;
+  /** The inline channel read failed; the target itself is still valid. */
+  channelsUnavailable: boolean;
+};
 
 async function describeTarget(
   context: CreationToolContext,
   guild: CreationGuildAccess,
   inlineChannels: boolean,
-): Promise<unknown> {
+): Promise<DescribedTarget> {
   const [report, subscription, competition] = await Promise.all([
     limitFor(context, guild, "report"),
     limitFor(context, guild, "subscription"),
     limitFor(context, guild, "competition"),
   ]);
+  const channels = inlineChannels
+    ? await boundedChannels(context, guild.guildId)
+    : null;
   return {
-    guildId: guild.guildId,
-    name: guild.name,
-    report: { permitted: permitted(guild, "report"), ...report },
-    subscription: {
-      permitted: permitted(guild, "subscription"),
-      ...subscription,
+    channelsUnavailable: channels?.kind === "unavailable",
+    target: {
+      guildId: guild.guildId,
+      name: guild.name,
+      report: { permitted: permitted(guild, "report"), ...report },
+      subscription: {
+        permitted: permitted(guild, "subscription"),
+        ...subscription,
+      },
+      competition: {
+        permitted: permitted(guild, "competition"),
+        ...competition,
+      },
+      channels: channels?.kind === "ok" ? channels.channels : null,
     },
-    competition: { permitted: permitted(guild, "competition"), ...competition },
-    channels: inlineChannels
-      ? await boundedChannels(context, guild.guildId)
-      : null,
   };
 }
 
@@ -124,22 +148,40 @@ export async function listCreationTargets(
   // whole agent step — the binding budget is EXPLORE_MAX_STEPS (12), not the
   // tool-call ceiling.
   const inlineChannels = eligible.length === 1;
-  const targets = await Promise.all(
+  const described = await Promise.all(
     eligible.map((guild) => describeTarget(context, guild, inlineChannels)),
+  );
+  // The targets themselves resolved; only the channel *inlining* — an
+  // optimization — failed. Refusing the whole tool here would turn a question
+  // Scout can answer into an outage, so the list is returned with channels
+  // omitted and the message stops promising them. `list_guild_channels` is the
+  // tool that will report the outage as a typed refusal.
+  const channelsUnavailable = described.some(
+    (entry) => entry.channelsUnavailable,
   );
   return CreationTargetsResultSchema.parse({
     kind: "targets",
-    message: targetsMessage(eligible.length, access.guilds.length),
-    targets,
+    message: targetsMessage(
+      eligible.length,
+      access.guilds.length,
+      channelsUnavailable,
+    ),
+    targets: described.map((entry) => entry.target),
   });
 }
 
-function targetsMessage(shown: number, total: number): string {
+function targetsMessage(
+  shown: number,
+  total: number,
+  channelsUnavailable: boolean,
+): string {
   if (total === 0) {
     return "This user cannot create anything from Explore right now: no server they belong to has it enabled, or they lack the permission there. Say so plainly and do not prepare anything.";
   }
   if (total === 1) {
-    return "One eligible server, with its postable channels included. Confirm every required field with the user before preparing anything.";
+    return channelsUnavailable
+      ? "One eligible server. Scout could not reach Discord to list its channels just now, so they are not included — call list_guild_channels before preparing anything, and do not tell the user Scout lacks permission."
+      : "One eligible server, with its postable channels included. Confirm every required field with the user before preparing anything.";
   }
   const suffix =
     shown < total
@@ -169,7 +211,18 @@ export async function listGuildChannels(
       channels: [],
     });
   }
-  const channels = await boundedChannels(context, guildId);
+  const bounded = await boundedChannels(context, guildId);
+  // An unreachable Discord is NOT an empty channel list: the empty case tells
+  // the user to grant Scout permissions, which is a flatly wrong instruction
+  // when the truth is that Scout could not ask.
+  if (bounded.kind === "unavailable") {
+    return CreationChannelsResultSchema.parse({
+      kind: "verification_unavailable",
+      message: bounded.message,
+      channels: [],
+    });
+  }
+  const channels = bounded.channels;
   return CreationChannelsResultSchema.parse({
     kind: "channels",
     message:

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/targets.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/targets.ts
@@ -73,12 +73,12 @@ async function limitFor(
   });
 }
 
-function boundedChannels(
+async function boundedChannels(
   context: CreationToolContext,
   guildId: DiscordGuildId,
-): { id: string; name: string }[] {
-  return context
-    .listChannels(guildId)
+): Promise<{ id: string; name: string }[]> {
+  const channels = await context.listChannels(guildId);
+  return channels
     .slice(0, CREATION_MAX_CHANNELS)
     .map((channel) => ({ id: channel.id, name: channel.name }));
 }
@@ -102,7 +102,9 @@ async function describeTarget(
       ...subscription,
     },
     competition: { permitted: permitted(guild, "competition"), ...competition },
-    channels: inlineChannels ? boundedChannels(context, guild.guildId) : null,
+    channels: inlineChannels
+      ? await boundedChannels(context, guild.guildId)
+      : null,
   };
 }
 
@@ -167,7 +169,7 @@ export async function listGuildChannels(
       channels: [],
     });
   }
-  const channels = boundedChannels(context, guildId);
+  const channels = await boundedChannels(context, guildId);
   return CreationChannelsResultSchema.parse({
     kind: "channels",
     message:

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/tools.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/tools.integration.test.ts
@@ -56,7 +56,7 @@ function executors(overrides?: { access?: CreationAccess }) {
       db: prisma,
       resolveAccess: () => Promise.resolve(overrides?.access ?? resolvedAccess),
       listChannels: (guildId: DiscordGuildId) =>
-        guildId === GUILD ? CHANNELS : [],
+        Promise.resolve(guildId === GUILD ? CHANNELS : []),
       resolvePuuid: () =>
         Promise.resolve({
           kind: "ok",
@@ -256,7 +256,7 @@ describe("prepare_subscription_creation", () => {
       dependencies: {
         db: prisma,
         resolveAccess: () => Promise.resolve(resolvedAccess),
-        listChannels: () => CHANNELS,
+        listChannels: () => Promise.resolve(CHANNELS),
         resolvePuuid: () =>
           Promise.resolve({
             kind: "riot-id-not-found",

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/tools.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/tools.integration.test.ts
@@ -7,6 +7,7 @@ import {
 import type { CreationAccess } from "#src/explore/creation/capability.ts";
 import { CREATION_INTENT_TTL_MS } from "#src/explore/creation/context.ts";
 import { createCreationToolExecutors } from "#src/explore/creation/tools.ts";
+import { DiscordUpstreamError } from "#src/lib/discord-rest.ts";
 import type { PostableChannel } from "#src/lib/discord/postable-channels.ts";
 import type { ToolTracker } from "#src/reports/ai/scoutql-tools.ts";
 import { createTestDatabase } from "#src/testing/test-database.ts";
@@ -47,7 +48,10 @@ const resolvedAccess: CreationAccess = {
   ],
 };
 
-function executors(overrides?: { access?: CreationAccess }) {
+function executors(overrides?: {
+  access?: CreationAccess;
+  listChannels?: (guildId: DiscordGuildId) => Promise<PostableChannel[]>;
+}) {
   return createCreationToolExecutors({
     capability: { guildIds: [GUILD] },
     requesterId: REQUESTER,
@@ -55,8 +59,10 @@ function executors(overrides?: { access?: CreationAccess }) {
     dependencies: {
       db: prisma,
       resolveAccess: () => Promise.resolve(overrides?.access ?? resolvedAccess),
-      listChannels: (guildId: DiscordGuildId) =>
-        Promise.resolve(guildId === GUILD ? CHANNELS : []),
+      listChannels:
+        overrides?.listChannels ??
+        ((guildId: DiscordGuildId) =>
+          Promise.resolve(guildId === GUILD ? CHANNELS : [])),
       resolvePuuid: () =>
         Promise.resolve({
           kind: "ok",
@@ -385,5 +391,62 @@ describe("list_guild_channels", () => {
 
     expect(result.kind).toBe("forbidden_target");
     expect(result.channels).toEqual([]);
+  });
+});
+
+/**
+ * Executors whose channel read cannot reach Discord.
+ *
+ * `listPostableChannels` raises DiscordUpstreamError for tRPC's benefit. If it
+ * escapes into a tool the model sees a generic tool failure with no refusal to
+ * relay, and is liable to invent a reason — "Scout cannot post there", "you lack
+ * permission" — which is the one thing the creation protocol forbids.
+ */
+function unavailable() {
+  return executors({
+    listChannels: () =>
+      Promise.reject(new DiscordUpstreamError("http_error", "down", 503)),
+  });
+}
+
+describe("an unreachable Discord is a typed refusal, never a tool crash", () => {
+  test("list_guild_channels reports it as verification_unavailable", async () => {
+    const result = await unavailable().listChannels({ guildId: GUILD });
+
+    expect(result.kind).toBe("verification_unavailable");
+    expect(result.channels).toEqual([]);
+    // Emphatically NOT the empty-channels copy, which tells the user to go
+    // grant Scout permissions it may already have.
+    expect(result.message).not.toContain("View Channel");
+  });
+
+  test("prepare_report refuses without claiming the channel is invalid", async () => {
+    const result = await unavailable().prepareReport(reportInput());
+
+    expect(result.kind).toBe("verification_unavailable");
+    expect(result.intent).toBeNull();
+    expect(result.message).not.toContain("cannot post");
+  });
+
+  test("prepare_subscription refuses the same way", async () => {
+    const result = await unavailable().prepareSubscription(subscriptionInput());
+
+    expect(result.kind).toBe("verification_unavailable");
+    expect(result.intent).toBeNull();
+  });
+
+  test("list_creation_targets still answers, with channels omitted", async () => {
+    // The targets resolved; only the channel *inlining* failed. Refusing the
+    // whole tool would turn a question Scout can answer into an outage.
+    const result = await unavailable().listTargets();
+
+    expect(result.kind).toBe("targets");
+    expect(result.targets).toHaveLength(1);
+    expect(result.message).toContain("could not reach Discord");
+    expect(result.message).not.toContain("channels included");
+  });
+
+  test("no intent row is minted by any of them", async () => {
+    expect(await prisma.confirmationIntent.count()).toBe(0);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/explore/creation/tools.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/creation/tools.ts
@@ -51,7 +51,7 @@ type CreationToolDependencies = {
     capability: CreationCapability;
     requesterId: DiscordAccountId;
   }) => Promise<CreationAccess>;
-  listChannels: (guildId: DiscordGuildId) => PostableChannel[];
+  listChannels: (guildId: DiscordGuildId) => Promise<PostableChannel[]>;
   resolvePuuid: typeof resolveSubscriptionPuuid;
   now: () => Date;
   newIdempotencyKey: () => string;

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest-schemas.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest-schemas.ts
@@ -1,0 +1,82 @@
+/**
+ * Zod shapes for the Discord REST payloads the web request path reads with the
+ * BOT token.
+ *
+ * These mirror Discord's wire format (snake_case, permission bitfields as
+ * decimal strings) rather than discord.js's structure classes on purpose: the
+ * whole point of reading them over REST is that no gateway connection — and so
+ * no discord.js cache — has to exist for a web request to be answered.
+ *
+ * Every field kept here is one a web-serving code path actually reads. Discord
+ * sends far more; unknown keys are ignored rather than rejected so a Discord
+ * addition never fails a permission check.
+ */
+
+import { z } from "zod";
+
+/**
+ * A channel permission overwrite. `allow`/`deny` are decimal bitfield strings;
+ * `type` is 0 for a role and 1 for a member.
+ */
+export const DiscordOverwriteSchema = z.object({
+  id: z.string(),
+  type: z.number(),
+  allow: z.string(),
+  deny: z.string(),
+});
+export type DiscordOverwrite = z.infer<typeof DiscordOverwriteSchema>;
+
+export const DiscordGuildChannelSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.number(),
+  parent_id: z.string().nullish(),
+  permission_overwrites: z.array(DiscordOverwriteSchema).default([]),
+});
+export type DiscordGuildChannel = z.infer<typeof DiscordGuildChannelSchema>;
+export const DiscordGuildChannelsSchema = z.array(DiscordGuildChannelSchema);
+
+export const DiscordRoleSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  permissions: z.string(),
+});
+export type DiscordRole = z.infer<typeof DiscordRoleSchema>;
+export const DiscordRolesSchema = z.array(DiscordRoleSchema);
+
+export const DiscordUserSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  /** The new display name. Absent/null for accounts that never set one. */
+  global_name: z.string().nullish(),
+  /** `"0"` for migrated accounts; a legacy four-digit tag otherwise. */
+  discriminator: z.string().nullish(),
+  avatar: z.string().nullish(),
+});
+export type DiscordUser = z.infer<typeof DiscordUserSchema>;
+
+export const DiscordGuildMemberSchema = z.object({
+  user: DiscordUserSchema,
+  nick: z.string().nullish(),
+  /** Per-guild avatar override, distinct from `user.avatar`. */
+  avatar: z.string().nullish(),
+  roles: z.array(z.string()).default([]),
+});
+export type DiscordGuildMember = z.infer<typeof DiscordGuildMemberSchema>;
+export const DiscordGuildMembersSchema = z.array(DiscordGuildMemberSchema);
+
+/**
+ * A channel fetched by id rather than through its guild's channel list, so the
+ * guild it belongs to has to come back with it.
+ */
+export const DiscordChannelSchema = DiscordGuildChannelSchema.extend({
+  guild_id: z.string().nullish(),
+});
+export type DiscordChannel = z.infer<typeof DiscordChannelSchema>;
+
+export const DiscordGuildSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  owner_id: z.string(),
+});
+export type DiscordGuildSummary = z.infer<typeof DiscordGuildSchema>;

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, test } from "vitest";
+import { DiscordUpstreamError } from "#src/lib/discord-rest.ts";
+import {
+  MEMBERSHIP_TTL_MS,
+  PERMISSION_TTL_MS,
+  createBotRestReader,
+  memberAvatarUrl,
+  memberDisplayName,
+  userAvatarUrl,
+  type BotRestGet,
+} from "#src/lib/discord/bot-rest.ts";
+
+const GUILD = "100";
+const BOT = "999";
+const USER = "200";
+
+/** Shaped like discord.js `DiscordAPIError`: a Discord code plus HTTP status. */
+class ApiError extends Error {
+  readonly code: number;
+  readonly status: number;
+  constructor(code: number, status: number) {
+    super(`Discord error ${code.toString()}`);
+    this.code = code;
+    this.status = status;
+  }
+}
+
+/** Shaped like discord.js `HTTPError`: a status with no Discord code. */
+class HttpError extends Error {
+  readonly status: number;
+  constructor(status: number) {
+    super(`HTTP ${status.toString()}`);
+    this.status = status;
+  }
+}
+
+function recorder(handler: BotRestGet) {
+  const routes: string[] = [];
+  const queries: (string | undefined)[] = [];
+  const get: BotRestGet = async (route, options) => {
+    routes.push(route);
+    queries.push(options?.query?.toString());
+    return await handler(route, options);
+  };
+  return { get, routes, queries };
+}
+
+function clockAtZero(): { value: number } {
+  return { value: 0 };
+}
+
+function reader(handler: BotRestGet, clock: { value: number } = clockAtZero()) {
+  const recorded = recorder(handler);
+  return {
+    ...recorded,
+    clock,
+    rest: createBotRestReader({
+      get: recorded.get,
+      now: () => clock.value,
+      botUserId: BOT,
+    }),
+  };
+}
+
+const ROLES = [{ id: GUILD, name: "@everyone", permissions: "1024" }];
+
+describe("createBotRestReader caching", () => {
+  test("collapses repeated reads within the TTL and refetches after it", async () => {
+    const clock = { value: 0 };
+    const harness = reader(() => Promise.resolve(ROLES), clock);
+
+    await harness.rest.guildRoles(GUILD);
+    await harness.rest.guildRoles(GUILD);
+    expect(harness.routes).toHaveLength(1);
+
+    clock.value += PERMISSION_TTL_MS - 1;
+    await harness.rest.guildRoles(GUILD);
+    expect(harness.routes).toHaveLength(1);
+
+    clock.value += 2;
+    await harness.rest.guildRoles(GUILD);
+    expect(harness.routes).toHaveLength(2);
+  });
+
+  test("member lookups expire on the shorter membership TTL", async () => {
+    const clock = { value: 0 };
+    const member = { user: { id: USER, username: "someone" }, roles: [] };
+    const harness = reader(() => Promise.resolve(member), clock);
+
+    await harness.rest.guildMember(GUILD, USER);
+    clock.value += MEMBERSHIP_TTL_MS + 1;
+    await harness.rest.guildMember(GUILD, USER);
+    expect(harness.routes).toHaveLength(2);
+    // Still inside the *permission* TTL, proving the caches are independent.
+    expect(MEMBERSHIP_TTL_MS).toBeLessThan(PERMISSION_TTL_MS);
+  });
+
+  test("caches per guild, not globally", async () => {
+    const harness = reader(() => Promise.resolve(ROLES));
+    await harness.rest.guildRoles(GUILD);
+    await harness.rest.guildRoles("101");
+    expect(harness.routes).toEqual(["/guilds/100/roles", "/guilds/101/roles"]);
+  });
+
+  test("failures are not cached", async () => {
+    let calls = 0;
+    const harness = reader(() => {
+      calls += 1;
+      return calls === 1
+        ? Promise.reject(new HttpError(500))
+        : Promise.resolve(ROLES);
+    });
+    await expect(harness.rest.guildRoles(GUILD)).rejects.toBeInstanceOf(
+      DiscordUpstreamError,
+    );
+    await expect(harness.rest.guildRoles(GUILD)).resolves.toEqual(ROLES);
+  });
+});
+
+describe("createBotRestReader absence vs unavailability", () => {
+  test("Unknown Guild is an answer, not a failure", async () => {
+    const harness = reader(() => Promise.reject(new ApiError(10_004, 404)));
+    await expect(harness.rest.guildExists(GUILD)).resolves.toBe(false);
+    await expect(harness.rest.guildChannels(GUILD)).resolves.toBeNull();
+    await expect(harness.rest.guildRoles(GUILD)).resolves.toBeNull();
+    await expect(harness.rest.botMember(GUILD)).resolves.toBeNull();
+    await expect(
+      harness.rest.searchGuildMembers({ guildId: GUILD, query: "a", limit: 5 }),
+    ).resolves.toEqual([]);
+  });
+
+  test("Unknown Member is an answer, not a failure", async () => {
+    const harness = reader(() => Promise.reject(new ApiError(10_007, 404)));
+    await expect(harness.rest.guildMember(GUILD, USER)).resolves.toBeNull();
+  });
+
+  test("an HTTP failure raises an upstream error, never a false absence", async () => {
+    const harness = reader(() => Promise.reject(new HttpError(503)));
+    const pending = harness.rest.guildExists(GUILD);
+    await expect(pending).rejects.toBeInstanceOf(DiscordUpstreamError);
+    await expect(pending).rejects.toMatchObject({
+      reason: "http_error",
+      status: 503,
+    });
+  });
+
+  test("a rate-limited read is upstream failure, not absence", async () => {
+    // Code 0 with status 429: a real Discord error code that is emphatically
+    // not "this guild does not exist".
+    const harness = reader(() => Promise.reject(new ApiError(0, 429)));
+    await expect(harness.rest.guildExists(GUILD)).rejects.toMatchObject({
+      reason: "http_error",
+      status: 429,
+    });
+  });
+
+  test("a transport failure with no status reports fetch_error", async () => {
+    const harness = reader(() => Promise.reject(new Error("socket hang up")));
+    await expect(harness.rest.guildRoles(GUILD)).rejects.toMatchObject({
+      reason: "fetch_error",
+    });
+  });
+
+  test("an unexpected payload shape reports schema_error", async () => {
+    const harness = reader(() => Promise.resolve({ unexpected: true }));
+    await expect(harness.rest.guildRoles(GUILD)).rejects.toMatchObject({
+      reason: "schema_error",
+    });
+  });
+});
+
+describe("createBotRestReader routes", () => {
+  test("reads the bot's own member row by application id", async () => {
+    const harness = reader(() =>
+      Promise.resolve({ user: { id: BOT, username: "scout" }, roles: [] }),
+    );
+    await harness.rest.botMember(GUILD);
+    expect(harness.routes).toEqual(["/guilds/100/members/999"]);
+  });
+
+  test("a single channel is read by id and not cached", async () => {
+    const harness = reader(() =>
+      Promise.resolve({
+        id: "5",
+        name: "lobby",
+        type: 2,
+        guild_id: GUILD,
+      }),
+    );
+    await harness.rest.channel("5");
+    await harness.rest.channel("5");
+    expect(harness.routes).toEqual(["/channels/5", "/channels/5"]);
+  });
+
+  test("an unknown channel is an answer, not a failure", async () => {
+    const harness = reader(() => Promise.reject(new ApiError(10_003, 404)));
+    await expect(harness.rest.channel("5")).resolves.toBeNull();
+  });
+
+  test("member search uses the REST search endpoint and is not cached", async () => {
+    const harness = reader(() => Promise.resolve([]));
+    await harness.rest.searchGuildMembers({
+      guildId: GUILD,
+      query: "ali",
+      limit: 7,
+    });
+    await harness.rest.searchGuildMembers({
+      guildId: GUILD,
+      query: "ali",
+      limit: 7,
+    });
+    expect(harness.routes).toEqual([
+      "/guilds/100/members/search",
+      "/guilds/100/members/search",
+    ]);
+    expect(harness.queries[0]).toBe("query=ali&limit=7");
+  });
+});
+
+describe("display helpers", () => {
+  test("prefers the guild nickname, then the global name, then the username", () => {
+    const user = { id: USER, username: "plain", global_name: "Global" };
+    expect(memberDisplayName({ user, nick: "Nick", roles: [] })).toBe("Nick");
+    expect(memberDisplayName({ user, roles: [] })).toBe("Global");
+    expect(
+      memberDisplayName({ user: { id: USER, username: "plain" }, roles: [] }),
+    ).toBe("plain");
+  });
+
+  test("prefers a per-guild avatar over the account avatar", () => {
+    const member = {
+      user: { id: USER, username: "plain", avatar: "useravatar" },
+      avatar: "guildavatar",
+      roles: [],
+    };
+    expect(memberAvatarUrl(member, GUILD)).toContain(
+      "/guilds/100/users/200/avatars/guildavatar",
+    );
+    expect(memberAvatarUrl({ ...member, avatar: null }, GUILD)).toContain(
+      "/avatars/200/useravatar",
+    );
+  });
+
+  test("falls back to the default avatar for accounts with none", () => {
+    expect(userAvatarUrl({ id: "1234567890123456789", username: "a" })).toBe(
+      "https://cdn.discordapp.com/embed/avatars/1.png",
+    );
+    // A legacy discriminator indexes into five avatars instead of six.
+    expect(
+      userAvatarUrl({
+        id: "1234567890123456789",
+        username: "a",
+        discriminator: "0007",
+      }),
+    ).toBe("https://cdn.discordapp.com/embed/avatars/2.png");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest.test.ts
@@ -95,6 +95,47 @@ describe("createBotRestReader caching", () => {
     expect(MEMBERSHIP_TTL_MS).toBeLessThan(PERMISSION_TTL_MS);
   });
 
+  test("freshGuildMember bypasses the cache on every call", async () => {
+    const clock = { value: 0 };
+    const member = { user: { id: USER, username: "someone" }, roles: [] };
+    const harness = reader(() => Promise.resolve(member), clock);
+
+    // Warm the cache, then prove the cached read is served from it and the
+    // fresh read is not — inside the same TTL window, with no clock movement.
+    await harness.rest.guildMember(GUILD, USER);
+    await harness.rest.guildMember(GUILD, USER);
+    expect(harness.routes).toHaveLength(1);
+
+    await harness.rest.freshGuildMember(GUILD, USER);
+    await harness.rest.freshGuildMember(GUILD, USER);
+    expect(harness.routes).toHaveLength(3);
+  });
+
+  test("a fresh read does not poison or refill the cached entry", async () => {
+    let present = true;
+    const clock = { value: 0 };
+    const harness = reader(
+      () =>
+        present
+          ? Promise.resolve({
+              user: { id: USER, username: "someone" },
+              roles: [],
+            })
+          : Promise.reject(new ApiError(10_007, 404)),
+      clock,
+    );
+
+    await expect(harness.rest.guildMember(GUILD, USER)).resolves.not.toBeNull();
+    present = false;
+    // The fresh read sees the departure immediately...
+    await expect(
+      harness.rest.freshGuildMember(GUILD, USER),
+    ).resolves.toBeNull();
+    // ...while the cached entry keeps serving its own (stale) answer, which is
+    // the documented contract for the paths that accept a 30s window.
+    await expect(harness.rest.guildMember(GUILD, USER)).resolves.not.toBeNull();
+  });
+
   test("caches per guild, not globally", async () => {
     const harness = reader(() => Promise.resolve(ROLES));
     await harness.rest.guildRoles(GUILD);

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest.ts
@@ -228,6 +228,25 @@ export type BotRestReader = {
     guildId: string,
     userId: string,
   ) => Promise<DiscordGuildMember | null>;
+  /**
+   * {@link guildMember}, bypassing the cache entirely.
+   *
+   * For the reads whose whole purpose is to be right *now* — a correctness
+   * invariant that a departed member must not satisfy. The ordinary read's
+   * {@link MEMBERSHIP_TTL_MS} window is fine for display and for access checks
+   * that fail safe, but a guard which counts remaining members has to see the
+   * roster as it actually is, or it permits the very state it exists to
+   * prevent. Use this only where staleness is a correctness bug, never for
+   * ordinary lookups: it is one uncached Discord request every call.
+   *
+   * The result is deliberately NOT written back into the cache — the cached
+   * entry belongs to paths that already accept a 30s window, and this one
+   * always reads fresh anyway.
+   */
+  readonly freshGuildMember: (
+    guildId: string,
+    userId: string,
+  ) => Promise<DiscordGuildMember | null>;
   /** Prefix search over usernames and nicknames. Empty when Scout is absent. */
   readonly searchGuildMembers: (input: {
     guildId: string;
@@ -286,6 +305,14 @@ export function createBotRestReader(
 
   const botUserId = () => options.botUserId ?? configuration.applicationId;
 
+  const readMember = async (guildId: string, userId: string) =>
+    await read(get, {
+      route: Routes.guildMember(guildId, userId),
+      schema: DiscordGuildMemberSchema,
+      description: `guild ${guildId} member ${userId}`,
+      absentCodes: [UNKNOWN_GUILD, UNKNOWN_MEMBER],
+    });
+
   const readBotMember = async (guildId: string) =>
     await read(get, {
       route: Routes.guildMember(guildId, botUserId()),
@@ -342,14 +369,11 @@ export function createBotRestReader(
     guildMember: async (guildId, userId) =>
       await memberCache(
         `${guildId}:${userId}`,
-        async () =>
-          await read(get, {
-            route: Routes.guildMember(guildId, userId),
-            schema: DiscordGuildMemberSchema,
-            description: `guild ${guildId} member ${userId}`,
-            absentCodes: [UNKNOWN_GUILD, UNKNOWN_MEMBER],
-          }),
+        async () => await readMember(guildId, userId),
       ),
+
+    freshGuildMember: async (guildId, userId) =>
+      await readMember(guildId, userId),
 
     searchGuildMembers: async (input) =>
       (await read(get, {

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest.ts
@@ -57,11 +57,13 @@ import {
   DiscordGuildChannelsSchema,
   DiscordGuildMemberSchema,
   DiscordGuildMembersSchema,
+  DiscordGuildSchema,
   DiscordRolesSchema,
   DiscordUserSchema,
   type DiscordChannel,
   type DiscordGuildChannel,
   type DiscordGuildMember,
+  type DiscordGuildSummary,
   type DiscordRole,
   type DiscordUser,
 } from "#src/lib/discord/bot-rest-schemas.ts";
@@ -203,7 +205,15 @@ async function read<Parsed>(
  * never that Scout failed to ask.
  */
 export type BotRestReader = {
-  /** Whether Scout is a member of the guild, straight from Discord. */
+  /**
+   * The guild itself, or `null` when Scout is not in it.
+   *
+   * `owner_id` matters beyond identification: Discord grants the owner every
+   * permission implicitly, with no role carrying it, so any permission answer
+   * computed from roles alone is wrong for exactly one member per guild.
+   */
+  readonly guild: (guildId: string) => Promise<DiscordGuildSummary | null>;
+  /** Whether Scout is a member of the guild. Shares {@link guild}'s cache. */
   readonly guildExists: (guildId: string) => Promise<boolean>;
   /** `null` when Scout is not in the guild. */
   readonly guildChannels: (
@@ -255,7 +265,7 @@ export function createBotRestReader(
     now,
   });
 
-  const guildCache = createBoundedAsyncCache<boolean>(
+  const guildCache = createBoundedAsyncCache<DiscordGuildSummary | null>(
     cacheOptions(INSTALL_TTL_MS),
   );
   const channelCache = createBoundedAsyncCache<DiscordGuildChannel[] | null>(
@@ -285,18 +295,22 @@ export function createBotRestReader(
       absentCodes: [UNKNOWN_GUILD, UNKNOWN_MEMBER],
     });
 
+  const readGuild = async (guildId: string) =>
+    await guildCache(
+      guildId,
+      async () =>
+        await read(get, {
+          route: Routes.guild(guildId),
+          schema: DiscordGuildSchema,
+          description: `guild ${guildId}`,
+          absentCodes: [UNKNOWN_GUILD],
+        }),
+    );
+
   return {
-    guildExists: async (guildId) =>
-      await guildCache(
-        guildId,
-        async () =>
-          (await read(get, {
-            route: Routes.guild(guildId),
-            schema: z.object({ id: z.string() }),
-            description: `guild ${guildId}`,
-            absentCodes: [UNKNOWN_GUILD],
-          })) !== null,
-      ),
+    guild: readGuild,
+
+    guildExists: async (guildId) => (await readGuild(guildId)) !== null,
 
     guildChannels: async (guildId) =>
       await channelCache(

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest.ts
@@ -1,0 +1,430 @@
+/**
+ * Authoritative Discord reads for web requests, over the BOT token's REST API.
+ *
+ * This is the application port that replaces `client.guilds.cache` on every
+ * HTTP/tRPC path. The gateway cache cannot back a web request honestly: an
+ * unconnected or still-backfilling client is indistinguishable from "Scout is
+ * not installed there", so an ordinary pod restart used to hand real members a
+ * NOT_FOUND. REST answers the same questions without a gateway connection, and
+ * an unreachable REST is *reported* as unreachable instead of being silently
+ * rewritten into a permission answer.
+ *
+ * Three outcomes are kept distinct and callers must preserve the distinction:
+ *
+ * - a value — Discord answered;
+ * - `null` / `false` — Discord authoritatively said the thing does not exist
+ *   (Unknown Guild/Member/User), which for a guild means Scout is not in it;
+ * - a thrown {@link DiscordUpstreamError} — Scout could not obtain an answer.
+ *   `trpc/discord-upstream.ts` turns that into SERVICE_UNAVAILABLE. It must
+ *   never become "not installed" or FORBIDDEN.
+ *
+ * Token wiring follows `src/discord/rest.ts`: its own `REST` instance carrying
+ * the bot token, so it works whether or not `client.login()` was ever called.
+ *
+ * ## Cache TTLs
+ *
+ * Every read is memoized in a bounded TTL cache (which also collapses
+ * concurrent identical reads into one request). The TTLs are chosen to be
+ * defensible for the decisions they feed:
+ *
+ * - channels / roles / the bot's own member — {@link PERMISSION_TTL_MS} (60s).
+ *   These three feed channel permission checks. A moved channel or an edited
+ *   role takes at most a minute to be reflected in the channel picker, which is
+ *   the same order of staleness the gateway cache had under a lagging shard,
+ *   and a stale answer here can only mis-*offer* a channel: every write is
+ *   re-checked by Discord itself when Scout actually posts.
+ * - a single member lookup — {@link MEMBERSHIP_TTL_MS} (30s). Shorter, because
+ *   this one gates access decisions (the last-role-manager check, Activity
+ *   membership): losing access should not lag by a whole minute.
+ * - guild existence — {@link INSTALL_TTL_MS} (60s). Only ever consulted after
+ *   the `GuildInstall` port has already said "no row" (see
+ *   `installed-guilds.ts`), and a fresh install writes that row immediately, so
+ *   this TTL delays nothing a user waits on.
+ * - user profiles — {@link USER_TTL_MS} (5m), matching the display-name cache
+ *   this replaced. Names and avatars are cosmetic.
+ *
+ * Member *search* is deliberately uncached: it is keyed by a free-text query,
+ * so a cache would be unbounded in keys while a typeahead re-queries on every
+ * keystroke anyway.
+ */
+
+import { CDN, REST, Routes } from "discord.js";
+import { z } from "zod";
+import configuration from "#src/configuration.ts";
+import { DiscordUpstreamError } from "#src/lib/discord-rest.ts";
+import {
+  DiscordChannelSchema,
+  DiscordGuildChannelsSchema,
+  DiscordGuildMemberSchema,
+  DiscordGuildMembersSchema,
+  DiscordRolesSchema,
+  DiscordUserSchema,
+  type DiscordChannel,
+  type DiscordGuildChannel,
+  type DiscordGuildMember,
+  type DiscordRole,
+  type DiscordUser,
+} from "#src/lib/discord/bot-rest-schemas.ts";
+import { createLogger } from "#src/logger.ts";
+import { createBoundedAsyncCache } from "#src/utils/bounded-async-cache.ts";
+
+const logger = createLogger("discord-bot-rest");
+
+export const PERMISSION_TTL_MS = 60 * 1000;
+export const MEMBERSHIP_TTL_MS = 30 * 1000;
+export const INSTALL_TTL_MS = 60 * 1000;
+export const USER_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Bound the number of guilds held per cache. Well above any realistic burst of
+ * distinct guilds in one TTL window, and small enough that a long-lived pod
+ * cannot grow without limit.
+ */
+const MAX_CACHE_ENTRIES = 2000;
+/** Cap concurrent outbound reads so one burst cannot saturate the REST pool. */
+const MAX_CONCURRENT_READS = 8;
+/**
+ * Bound an inbound web request's wait on Discord. discord.js defaults to 15s,
+ * which is long enough for a stalled upstream to hold tRPC requests open.
+ */
+const REST_TIMEOUT_MS = 5000;
+
+/** Discord "this does not exist" error codes. */
+const UNKNOWN_CHANNEL = 10_003;
+const UNKNOWN_GUILD = 10_004;
+const UNKNOWN_MEMBER = 10_007;
+const UNKNOWN_USER = 10_013;
+
+const DiscordApiErrorSchema = z.object({
+  code: z.number(),
+  status: z.number().optional(),
+});
+const HttpErrorSchema = z.object({ status: z.number() });
+
+/** The single transport seam; tests substitute this instead of the network. */
+export type BotRestGet = (
+  route: `/${string}`,
+  options?: { readonly query?: URLSearchParams },
+) => Promise<unknown>;
+
+let sharedRest: REST | undefined;
+
+/**
+ * The bot-token REST client, created on first use.
+ *
+ * Lazy so that importing this module does not require `DISCORD_TOKEN` — unit
+ * tests inject {@link BotRestGet} and never reach the network.
+ */
+function sharedGet(): BotRestGet {
+  sharedRest ??= new REST({
+    timeout: REST_TIMEOUT_MS,
+    retries: 1,
+  }).setToken(configuration.discordToken);
+  const rest = sharedRest;
+  return async (route, options) =>
+    await rest.get(
+      route,
+      options?.query === undefined ? {} : { query: options.query },
+    );
+}
+
+function discordErrorCode(error: unknown): number | undefined {
+  const parsed = DiscordApiErrorSchema.safeParse(error);
+  return parsed.success ? parsed.data.code : undefined;
+}
+
+function upstreamError(
+  error: unknown,
+  description: string,
+): DiscordUpstreamError {
+  const api = DiscordApiErrorSchema.safeParse(error);
+  const http = HttpErrorSchema.safeParse(error);
+  const status = api.success
+    ? api.data.status
+    : http.success
+      ? http.data.status
+      : undefined;
+  logger.warn(`Discord bot REST failed: ${description}`, { status, error });
+  return new DiscordUpstreamError(
+    status === undefined ? "fetch_error" : "http_error",
+    `Discord bot REST request failed: ${description}`,
+    status,
+  );
+}
+
+type ReadRequest<Parsed> = {
+  readonly route: `/${string}`;
+  readonly schema: z.ZodType<Parsed>;
+  readonly description: string;
+  /**
+   * Discord error codes that mean "this authoritatively does not exist" for
+   * this route, and so resolve to `null` rather than an upstream failure.
+   */
+  readonly absentCodes: readonly number[];
+  readonly query?: URLSearchParams;
+};
+
+/**
+ * Perform one read, returning `null` for an authoritative "does not exist" and
+ * throwing {@link DiscordUpstreamError} for everything else.
+ */
+async function read<Parsed>(
+  get: BotRestGet,
+  request: ReadRequest<Parsed>,
+): Promise<Parsed | null> {
+  let body: unknown;
+  try {
+    body = await get(
+      request.route,
+      request.query === undefined ? undefined : { query: request.query },
+    );
+  } catch (error) {
+    const code = discordErrorCode(error);
+    if (code !== undefined && request.absentCodes.includes(code)) return null;
+    throw upstreamError(error, request.description);
+  }
+  const parsed = request.schema.safeParse(body);
+  if (!parsed.success) {
+    logger.warn(`Discord bot REST schema mismatch: ${request.description}`, {
+      issues: parsed.error.issues.slice(0, 3),
+    });
+    throw new DiscordUpstreamError(
+      "schema_error",
+      `Discord returned an unexpected shape: ${request.description}`,
+    );
+  }
+  return parsed.data;
+}
+
+/**
+ * The authoritative Discord reads a web request may need.
+ *
+ * A `null` result always means Discord said the resource does not exist —
+ * never that Scout failed to ask.
+ */
+export type BotRestReader = {
+  /** Whether Scout is a member of the guild, straight from Discord. */
+  readonly guildExists: (guildId: string) => Promise<boolean>;
+  /** `null` when Scout is not in the guild. */
+  readonly guildChannels: (
+    guildId: string,
+  ) => Promise<DiscordGuildChannel[] | null>;
+  /** `null` when Scout is not in the guild. */
+  readonly guildRoles: (guildId: string) => Promise<DiscordRole[] | null>;
+  /** Scout's own member row, for channel permission checks. */
+  readonly botMember: (guildId: string) => Promise<DiscordGuildMember | null>;
+  /** `null` when the user is not a member (or Scout is not in the guild). */
+  readonly guildMember: (
+    guildId: string,
+    userId: string,
+  ) => Promise<DiscordGuildMember | null>;
+  /** Prefix search over usernames and nicknames. Empty when Scout is absent. */
+  readonly searchGuildMembers: (input: {
+    guildId: string;
+    query: string;
+    limit: number;
+  }) => Promise<DiscordGuildMember[]>;
+  readonly user: (userId: string) => Promise<DiscordUser | null>;
+  /**
+   * One channel by id, uncached and NOT guild-scoped — the caller must check
+   * `guild_id` itself. For the case where the id came from outside Scout (a
+   * Discord Activity launch) rather than from a list Scout offered, so a
+   * seconds-old channel must resolve rather than wait out a cache TTL.
+   */
+  readonly channel: (channelId: string) => Promise<DiscordChannel | null>;
+  /** Drop every cached answer. Test-only; the caches are process singletons. */
+  readonly clearCaches: () => void;
+};
+
+export type BotRestReaderOptions = {
+  readonly get?: BotRestGet;
+  readonly now?: () => number;
+  /** The bot user's id. For a Discord bot this equals the application id. */
+  readonly botUserId?: string;
+};
+
+export function createBotRestReader(
+  options: BotRestReaderOptions = {},
+): BotRestReader {
+  const get = options.get ?? sharedGet();
+  const now = options.now ?? (() => Date.now());
+  const cacheOptions = (ttlMs: number) => ({
+    ttlMs,
+    maxEntries: MAX_CACHE_ENTRIES,
+    maxConcurrent: MAX_CONCURRENT_READS,
+    now,
+  });
+
+  const guildCache = createBoundedAsyncCache<boolean>(
+    cacheOptions(INSTALL_TTL_MS),
+  );
+  const channelCache = createBoundedAsyncCache<DiscordGuildChannel[] | null>(
+    cacheOptions(PERMISSION_TTL_MS),
+  );
+  const roleCache = createBoundedAsyncCache<DiscordRole[] | null>(
+    cacheOptions(PERMISSION_TTL_MS),
+  );
+  const botMemberCache = createBoundedAsyncCache<DiscordGuildMember | null>(
+    cacheOptions(PERMISSION_TTL_MS),
+  );
+  const memberCache = createBoundedAsyncCache<DiscordGuildMember | null>(
+    cacheOptions(MEMBERSHIP_TTL_MS),
+  );
+  const userCache = createBoundedAsyncCache<DiscordUser | null>(
+    cacheOptions(USER_TTL_MS),
+  );
+
+  const botUserId = () => options.botUserId ?? configuration.applicationId;
+
+  const readBotMember = async (guildId: string) =>
+    await read(get, {
+      route: Routes.guildMember(guildId, botUserId()),
+      schema: DiscordGuildMemberSchema,
+      description: `guild ${guildId} bot member`,
+      // 10007 here means Scout is not in the guild, same as 10004.
+      absentCodes: [UNKNOWN_GUILD, UNKNOWN_MEMBER],
+    });
+
+  return {
+    guildExists: async (guildId) =>
+      await guildCache(
+        guildId,
+        async () =>
+          (await read(get, {
+            route: Routes.guild(guildId),
+            schema: z.object({ id: z.string() }),
+            description: `guild ${guildId}`,
+            absentCodes: [UNKNOWN_GUILD],
+          })) !== null,
+      ),
+
+    guildChannels: async (guildId) =>
+      await channelCache(
+        guildId,
+        async () =>
+          await read(get, {
+            route: Routes.guildChannels(guildId),
+            schema: DiscordGuildChannelsSchema,
+            description: `guild ${guildId} channels`,
+            absentCodes: [UNKNOWN_GUILD],
+          }),
+      ),
+
+    guildRoles: async (guildId) =>
+      await roleCache(
+        guildId,
+        async () =>
+          await read(get, {
+            route: Routes.guildRoles(guildId),
+            schema: DiscordRolesSchema,
+            description: `guild ${guildId} roles`,
+            absentCodes: [UNKNOWN_GUILD],
+          }),
+      ),
+
+    botMember: async (guildId) =>
+      await botMemberCache(guildId, async () => await readBotMember(guildId)),
+
+    guildMember: async (guildId, userId) =>
+      await memberCache(
+        `${guildId}:${userId}`,
+        async () =>
+          await read(get, {
+            route: Routes.guildMember(guildId, userId),
+            schema: DiscordGuildMemberSchema,
+            description: `guild ${guildId} member ${userId}`,
+            absentCodes: [UNKNOWN_GUILD, UNKNOWN_MEMBER],
+          }),
+      ),
+
+    searchGuildMembers: async (input) =>
+      (await read(get, {
+        route: Routes.guildMembersSearch(input.guildId),
+        schema: DiscordGuildMembersSchema,
+        description: `guild ${input.guildId} member search`,
+        absentCodes: [UNKNOWN_GUILD],
+        query: new URLSearchParams({
+          query: input.query,
+          limit: input.limit.toString(),
+        }),
+      })) ?? [],
+
+    user: async (userId) =>
+      await userCache(
+        userId,
+        async () =>
+          await read(get, {
+            route: Routes.user(userId),
+            schema: DiscordUserSchema,
+            description: `user ${userId}`,
+            absentCodes: [UNKNOWN_USER],
+          }),
+      ),
+
+    channel: async (channelId) =>
+      await read(get, {
+        route: Routes.channel(channelId),
+        schema: DiscordChannelSchema,
+        description: `channel ${channelId}`,
+        absentCodes: [UNKNOWN_CHANNEL],
+      }),
+
+    clearCaches: () => {
+      guildCache.clear();
+      channelCache.clear();
+      roleCache.clear();
+      botMemberCache.clear();
+      memberCache.clear();
+      userCache.clear();
+    },
+  };
+}
+
+let sharedReader: BotRestReader | undefined;
+
+/** The process-wide reader. Call sites take it as an injectable default. */
+export function botRest(): BotRestReader {
+  sharedReader ??= createBotRestReader();
+  return sharedReader;
+}
+
+const cdn = new CDN();
+
+/** The display name Discord would show for a member inside their guild. */
+export function memberDisplayName(member: DiscordGuildMember): string {
+  return member.nick ?? member.user.global_name ?? member.user.username;
+}
+
+/** The avatar Discord would show for a user, honouring a per-guild override. */
+export function memberAvatarUrl(
+  member: DiscordGuildMember,
+  guildId: string,
+): string {
+  if (member.avatar !== null && member.avatar !== undefined) {
+    return cdn.guildMemberAvatar(guildId, member.user.id, member.avatar);
+  }
+  return userAvatarUrl(member.user);
+}
+
+/**
+ * The avatar Discord would show for a user with no guild context. Mirrors
+ * discord.js `User#displayAvatarURL`, including the default-avatar fallback:
+ * migrated accounts (`discriminator === "0"`) index by snowflake, legacy ones
+ * by their four-digit tag.
+ */
+export function userAvatarUrl(user: DiscordUser): string {
+  if (user.avatar !== null && user.avatar !== undefined) {
+    return cdn.avatar(user.id, user.avatar);
+  }
+  const legacyTag =
+    user.discriminator === null ||
+    user.discriminator === undefined ||
+    user.discriminator === "0"
+      ? undefined
+      : Number.parseInt(user.discriminator, 10);
+  const index =
+    legacyTag === undefined || Number.isNaN(legacyTag)
+      ? Number(BigInt(user.id) >> 22n) % 6
+      : legacyTag % 5;
+  return cdn.defaultAvatar(index);
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/channel-permissions.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/channel-permissions.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "vitest";
+import { PermissionFlagsBits, PermissionsBitField } from "discord.js";
+import {
+  computeChannelPermissions,
+  hasPermission,
+} from "#src/lib/discord/channel-permissions.ts";
+
+const GUILD = "100";
+const MEMBER = "200";
+const ROLE = "300";
+const OTHER_ROLE = "400";
+
+const VIEW = PermissionFlagsBits.ViewChannel;
+const SEND = PermissionFlagsBits.SendMessages;
+
+function permissions(input: {
+  rolePermissions: Record<string, string>;
+  memberRoleIds?: string[];
+  overwrites?: {
+    id: string;
+    type: number;
+    allow: string;
+    deny: string;
+  }[];
+}): bigint {
+  return computeChannelPermissions({
+    guildId: GUILD,
+    memberId: MEMBER,
+    memberRoleIds: input.memberRoleIds ?? [],
+    rolePermissions: new Map(Object.entries(input.rolePermissions)),
+    overwrites: input.overwrites ?? [],
+  });
+}
+
+describe("computeChannelPermissions", () => {
+  test("unions @everyone with the member's roles", () => {
+    const result = permissions({
+      rolePermissions: {
+        [GUILD]: VIEW.toString(),
+        [ROLE]: SEND.toString(),
+      },
+      memberRoleIds: [ROLE],
+    });
+    expect(hasPermission(result, VIEW)).toBe(true);
+    expect(hasPermission(result, SEND)).toBe(true);
+  });
+
+  test("ignores roles the member does not hold", () => {
+    const result = permissions({
+      rolePermissions: {
+        [GUILD]: VIEW.toString(),
+        [ROLE]: SEND.toString(),
+      },
+    });
+    expect(hasPermission(result, SEND)).toBe(false);
+  });
+
+  test("guild Administrator wins over every channel denial", () => {
+    const result = permissions({
+      rolePermissions: {
+        [GUILD]: PermissionFlagsBits.Administrator.toString(),
+      },
+      overwrites: [
+        { id: GUILD, type: 0, allow: "0", deny: (VIEW | SEND).toString() },
+      ],
+    });
+    expect(result).toBe(PermissionsBitField.All);
+  });
+
+  test("an @everyone overwrite denies, a role overwrite restores", () => {
+    const denied = permissions({
+      rolePermissions: { [GUILD]: (VIEW | SEND).toString() },
+      overwrites: [{ id: GUILD, type: 0, allow: "0", deny: SEND.toString() }],
+    });
+    expect(hasPermission(denied, SEND)).toBe(false);
+
+    const restored = permissions({
+      rolePermissions: { [GUILD]: (VIEW | SEND).toString(), [ROLE]: "0" },
+      memberRoleIds: [ROLE],
+      overwrites: [
+        { id: GUILD, type: 0, allow: "0", deny: SEND.toString() },
+        { id: ROLE, type: 0, allow: SEND.toString(), deny: "0" },
+      ],
+    });
+    expect(hasPermission(restored, SEND)).toBe(true);
+  });
+
+  test("role overwrites are one pass: an allow on any held role wins", () => {
+    // Applied one at a time in list order, the trailing deny would win and the
+    // member would lose SendMessages — Discord's answer is that it does not.
+    const result = permissions({
+      rolePermissions: {
+        [GUILD]: VIEW.toString(),
+        [ROLE]: "0",
+        [OTHER_ROLE]: "0",
+      },
+      memberRoleIds: [ROLE, OTHER_ROLE],
+      overwrites: [
+        { id: ROLE, type: 0, allow: SEND.toString(), deny: "0" },
+        { id: OTHER_ROLE, type: 0, allow: "0", deny: SEND.toString() },
+      ],
+    });
+    expect(hasPermission(result, SEND)).toBe(true);
+  });
+
+  test("a member overwrite beats every role overwrite", () => {
+    const result = permissions({
+      rolePermissions: { [GUILD]: (VIEW | SEND).toString(), [ROLE]: "0" },
+      memberRoleIds: [ROLE],
+      overwrites: [
+        { id: ROLE, type: 0, allow: SEND.toString(), deny: "0" },
+        { id: MEMBER, type: 1, allow: "0", deny: SEND.toString() },
+      ],
+    });
+    expect(hasPermission(result, SEND)).toBe(false);
+  });
+
+  test("a member overwrite for someone else is not applied", () => {
+    const result = permissions({
+      rolePermissions: { [GUILD]: (VIEW | SEND).toString() },
+      overwrites: [{ id: "999", type: 1, allow: "0", deny: SEND.toString() }],
+    });
+    expect(hasPermission(result, SEND)).toBe(true);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/channel-permissions.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/channel-permissions.test.ts
@@ -16,6 +16,7 @@ const SEND = PermissionFlagsBits.SendMessages;
 function permissions(input: {
   rolePermissions: Record<string, string>;
   memberRoleIds?: string[];
+  guildOwnerId?: string | null;
   overwrites?: {
     id: string;
     type: number;
@@ -25,6 +26,7 @@ function permissions(input: {
 }): bigint {
   return computeChannelPermissions({
     guildId: GUILD,
+    guildOwnerId: input.guildOwnerId ?? null,
     memberId: MEMBER,
     memberRoleIds: input.memberRoleIds ?? [],
     rolePermissions: new Map(Object.entries(input.rolePermissions)),
@@ -52,6 +54,43 @@ describe("computeChannelPermissions", () => {
         [ROLE]: SEND.toString(),
       },
     });
+    expect(hasPermission(result, SEND)).toBe(false);
+  });
+
+  test("the guild owner holds everything with no role saying so", () => {
+    // The common real setup: whoever made the server never gave themselves an
+    // Administrator role, because they never needed one.
+    const result = permissions({
+      guildOwnerId: MEMBER,
+      rolePermissions: { [GUILD]: "0" },
+    });
+    expect(result).toBe(PermissionsBitField.All);
+    expect(hasPermission(result, PermissionFlagsBits.Administrator)).toBe(true);
+  });
+
+  test("the owner grant survives an explicit channel denial", () => {
+    // Same gate `listPostableChannels` applies, against a channel that denies
+    // @everyone outright.
+    const result = permissions({
+      guildOwnerId: MEMBER,
+      rolePermissions: { [GUILD]: "0" },
+      overwrites: [
+        { id: GUILD, type: 0, allow: "0", deny: (VIEW | SEND).toString() },
+        { id: MEMBER, type: 1, allow: "0", deny: (VIEW | SEND).toString() },
+      ],
+    });
+    expect(hasPermission(result, VIEW)).toBe(true);
+    expect(hasPermission(result, SEND)).toBe(true);
+  });
+
+  test("a different member is not granted the owner's permissions", () => {
+    const result = permissions({
+      guildOwnerId: "999",
+      rolePermissions: { [GUILD]: VIEW.toString() },
+    });
+    expect(hasPermission(result, PermissionFlagsBits.Administrator)).toBe(
+      false,
+    );
     expect(hasPermission(result, SEND)).toBe(false);
   });
 

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/channel-permissions.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/channel-permissions.ts
@@ -1,0 +1,100 @@
+/**
+ * Discord's channel permission resolution, computed from raw REST payloads.
+ *
+ * discord.js normally does this for you through `GuildMember#permissionsIn`,
+ * but that reads the gateway cache: it needs the guild, its roles, the member,
+ * and the channel to already be resident. Web requests must be answerable with
+ * no gateway connection at all, so the same algorithm is reproduced here over
+ * the REST shapes in `bot-rest-schemas.ts`.
+ *
+ * The order below is Discord's, and the order is the whole algorithm — applying
+ * the member overwrite before the role overwrites, or skipping the @everyone
+ * pass, silently produces a *different* channel list than Discord would.
+ *
+ * https://discord.com/developers/docs/topics/permissions#permission-overwrites
+ */
+
+import { PermissionFlagsBits, PermissionsBitField } from "discord.js";
+import type { DiscordOverwrite } from "#src/lib/discord/bot-rest-schemas.ts";
+
+/** Overwrite `type` discriminants on the wire. */
+const OVERWRITE_TYPE_ROLE = 0;
+const OVERWRITE_TYPE_MEMBER = 1;
+
+/**
+ * The member's guild-wide permissions: the @everyone role (whose id is the
+ * guild id) unioned with every role they hold.
+ */
+function basePermissions(input: {
+  guildId: string;
+  memberRoleIds: readonly string[];
+  rolePermissions: ReadonlyMap<string, string>;
+}): bigint {
+  let base = BigInt(input.rolePermissions.get(input.guildId) ?? "0");
+  for (const roleId of input.memberRoleIds) {
+    const permissions = input.rolePermissions.get(roleId);
+    if (permissions !== undefined) base |= BigInt(permissions);
+  }
+  return base;
+}
+
+function applyOverwrite(
+  permissions: bigint,
+  overwrite: { allow: string; deny: string },
+): bigint {
+  return (permissions & ~BigInt(overwrite.deny)) | BigInt(overwrite.allow);
+}
+
+/**
+ * The permissions `memberId` holds inside one channel.
+ *
+ * `rolePermissions` maps every role id in the guild (including @everyone, keyed
+ * by the guild id) to its decimal bitfield string.
+ */
+export function computeChannelPermissions(input: {
+  guildId: string;
+  memberId: string;
+  memberRoleIds: readonly string[];
+  rolePermissions: ReadonlyMap<string, string>;
+  overwrites: readonly DiscordOverwrite[];
+}): bigint {
+  const base = basePermissions(input);
+  // Administrator short-circuits every overwrite, at the guild level only.
+  if ((base & PermissionFlagsBits.Administrator) !== 0n) {
+    return PermissionsBitField.All;
+  }
+
+  const everyone = input.overwrites.find(
+    (overwrite) => overwrite.id === input.guildId,
+  );
+  let permissions =
+    everyone === undefined ? base : applyOverwrite(base, everyone);
+
+  // Every role overwrite is accumulated first and applied as one pass, so a
+  // deny on one role cannot cancel an allow on another applied later.
+  const memberRoles = new Set(input.memberRoleIds);
+  let roleAllow = 0n;
+  let roleDeny = 0n;
+  for (const overwrite of input.overwrites) {
+    if (overwrite.type !== OVERWRITE_TYPE_ROLE) continue;
+    if (overwrite.id === input.guildId) continue;
+    if (!memberRoles.has(overwrite.id)) continue;
+    roleAllow |= BigInt(overwrite.allow);
+    roleDeny |= BigInt(overwrite.deny);
+  }
+  permissions = (permissions & ~roleDeny) | roleAllow;
+
+  const member = input.overwrites.find(
+    (overwrite) =>
+      overwrite.type === OVERWRITE_TYPE_MEMBER &&
+      overwrite.id === input.memberId,
+  );
+  return member === undefined
+    ? permissions
+    : applyOverwrite(permissions, member);
+}
+
+/** Whether every bit in `flag` is set in `permissions`. */
+export function hasPermission(permissions: bigint, flag: bigint): boolean {
+  return (permissions & flag) === flag;
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/channel-permissions.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/channel-permissions.ts
@@ -9,7 +9,9 @@
  *
  * The order below is Discord's, and the order is the whole algorithm — applying
  * the member overwrite before the role overwrites, or skipping the @everyone
- * pass, silently produces a *different* channel list than Discord would.
+ * pass, silently produces a *different* channel list than Discord would. Two of
+ * the steps are implicit grants that appear in no bitfield at all: the guild
+ * owner holds everything, and so does anyone with Administrator.
  *
  * https://discord.com/developers/docs/topics/permissions#permission-overwrites
  */
@@ -50,14 +52,27 @@ function applyOverwrite(
  *
  * `rolePermissions` maps every role id in the guild (including @everyone, keyed
  * by the guild id) to its decimal bitfield string.
+ *
+ * `guildOwnerId` is required rather than optional because Discord grants the
+ * owner every permission *implicitly* — no role carries it, so a computation
+ * from roles alone silently under-reports for exactly one member per guild, and
+ * an owner who never gave themselves an Administrator role is a completely
+ * ordinary setup. Pass `null` only where the answer is definitionally not about
+ * the owner. Callers get it from `BotRestReader#guild`.
  */
 export function computeChannelPermissions(input: {
   guildId: string;
+  guildOwnerId: string | null;
   memberId: string;
   memberRoleIds: readonly string[];
   rolePermissions: ReadonlyMap<string, string>;
   overwrites: readonly DiscordOverwrite[];
 }): bigint {
+  // The owner outranks every role and every overwrite, including a channel that
+  // explicitly denies them.
+  if (input.guildOwnerId !== null && input.memberId === input.guildOwnerId) {
+    return PermissionsBitField.All;
+  }
   const base = basePermissions(input);
   // Administrator short-circuits every overwrite, at the guild level only.
   if ((base & PermissionFlagsBits.Administrator) !== 0n) {

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/installed-guilds.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/installed-guilds.test.ts
@@ -48,6 +48,7 @@ function restStub(
       guildRoles: unused,
       botMember: unused,
       guildMember: unused,
+      freshGuildMember: unused,
       searchGuildMembers: unused,
       user: unused,
       channel: unused,

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/installed-guilds.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/installed-guilds.test.ts
@@ -1,0 +1,204 @@
+/**
+ * The installation port's contract, exercised against a real `GuildInstall`
+ * table because the whole point of the module is which *rows* count.
+ */
+
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import type { DiscordGuildId } from "@scout-for-lol/data";
+import { DiscordUpstreamError } from "#src/lib/discord-rest.ts";
+import {
+  installedGuildIdsAmong,
+  installedGuildName,
+  isScoutInstalledInGuild,
+  type InstalledGuildsDependencies,
+} from "#src/lib/discord/installed-guilds.ts";
+import type { BotRestReader } from "#src/lib/discord/bot-rest.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import { testAccountId, testGuildId } from "#src/testing/test-ids.ts";
+
+const { prisma } = createTestDatabase("installed-guilds-port");
+
+const INSTALLED = testGuildId("701");
+const REMOVED = testGuildId("702");
+const ABSENT = testGuildId("703");
+const DEV_ONLY = testGuildId("704");
+
+type RestStub = {
+  reader: BotRestReader;
+  calls: string[];
+};
+
+function unused(): never {
+  throw new Error("not used by the installation port");
+}
+
+function restStub(
+  guildExists: (guildId: string) => Promise<boolean>,
+): RestStub {
+  const calls: string[] = [];
+  return {
+    calls,
+    reader: {
+      guildExists: async (guildId) => {
+        calls.push(guildId);
+        return await guildExists(guildId);
+      },
+      guildChannels: unused,
+      guildRoles: unused,
+      botMember: unused,
+      guildMember: unused,
+      searchGuildMembers: unused,
+      user: unused,
+      channel: unused,
+      clearCaches: () => {
+        /* no cache in the stub */
+      },
+    },
+  };
+}
+
+function dependencies(
+  rest: BotRestReader,
+  devGuildIds: readonly string[] = [],
+): InstalledGuildsDependencies {
+  return {
+    db: prisma,
+    rest,
+    isDevOverrideGuild: (guildId) => devGuildIds.includes(guildId),
+  };
+}
+
+async function seed(
+  serverId: DiscordGuildId,
+  removedAt: Date | null,
+): Promise<void> {
+  await prisma.guildInstall.create({
+    data: {
+      serverId,
+      serverName: `Server ${serverId}`,
+      ownerDiscordId: testAccountId("81"),
+      addedByDiscordId: testAccountId("81"),
+      memberCount: 3,
+      installedAt: new Date("2026-01-01T00:00:00.000Z"),
+      removedAt,
+    },
+  });
+}
+
+describe("isScoutInstalledInGuild", () => {
+  beforeEach(async () => {
+    await prisma.guildInstall.deleteMany();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  test("a live row answers yes without asking Discord", async () => {
+    await seed(INSTALLED, null);
+    const rest = restStub(() => Promise.resolve(false));
+    await expect(
+      isScoutInstalledInGuild(INSTALLED, dependencies(rest.reader)),
+    ).resolves.toBe(true);
+    expect(rest.calls).toEqual([]);
+  });
+
+  test("a removed row is not treated as installed", async () => {
+    await seed(REMOVED, new Date("2026-02-01T00:00:00.000Z"));
+    const rest = restStub(() => Promise.resolve(false));
+    await expect(
+      isScoutInstalledInGuild(REMOVED, dependencies(rest.reader)),
+    ).resolves.toBe(false);
+    // Row existence is not the signal, so the negative had to be confirmed.
+    expect(rest.calls).toEqual([REMOVED]);
+  });
+
+  test("a re-installed row (removedAt cleared) is installed again", async () => {
+    await seed(REMOVED, new Date("2026-02-01T00:00:00.000Z"));
+    await prisma.guildInstall.update({
+      where: { serverId: REMOVED },
+      data: { removedAt: null },
+    });
+    const rest = restStub(() => Promise.resolve(false));
+    await expect(
+      isScoutInstalledInGuild(REMOVED, dependencies(rest.reader)),
+    ).resolves.toBe(true);
+    expect(rest.calls).toEqual([]);
+  });
+
+  test("a missing row is confirmed against Discord, not assumed absent", async () => {
+    const rest = restStub(() => Promise.resolve(true));
+    await expect(
+      isScoutInstalledInGuild(ABSENT, dependencies(rest.reader)),
+    ).resolves.toBe(true);
+    expect(rest.calls).toEqual([ABSENT]);
+  });
+
+  test("Discord confirming absence answers no", async () => {
+    const rest = restStub(() => Promise.resolve(false));
+    await expect(
+      isScoutInstalledInGuild(ABSENT, dependencies(rest.reader)),
+    ).resolves.toBe(false);
+  });
+
+  test("an unreachable Discord propagates instead of answering 'not installed'", async () => {
+    const rest = restStub(() =>
+      Promise.reject(new DiscordUpstreamError("http_error", "boom", 503)),
+    );
+    await expect(
+      isScoutInstalledInGuild(ABSENT, dependencies(rest.reader)),
+    ).rejects.toBeInstanceOf(DiscordUpstreamError);
+  });
+
+  test("a dev-override guild is installed with no row and no Discord call", async () => {
+    const rest = restStub(() => Promise.resolve(false));
+    await expect(
+      isScoutInstalledInGuild(DEV_ONLY, dependencies(rest.reader, [DEV_ONLY])),
+    ).resolves.toBe(true);
+    expect(rest.calls).toEqual([]);
+  });
+});
+
+describe("installedGuildIdsAmong", () => {
+  beforeEach(async () => {
+    await prisma.guildInstall.deleteMany();
+  });
+
+  test("returns only live rows and never fans out to Discord", async () => {
+    await seed(INSTALLED, null);
+    await seed(REMOVED, new Date("2026-02-01T00:00:00.000Z"));
+    const rest = restStub(() => Promise.resolve(true));
+    const installed = await installedGuildIdsAmong(
+      [INSTALLED, REMOVED, ABSENT],
+      dependencies(rest.reader),
+    );
+    expect([...installed]).toEqual([INSTALLED]);
+    expect(rest.calls).toEqual([]);
+  });
+
+  test("includes dev-override guilds", async () => {
+    const rest = restStub(() => Promise.resolve(false));
+    const installed = await installedGuildIdsAmong(
+      [DEV_ONLY],
+      dependencies(rest.reader, [DEV_ONLY]),
+    );
+    expect([...installed]).toEqual([DEV_ONLY]);
+  });
+});
+
+describe("installedGuildName", () => {
+  beforeEach(async () => {
+    await prisma.guildInstall.deleteMany();
+  });
+
+  test("returns the recorded name, or null when there is no row", async () => {
+    await seed(INSTALLED, null);
+    const rest = restStub(() => Promise.resolve(false));
+    await expect(
+      installedGuildName(INSTALLED, dependencies(rest.reader)),
+    ).resolves.toBe(`Server ${INSTALLED}`);
+    await expect(
+      installedGuildName(ABSENT, dependencies(rest.reader)),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/installed-guilds.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/installed-guilds.test.ts
@@ -43,6 +43,7 @@ function restStub(
         calls.push(guildId);
         return await guildExists(guildId);
       },
+      guild: unused,
       guildChannels: unused,
       guildRoles: unused,
       botMember: unused,
@@ -94,13 +95,37 @@ describe("isScoutInstalledInGuild", () => {
     await prisma.$disconnect();
   });
 
-  test("a live row answers yes without asking Discord", async () => {
+  test("a live row confirmed by Discord is installed", async () => {
+    await seed(INSTALLED, null);
+    const rest = restStub(() => Promise.resolve(true));
+    await expect(
+      isScoutInstalledInGuild(INSTALLED, dependencies(rest.reader)),
+    ).resolves.toBe(true);
+    // The row is not taken on trust: a removal while the gateway was down
+    // fires no guildDelete, so the positive is confirmed too.
+    expect(rest.calls).toEqual([INSTALLED]);
+  });
+
+  test("a live row is overruled when Discord says Scout was removed", async () => {
     await seed(INSTALLED, null);
     const rest = restStub(() => Promise.resolve(false));
     await expect(
       isScoutInstalledInGuild(INSTALLED, dependencies(rest.reader)),
+    ).resolves.toBe(false);
+    expect(rest.calls).toEqual([INSTALLED]);
+  });
+
+  test("a live row is TRUSTED when Discord cannot be reached", async () => {
+    // The asymmetry: with a row to fall back on, availability wins. 503ing a
+    // working dashboard over a Discord blip is worse than the staleness this
+    // system already had before the row was consulted.
+    await seed(INSTALLED, null);
+    const rest = restStub(() =>
+      Promise.reject(new DiscordUpstreamError("fetch_error", "blip")),
+    );
+    await expect(
+      isScoutInstalledInGuild(INSTALLED, dependencies(rest.reader)),
     ).resolves.toBe(true);
-    expect(rest.calls).toEqual([]);
   });
 
   test("a removed row is not treated as installed", async () => {
@@ -119,11 +144,10 @@ describe("isScoutInstalledInGuild", () => {
       where: { serverId: REMOVED },
       data: { removedAt: null },
     });
-    const rest = restStub(() => Promise.resolve(false));
+    const rest = restStub(() => Promise.resolve(true));
     await expect(
       isScoutInstalledInGuild(REMOVED, dependencies(rest.reader)),
     ).resolves.toBe(true);
-    expect(rest.calls).toEqual([]);
   });
 
   test("a missing row is confirmed against Discord, not assumed absent", async () => {
@@ -141,12 +165,24 @@ describe("isScoutInstalledInGuild", () => {
     ).resolves.toBe(false);
   });
 
-  test("an unreachable Discord propagates instead of answering 'not installed'", async () => {
+  test("with NO row, an unreachable Discord propagates rather than denying", async () => {
+    // The other half of the asymmetry: nothing to fall back on, so the outage
+    // has to surface as an outage instead of "Scout is not installed".
     const rest = restStub(() =>
       Promise.reject(new DiscordUpstreamError("http_error", "boom", 503)),
     );
     await expect(
       isScoutInstalledInGuild(ABSENT, dependencies(rest.reader)),
+    ).rejects.toBeInstanceOf(DiscordUpstreamError);
+  });
+
+  test("with a REMOVED row, an unreachable Discord also propagates", async () => {
+    await seed(REMOVED, new Date("2026-02-01T00:00:00.000Z"));
+    const rest = restStub(() =>
+      Promise.reject(new DiscordUpstreamError("http_error", "boom", 503)),
+    );
+    await expect(
+      isScoutInstalledInGuild(REMOVED, dependencies(rest.reader)),
     ).rejects.toBeInstanceOf(DiscordUpstreamError);
   });
 

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/installed-guilds.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/installed-guilds.ts
@@ -1,0 +1,122 @@
+/**
+ * "Is Scout installed in this guild?" — the application port every web request
+ * asks instead of reading `client.guilds.cache`.
+ *
+ * **This promotes `GuildInstall` from an analytics/outreach table to an
+ * authorization source.** A row with `removedAt: null` is now part of what
+ * decides whether the dashboard answers NOT_FOUND, so its writers
+ * (`discord/events/guild-create.ts` sets `removedAt: null`,
+ * `analytics/guild-lifecycle.ts` and `guild-delete` set it) are load-bearing
+ * for access control, not just reporting. Row *existence* is deliberately not
+ * the signal: rows outlive removal on purpose so a re-install can be told from
+ * a first install, so an existence check would keep serving a guild that
+ * removed Scout months ago.
+ *
+ * The gateway keeps writing those rows; nothing here reads the gateway. That is
+ * the point — a pod serving HTTP with no gateway connection answers the same
+ * way as one with a fully backfilled cache.
+ *
+ * ## Why a negative is re-checked against Discord
+ *
+ * `GuildInstall` is written by a `guildCreate` handler that swallows its own
+ * write failures, and it did not exist for Scout's earliest guilds. A missing
+ * row therefore is not proof of absence, and treating it as proof would lock a
+ * real server out of its own dashboard with a message saying Scout was never
+ * installed — the exact class of wrong answer this whole change exists to
+ * remove. So a negative from the table is confirmed against Discord over the
+ * bot REST API before it is believed, and a REST failure propagates as
+ * {@link DiscordUpstreamError} (⇒ SERVICE_UNAVAILABLE) rather than "not
+ * installed".
+ *
+ * {@link installedGuildIdsAmong} does NOT do that confirmation: it answers for
+ * a whole guild picker at once, where one REST call per non-installed guild
+ * would mean dozens of requests per page load. The picker is allowed to omit a
+ * guild whose row is missing; opening that guild directly still works, because
+ * the single-guild path above confirms.
+ */
+
+import type { DiscordGuildId } from "@scout-for-lol/data";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { isDevGuildOverrideGuild } from "#src/lib/discord-rest.ts";
+import { botRest, type BotRestReader } from "#src/lib/discord/bot-rest.ts";
+
+export type InstalledGuildsDependencies = {
+  readonly db: ExtendedPrismaClient;
+  readonly rest: BotRestReader;
+  /** Local dev-login fixture guilds, which no real Discord answer covers. */
+  readonly isDevOverrideGuild: (guildId: string) => boolean;
+};
+
+export function defaultInstalledGuildsDependencies(): InstalledGuildsDependencies {
+  return {
+    db: prisma,
+    rest: botRest(),
+    isDevOverrideGuild: isDevGuildOverrideGuild,
+  };
+}
+
+async function hasLiveInstallRow(
+  db: ExtendedPrismaClient,
+  guildId: string,
+): Promise<boolean> {
+  const install = await db.guildInstall.findUnique({
+    where: { serverId: guildId },
+    select: { removedAt: true },
+  });
+  return install !== null && install.removedAt === null;
+}
+
+/**
+ * Whether Scout is installed in one guild.
+ *
+ * Throws {@link DiscordUpstreamError} when the table says no and Discord could
+ * not be reached to confirm it — never returns `false` in that case.
+ */
+export async function isScoutInstalledInGuild(
+  guildId: string,
+  dependencies: InstalledGuildsDependencies = defaultInstalledGuildsDependencies(),
+): Promise<boolean> {
+  if (dependencies.isDevOverrideGuild(guildId)) return true;
+  if (await hasLiveInstallRow(dependencies.db, guildId)) return true;
+  return await dependencies.rest.guildExists(guildId);
+}
+
+/**
+ * Which of `guildIds` Scout is installed in, from the table alone.
+ *
+ * One query regardless of input size, and no Discord I/O — see the module
+ * docblock for why this half does not confirm negatives.
+ */
+export async function installedGuildIdsAmong(
+  guildIds: readonly string[],
+  dependencies: InstalledGuildsDependencies = defaultInstalledGuildsDependencies(),
+): Promise<Set<string>> {
+  const unique = [...new Set(guildIds)];
+  const installed = new Set(
+    unique.filter((guildId) => dependencies.isDevOverrideGuild(guildId)),
+  );
+  if (unique.length === 0) return installed;
+  const rows = await dependencies.db.guildInstall.findMany({
+    where: { serverId: { in: unique }, removedAt: null },
+    select: { serverId: true },
+  });
+  for (const row of rows) installed.add(row.serverId);
+  return installed;
+}
+
+/**
+ * The guild's name as Scout last recorded it, or `null` when there is no row.
+ *
+ * `guildCreate` refreshes `serverName` on every install and re-install, so this
+ * is the same string the bot's cache used to report, without a gateway.
+ */
+export async function installedGuildName(
+  guildId: DiscordGuildId,
+  dependencies: InstalledGuildsDependencies = defaultInstalledGuildsDependencies(),
+): Promise<string | null> {
+  const install = await dependencies.db.guildInstall.findUnique({
+    where: { serverId: guildId },
+    select: { serverName: true },
+  });
+  return install?.serverName ?? null;
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/installed-guilds.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/installed-guilds.ts
@@ -16,29 +16,59 @@
  * the point — a pod serving HTTP with no gateway connection answers the same
  * way as one with a fully backfilled cache.
  *
- * ## Why a negative is re-checked against Discord
+ * ## The table is never the final word, in either direction
  *
- * `GuildInstall` is written by a `guildCreate` handler that swallows its own
- * write failures, and it did not exist for Scout's earliest guilds. A missing
- * row therefore is not proof of absence, and treating it as proof would lock a
- * real server out of its own dashboard with a message saying Scout was never
- * installed — the exact class of wrong answer this whole change exists to
- * remove. So a negative from the table is confirmed against Discord over the
- * bot REST API before it is believed, and a REST failure propagates as
- * {@link DiscordUpstreamError} (⇒ SERVICE_UNAVAILABLE) rather than "not
- * installed".
+ * `GuildInstall` is maintained by gateway handlers, so it is only as current as
+ * the gateway was. Both directions can be stale, and both are confirmed against
+ * Discord over the bot REST API:
  *
- * {@link installedGuildIdsAmong} does NOT do that confirmation: it answers for
- * a whole guild picker at once, where one REST call per non-installed guild
- * would mean dozens of requests per page load. The picker is allowed to omit a
- * guild whose row is missing; opening that guild directly still works, because
- * the single-guild path above confirms.
+ * - A **missing or removed row** is not proof of absence. `guildCreate`
+ *   swallows its own write failures, and the table did not exist for Scout's
+ *   earliest guilds, so believing it would lock a real server out of its own
+ *   dashboard with a message saying Scout was never installed.
+ * - A **live row** is not proof of presence. A removal that happens while the
+ *   gateway is down fires no `guildDelete`, and a `guildDelete` whose cleanup
+ *   fails leaves `removedAt` null — so an unconfirmed positive would keep
+ *   authorizing dashboard access to a server Scout was thrown out of, for as
+ *   long as nobody restarted the bot.
+ *
+ * ## The failure semantics are deliberately asymmetric
+ *
+ * What differs between the two directions is what happens when Discord cannot
+ * be reached, and the asymmetry is the point:
+ *
+ * | table | Discord says absent | Discord unreachable |
+ * | ----- | ------------------- | ------------------- |
+ * | live row | `false` — removal wins | **`true` — trust the row** |
+ * | no row   | `false`             | throws ⇒ SERVICE_UNAVAILABLE |
+ *
+ * A live row plus an unreachable Discord resolves to `true` on purpose. The
+ * alternative — 503ing every guild-scoped request whenever Discord blips — takes
+ * a working dashboard offline to defend against a stale row, and the worst case
+ * of trusting the row is exactly the staleness this system had before the row
+ * was consulted at all. With no row there is nothing to fall back on, so the
+ * failure has to surface.
+ *
+ * Either way an outage never becomes "Scout is not installed": in the first case
+ * it is invisible, in the second it is reported as an outage.
+ *
+ * {@link installedGuildIdsAmong} does NOT confirm at all: it answers for a whole
+ * guild picker at once, where one REST call per guild would mean dozens of
+ * requests per page load. The picker is allowed to be one gateway-write stale in
+ * either direction; opening a guild directly still confirms, and every mutation
+ * behind it goes through the single-guild path.
  */
 
 import type { DiscordGuildId } from "@scout-for-lol/data";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
-import { isDevGuildOverrideGuild } from "#src/lib/discord-rest.ts";
+import {
+  DiscordUpstreamError,
+  isDevGuildOverrideGuild,
+} from "#src/lib/discord-rest.ts";
 import { botRest, type BotRestReader } from "#src/lib/discord/bot-rest.ts";
+import { createLogger } from "#src/logger.ts";
+
+const logger = createLogger("installed-guilds");
 
 export type InstalledGuildsDependencies = {
   readonly db: ExtendedPrismaClient;
@@ -67,18 +97,35 @@ async function hasLiveInstallRow(
 }
 
 /**
- * Whether Scout is installed in one guild.
+ * Whether Scout is installed in one guild, confirmed against Discord.
  *
- * Throws {@link DiscordUpstreamError} when the table says no and Discord could
- * not be reached to confirm it — never returns `false` in that case.
+ * See the module docblock for the truth table. In short: Discord's answer wins
+ * whenever there is one, and when there is not, a live row is trusted while a
+ * missing row throws {@link DiscordUpstreamError} (⇒ SERVICE_UNAVAILABLE). This
+ * never returns `false` because Scout failed to ask.
  */
 export async function isScoutInstalledInGuild(
   guildId: string,
   dependencies: InstalledGuildsDependencies = defaultInstalledGuildsDependencies(),
 ): Promise<boolean> {
   if (dependencies.isDevOverrideGuild(guildId)) return true;
-  if (await hasLiveInstallRow(dependencies.db, guildId)) return true;
-  return await dependencies.rest.guildExists(guildId);
+  const hasRow = await hasLiveInstallRow(dependencies.db, guildId);
+  if (!hasRow) {
+    // Nothing to fall back on: an unreachable Discord must surface, not deny.
+    return await dependencies.rest.guildExists(guildId);
+  }
+  try {
+    return await dependencies.rest.guildExists(guildId);
+  } catch (error) {
+    if (error instanceof DiscordUpstreamError) {
+      logger.warn(
+        "Discord could not confirm an installed guild; trusting the GuildInstall row",
+        { guildId, reason: error.reason },
+      );
+      return true;
+    }
+    throw error;
+  }
 }
 
 /**

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/postable-channels.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/postable-channels.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "vitest";
+import { ChannelType, PermissionFlagsBits } from "discord.js";
+import { DiscordGuildIdSchema } from "@scout-for-lol/data";
+import { DiscordUpstreamError } from "#src/lib/discord-rest.ts";
+import type { BotRestReader } from "#src/lib/discord/bot-rest.ts";
+import type { DiscordGuildChannel } from "#src/lib/discord/bot-rest-schemas.ts";
+import { listPostableChannels } from "#src/lib/discord/postable-channels.ts";
+import { testGuildId } from "#src/testing/test-ids.ts";
+
+const GUILD = testGuildId("801");
+const GUILD_ID = DiscordGuildIdSchema.parse(GUILD);
+const BOT = "900";
+const BOT_ROLE = "901";
+
+const VIEW_AND_SEND = (
+  PermissionFlagsBits.ViewChannel | PermissionFlagsBits.SendMessages
+).toString();
+
+type Overwrite = DiscordGuildChannel["permission_overwrites"][number];
+
+function channel(input: {
+  id: string;
+  name: string;
+  type: number;
+  parentId?: string | null;
+  overwrites?: Overwrite[];
+}): DiscordGuildChannel {
+  return {
+    id: input.id,
+    name: input.name,
+    type: input.type,
+    parent_id: input.parentId ?? null,
+    permission_overwrites: input.overwrites ?? [],
+  };
+}
+
+function unused(): never {
+  throw new Error("not used by listPostableChannels");
+}
+
+function rest(overrides: Partial<BotRestReader>): BotRestReader {
+  return {
+    guildExists: unused,
+    guildChannels: unused,
+    guildRoles: unused,
+    botMember: unused,
+    guildMember: unused,
+    searchGuildMembers: unused,
+    user: unused,
+    channel: unused,
+    clearCaches: () => {
+      /* no cache in the stub */
+    },
+    ...overrides,
+  };
+}
+
+function reader(input: {
+  channels: DiscordGuildChannel[] | null;
+  botRolePermissions?: string;
+}): BotRestReader {
+  return rest({
+    guildChannels: () => Promise.resolve(input.channels),
+    guildRoles: () =>
+      Promise.resolve([
+        { id: GUILD, name: "@everyone", permissions: "0" },
+        {
+          id: BOT_ROLE,
+          name: "Scout",
+          permissions: input.botRolePermissions ?? VIEW_AND_SEND,
+        },
+      ]),
+    botMember: () =>
+      Promise.resolve({
+        user: { id: BOT, username: "scout" },
+        roles: [BOT_ROLE],
+      }),
+  });
+}
+
+describe("listPostableChannels", () => {
+  test("offers text and announcement channels the bot can post in, by name", async () => {
+    const channels = await listPostableChannels(GUILD_ID, {
+      rest: reader({
+        channels: [
+          channel({ id: "2", name: "zulu", type: ChannelType.GuildText }),
+          channel({ id: "1", name: "alpha", type: ChannelType.GuildText }),
+          channel({
+            id: "3",
+            name: "news",
+            type: ChannelType.GuildAnnouncement,
+            parentId: "cat",
+          }),
+          channel({ id: "4", name: "voice", type: ChannelType.GuildVoice }),
+          channel({
+            id: "5",
+            name: "Category",
+            type: ChannelType.GuildCategory,
+          }),
+        ],
+      }),
+    });
+    expect(channels).toEqual([
+      { id: "1", name: "alpha", parentId: null },
+      { id: "3", name: "news", parentId: "cat" },
+      { id: "2", name: "zulu", parentId: null },
+    ]);
+  });
+
+  test("omits channels an overwrite denies the bot", async () => {
+    const channels = await listPostableChannels(GUILD_ID, {
+      rest: reader({
+        channels: [
+          channel({ id: "1", name: "open", type: ChannelType.GuildText }),
+          channel({
+            id: "2",
+            name: "locked",
+            type: ChannelType.GuildText,
+            overwrites: [
+              {
+                id: BOT_ROLE,
+                type: 0,
+                allow: "0",
+                deny: PermissionFlagsBits.SendMessages.toString(),
+              },
+            ],
+          }),
+        ],
+      }),
+    });
+    expect(channels.map((entry) => entry.id)).toEqual(["1"]);
+  });
+
+  test("returns nothing when the bot lacks Send Messages anywhere", async () => {
+    const channels = await listPostableChannels(GUILD_ID, {
+      rest: reader({
+        channels: [
+          channel({ id: "1", name: "open", type: ChannelType.GuildText }),
+        ],
+        botRolePermissions: PermissionFlagsBits.ViewChannel.toString(),
+      }),
+    });
+    expect(channels).toEqual([]);
+  });
+
+  test("returns [] when Discord says Scout is not in the guild", async () => {
+    const channels = await listPostableChannels(GUILD_ID, {
+      rest: reader({ channels: null }),
+    });
+    expect(channels).toEqual([]);
+  });
+
+  test("an unreachable Discord throws instead of reading as 'no channels'", async () => {
+    await expect(
+      listPostableChannels(GUILD_ID, {
+        rest: rest({
+          guildChannels: () =>
+            Promise.reject(new DiscordUpstreamError("http_error", "boom", 503)),
+          guildRoles: () => Promise.resolve([]),
+          botMember: () => Promise.resolve(null),
+        }),
+      }),
+    ).rejects.toBeInstanceOf(DiscordUpstreamError);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/postable-channels.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/postable-channels.test.ts
@@ -40,6 +40,7 @@ function unused(): never {
 
 function rest(overrides: Partial<BotRestReader>): BotRestReader {
   return {
+    guild: unused,
     guildExists: unused,
     guildChannels: unused,
     guildRoles: unused,

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/postable-channels.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/postable-channels.test.ts
@@ -46,6 +46,7 @@ function rest(overrides: Partial<BotRestReader>): BotRestReader {
     guildRoles: unused,
     botMember: unused,
     guildMember: unused,
+    freshGuildMember: unused,
     searchGuildMembers: unused,
     user: unused,
     channel: unused,

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/postable-channels.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/postable-channels.ts
@@ -81,6 +81,8 @@ export async function listPostableChannels(
       // show channels Scout could read but never message.
       const permissions = computeChannelPermissions({
         guildId,
+        // A bot can never own a guild, so the owner grant cannot apply here.
+        guildOwnerId: null,
         memberId: me.user.id,
         memberRoleIds: me.roles,
         rolePermissions,

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/postable-channels.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/postable-channels.ts
@@ -1,19 +1,28 @@
 /**
- * The bot-postable text channels of a guild, read from the gateway cache.
+ * The bot-postable text channels of a guild, read over the bot REST API.
  *
  * Extracted from `guild.router.ts` because more than one surface has to offer
  * the same channel list — the dashboard picker and, separately, the Explore
  * agent when it prepares a create intent. Two copies of the filter would drift
  * into offering channels the bot cannot actually post in.
+ *
+ * The filter needs Scout's *effective* permissions in each channel, which the
+ * gateway used to compute for us. Over REST that means three reads — the
+ * guild's channels, its roles, and Scout's own member row — combined by
+ * `channel-permissions.ts`. All three are TTL-cached per guild, so a picker
+ * render is at most three Discord requests and usually none.
  */
 
-import {
-  ChannelType,
-  PermissionFlagsBits,
-  type GuildBasedChannel,
-} from "discord.js";
+import { ChannelType, PermissionFlagsBits } from "discord.js";
 import type { DiscordGuildId } from "@scout-for-lol/data";
-import { client as discordClient } from "#src/discord/client.ts";
+import { botRest, type BotRestReader } from "#src/lib/discord/bot-rest.ts";
+import {
+  computeChannelPermissions,
+  hasPermission,
+} from "#src/lib/discord/channel-permissions.ts";
+import { createLogger } from "#src/logger.ts";
+
+const logger = createLogger("discord-postable-channels");
 
 export type PostableChannel = {
   id: string;
@@ -21,41 +30,75 @@ export type PostableChannel = {
   parentId: string | null;
 };
 
-/** Text channels in `guildId` that the bot can post to, sorted by name. */
-export function listPostableChannels(
+export type PostableChannelDependencies = {
+  readonly rest: BotRestReader;
+};
+
+function defaultDependencies(): PostableChannelDependencies {
+  return { rest: botRest() };
+}
+
+/**
+ * The channel types Scout can post reports into. A `Set<number>` rather than
+ * enum comparisons because Discord's wire `type` is an open integer: a channel
+ * kind added tomorrow must be *skipped*, not crash the picker.
+ */
+const POSTABLE_CHANNEL_TYPES = new Set<number>([
+  ChannelType.GuildText,
+  ChannelType.GuildAnnouncement,
+]);
+
+/**
+ * Text channels in `guildId` that the bot can post to, sorted by name.
+ *
+ * Returns `[]` when Discord says Scout is not in the guild — callers have
+ * already proved installation, so that is a narrowing, not a decision. A
+ * failure to reach Discord throws {@link DiscordUpstreamError} instead, so an
+ * outage is never presented as "this server has no channels".
+ */
+export async function listPostableChannels(
   guildId: DiscordGuildId,
-): PostableChannel[] {
-  const guild = discordClient.guilds.cache.get(guildId);
-  if (guild === undefined) {
-    // Callers have already proved Scout is installed, but the cache lookup is
-    // still narrowed here for type-safety.
+  dependencies: PostableChannelDependencies = defaultDependencies(),
+): Promise<PostableChannel[]> {
+  const { rest } = dependencies;
+  const [channels, roles, me] = await Promise.all([
+    rest.guildChannels(guildId),
+    rest.guildRoles(guildId),
+    rest.botMember(guildId),
+  ]);
+  if (channels === null || roles === null || me === null) {
+    logger.warn("Discord reports Scout is not in the guild", { guildId });
     return [];
   }
 
-  const me = guild.members.me;
-  const channels = guild.channels.cache
-    .filter((c: GuildBasedChannel) => {
-      const isText =
-        c.type === ChannelType.GuildText ||
-        c.type === ChannelType.GuildAnnouncement;
-      if (!isText) return false;
-      // Only offer channels the bot can actually post in. Without
-      // this we'd show channels Scout could read but never message.
-      const perms = me?.permissionsIn(c);
+  const rolePermissions = new Map(
+    roles.map((role) => [role.id, role.permissions]),
+  );
+  const postable = channels
+    .filter((channel) => {
+      if (!POSTABLE_CHANNEL_TYPES.has(channel.type)) return false;
+      // Only offer channels the bot can actually post in. Without this we'd
+      // show channels Scout could read but never message.
+      const permissions = computeChannelPermissions({
+        guildId,
+        memberId: me.user.id,
+        memberRoleIds: me.roles,
+        rolePermissions,
+        overwrites: channel.permission_overwrites,
+      });
       return (
-        perms !== undefined &&
-        perms.has(PermissionFlagsBits.ViewChannel) &&
-        perms.has(PermissionFlagsBits.SendMessages)
+        hasPermission(permissions, PermissionFlagsBits.ViewChannel) &&
+        hasPermission(permissions, PermissionFlagsBits.SendMessages)
       );
     })
-    .map((c: GuildBasedChannel) => ({
-      id: c.id,
-      name: c.name,
-      parentId: c.parentId,
+    .map((channel) => ({
+      id: channel.id,
+      name: channel.name,
+      parentId: channel.parent_id ?? null,
     }));
 
   // Keep the response deterministic.
-  channels.sort((a, b) => a.name.localeCompare(b.name));
+  postable.sort((a, b) => a.name.localeCompare(b.name));
 
-  return channels;
+  return postable;
 }

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/resolve-users.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/resolve-users.ts
@@ -1,17 +1,24 @@
 /**
  * Batch-resolve Discord user IDs to display names/avatars for the web UI.
  *
- * Domain payloads (players, subscriptions, competitions, audit log) store
- * raw Discord snowflakes. The dashboard wants human-readable names, so we
- * resolve them via the bot's gateway client (`client.users.fetch`), backed
- * by a short in-memory TTL cache to avoid re-fetching the same IDs across a
- * burst of reads. Resolution is fail-soft: on any error we return the raw ID
- * as the name and do NOT cache the failure (so a transient gateway hiccup
- * doesn't pin a user to its raw ID for the whole TTL).
+ * Domain payloads (players, subscriptions, competitions, audit log) store raw
+ * Discord snowflakes. The dashboard wants human-readable names, so we resolve
+ * them over the bot REST API (`GET /users/{id}`), TTL-cached in
+ * `bot-rest.ts` to avoid re-fetching the same IDs across a burst of reads.
+ *
+ * This used to go through `client.users.fetch`, whose REST client only carries
+ * a token once `client.login()` has run — so on a pod serving HTTP without a
+ * gateway connection every name silently degraded to a raw snowflake.
+ * Resolution stays fail-soft: on any error we return the raw ID as the name and
+ * do NOT cache the failure.
  */
 
 import { z } from "zod";
-import { client as discordClient } from "#src/discord/client.ts";
+import {
+  botRest,
+  userAvatarUrl,
+  type BotRestReader,
+} from "#src/lib/discord/bot-rest.ts";
 import { createLogger } from "#src/logger.ts";
 
 const logger = createLogger("discord-resolve-users");
@@ -24,32 +31,34 @@ export const ResolvedDiscordUserSchema = z.object({
 });
 export type ResolvedDiscordUser = z.infer<typeof ResolvedDiscordUserSchema>;
 
-type CacheEntry = { user: ResolvedDiscordUser; fetchedAt: number };
-const cache = new Map<string, CacheEntry>();
-const TTL_MS = 5 * 60 * 1000;
-/** Hard cap so a single call can't fan out to the gateway unbounded. */
+/** Hard cap so a single call can't fan out to Discord unbounded. */
 export const MAX_IDS_PER_RESOLVE = 100;
+
+export type ResolveUsersDependencies = {
+  readonly rest: BotRestReader;
+};
+
+function defaultDependencies(): ResolveUsersDependencies {
+  return { rest: botRest() };
+}
 
 function fallback(id: string): ResolvedDiscordUser {
   return { id, username: id, displayName: id, avatar: null };
 }
 
-async function resolveOne(id: string): Promise<ResolvedDiscordUser> {
-  const cached = cache.get(id);
-  if (cached !== undefined && Date.now() - cached.fetchedAt < TTL_MS) {
-    return cached.user;
-  }
-  cache.delete(id);
+async function resolveOne(
+  id: string,
+  rest: BotRestReader,
+): Promise<ResolvedDiscordUser> {
   try {
-    const user = await discordClient.users.fetch(id);
-    const resolved: ResolvedDiscordUser = {
+    const user = await rest.user(id);
+    if (user === null) return fallback(id);
+    return {
       id,
       username: user.username,
-      displayName: user.globalName ?? user.username,
-      avatar: user.displayAvatarURL(),
+      displayName: user.global_name ?? user.username,
+      avatar: userAvatarUrl(user),
     };
-    cache.set(id, { user: resolved, fetchedAt: Date.now() });
-    return resolved;
   } catch (error) {
     logger.debug("Discord user resolve failed; falling back to raw id", {
       id,
@@ -66,8 +75,11 @@ async function resolveOne(id: string): Promise<ResolvedDiscordUser> {
  */
 export async function resolveDiscordUsers(
   ids: readonly string[],
+  dependencies: ResolveUsersDependencies = defaultDependencies(),
 ): Promise<Record<string, ResolvedDiscordUser>> {
   const unique = [...new Set(ids)].slice(0, MAX_IDS_PER_RESOLVE);
-  const resolved = await Promise.all(unique.map((id) => resolveOne(id)));
+  const resolved = await Promise.all(
+    unique.map((id) => resolveOne(id, dependencies.rest)),
+  );
   return Object.fromEntries(resolved.map((user) => [user.id, user]));
 }

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/search-members.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/search-members.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The typeahead's failure contract: an empty list is an answer about the
+ * roster, never a stand-in for "Scout could not ask Discord".
+ */
+
+import { describe, expect, test } from "vitest";
+import { DiscordGuildIdSchema } from "@scout-for-lol/data";
+import { DiscordUpstreamError } from "#src/lib/discord-rest.ts";
+import type { BotRestReader } from "#src/lib/discord/bot-rest.ts";
+import type { DiscordGuildMember } from "#src/lib/discord/bot-rest-schemas.ts";
+import { searchGuildMembers } from "#src/lib/discord/search-members.ts";
+import { testGuildId } from "#src/testing/test-ids.ts";
+
+const GUILD = DiscordGuildIdSchema.parse(testGuildId("881"));
+
+function unused(): never {
+  throw new Error("not used by searchGuildMembers");
+}
+
+function reader(search: () => Promise<DiscordGuildMember[]>): BotRestReader {
+  return {
+    guild: unused,
+    guildExists: unused,
+    guildChannels: unused,
+    guildRoles: unused,
+    botMember: unused,
+    guildMember: unused,
+    freshGuildMember: unused,
+    searchGuildMembers: search,
+    user: unused,
+    channel: unused,
+    clearCaches: () => {
+      /* no cache in the stub */
+    },
+  };
+}
+
+const input = { guildId: GUILD, query: "ali", limit: 10 };
+
+describe("searchGuildMembers", () => {
+  test("maps the members Discord returned", async () => {
+    const results = await searchGuildMembers(input, {
+      rest: reader(() =>
+        Promise.resolve([
+          {
+            user: { id: "1", username: "alice", global_name: "Alice" },
+            nick: "Al",
+            avatar: null,
+            roles: [],
+          },
+        ]),
+      ),
+    });
+    expect(results).toEqual([
+      {
+        id: "1",
+        username: "alice",
+        displayName: "Al",
+        avatar: expect.stringContaining("cdn.discordapp.com"),
+      },
+    ]);
+  });
+
+  test("a successful search with no matches is an empty list", async () => {
+    // The ONLY thing that may produce []: Discord answered, nobody matched.
+    await expect(
+      searchGuildMembers(input, { rest: reader(() => Promise.resolve([])) }),
+    ).resolves.toEqual([]);
+  });
+
+  test("a 403 propagates instead of blanking the typeahead", async () => {
+    // A misconfigured install must not read as "that person is not in your
+    // server" — that sends the user looking for a problem that isn't theirs.
+    await expect(
+      searchGuildMembers(input, {
+        rest: reader(() =>
+          Promise.reject(
+            new DiscordUpstreamError("http_error", "Missing Access", 403),
+          ),
+        ),
+      }),
+    ).rejects.toMatchObject({ reason: "http_error", status: 403 });
+  });
+
+  test("a 5xx propagates", async () => {
+    await expect(
+      searchGuildMembers(input, {
+        rest: reader(() =>
+          Promise.reject(new DiscordUpstreamError("http_error", "boom", 503)),
+        ),
+      }),
+    ).rejects.toBeInstanceOf(DiscordUpstreamError);
+  });
+
+  test("a network fault propagates", async () => {
+    await expect(
+      searchGuildMembers(input, {
+        rest: reader(() =>
+          Promise.reject(
+            new DiscordUpstreamError("fetch_error", "socket hang up"),
+          ),
+        ),
+      }),
+    ).rejects.toBeInstanceOf(DiscordUpstreamError);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/search-members.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/search-members.ts
@@ -1,8 +1,12 @@
 /**
- * Guild-member typeahead for the web UI's add/invite flows. Backed by
- * discord.js `guild.members.fetch({ query, limit })`, which performs a
- * gateway member-search (prefix match on username/nickname) and does NOT
- * require the privileged GuildMembers intent for the query-based form.
+ * Guild-member typeahead for the web UI's add/invite flows.
+ *
+ * This used to call discord.js `guild.members.fetch({ query, limit })`, which
+ * issues an OP 8 REQUEST_GUILD_MEMBERS over the gateway — it cannot answer at
+ * all without a live shard, and it first has to find the guild in the gateway
+ * cache. The equivalent REST endpoint (`GET /guilds/{id}/members/search`) takes
+ * the same prefix query over usernames and nicknames, needs no privileged
+ * intent, and works from a pod that never connected a gateway.
  *
  * Authorization is handled by the router before this function is called;
  * fail-soft (returns [] on any error) so a flaky search never breaks the form.
@@ -10,7 +14,12 @@
 
 import { z } from "zod";
 import { DiscordGuildIdSchema } from "@scout-for-lol/data";
-import { client as discordClient } from "#src/discord/client.ts";
+import {
+  botRest,
+  memberAvatarUrl,
+  memberDisplayName,
+  type BotRestReader,
+} from "#src/lib/discord/bot-rest.ts";
 import { createLogger } from "#src/logger.ts";
 
 const logger = createLogger("discord-search-members");
@@ -29,22 +38,29 @@ export type SearchedMember = {
   avatar: string;
 };
 
+export type SearchMembersDependencies = {
+  readonly rest: BotRestReader;
+};
+
+function defaultDependencies(): SearchMembersDependencies {
+  return { rest: botRest() };
+}
+
 export async function searchGuildMembers(
   input: SearchMembersInput,
+  dependencies: SearchMembersDependencies = defaultDependencies(),
 ): Promise<SearchedMember[]> {
-  const guild = discordClient.guilds.cache.get(input.guildId);
-  if (guild === undefined) return [];
-
   try {
-    const members = await guild.members.fetch({
+    const members = await dependencies.rest.searchGuildMembers({
+      guildId: input.guildId,
       query: input.query,
       limit: input.limit,
     });
     return members.map((member) => ({
-      id: member.id,
+      id: member.user.id,
       username: member.user.username,
-      displayName: member.displayName,
-      avatar: member.displayAvatarURL(),
+      displayName: memberDisplayName(member),
+      avatar: memberAvatarUrl(member, input.guildId),
     }));
   } catch (error) {
     logger.warn("Guild member search failed", {

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/search-members.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/search-members.ts
@@ -4,12 +4,30 @@
  * This used to call discord.js `guild.members.fetch({ query, limit })`, which
  * issues an OP 8 REQUEST_GUILD_MEMBERS over the gateway — it cannot answer at
  * all without a live shard, and it first has to find the guild in the gateway
- * cache. The equivalent REST endpoint (`GET /guilds/{id}/members/search`) takes
- * the same prefix query over usernames and nicknames, needs no privileged
- * intent, and works from a pod that never connected a gateway.
+ * cache. The equivalent REST endpoint is `GET /guilds/{id}/members/search`,
+ * which takes the same prefix query over usernames and nicknames and works from
+ * a pod that never connected a gateway.
  *
- * Authorization is handled by the router before this function is called;
- * fail-soft (returns [] on any error) so a flaky search never breaks the form.
+ * Note which endpoint that is: **Search** Guild Members, not **List** Guild
+ * Members. Listing the roster (`GET /guilds/{id}/members`) is the one that
+ * requires the privileged GUILD_MEMBERS intent; the search endpoint documents
+ * no intent requirement, which is the same asymmetry the gateway had — the
+ * query-limited member fetch this replaced also worked without the intent,
+ * while an unfiltered chunk request did not.
+ *
+ * Authorization is handled by the router before this function is called.
+ *
+ * ## Failures are not empty results
+ *
+ * This deliberately does NOT swallow errors. An empty array means Discord
+ * answered and nobody matched; anything else propagates as
+ * {@link DiscordUpstreamError} so the router reports SERVICE_UNAVAILABLE and
+ * increments the bot-REST failure counter. Returning `[]` on failure — as this
+ * did originally — makes a 403 from a misconfigured install, a 5xx, or a
+ * network fault indistinguishable from "no such member": four typeaheads would
+ * silently blank, the user would conclude the person is not in their server,
+ * and nothing would be counted or alerted on. A typeahead that reports it could
+ * not reach Discord is strictly better than one that quietly lies.
  */
 
 import { z } from "zod";
@@ -20,9 +38,6 @@ import {
   memberDisplayName,
   type BotRestReader,
 } from "#src/lib/discord/bot-rest.ts";
-import { createLogger } from "#src/logger.ts";
-
-const logger = createLogger("discord-search-members");
 
 export const SearchMembersInputSchema = z.object({
   guildId: DiscordGuildIdSchema,
@@ -46,27 +61,26 @@ function defaultDependencies(): SearchMembersDependencies {
   return { rest: botRest() };
 }
 
+/**
+ * Members of `guildId` whose username or nickname starts with `query`.
+ *
+ * `[]` means Discord answered with no matches (including the case where Scout
+ * is not in the guild, which the port reports as absence). Throws
+ * {@link DiscordUpstreamError} when Discord could not be asked.
+ */
 export async function searchGuildMembers(
   input: SearchMembersInput,
   dependencies: SearchMembersDependencies = defaultDependencies(),
 ): Promise<SearchedMember[]> {
-  try {
-    const members = await dependencies.rest.searchGuildMembers({
-      guildId: input.guildId,
-      query: input.query,
-      limit: input.limit,
-    });
-    return members.map((member) => ({
-      id: member.user.id,
-      username: member.user.username,
-      displayName: memberDisplayName(member),
-      avatar: memberAvatarUrl(member, input.guildId),
-    }));
-  } catch (error) {
-    logger.warn("Guild member search failed", {
-      guildId: input.guildId,
-      error,
-    });
-    return [];
-  }
+  const members = await dependencies.rest.searchGuildMembers({
+    guildId: input.guildId,
+    query: input.query,
+    limit: input.limit,
+  });
+  return members.map((member) => ({
+    id: member.user.id,
+    username: member.user.username,
+    displayName: memberDisplayName(member),
+    avatar: memberAvatarUrl(member, input.guildId),
+  }));
 }

--- a/packages/scout-for-lol/packages/backend/src/metrics/platform/web.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/platform/web.ts
@@ -130,6 +130,23 @@ export const discordUserGuildsFailures = new Counter({
   registers: [registry],
 });
 
+/**
+ * Why a bot-token Discord REST read on a web request could not be answered.
+ *
+ * The counterpart of {@link discordUserGuildsFailures} for the reads that
+ * replaced the gateway guild cache (installation, channels, roles, members).
+ * Those calls are now on the critical path of guild-scoped requests, and every
+ * one of them fails the request as SERVICE_UNAVAILABLE rather than degrading
+ * into "Scout is not installed" — so this counter is how that failure mode
+ * stays visible instead of looking like ordinary user error.
+ */
+export const discordBotRestFailures = new Counter({
+  name: "scout_discord_bot_rest_failures_total",
+  help: "Failures reading Discord with the bot token during a web request, by reason",
+  labelNames: ["reason"] as const,
+  registers: [registry],
+});
+
 /** Feedback submissions from the web dashboard, split by whether a rating was given. */
 export const feedbackSubmittedTotal = new Counter({
   name: "scout_feedback_submitted_total",

--- a/packages/scout-for-lol/packages/backend/src/startup.ts
+++ b/packages/scout-for-lol/packages/backend/src/startup.ts
@@ -37,12 +37,17 @@ export async function runBackendStartup(
   if (dependencies.startTemporalCore !== undefined) {
     await dependencies.startTemporalCore();
   }
-  // Discord connects before the HTTP server accepts traffic. Authorization
-  // paths read the live guild cache, and an unready cache is indistinguishable
-  // from "Scout is not installed" at several call sites — so serving while the
-  // gateway is still connecting hands out false NOT_FOUNDs to real members.
-  // This ordering used to be implicit: the client module logged in from a
-  // top-level await, which the HTTP server pulled in through its tRPC routers.
+  // Discord connects before the HTTP server accepts traffic.
+  //
+  // The original reason no longer holds: web-serving code used to read the live
+  // guild cache, where an unready cache was indistinguishable from "Scout is not
+  // installed", so serving during connect handed real members false NOT_FOUNDs.
+  // Those paths now go through the `installed-guilds` / `bot-rest` ports and are
+  // independent of gateway state (see the backend README).
+  //
+  // The ordering is kept as-is here rather than relaxed opportunistically: the
+  // gateway-owning process still wants its shard up before it takes traffic, and
+  // separating the HTTP and gateway roles is its own change.
   await dependencies.startDiscord();
   if (dependencies.startTemporalDiscordWorkers !== undefined) {
     await dependencies.startTemporalDiscordWorkers();

--- a/packages/scout-for-lol/packages/backend/src/testing/test-trpc-caller.ts
+++ b/packages/scout-for-lol/packages/backend/src/testing/test-trpc-caller.ts
@@ -207,6 +207,18 @@ export async function createOfflineTrpcHarness(
       guildChannels: () => Promise.resolve(null),
       guildRoles: () => Promise.resolve(null),
       botMember: () => Promise.resolve(null),
+      // The offline harness has no cache, so the fresh read is the same stub.
+      freshGuildMember: (guildId: string, userId: string) =>
+        Promise.resolve(
+          state.guildMembers.get(guildId)?.has(userId) === true
+            ? {
+                user: { id: userId, username: userId },
+                nick: null,
+                avatar: null,
+                roles: [],
+              }
+            : null,
+        ),
       guildMember: (guildId: string, userId: string) =>
         Promise.resolve(
           state.guildMembers.get(guildId)?.has(userId) === true

--- a/packages/scout-for-lol/packages/backend/src/testing/test-trpc-caller.ts
+++ b/packages/scout-for-lol/packages/backend/src/testing/test-trpc-caller.ts
@@ -16,6 +16,11 @@
  *     at an isolated, migrated test DB (a copy of `template.db`). The real
  *     module is spread so its other exports stay intact for the rest of the
  *     router graph.
+ *   - `vi.doMock("#src/lib/discord/installed-guilds.ts", …)` and
+ *     `vi.doMock("#src/lib/discord/bot-rest.ts", …)` → the two application
+ *     ports the web request path reads Discord through. These replaced a mock
+ *     of the gateway client's `guilds.cache`, which is no longer consulted by
+ *     any web-serving code.
  *
  * Because it mutates the module registry, call this at the TOP of a test file,
  * before anything imports `appRouter`, and take `appRouter` from the returned
@@ -58,10 +63,6 @@ type TrpcCaller = ReturnType<AppRouter["createCaller"]>;
  * per-permission gating.
  */
 type MembershipConfig = "root" | { guildId: string; asAdmin: boolean }[];
-
-class UnknownMemberError extends Error {
-  readonly code = 10_007;
-}
 
 // test-ids requires a digits-only identifier (it builds a snowflake).
 const DEFAULT_ACTOR = testAccountId("900000001");
@@ -179,39 +180,64 @@ export async function createOfflineTrpcHarness(
     ...discordUpstreamModule,
     fetchUserGuildsForRequest: () => Promise.resolve(toPartialGuilds()),
   }));
+  // "Is Scout installed here?" — root mode says yes for every guild the guard
+  // asks about, matching the old cache stub. The bulk (guild-picker) form
+  // returns only explicitly-listed guilds, because root mode has no guild list.
+  vi.doMock("#src/lib/discord/installed-guilds.ts", () => ({
+    isScoutInstalledInGuild: (guildId: string) =>
+      Promise.resolve(
+        state.membership === "root" || installedGuildIds().has(guildId),
+      ),
+    installedGuildIdsAmong: (guildIds: readonly string[]) =>
+      Promise.resolve(
+        new Set(guildIds.filter((id) => installedGuildIds().has(id))),
+      ),
+    installedGuildName: () => Promise.resolve(null),
+  }));
+  // The bot-token REST reads. Membership is driven by `setGuildMembers`;
+  // everything else answers "Scout is not in that guild" so a test that
+  // accidentally depends on a real Discord read fails visibly rather than
+  // hanging on the network.
+  vi.doMock("#src/lib/discord/bot-rest.ts", () => ({
+    botRest: () => ({
+      guildExists: (guildId: string) =>
+        Promise.resolve(
+          state.membership === "root" || installedGuildIds().has(guildId),
+        ),
+      guildChannels: () => Promise.resolve(null),
+      guildRoles: () => Promise.resolve(null),
+      botMember: () => Promise.resolve(null),
+      guildMember: (guildId: string, userId: string) =>
+        Promise.resolve(
+          state.guildMembers.get(guildId)?.has(userId) === true
+            ? {
+                user: { id: userId, username: userId },
+                nick: null,
+                avatar: null,
+                roles: [],
+              }
+            : null,
+        ),
+      searchGuildMembers: () => Promise.resolve([]),
+      user: () => Promise.resolve(null),
+      channel: () => Promise.resolve(null),
+      clearCaches: () => {
+        /* no cache in the offline stub */
+      },
+    }),
+    memberDisplayName: (member: { user: { username: string } }) =>
+      member.user.username,
+    memberAvatarUrl: () => "",
+    userAvatarUrl: () => "",
+  }));
   vi.doMock("#src/discord/client.ts", () => ({
     client: {
       isReady: () => false,
+      // No web-serving code reads the gateway cache any more; anything that
+      // reaches for the client offline should fail loudly, not read a stub.
       guilds: {
-        cache: {
-          has: (id: string) =>
-            state.membership === "root" || installedGuildIds().has(id),
-          get: (id: string) => {
-            if (state.membership !== "root" && !installedGuildIds().has(id)) {
-              return;
-            }
-            return {
-              members: {
-                fetch: (options: { user?: string; query?: string }) => {
-                  if (options.query !== undefined) {
-                    return Promise.resolve({ map: () => [] });
-                  }
-                  if (
-                    options.user !== undefined &&
-                    state.guildMembers.get(id)?.has(options.user) === true
-                  ) {
-                    return Promise.resolve({ id: options.user });
-                  }
-                  return Promise.reject(
-                    new UnknownMemberError("Unknown Member"),
-                  );
-                },
-              },
-            };
-          },
-          map: <T>(fn: (g: { id: string }) => T): T[] =>
-            [...installedGuildIds()].map((id) => fn({ id })),
-        },
+        fetch: () =>
+          Promise.reject(new Error("offline harness: no Discord gateway")),
       },
     },
   }));

--- a/packages/scout-for-lol/packages/backend/src/trpc/discord-upstream.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/discord-upstream.ts
@@ -17,7 +17,10 @@ import {
   fetchUserGuilds,
   type PartialGuild,
 } from "#src/lib/discord-rest.ts";
-import { discordUserGuildsFailures } from "#src/metrics/platform/web.ts";
+import {
+  discordBotRestFailures,
+  discordUserGuildsFailures,
+} from "#src/metrics/platform/web.ts";
 
 /**
  * Map a {@link DiscordUpstreamError} onto the tRPC error the user should see.
@@ -56,6 +59,31 @@ export async function fetchUserGuildsForRequest(
   } catch (error) {
     if (error instanceof DiscordUpstreamError) {
       discordUserGuildsFailures.inc({ reason: error.reason });
+      throw toTrpcError(error);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Run a bot-token Discord read (`lib/discord/bot-rest.ts`) on a request path.
+ *
+ * Those reads replaced the gateway guild cache, so they now decide whether a
+ * guild-scoped procedure answers at all. Wrapping them here keeps the same rule
+ * the OAuth path already follows: a failure to reach Discord surfaces as
+ * SERVICE_UNAVAILABLE, never as NOT_FOUND ("Scout is not installed") or
+ * FORBIDDEN. Without this an unwrapped `DiscordUpstreamError` would reach tRPC
+ * as an opaque INTERNAL_SERVER_ERROR, which tells the user nothing about
+ * retrying.
+ */
+export async function callDiscordForRequest<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof DiscordUpstreamError) {
+      discordBotRestFailures.inc({ reason: error.reason });
       throw toTrpcError(error);
     }
     throw error;

--- a/packages/scout-for-lol/packages/backend/src/trpc/guild-guard.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/guild-guard.ts
@@ -3,17 +3,28 @@
  * target guild AND Scout is installed there." Mirrors the Discord-side
  * Discord command access is intentionally lightweight; management permissions
  * are enforced by the web UI's guild procedures.
+ *
+ * Both checks read application ports (`installed-guilds.ts` for installation,
+ * `bot-rest.ts` for channels) rather than the gateway guild cache, so they
+ * answer the same way whether or not this pod holds a gateway connection.
  */
 
 import { TRPCError } from "@trpc/server";
 import { ChannelType } from "discord.js";
 import type { User } from "#generated/prisma/client/index.js";
+import { hasAdministrator } from "#src/lib/discord-rest.ts";
+import { botRest } from "#src/lib/discord/bot-rest.ts";
+import { isScoutInstalledInGuild } from "#src/lib/discord/installed-guilds.ts";
 import {
-  hasAdministrator,
-  isDevGuildOverrideGuild,
-} from "#src/lib/discord-rest.ts";
-import { fetchUserGuildsForRequest } from "#src/trpc/discord-upstream.ts";
-import { client as discordClient } from "#src/discord/client.ts";
+  callDiscordForRequest,
+  fetchUserGuildsForRequest,
+} from "#src/trpc/discord-upstream.ts";
+
+/** Same open-integer reasoning as the picker's filter in `postable-channels.ts`. */
+const POSTABLE_CHANNEL_TYPES = new Set<number>([
+  ChannelType.GuildText,
+  ChannelType.GuildAnnouncement,
+]);
 
 export async function assertGuildAdmin(params: {
   user: User;
@@ -35,10 +46,10 @@ export async function assertGuildAdmin(params: {
       message: "Administrator permission required",
     });
   }
-  if (
-    !discordClient.guilds.cache.has(params.guildId) &&
-    !isDevGuildOverrideGuild(params.guildId)
-  ) {
+  const installed = await callDiscordForRequest(() =>
+    isScoutInstalledInGuild(params.guildId),
+  );
+  if (!installed) {
     throw new TRPCError({
       code: "NOT_FOUND",
       message: "Scout is not installed in that guild",
@@ -56,28 +67,29 @@ export async function assertGuildAdmin(params: {
  * Mirrors the filter in `guildRouter.listChannels` so mutations only accept
  * channels the picker would have offered.
  */
-export function assertChannelInGuild(params: {
+export async function assertChannelInGuild(params: {
   guildId: string;
   channelId: string;
-}): void {
-  const guild = discordClient.guilds.cache.get(params.guildId);
-  if (guild === undefined) {
+}): Promise<void> {
+  const channels = await callDiscordForRequest(() =>
+    botRest().guildChannels(params.guildId),
+  );
+  if (channels === null) {
     throw new TRPCError({
       code: "NOT_FOUND",
       message: "Scout is not installed in that guild",
     });
   }
-  const channel = guild.channels.cache.get(params.channelId);
+  const channel = channels.find(
+    (candidate) => candidate.id === params.channelId,
+  );
   if (channel === undefined) {
     throw new TRPCError({
       code: "BAD_REQUEST",
       message: "Channel does not belong to that guild",
     });
   }
-  if (
-    channel.type !== ChannelType.GuildText &&
-    channel.type !== ChannelType.GuildAnnouncement
-  ) {
+  if (!POSTABLE_CHANNEL_TYPES.has(channel.type)) {
     throw new TRPCError({
       code: "BAD_REQUEST",
       message: "Channel must be a text or announcement channel",

--- a/packages/scout-for-lol/packages/backend/src/trpc/guild-permission.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/guild-permission.ts
@@ -7,6 +7,10 @@
  * Administrator or owner is Scout's root/sudo (all permissions). Everyone else's
  * access comes purely from Scout-managed grants in the `ServerPermission` table.
  * Membership (from the OAuth guild list) is a precondition either way.
+ *
+ * Whether Scout is installed at all comes from `lib/discord/installed-guilds.ts`
+ * rather than the gateway guild cache, so this resolver answers identically on a
+ * pod with no gateway connection.
  */
 
 import { TRPCError } from "@trpc/server";
@@ -25,12 +29,12 @@ import {
 } from "@scout-for-lol/data";
 import type { User } from "#generated/prisma/client/index.js";
 import { prisma } from "#src/database/index.ts";
-import { client as discordClient } from "#src/discord/client.ts";
+import { hasAdministrator } from "#src/lib/discord-rest.ts";
+import { isScoutInstalledInGuild } from "#src/lib/discord/installed-guilds.ts";
 import {
-  hasAdministrator,
-  isDevGuildOverrideGuild,
-} from "#src/lib/discord-rest.ts";
-import { fetchUserGuildsForRequest } from "#src/trpc/discord-upstream.ts";
+  callDiscordForRequest,
+  fetchUserGuildsForRequest,
+} from "#src/trpc/discord-upstream.ts";
 import { webMutationProcedure, webProcedure } from "#src/trpc/trpc.ts";
 
 const GuildIdInput = z.object({ guildId: DiscordGuildIdSchema });
@@ -63,10 +67,10 @@ export async function resolveGuildPermissions(
       message: "You are not a member of that guild",
     });
   }
-  if (
-    !discordClient.guilds.cache.has(guildId) &&
-    !isDevGuildOverrideGuild(guildId)
-  ) {
+  const installed = await callDiscordForRequest(() =>
+    isScoutInstalledInGuild(guildId),
+  );
+  if (!installed) {
     throw new TRPCError({
       code: "NOT_FOUND",
       message: "Scout is not installed in that guild",

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competitions/competition.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competitions/competition.router.ts
@@ -159,7 +159,7 @@ export const competitionRouter = router({
   create: guildMutationProcedure("competitions", "create")
     .input(GuildInput.extend(CompetitionWriteSchema.shape))
     .mutation(async ({ ctx, input }) => {
-      assertChannelInGuild({
+      await assertChannelInGuild({
         guildId: input.guildId,
         channelId: input.channelId,
       });
@@ -242,7 +242,7 @@ export const competitionRouter = router({
       }
 
       if (input.channelId !== undefined) {
-        assertChannelInGuild({
+        await assertChannelInGuild({
           guildId: input.guildId,
           channelId: input.channelId,
         });

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competitions/duel.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competitions/duel.router.ts
@@ -109,7 +109,7 @@ export const duelRouter = router({
     .input(DirectDuelChallengeInputSchema)
     .mutation(async ({ ctx, input }) => {
       await assertMemberAndFeature(ctx.user, input.guildId);
-      assertChannelInGuild({
+      await assertChannelInGuild({
         guildId: input.guildId,
         channelId: input.channelId,
       });
@@ -238,7 +238,7 @@ export const duelRouter = router({
         input.guildId,
         configuration.environment,
       );
-      assertChannelInGuild({
+      await assertChannelInGuild({
         guildId: input.guildId,
         channelId: input.channelId,
       });

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/discord.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/discord.router.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { type Permission, P } from "@scout-for-lol/data";
 import { router, webProcedure } from "#src/trpc/trpc.ts";
+import { callDiscordForRequest } from "#src/trpc/discord-upstream.ts";
 import { resolveGuildPermissions } from "#src/trpc/guild-permission.ts";
 import {
   MAX_IDS_PER_RESOLVE,
@@ -38,8 +39,13 @@ export const discordRouter = router({
 
   /**
    * Typeahead search for members of a guild. The roster is available to callers
-   * holding any action whose UI needs a member selector; the Discord lookup
-   * still returns [] on failure so an authorized form degrades gracefully.
+   * holding any action whose UI needs a member selector.
+   *
+   * A failure to reach Discord surfaces as SERVICE_UNAVAILABLE rather than an
+   * empty result: `[]` has to keep meaning "nobody matched", or the picker tells
+   * the user their teammate is not in the server when the truth is that Scout
+   * could not ask. `callDiscordForRequest` also counts the failure, so a broken
+   * install is visible in metrics instead of looking like an unpopular server.
    */
   searchMembers: webProcedure
     .input(SearchMembersInputSchema)
@@ -55,6 +61,6 @@ export const discordRouter = router({
             "Missing a permission that authorizes Discord member selection",
         });
       }
-      return searchGuildMembers(input);
+      return await callDiscordForRequest(() => searchGuildMembers(input));
     }),
 });

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/explore/explore-creation-procedures.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/explore/explore-creation-procedures.ts
@@ -173,7 +173,7 @@ async function authorizeCreation(
   // the creation rate limit live inside `createCompetitionForActor`, which
   // receives this same PermissionSet — re-checking them here would be a second
   // copy of a reviewed policy.
-  assertChannelInGuild({
+  await assertChannelInGuild({
     guildId: loaded.guildId,
     channelId: loaded.payload.channelId,
   });

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/gatewayless-web.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/gatewayless-web.test.ts
@@ -1,0 +1,393 @@
+/**
+ * The web API answered with NO Discord gateway client at all.
+ *
+ * The harness below deliberately does not stub `client.guilds` — reading it
+ * throws — so any web-serving path that regressed to the gateway cache fails
+ * here rather than silently working in a combined-mode dev process and handing
+ * out NOT_FOUNDs on a gatewayless pod. Everything Discord-shaped comes from the
+ * bot REST port; installation comes from the real `GuildInstall` port running
+ * against a real table.
+ */
+
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { ChannelType, PermissionFlagsBits } from "discord.js";
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+  permissionKey,
+  type Permission,
+} from "@scout-for-lol/data";
+import type { User } from "#generated/prisma/client/index.js";
+import type { AppRouter } from "#src/trpc/router/index.ts";
+import type { PartialGuild } from "#src/lib/discord-rest.ts";
+import type { BotRestReader } from "#src/lib/discord/bot-rest.ts";
+import type { DiscordGuildChannel } from "#src/lib/discord/bot-rest-schemas.ts";
+import { DiscordUpstreamError } from "#src/lib/discord-rest.ts";
+import * as databaseModule from "#src/database/index.ts";
+import * as discordUpstreamModule from "#src/trpc/discord-upstream.ts";
+import configuration from "#src/configuration.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+
+const { prisma } = createTestDatabase("gatewayless-web");
+
+const INSTALLED = DiscordGuildIdSchema.parse("100000000000009101");
+const UNROWED = DiscordGuildIdSchema.parse("100000000000009102");
+const GONE = DiscordGuildIdSchema.parse("100000000000009103");
+const ACTOR = DiscordAccountIdSchema.parse("900000000000009001");
+const PEER = DiscordAccountIdSchema.parse("900000000000009002");
+const BOT = "900000000000000000";
+const BOT_ROLE = "100000000000009901";
+
+type RestState = {
+  guildsOnDiscord: Set<string>;
+  members: Map<string, Set<string>>;
+  channels: DiscordGuildChannel[];
+  unavailable: boolean;
+  restCalls: number;
+};
+
+const state: RestState = {
+  guildsOnDiscord: new Set(),
+  members: new Map(),
+  channels: [],
+  unavailable: false,
+  restCalls: 0,
+};
+
+function member(userId: string) {
+  return {
+    user: { id: userId, username: `user-${userId}` },
+    nick: null,
+    avatar: null,
+    roles: [BOT_ROLE],
+  };
+}
+
+function guard<T>(produce: () => T): Promise<T> {
+  state.restCalls += 1;
+  if (state.unavailable) {
+    return Promise.reject(
+      new DiscordUpstreamError("http_error", "Discord is down", 503),
+    );
+  }
+  return Promise.resolve(produce());
+}
+
+const fakeRest: BotRestReader = {
+  guildExists: (guildId) => guard(() => state.guildsOnDiscord.has(guildId)),
+  guildChannels: (guildId) =>
+    guard(() => (state.guildsOnDiscord.has(guildId) ? state.channels : null)),
+  guildRoles: (guildId) =>
+    guard(() =>
+      state.guildsOnDiscord.has(guildId)
+        ? [
+            { id: guildId, name: "@everyone", permissions: "0" },
+            {
+              id: BOT_ROLE,
+              name: "Scout",
+              permissions: (
+                PermissionFlagsBits.ViewChannel |
+                PermissionFlagsBits.SendMessages
+              ).toString(),
+            },
+          ]
+        : null,
+    ),
+  botMember: (guildId) =>
+    guard(() => (state.guildsOnDiscord.has(guildId) ? member(BOT) : null)),
+  guildMember: (guildId, userId) =>
+    guard(() =>
+      state.members.get(guildId)?.has(userId) === true ? member(userId) : null,
+    ),
+  searchGuildMembers: (input) =>
+    guard(() =>
+      [...(state.members.get(input.guildId) ?? [])]
+        .filter((id) => id.includes(input.query))
+        .slice(0, input.limit)
+        .map((id) => member(id)),
+    ),
+  user: (userId) => guard(() => ({ id: userId, username: `user-${userId}` })),
+  channel: (channelId) =>
+    guard(() => state.channels.find((entry) => entry.id === channelId) ?? null),
+  clearCaches: () => {
+    /* the fake holds no cache */
+  },
+};
+
+let membership: PartialGuild[] = [];
+
+vi.doMock("#src/database/index.ts", () => ({ ...databaseModule, prisma }));
+// Only the OAuth membership call is stubbed; `callDiscordForRequest` — the
+// thing that decides an outage is SERVICE_UNAVAILABLE — stays real.
+vi.doMock("#src/trpc/discord-upstream.ts", () => ({
+  ...discordUpstreamModule,
+  fetchUserGuildsForRequest: () => Promise.resolve(membership),
+}));
+vi.doMock("#src/lib/discord/bot-rest.ts", async () => {
+  const actual = await import("#src/lib/discord/bot-rest.ts");
+  return { ...actual, botRest: () => fakeRest };
+});
+vi.doMock("#src/discord/client.ts", () => ({
+  client: {
+    isReady: () => false,
+    get guilds(): never {
+      throw new Error(
+        "web-serving code must not read the Discord gateway guild cache",
+      );
+    },
+  },
+}));
+
+const { appRouter } = await import("#src/trpc/router/index.ts");
+
+type TrpcCaller = ReturnType<AppRouter["createCaller"]>;
+
+function user(discordId: string): User {
+  return {
+    discordId: DiscordAccountIdSchema.parse(discordId),
+    discordUsername: "gatewayless",
+    discordAvatar: null,
+    discordAccessToken: null,
+    discordRefreshToken: null,
+    tokenExpiresAt: null,
+    analyticsUserId: `analytics-${discordId}`,
+    lastSeenAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function caller(discordId: string = ACTOR): TrpcCaller {
+  return appRouter.createCaller({
+    user: user(discordId),
+    apiToken: null,
+    activitySession: null,
+    webSession: {
+      discordId,
+      csrfToken: "csrf",
+      csrfHeader: "csrf",
+      origin: configuration.webAppOrigin ?? null,
+      ipAddress: "127.0.0.1",
+      userAgent: "gatewayless-test",
+    },
+    clientIp: null,
+    requestId: "gatewayless-test",
+  });
+}
+
+function asMemberOf(guildIds: readonly string[], asAdmin = true): void {
+  membership = guildIds.map((id) => ({
+    id,
+    name: "test-guild",
+    icon: null,
+    owner: asAdmin,
+    permissions: asAdmin ? "8" : "0",
+  }));
+}
+
+async function seedInstall(
+  serverId: typeof INSTALLED,
+  removedAt: Date | null = null,
+): Promise<void> {
+  await prisma.guildInstall.create({
+    data: {
+      serverId,
+      serverName: `Server ${serverId}`,
+      ownerDiscordId: ACTOR,
+      addedByDiscordId: ACTOR,
+      memberCount: 5,
+      installedAt: new Date("2026-01-01T00:00:00.000Z"),
+      removedAt,
+    },
+  });
+}
+
+async function seedGrants(
+  discordUserId: string,
+  permissions: readonly Permission[],
+): Promise<void> {
+  await prisma.serverPermission.createMany({
+    data: permissions.map((permission) => ({
+      serverId: INSTALLED,
+      discordUserId: DiscordAccountIdSchema.parse(discordUserId),
+      permission: permissionKey(permission),
+      grantedBy: ACTOR,
+      grantedAt: new Date(),
+    })),
+  });
+}
+
+const MANAGER: Permission[] = [
+  { resource: "roles", action: "grant" },
+  { resource: "roles", action: "revoke" },
+];
+
+beforeEach(async () => {
+  await prisma.auditLog.deleteMany({});
+  await prisma.serverPermission.deleteMany({});
+  await prisma.guildInstall.deleteMany({});
+  state.guildsOnDiscord = new Set([INSTALLED, UNROWED]);
+  state.members = new Map([
+    [INSTALLED, new Set([ACTOR, PEER])],
+    [UNROWED, new Set([ACTOR])],
+  ]);
+  state.channels = [];
+  state.unavailable = false;
+  state.restCalls = 0;
+  membership = [];
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("guild picker without a gateway", () => {
+  test("lists guilds from GuildInstall rows and asks Discord for none of them", async () => {
+    await seedInstall(INSTALLED);
+    await seedInstall(GONE, new Date("2026-02-01T00:00:00.000Z"));
+    asMemberOf([INSTALLED, GONE, UNROWED]);
+
+    const guilds = await caller().guild.listManageable();
+
+    expect(guilds.map((guild) => guild.id)).toEqual([INSTALLED]);
+    expect(state.restCalls).toBe(0);
+  });
+});
+
+describe("single-guild access without a gateway", () => {
+  test("a live install row grants access", async () => {
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED]);
+    await expect(
+      caller().guild.myPermissions({ guildId: INSTALLED }),
+    ).resolves.not.toHaveLength(0);
+  });
+
+  test("a missing row is confirmed with Discord rather than refused", async () => {
+    asMemberOf([UNROWED]);
+    await expect(
+      caller().guild.myPermissions({ guildId: UNROWED }),
+    ).resolves.not.toHaveLength(0);
+  });
+
+  test("a guild Scout is genuinely absent from is NOT_FOUND, as before", async () => {
+    asMemberOf([GONE]);
+    await expect(
+      caller().guild.myPermissions({ guildId: GONE }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  test("a removed install row is NOT_FOUND once Discord agrees", async () => {
+    await seedInstall(GONE, new Date("2026-02-01T00:00:00.000Z"));
+    asMemberOf([GONE]);
+    await expect(
+      caller().guild.myPermissions({ guildId: GONE }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  test("a non-member is FORBIDDEN before Discord is consulted at all", async () => {
+    await seedInstall(INSTALLED);
+    asMemberOf([]);
+    await expect(
+      caller().guild.myPermissions({ guildId: INSTALLED }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(state.restCalls).toBe(0);
+  });
+
+  test("an unreachable Discord is SERVICE_UNAVAILABLE, never NOT_FOUND", async () => {
+    asMemberOf([UNROWED]);
+    state.unavailable = true;
+    await expect(
+      caller().guild.myPermissions({ guildId: UNROWED }),
+    ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+  });
+});
+
+describe("channel picker without a gateway", () => {
+  test("offers the channels the bot can post in", async () => {
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED]);
+    state.channels = [
+      {
+        id: "1",
+        name: "general",
+        type: ChannelType.GuildText,
+        permission_overwrites: [],
+      },
+      {
+        id: "2",
+        name: "stage",
+        type: ChannelType.GuildVoice,
+        permission_overwrites: [],
+      },
+    ];
+
+    await expect(
+      caller().guild.listChannels({ guildId: INSTALLED }),
+    ).resolves.toEqual([{ id: "1", name: "general", parentId: null }]);
+  });
+
+  test("an unreachable Discord is SERVICE_UNAVAILABLE", async () => {
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED]);
+    state.unavailable = true;
+    await expect(
+      caller().guild.listChannels({ guildId: INSTALLED }),
+    ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+  });
+});
+
+describe("member-backed role management without a gateway", () => {
+  test("member search answers from the REST search endpoint", async () => {
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED]);
+    const results = await caller().discord.searchMembers({
+      guildId: INSTALLED,
+      query: PEER,
+      limit: 5,
+    });
+    expect(results.map((entry) => entry.id)).toEqual([PEER]);
+  });
+
+  test("revoking one of two managers checks the other's membership over REST", async () => {
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED], false);
+    await seedGrants(ACTOR, MANAGER);
+    await seedGrants(PEER, MANAGER);
+
+    await expect(
+      caller().roles.clear({ guildId: INSTALLED, discordUserId: PEER }),
+    ).resolves.toEqual({ ok: true });
+    expect(
+      await prisma.serverPermission.count({
+        where: { serverId: INSTALLED, discordUserId: PEER },
+      }),
+    ).toBe(0);
+  });
+
+  test("the last manager cannot be revoked when the others have left", async () => {
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED], false);
+    await seedGrants(ACTOR, MANAGER);
+    await seedGrants(PEER, MANAGER);
+    // The acting manager is no longer in the guild, so removing PEER would
+    // leave nobody able to restore access.
+    state.members.set(INSTALLED, new Set([PEER]));
+
+    await expect(
+      caller().roles.clear({ guildId: INSTALLED, discordUserId: PEER }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  test("an unreachable Discord blocks the revoke as SERVICE_UNAVAILABLE", async () => {
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED], false);
+    await seedGrants(ACTOR, MANAGER);
+    await seedGrants(PEER, MANAGER);
+    state.unavailable = true;
+
+    await expect(
+      caller().roles.clear({ guildId: INSTALLED, discordUserId: PEER }),
+    ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/gatewayless-web.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/gatewayless-web.test.ts
@@ -46,6 +46,8 @@ type RestState = {
   freshMembers: Map<string, Set<string>> | null;
   channels: DiscordGuildChannel[];
   unavailable: boolean;
+  /** When set, member search fails with this HTTP status. */
+  searchFailureStatus: number | null;
   restCalls: number;
   cachedMemberReads: number;
   freshMemberReads: number;
@@ -57,6 +59,7 @@ const state: RestState = {
   freshMembers: null,
   channels: [],
   unavailable: false,
+  searchFailureStatus: null,
   restCalls: 0,
   cachedMemberReads: 0,
   freshMemberReads: 0,
@@ -126,12 +129,19 @@ const fakeRest: BotRestReader = {
       return roster.get(guildId)?.has(userId) === true ? member(userId) : null;
     }),
   searchGuildMembers: (input) =>
-    guard(() =>
-      [...(state.members.get(input.guildId) ?? [])]
+    guard(() => {
+      if (state.searchFailureStatus !== null) {
+        throw new DiscordUpstreamError(
+          "http_error",
+          "Missing Access",
+          state.searchFailureStatus,
+        );
+      }
+      return [...(state.members.get(input.guildId) ?? [])]
         .filter((id) => id.includes(input.query))
         .slice(0, input.limit)
-        .map((id) => member(id)),
-    ),
+        .map((id) => member(id));
+    }),
   user: (userId) => guard(() => ({ id: userId, username: `user-${userId}` })),
   channel: (channelId) =>
     guard(() => state.channels.find((entry) => entry.id === channelId) ?? null),
@@ -165,6 +175,16 @@ vi.doMock("#src/discord/client.ts", () => ({
 }));
 
 const { appRouter } = await import("#src/trpc/router/index.ts");
+const { discordBotRestFailures } = await import("#src/metrics/platform/web.ts");
+
+/** Total across every `reason` label, so a test can assert "went up by one". */
+async function botRestFailureCount(): Promise<number> {
+  const metric = await discordBotRestFailures.get();
+  return metric.values.reduce(
+    (total: number, entry: { value: number }) => total + entry.value,
+    0,
+  );
+}
 
 type TrpcCaller = ReturnType<AppRouter["createCaller"]>;
 
@@ -260,6 +280,7 @@ beforeEach(async () => {
   state.freshMembers = null;
   state.channels = [];
   state.unavailable = false;
+  state.searchFailureStatus = null;
   state.restCalls = 0;
   state.cachedMemberReads = 0;
   state.freshMemberReads = 0;
@@ -414,6 +435,38 @@ describe("member-backed role management without a gateway", () => {
         where: { serverId: INSTALLED, discordUserId: PEER },
       }),
     ).toBe(0);
+  });
+
+  test("a search with no matches is an empty list", async () => {
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED]);
+    await expect(
+      caller().discord.searchMembers({
+        guildId: INSTALLED,
+        query: "nobody-by-that-name",
+        limit: 5,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  test("a 403 on search is SERVICE_UNAVAILABLE, not a blank typeahead", async () => {
+    // Blanking the picker would tell the user their teammate is not in the
+    // server, sending them to look for a problem that isn't theirs.
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED]);
+    state.searchFailureStatus = 403;
+    const before = await botRestFailureCount();
+
+    await expect(
+      caller().discord.searchMembers({
+        guildId: INSTALLED,
+        query: PEER,
+        limit: 5,
+      }),
+    ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+    // ...and the failure is counted, so a broken install shows up in metrics
+    // rather than looking like an unpopular server.
+    expect(await botRestFailureCount()).toBe(before + 1);
   });
 
   test("a manager who left is not counted, even while the cache still has them", async () => {

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/gatewayless-web.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/gatewayless-web.test.ts
@@ -40,18 +40,26 @@ const BOT_ROLE = "100000000000009901";
 
 type RestState = {
   guildsOnDiscord: Set<string>;
+  /** What a cached (`guildMember`) read sees. */
   members: Map<string, Set<string>>;
+  /** What an uncached (`freshGuildMember`) read sees; null = same as cached. */
+  freshMembers: Map<string, Set<string>> | null;
   channels: DiscordGuildChannel[];
   unavailable: boolean;
   restCalls: number;
+  cachedMemberReads: number;
+  freshMemberReads: number;
 };
 
 const state: RestState = {
   guildsOnDiscord: new Set(),
   members: new Map(),
+  freshMembers: null,
   channels: [],
   unavailable: false,
   restCalls: 0,
+  cachedMemberReads: 0,
+  freshMemberReads: 0,
 };
 
 function member(userId: string) {
@@ -102,9 +110,21 @@ const fakeRest: BotRestReader = {
   botMember: (guildId) =>
     guard(() => (state.guildsOnDiscord.has(guildId) ? member(BOT) : null)),
   guildMember: (guildId, userId) =>
-    guard(() =>
-      state.members.get(guildId)?.has(userId) === true ? member(userId) : null,
-    ),
+    guard(() => {
+      state.cachedMemberReads += 1;
+      return state.members.get(guildId)?.has(userId) === true
+        ? member(userId)
+        : null;
+    }),
+  // Modelled as a genuinely different source so a test can express "the cache
+  // still says present, Discord says gone" — the staleness this read exists to
+  // close. Defaults to agreeing with the cached view.
+  freshGuildMember: (guildId, userId) =>
+    guard(() => {
+      state.freshMemberReads += 1;
+      const roster = state.freshMembers ?? state.members;
+      return roster.get(guildId)?.has(userId) === true ? member(userId) : null;
+    }),
   searchGuildMembers: (input) =>
     guard(() =>
       [...(state.members.get(input.guildId) ?? [])]
@@ -237,9 +257,12 @@ beforeEach(async () => {
     [INSTALLED, new Set([ACTOR, PEER])],
     [UNROWED, new Set([ACTOR])],
   ]);
+  state.freshMembers = null;
   state.channels = [];
   state.unavailable = false;
   state.restCalls = 0;
+  state.cachedMemberReads = 0;
+  state.freshMemberReads = 0;
   membership = [];
 });
 
@@ -391,6 +414,38 @@ describe("member-backed role management without a gateway", () => {
         where: { serverId: INSTALLED, discordUserId: PEER },
       }),
     ).toBe(0);
+  });
+
+  test("a manager who left is not counted, even while the cache still has them", async () => {
+    // The staleness bug this guards: the cached roster (up to 30s old) still
+    // lists ACTOR as a manager, but Discord says they are gone. Counting the
+    // cached view would let PEER — the genuinely last manager — be revoked,
+    // locking the guild out of its own access management.
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED], false);
+    await seedGrants(ACTOR, MANAGER);
+    await seedGrants(PEER, MANAGER);
+    state.freshMembers = new Map([[INSTALLED, new Set([PEER])]]);
+
+    await expect(
+      caller().roles.clear({ guildId: INSTALLED, discordUserId: PEER }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    // The invariant read the uncached source, not the cached one.
+    expect(state.freshMemberReads).toBeGreaterThan(0);
+    expect(state.cachedMemberReads).toBe(0);
+  });
+
+  test("ordinary member reads still use the cached path", async () => {
+    // Only the invariant is uncached; nothing else pays a Discord request per
+    // lookup. Member search is the ordinary roster surface.
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED]);
+    await caller().discord.searchMembers({
+      guildId: INSTALLED,
+      query: PEER,
+      limit: 5,
+    });
+    expect(state.freshMemberReads).toBe(0);
   });
 
   test("the last manager cannot be revoked when the others have left", async () => {

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/gatewayless-web.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/gatewayless-web.test.ts
@@ -74,6 +74,12 @@ function guard<T>(produce: () => T): Promise<T> {
 }
 
 const fakeRest: BotRestReader = {
+  guild: (guildId) =>
+    guard(() =>
+      state.guildsOnDiscord.has(guildId)
+        ? { id: guildId, name: "test-guild", owner_id: ACTOR }
+        : null,
+    ),
   guildExists: (guildId) => guard(() => state.guildsOnDiscord.has(guildId)),
   guildChannels: (guildId) =>
     guard(() => (state.guildsOnDiscord.has(guildId) ? state.channels : null)),
@@ -267,6 +273,28 @@ describe("single-guild access without a gateway", () => {
     asMemberOf([UNROWED]);
     await expect(
       caller().guild.myPermissions({ guildId: UNROWED }),
+    ).resolves.not.toHaveLength(0);
+  });
+
+  test("Discord overrules a stale live row and answers NOT_FOUND", async () => {
+    // Scout was removed while the gateway was down, so no guildDelete ever
+    // fired and the row still says installed. Discord's answer wins.
+    await seedInstall(INSTALLED);
+    state.guildsOnDiscord.delete(INSTALLED);
+    asMemberOf([INSTALLED]);
+    await expect(
+      caller().guild.myPermissions({ guildId: INSTALLED }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  test("a live row keeps the dashboard up when Discord is unreachable", async () => {
+    // The asymmetry, end to end: with a row to fall back on, a Discord blip
+    // must not 503 a working dashboard.
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED]);
+    state.unavailable = true;
+    await expect(
+      caller().guild.myPermissions({ guildId: INSTALLED }),
     ).resolves.not.toHaveLength(0);
   });
 

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/guild.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/guild.router.ts
@@ -22,13 +22,13 @@ import {
   guildProcedure,
   resolveGuildPermissions,
 } from "#src/trpc/guild-permission.ts";
-import { client as discordClient } from "#src/discord/client.ts";
-import {
-  hasAdministrator,
-  isDevGuildOverrideGuild,
-} from "#src/lib/discord-rest.ts";
+import { hasAdministrator } from "#src/lib/discord-rest.ts";
+import { installedGuildIdsAmong } from "#src/lib/discord/installed-guilds.ts";
 import { listPostableChannels } from "#src/lib/discord/postable-channels.ts";
-import { fetchUserGuildsForRequest } from "#src/trpc/discord-upstream.ts";
+import {
+  callDiscordForRequest,
+  fetchUserGuildsForRequest,
+} from "#src/trpc/discord-upstream.ts";
 import { prisma } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
@@ -43,10 +43,13 @@ export const guildRouter = router({
    */
   listManageable: webProcedure.query(async ({ ctx }) => {
     const userGuilds = await fetchUserGuildsForRequest(ctx.user);
-    const botGuildIds = new Set(discordClient.guilds.cache.map((g) => g.id));
-    const present = userGuilds.filter(
-      (g) => botGuildIds.has(g.id) || isDevGuildOverrideGuild(g.id),
+    // One `GuildInstall` query for the whole picker; see
+    // `installed-guilds.ts` for why the bulk path does not confirm negatives
+    // against Discord the way the single-guild path does.
+    const installedGuildIds = await installedGuildIdsAmong(
+      userGuilds.map((g) => g.id),
     );
+    const present = userGuilds.filter((g) => installedGuildIds.has(g.id));
 
     // One query for the user's grants across all present guilds (no N+1).
     const grantRows = await prisma.serverPermission.findMany({
@@ -128,5 +131,8 @@ export const guildRouter = router({
    */
   listChannels: guildProcedure("channels", "read")
     .input(z.object({ guildId: DiscordGuildIdSchema }))
-    .query(({ input }) => listPostableChannels(input.guildId)),
+    .query(
+      async ({ input }) =>
+        await callDiscordForRequest(() => listPostableChannels(input.guildId)),
+    ),
 });

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/hall.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/hall.router.ts
@@ -51,7 +51,7 @@ export const hallRouter = router({
     .mutation(async ({ ctx, input }) => {
       await assertHallEnabled(input.guildId);
       if (input.channelId !== null) {
-        assertChannelInGuild({
+        await assertChannelInGuild({
           guildId: input.guildId,
           channelId: input.channelId,
         });

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/report.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/report.router.ts
@@ -199,7 +199,7 @@ export const reportRouter = router({
   create: guildMutationProcedure("reports", "create")
     .input(GuildInput.extend(ReportCreateInputSchema.shape))
     .mutation(async ({ ctx, input }) => {
-      assertChannelInGuild({
+      await assertChannelInGuild({
         guildId: input.guildId,
         channelId: input.channelId,
       });
@@ -255,7 +255,7 @@ export const reportRouter = router({
       assertReportMutable(report);
 
       if (input.channelId !== undefined) {
-        assertChannelInGuild({
+        await assertChannelInGuild({
           guildId: input.guildId,
           channelId: input.channelId,
         });

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/roles.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/roles.router.ts
@@ -29,7 +29,8 @@ import {
 import { prisma, type Db } from "#src/database/index.ts";
 import { recordAudit } from "#src/lib/audit/index.ts";
 import { resolveDiscordUsers } from "#src/lib/discord/resolve-users.ts";
-import { client as discordClient } from "#src/discord/client.ts";
+import { botRest } from "#src/lib/discord/bot-rest.ts";
+import { callDiscordForRequest } from "#src/trpc/discord-upstream.ts";
 
 const GuildInput = z.object({ guildId: DiscordGuildIdSchema });
 /**
@@ -59,28 +60,24 @@ async function lockGuildRoleMutations(
 
 const GRANT_KEY = permissionKey({ resource: "roles", action: "grant" });
 const REVOKE_KEY = permissionKey({ resource: "roles", action: "revoke" });
-const DiscordApiErrorSchema = z.object({ code: z.number() });
-const UNKNOWN_MEMBER_CODE = 10_007;
 
+/**
+ * Whether the account still belongs to the guild, straight from Discord.
+ *
+ * The port returns `null` only for an authoritative "not a member"; a failure
+ * to reach Discord throws, and `callDiscordForRequest` turns that into
+ * SERVICE_UNAVAILABLE. That distinction is load-bearing here: reading an
+ * outage as "not a member" would let the last-role-manager guard conclude the
+ * guild has no other manager and block a legitimate revoke.
+ */
 async function isCurrentGuildMember(
   guildId: DiscordGuildId,
   discordId: DiscordAccountId,
 ): Promise<boolean> {
-  const guild = discordClient.guilds.cache.get(guildId);
-  if (guild === undefined) {
-    throw new Error(`Discord guild ${guildId} is unavailable`);
-  }
-
-  try {
-    await guild.members.fetch({ user: discordId, force: true });
-    return true;
-  } catch (error) {
-    const parsed = DiscordApiErrorSchema.safeParse(error);
-    if (parsed.success && parsed.data.code === UNKNOWN_MEMBER_CODE) {
-      return false;
-    }
-    throw error;
-  }
+  const member = await callDiscordForRequest(() =>
+    botRest().guildMember(guildId, discordId),
+  );
+  return member !== null;
 }
 
 /**

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/roles.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/roles.router.ts
@@ -62,20 +62,30 @@ const GRANT_KEY = permissionKey({ resource: "roles", action: "grant" });
 const REVOKE_KEY = permissionKey({ resource: "roles", action: "revoke" });
 
 /**
- * Whether the account still belongs to the guild, straight from Discord.
+ * Whether the account still belongs to the guild, read fresh from Discord.
+ *
+ * **Correctness-critical: the cached read is not acceptable here.** This feeds
+ * the last-role-manager invariant, which counts the managers who remain. The
+ * ordinary `guildMember` read is memoized for `MEMBERSHIP_TTL_MS` (30s), so a
+ * manager who left inside that window would still be counted as present — and
+ * the guard would then permit revoking the genuinely last manager, producing
+ * exactly the locked-out guild it exists to prevent. A 30s window is fine for
+ * display and for checks that fail safe; it is a bug for a check whose answer
+ * decides whether anyone can restore access. (The pre-port code passed
+ * `force: true` to discord.js for the same reason.)
  *
  * The port returns `null` only for an authoritative "not a member"; a failure
  * to reach Discord throws, and `callDiscordForRequest` turns that into
- * SERVICE_UNAVAILABLE. That distinction is load-bearing here: reading an
- * outage as "not a member" would let the last-role-manager guard conclude the
- * guild has no other manager and block a legitimate revoke.
+ * SERVICE_UNAVAILABLE. That distinction is load-bearing too: reading an outage
+ * as "not a member" would let the guard conclude the guild has no other
+ * manager and block a legitimate revoke.
  */
 async function isCurrentGuildMember(
   guildId: DiscordGuildId,
   discordId: DiscordAccountId,
 ): Promise<boolean> {
   const member = await callDiscordForRequest(() =>
-    botRest().guildMember(guildId, discordId),
+    botRest().freshGuildMember(guildId, discordId),
   );
   return member !== null;
 }

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/subscription.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/subscription.router.ts
@@ -110,7 +110,7 @@ export const subscriptionRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      assertChannelInGuild({
+      await assertChannelInGuild({
         guildId: input.guildId,
         channelId: input.channelId,
       });
@@ -270,7 +270,7 @@ export const subscriptionRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      assertChannelInGuild({
+      await assertChannelInGuild({
         guildId: input.guildId,
         channelId: input.channelId,
       });
@@ -310,11 +310,11 @@ export const subscriptionRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      assertChannelInGuild({
+      await assertChannelInGuild({
         guildId: input.guildId,
         channelId: input.fromChannelId,
       });
-      assertChannelInGuild({
+      await assertChannelInGuild({
         guildId: input.guildId,
         channelId: input.toChannelId,
       });
@@ -365,7 +365,7 @@ export const subscriptionRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      assertChannelInGuild({
+      await assertChannelInGuild({
         guildId: input.guildId,
         channelId: input.channelId,
       });
@@ -406,7 +406,7 @@ export const subscriptionRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      assertChannelInGuild({
+      await assertChannelInGuild({
         guildId: input.guildId,
         channelId: input.channelId,
       });
@@ -452,7 +452,7 @@ export const subscriptionRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      assertChannelInGuild({
+      await assertChannelInGuild({
         guildId: input.guildId,
         channelId: input.channelId,
       });


### PR DESCRIPTION
## Why

Every web authorization path read `discordClient.guilds.cache`, so an unready cache was indistinguishable from 'not installed' and the HTTP server could not start before the Gateway connected — the blocking constraint on splitting the Scout runtime (SJ-186 / SJ-189).

## What

Web-serving reads now go through explicit application ports; Gateway events keep writing installation state; background/bot-command cache readers are unchanged by scope.

- **`lib/discord/installed-guilds.ts`** — `GuildInstall` with `removedAt: null` promoted to an authorization source. A table **negative is confirmed against Discord over bot REST before it is believed**: `guildCreate` fires only for uncached guilds, its writer swallows write failures, and no backfill exists — so a missing row is not proof of absence, and believing it would lock a real server out of its dashboard. REST failure propagates as SERVICE_UNAVAILABLE, never 'not installed'. The bulk picker query deliberately skips negative confirmation (no per-guild REST fan-out; deep links still work and REST decides).
- **`lib/discord/bot-rest.ts` + `bot-rest-schemas.ts` + `channel-permissions.ts`** — TTL-cached bot-REST reader (channels/roles/botMember 60s, single member 30s, user profiles 5min, member-search and channel-by-id uncached — rationale documented per TTL) over the existing bounded async cache; Discord's permission-overwrite algorithm reimplemented over REST shapes; member search via REST `GET /guilds/{id}/members/search` (the Gateway query API is gone from web paths).
- All twelve web-serving cache read sites converted (trpc guards + guild/roles routers, member search, postable channels, explore creation capability, customs activity auth/actor/voice) plus `resolve-users.ts`, which silently degraded display names to snowflakes on a gatewayless pod.
- Three-outcome rule everywhere (`discord-upstream.ts` pattern): unavailable vs not-installed vs not-authorized.
- New metric `scout_discord_bot_rest_failures_total{reason}`; backend README gained 'How web requests read Discord'.
- Deliberately unchanged: startup ordering and the `ENABLE_DISCORD_GATEWAY` guard (the stacked runtime-roles PR owns those); the shared client's customs fetch paths need a construction-time REST token, noted for that PR.

## Verification

- `bunx turbo run typecheck test lint --filter=@scout-for-lol/backend --force` — 389 test files / 3659 tests green, lint clean, architecture 1210 modules clean (re-verified after restacking through main's customs/metrics directory split).
- `bunx turbo run typecheck --filter='@scout-for-lol/*'` — 35 tasks, AppRouter shapes unchanged.
- `gatewayless-web.test.ts` gives the test client a `guilds` getter that **throws**: guild list, channel list, member search, and role revoke run with no gateway; an uninstalled guild 403/404s identically to today; a REST outage is SERVICE_UNAVAILABLE, never NOT_FOUND.
- **Not run**: live Discord REST parity / beta smoke (guild picker, channel picker, member typeahead, Customs launch) — deployment acceptance step.

Part of SJ-189 (Wave 2 of the Scout durable-architecture program, SJ-186).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qRdG6fzJr3THzYzAJwTZB