### PR TITLE
feat(homelab): route every AI workload through the OTLP gateway

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -640,13 +640,9 @@
       "clones": 1,
       "tokens": 73
     },
-    "packages/homelab/src/cdk8s/src/cdk8s-charts/home.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/media/redlib.ts": {
-      "clones": 1,
-      "tokens": 80
-    },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/home.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts": {
       "clones": 1,
-      "tokens": 88
+      "tokens": 131
     },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/media/redlib.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/media/syncthing.ts": {
       "clones": 1,

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/platform/alert-dashboard.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/platform/alert-dashboard.ts
@@ -104,7 +104,7 @@ export function createAlertDashboardChart(app: App) {
           to: [
             {
               namespaceSelector: {
-                matchLabels: { "kubernetes.io/metadata.name": "tempo" },
+                matchLabels: { "kubernetes.io/metadata.name": "alloy-gateway" },
               },
             },
           ],

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts
@@ -108,7 +108,7 @@ export function createScoutChart(
     },
   });
 
-  // NetworkPolicy: Allow egress to DNS, Tempo (OTLP), Flipt, SeaweedFS S3, PostgreSQL, and external HTTPS
+  // NetworkPolicy: Allow egress to DNS, the OTLP trace gateway, Flipt, SeaweedFS S3, PostgreSQL, and external HTTPS
   new KubeNetworkPolicy(chart, "scout-egress-netpol", {
     metadata: { name: "scout-egress-netpol" },
     spec: {
@@ -129,12 +129,12 @@ export function createScoutChart(
             { port: IntOrString.fromNumber(53), protocol: "TCP" },
           ],
         },
-        // Tempo OTLP (tempo.tempo.svc.cluster.local:4318)
+        // OTLP trace gateway (alloy-gateway.alloy-gateway.svc.cluster.local:4318)
         {
           to: [
             {
               namespaceSelector: {
-                matchLabels: { "kubernetes.io/metadata.name": "tempo" },
+                matchLabels: { "kubernetes.io/metadata.name": "alloy-gateway" },
               },
             },
           ],

--- a/packages/homelab/src/cdk8s/src/resources/alert-dashboard/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/alert-dashboard/index.ts
@@ -22,6 +22,7 @@ import { TailscaleIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailsca
 import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepassword-vault.ts";
 import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/storage/zfs-nvme-volume.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+import { OTLP_GATEWAY_BASE_URL } from "@shepherdjerred/homelab/cdk8s/src/misc/otlp.ts";
 
 const IMAGE = `ghcr.io/shepherdjerred/alert-dashboard:${versions["shepherdjerred/alert-dashboard"]}`;
 
@@ -162,9 +163,7 @@ export function createAlertDashboardDeployment(chart: Chart) {
           key: "POSTAL_HOST_HEADER",
         }),
         POSTAL_TO: EnvValue.fromSecretValue({ secret, key: "POSTAL_TO" }),
-        OTEL_EXPORTER_OTLP_ENDPOINT: EnvValue.fromValue(
-          "http://tempo.tempo.svc.cluster.local:4318",
-        ),
+        OTEL_EXPORTER_OTLP_ENDPOINT: EnvValue.fromValue(OTLP_GATEWAY_BASE_URL),
         OTEL_SERVICE_NAME: EnvValue.fromValue("alert-dashboard"),
         TELEMETRY_ENABLED: EnvValue.fromValue("true"),
       },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/ci/buildkite-maintenance-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/ci/buildkite-maintenance-worker.ts
@@ -29,6 +29,7 @@ import {
   withCommonProps,
 } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
 import { temporalFeatureFlagEnvironment } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/feature-flags.ts";
+import { OTLP_GATEWAY_BASE_URL } from "@shepherdjerred/homelab/cdk8s/src/misc/otlp.ts";
 
 const NAMESPACE = "buildkite";
 const WORKER_NAME = "temporal-maintenance-worker";
@@ -308,9 +309,7 @@ export function createBuildkiteMaintenanceWorker(chart: Chart): void {
         TEMPORAL_WORKER_ROLE: EnvValue.fromValue("maintenance"),
         ENVIRONMENT: EnvValue.fromValue("production"),
         TELEMETRY_ENABLED: EnvValue.fromValue("true"),
-        OTLP_ENDPOINT: EnvValue.fromValue(
-          "http://tempo.tempo.svc.cluster.local:4318",
-        ),
+        OTLP_ENDPOINT: EnvValue.fromValue(OTLP_GATEWAY_BASE_URL),
         TELEMETRY_SERVICE_NAME: EnvValue.fromValue(WORKER_NAME),
         HOME: EnvValue.fromValue("/tmp"),
         KOMETA_PLEXTOKEN_FILE: EnvValue.fromValue(

--- a/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
@@ -21,6 +21,7 @@ import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/pro
 import { OnePasswordItem } from "@shepherdjerred/homelab/cdk8s/generated/imports/onepassword.com.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import { peerUserbotIds } from "@shepherdjerred/homelab/cdk8s/src/resources/userbot-ids.ts";
+import { OTLP_GATEWAY_BASE_URL } from "@shepherdjerred/homelab/cdk8s/src/misc/otlp.ts";
 
 // Headless Discord Plays Mario Kart 64: a patched N64Wasm core (parallel-n64 +
 // angrylion software RDP) runs in Bun, renders frames in software, and streams
@@ -136,9 +137,7 @@ export function createMarioKartDeployment(chart: Chart) {
         // OTLP traces → Tempo; frame metrics are scraped from /metrics.
         TELEMETRY_ENABLED: EnvValue.fromValue("true"),
         TELEMETRY_SERVICE_NAME: EnvValue.fromValue("discord-plays-mario-kart"),
-        OTLP_ENDPOINT: EnvValue.fromValue(
-          "http://tempo.tempo.svc.cluster.local:4318",
-        ),
+        OTLP_ENDPOINT: EnvValue.fromValue(OTLP_GATEWAY_BASE_URL),
         // Leaderboard SQLite DB on the persistent data volume (overrides the
         // config's relative db_path). The image entrypoint runs `prisma db
         // push` against this before start.

--- a/packages/homelab/src/cdk8s/src/resources/pokemon.ts
+++ b/packages/homelab/src/cdk8s/src/resources/pokemon.ts
@@ -23,6 +23,7 @@ import { llmArchiveEnvVars } from "@shepherdjerred/homelab/cdk8s/src/misc/llm-ar
 import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepassword-vault.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import { peerUserbotIds } from "@shepherdjerred/homelab/cdk8s/src/resources/userbot-ids.ts";
+import { OTLP_GATEWAY_BASE_URL } from "@shepherdjerred/homelab/cdk8s/src/misc/otlp.ts";
 
 // Headless Discord Plays Pokemon: pokeemerald-wasm runs in Bun, renders frames
 // in software, and streams to a Discord voice channel via the voice UDP path.
@@ -125,9 +126,7 @@ export function createPokemonDeployment(chart: Chart) {
         // OTLP traces → Tempo; frame metrics are scraped from /metrics.
         TELEMETRY_ENABLED: EnvValue.fromValue("true"),
         TELEMETRY_SERVICE_NAME: EnvValue.fromValue("discord-plays-pokemon"),
-        OTLP_ENDPOINT: EnvValue.fromValue(
-          "http://tempo.tempo.svc.cluster.local:4318",
-        ),
+        OTLP_ENDPOINT: EnvValue.fromValue(OTLP_GATEWAY_BASE_URL),
         // Codex SDK goal-mode OAuth. Direct provider API keys are deliberately
         // absent; a mounted auth cache remains valid for local development.
         CODEX_ACCESS_TOKEN: EnvValue.fromSecretValue({

--- a/packages/homelab/src/cdk8s/src/resources/scout/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout/index.ts
@@ -32,6 +32,7 @@ import {
 import { scoutAnalyticsConfiguration } from "@shepherdjerred/homelab/cdk8s/src/resources/scout/analytics.ts";
 import { scoutImageUsesPostgres } from "@shepherdjerred/homelab/cdk8s/src/release-configuration.ts";
 import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepassword-vault.ts";
+import { OTLP_GATEWAY_BASE_URL } from "@shepherdjerred/homelab/cdk8s/src/misc/otlp.ts";
 
 function requiredWeeklyParlaySecret(secret: ISecret | undefined): ISecret {
   if (secret === undefined) {
@@ -186,9 +187,7 @@ export function createScoutDeployment(chart: Chart, stage: Stage) {
     // TELEMETRY_ENABLED.
     TELEMETRY_ENABLED: EnvValue.fromValue("true"),
     TELEMETRY_SERVICE_NAME: EnvValue.fromValue("scout-backend"),
-    OTLP_ENDPOINT: EnvValue.fromValue(
-      "http://tempo.tempo.svc.cluster.local:4318",
-    ),
+    OTLP_ENDPOINT: EnvValue.fromValue(OTLP_GATEWAY_BASE_URL),
     TEMPORAL_ADDRESS: EnvValue.fromValue(
       "temporal-temporal-server-service.temporal.svc.cluster.local:7233",
     ),

--- a/packages/homelab/src/cdk8s/src/resources/scout/scout-network-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout/scout-network-policy.test.ts
@@ -22,7 +22,9 @@ describe("Scout backend telemetry boundary", () => {
               to: [
                 {
                   namespaceSelector: {
-                    matchLabels: { "kubernetes.io/metadata.name": "tempo" },
+                    matchLabels: {
+                      "kubernetes.io/metadata.name": "alloy-gateway",
+                    },
                   },
                 },
               ],

--- a/packages/homelab/src/cdk8s/src/resources/temporal/runtime-env.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/runtime-env.ts
@@ -1,4 +1,5 @@
 import { EnvValue, type ISecret } from "cdk8s-plus-31";
+import { OTLP_GATEWAY_BASE_URL } from "@shepherdjerred/homelab/cdk8s/src/misc/otlp.ts";
 
 export type TemporalRuntimeRole =
   | "backup"
@@ -23,9 +24,7 @@ export function temporalRuntimeEnv(
     TEMPORAL_WORKER_ROLE: EnvValue.fromValue(role),
     ENVIRONMENT: EnvValue.fromValue("production"),
     TELEMETRY_ENABLED: EnvValue.fromValue("true"),
-    OTLP_ENDPOINT: EnvValue.fromValue(
-      "http://tempo.tempo.svc.cluster.local:4318",
-    ),
+    OTLP_ENDPOINT: EnvValue.fromValue(OTLP_GATEWAY_BASE_URL),
     TELEMETRY_SERVICE_NAME: EnvValue.fromValue(serviceName),
     SENTRY_DSN: EnvValue.fromSecretValue({ secret, key: "SENTRY_DSN" }),
   };

--- a/packages/homelab/src/cdk8s/src/resources/temporal/temporal-workflow-boundary.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/temporal-workflow-boundary.test.ts
@@ -180,7 +180,7 @@ describe("central Temporal Workflow boundary", () => {
     expect(otlpRule?.to).toEqual([
       {
         namespaceSelector: {
-          matchLabels: { "kubernetes.io/metadata.name": "tempo" },
+          matchLabels: { "kubernetes.io/metadata.name": "alloy-gateway" },
         },
       },
     ]);

--- a/packages/homelab/src/cdk8s/src/resources/temporal/workers/agent-worker-network-policy.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/workers/agent-worker-network-policy.ts
@@ -85,7 +85,7 @@ export function createTemporalAgentWorkerNetworkPolicy(chart: Chart): void {
           to: [
             {
               namespaceSelector: {
-                matchLabels: { "kubernetes.io/metadata.name": "tempo" },
+                matchLabels: { "kubernetes.io/metadata.name": "alloy-gateway" },
               },
             },
           ],

--- a/packages/homelab/src/cdk8s/src/resources/temporal/workers/operations-workers.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/workers/operations-workers.ts
@@ -10,6 +10,7 @@ import {
 import { llmArchiveEnvVars } from "@shepherdjerred/homelab/cdk8s/src/misc/llm-archive-env.ts";
 import { createTemporalDomainWorker } from "./domain-worker.ts";
 import { temporalRuntimeEnv } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/runtime-env.ts";
+import { OTLP_GATEWAY_BASE_URL } from "@shepherdjerred/homelab/cdk8s/src/misc/otlp.ts";
 
 function s3Env(secret: ISecret): Record<string, EnvValue> {
   return {
@@ -122,9 +123,7 @@ export function createTemporalOperationsWorkers(
       FEATURE_FLAGS_MODE: EnvValue.fromValue("disabled"),
       ENVIRONMENT: EnvValue.fromValue("production"),
       TELEMETRY_ENABLED: EnvValue.fromValue("true"),
-      OTLP_ENDPOINT: EnvValue.fromValue(
-        "http://tempo.tempo.svc.cluster.local:4318",
-      ),
+      OTLP_ENDPOINT: EnvValue.fromValue(OTLP_GATEWAY_BASE_URL),
       TELEMETRY_SERVICE_NAME: EnvValue.fromValue("temporal-billing-worker"),
       OPENAI_ADMIN_KEY: EnvValue.fromSecretValue({
         secret: props.billingSecret,

--- a/packages/homelab/src/cdk8s/src/resources/temporal/workers/worker-network-policies.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/workers/worker-network-policies.ts
@@ -118,7 +118,7 @@ export function createTemporalWorkerNetworkPolicies(chart: Chart): void {
           to: [
             {
               namespaceSelector: {
-                matchLabels: { "kubernetes.io/metadata.name": "tempo" },
+                matchLabels: { "kubernetes.io/metadata.name": "alloy-gateway" },
               },
             },
           ],

--- a/packages/homelab/src/cdk8s/src/resources/temporal/workers/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/workers/worker.ts
@@ -30,6 +30,7 @@ import {
   createTemporalWorkerServiceAccount,
 } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/worker-rbac.ts";
 import { temporalFeatureFlagEnvironment } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/feature-flags.ts";
+import { OTLP_GATEWAY_BASE_URL } from "@shepherdjerred/homelab/cdk8s/src/misc/otlp.ts";
 
 export type CreateTemporalWorkerDeploymentProps = {
   serverServiceName: string;
@@ -171,9 +172,7 @@ export function createTemporalWorkerDeployment(
       ENVIRONMENT: EnvValue.fromValue("production"),
       DISABLE_AUTOUPDATER: EnvValue.fromValue("1"),
       TELEMETRY_ENABLED: EnvValue.fromValue("true"),
-      OTLP_ENDPOINT: EnvValue.fromValue(
-        "http://tempo.tempo.svc.cluster.local:4318",
-      ),
+      OTLP_ENDPOINT: EnvValue.fromValue(OTLP_GATEWAY_BASE_URL),
       TELEMETRY_SERVICE_NAME: EnvValue.fromValue("temporal-agent-worker"),
       NODE_EXTRA_CA_CERTS: EnvValue.fromValue(
         "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
@@ -209,9 +208,7 @@ export function createTemporalWorkerDeployment(
     TEMPORAL_METRICS_ADDRESS: EnvValue.fromValue("0.0.0.0:9464"),
     ENVIRONMENT: EnvValue.fromValue("production"),
     TELEMETRY_ENABLED: EnvValue.fromValue("true"),
-    OTLP_ENDPOINT: EnvValue.fromValue(
-      "http://tempo.tempo.svc.cluster.local:4318",
-    ),
+    OTLP_ENDPOINT: EnvValue.fromValue(OTLP_GATEWAY_BASE_URL),
     SENTRY_DSN: EnvValue.fromSecretValue({ secret, key: "SENTRY_DSN" }),
   };
   const { corpusDeployment, contextDeployment } = createTemporalGlitterWorkers(

--- a/packages/homelab/src/cdk8s/src/resources/temporal/workers/workflow-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/workers/workflow-worker.ts
@@ -2,6 +2,7 @@ import type { Chart } from "cdk8s";
 import { Size } from "cdk8s";
 import { Cpu, type Deployment, EnvValue } from "cdk8s-plus-31";
 import { createTemporalDomainWorker } from "./domain-worker.ts";
+import { OTLP_GATEWAY_BASE_URL } from "@shepherdjerred/homelab/cdk8s/src/misc/otlp.ts";
 
 const DEPLOYMENT_NAME = "monorepo-central-workflows";
 
@@ -37,9 +38,7 @@ function createWorkflowWorker(
       TEMPORAL_WORKER_DEPLOYMENT_NAME: EnvValue.fromValue(DEPLOYMENT_NAME),
       ENVIRONMENT: EnvValue.fromValue("production"),
       TELEMETRY_ENABLED: EnvValue.fromValue("true"),
-      OTLP_ENDPOINT: EnvValue.fromValue(
-        "http://tempo.tempo.svc.cluster.local:4318",
-      ),
+      OTLP_ENDPOINT: EnvValue.fromValue(OTLP_GATEWAY_BASE_URL),
       TELEMETRY_SERVICE_NAME: EnvValue.fromValue("temporal-central-workflows"),
     },
   });


### PR DESCRIPTION
## Why

Birmel proved the gateway's Braintrust export end to end (#2827: 106 spans, zero failures, full content in the `birmel` project). The remaining producers still send OTLP straight to Tempo, so their LLM traces never reach the Braintrust projects that already exist for them in the gateway config. Phase 4 of the rollout.

## What

- `OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT` → `OTLP_GATEWAY_BASE_URL` for: scout-backend (beta+prod), alert-dashboard, pokemon, mario-kart, temporal runtime-env + worker + workflow-worker + operations-workers, and buildkite-maintenance-worker. App-code defaults untouched.
- Egress netpols for scout, alert-dashboard, the temporal workers, and the agent worker now select the `alloy-gateway` namespace instead of `tempo` (port 4318 unchanged); tests updated to match.
- jscpd baseline reverts to its pre-#2827 shape for `home|scout` / `home|redlib` — the scout netpol edit re-partitioned the same shared boilerplate clones back (hand-edited entries, no wholesale --update).

## Verification

- `bunx turbo run build typecheck test lint` green for `homelab` + `@homelab/cdk8s`; `check:kubeconform` valid; `check:1password` green; `bun run jscpd` passes; lefthook pre-commit clean.
- **Not yet verified (post-deploy):** per-service TraceQL in Tempo via the gateway — scout-backend appearing at all is notable since its old netpol had no 4318 egress path that matched its endpoint; Braintrust `scout-*`/`temporal`/`discord-plays`/`misc` projects populating on LLM activity; `bt_*` failure counters at zero; Braintrust usage vs the 1 GB/month budget over the first days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcyMV8Vj166JoGyP6dJe6F