### PR TITLE
feat(homelab): route streambot traces through the OTLP gateway

### DIFF
--- a/packages/homelab/src/cdk8s/src/misc/otlp.ts
+++ b/packages/homelab/src/cdk8s/src/misc/otlp.ts
@@ -1,0 +1,10 @@
+// The alloy-gateway Deployment is the single OTLP entry point for every
+// in-cluster trace producer: it forwards all spans to Tempo and is the future
+// fan-out for additional consumers. Producers must not point at Tempo
+// directly, or they bypass that fan-out.
+export const OTLP_GATEWAY_BASE_URL =
+  "http://alloy-gateway.alloy-gateway.svc.cluster.local:4318";
+
+// For producers that POST OTLP JSON to the traces path via fetch instead of an
+// OTLP SDK exporter.
+export const OTLP_GATEWAY_TRACES_URL = `${OTLP_GATEWAY_BASE_URL}/v1/traces`;

--- a/packages/homelab/src/cdk8s/src/resources/streambot.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/streambot.test.ts
@@ -160,7 +160,7 @@ describe("streambot deployment (media namespace)", () => {
     expect(env.get("TELEMETRY_ENABLED")?.value).toBe("true");
     expect(env.get("TELEMETRY_SERVICE_NAME")?.value).toBe("streambot");
     expect(env.get("OTLP_ENDPOINT")?.value).toBe(
-      "http://tempo.tempo.svc.cluster.local:4318",
+      "http://alloy-gateway.alloy-gateway.svc.cluster.local:4318",
     );
     expect(env.get("LOKI_OTLP_ENDPOINT")?.value).toBe(
       "http://loki-gateway.loki/otlp/v1/logs",

--- a/packages/homelab/src/cdk8s/src/resources/streambot.ts
+++ b/packages/homelab/src/cdk8s/src/resources/streambot.ts
@@ -17,6 +17,7 @@ import {
 } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
 import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/service-monitor.ts";
 import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepassword-vault.ts";
+import { OTLP_GATEWAY_BASE_URL } from "@shepherdjerred/homelab/cdk8s/src/misc/otlp.ts";
 import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-nvme-volume.ts";
 import { peerUserbotIds } from "@shepherdjerred/homelab/cdk8s/src/resources/userbot-ids.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
@@ -179,9 +180,7 @@ export function createStreambotDeployment(
         }),
         TELEMETRY_ENABLED: EnvValue.fromValue("true"),
         TELEMETRY_SERVICE_NAME: EnvValue.fromValue("streambot"),
-        OTLP_ENDPOINT: EnvValue.fromValue(
-          "http://tempo.tempo.svc.cluster.local:4318",
-        ),
+        OTLP_ENDPOINT: EnvValue.fromValue(OTLP_GATEWAY_BASE_URL),
         LOKI_OTLP_ENDPOINT: EnvValue.fromValue(
           "http://loki-gateway.loki/otlp/v1/logs",
         ),


### PR DESCRIPTION
## Why

The `alloy-gateway` OTLP trace gateway (#2772) is deployed as the fan-out point for all trace consumers, but every producer still sends OTLP directly to Tempo. This is Phase 2 of the Braintrust rollout: repoint the lowest-risk canary producer before enabling the Braintrust tail-sampling branch. Streambot is the canary because it emits no LLM spans, has no egress network policy, and the repoint is an env-only change.

## What

- New shared constants `OTLP_GATEWAY_BASE_URL` / `OTLP_GATEWAY_TRACES_URL` in `misc/otlp.ts` — later phases repoint the remaining ~11 producers to the same constants.
- Streambot `OTLP_ENDPOINT` now targets `http://alloy-gateway.alloy-gateway.svc.cluster.local:4318` instead of Tempo. The gateway forwards all spans to Tempo, so trace delivery is unchanged.

## Verification

- `bunx turbo run build typecheck test lint` green for `homelab` and `@homelab/cdk8s`; `streambot.test.ts` asserts the rendered gateway URL literal.
- `bunx lefthook run pre-commit` green.
- **Not yet verified (post-deploy):** streambot traces still landing in Tempo (`{resource.service.name="streambot"}`), gateway `otelcol_receiver_accepted_spans_total` increasing with `otelcol_exporter_send_failed_spans_total` flat, and no step change in `tempo_distributor_spans_received_total`. These run after ArgoCD reconciles this manifest change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcyMV8Vj166JoGyP6dJe6F