### PR TITLE
feat(scout-for-lol): add Hall of Fame to consumer navigation and records view

### DIFF
--- a/packages/scout-for-lol/packages/app/src/components/chrome/app-navigation.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/chrome/app-navigation.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { NavLink, useLocation, useNavigate } from "react-router";
 import {
   Bell,
@@ -18,7 +17,6 @@ import {
   Trophy,
   Users,
 } from "lucide-react";
-import type { ExploreConversation } from "@scout-for-lol/data";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -28,171 +26,23 @@ import {
 } from "@scout-for-lol/design-system/components/overlays/dropdown-menu";
 import { usePermissions } from "#src/hooks/use-permissions.ts";
 import {
+  type GuildNavigationItem,
   consumerNavigationItems,
   guildIdFromAppPath,
   guildWorkspacePath,
   isExplorePath,
+  resolveHallTo,
   visibleGuildNavigationItems,
 } from "#src/lib/routes/app-navigation.ts";
 import { STALE_TIME_SLOW_LIST } from "#src/lib/query/stale-times.ts";
 import { useTRPC } from "#src/lib/query/trpc.ts";
-import { ExploreSidebar } from "#src/components/explore/explore-sidebar.tsx";
-import { useOptionalExploreRuns } from "#src/components/explore/explore-runs-context.ts";
-import { RenameConversationDialog } from "#src/components/dialogs/rename-conversation-dialog.tsx";
-import { ConfirmDeleteDialog } from "#src/components/dialogs/confirm-delete-dialog.tsx";
-import { analyticsMeta } from "#src/lib/analytics.ts";
+import { ExploreNavigationSection } from "#src/components/explore/explore-navigation-section.tsx";
 
 function getActiveConversationId(pathname: string): string | null {
   const match = /^\/(?:app\/)?explore\/([^/]+)/.exec(pathname);
   if (!match) return null;
   if (match[1] === "s") return null;
   return match[1] ?? null;
-}
-
-function ExploreNavigationSection(props: { activeId: string | null }) {
-  const trpc = useTRPC();
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const runs = useOptionalExploreRuns();
-  const [renaming, setRenaming] = useState<ExploreConversation | null>(null);
-  const [deleting, setDeleting] = useState<ExploreConversation | null>(null);
-
-  const conversationsQuery = useQuery({
-    ...trpc.explore.list.queryOptions(),
-    staleTime: 60_000,
-  });
-
-  const renameMutation = useMutation(
-    trpc.explore.rename.mutationOptions({
-      meta: analyticsMeta("explore_conversation_renamed"),
-    }),
-  );
-  const deleteMutation = useMutation(
-    trpc.explore.delete.mutationOptions({
-      meta: analyticsMeta("explore_conversation_deleted"),
-    }),
-  );
-
-  const [renameError, setRenameError] = useState<string | null>(null);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
-
-  const handleSelect = (id: string) => {
-    void navigate(`/explore/${id}`);
-  };
-
-  const handleNew = () => {
-    void navigate("/explore");
-  };
-
-  const handleStartRename = (conversation: ExploreConversation) => {
-    setRenameError(null);
-    setRenaming(conversation);
-  };
-
-  const handleStartDelete = (conversation: ExploreConversation) => {
-    setDeleteError(null);
-    setDeleting(conversation);
-  };
-
-  const handleRename = (
-    conversation: ExploreConversation,
-    nextTitle: string,
-  ) => {
-    setRenameError(null);
-    renameMutation.mutate(
-      {
-        conversationId: conversation.id,
-        title: nextTitle,
-      },
-      {
-        onSuccess: () => {
-          setRenaming(null);
-          void Promise.all([
-            queryClient.invalidateQueries({
-              queryKey: trpc.explore.list.queryKey(),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: trpc.explore.get.queryKey({
-                conversationId: conversation.id,
-              }),
-            }),
-          ]);
-        },
-        onError: (err: unknown) => {
-          setRenameError(err instanceof Error ? err.message : String(err));
-        },
-      },
-    );
-  };
-
-  const handleDelete = (conversation: ExploreConversation) => {
-    setDeleteError(null);
-    deleteMutation.mutate(
-      { conversationId: conversation.id },
-      {
-        onSuccess: () => {
-          setDeleting(null);
-          queryClient.removeQueries({
-            queryKey: trpc.explore.get.queryKey({
-              conversationId: conversation.id,
-            }),
-          });
-          void queryClient.invalidateQueries({
-            queryKey: trpc.explore.list.queryKey(),
-          });
-          if (props.activeId === conversation.id) {
-            void navigate("/explore", { replace: true });
-          }
-        },
-        onError: (err: unknown) => {
-          setDeleteError(err instanceof Error ? err.message : String(err));
-        },
-      },
-    );
-  };
-
-  const statusForConversation = runs?.status ?? (() => null);
-
-  return (
-    <>
-      <ExploreSidebar
-        conversations={conversationsQuery.data ?? []}
-        activeId={props.activeId}
-        onSelect={handleSelect}
-        onNew={handleNew}
-        onRename={handleStartRename}
-        onDelete={handleStartDelete}
-        statusForConversation={statusForConversation}
-        showNewButton={false}
-      />
-
-      <RenameConversationDialog
-        conversation={renaming}
-        pending={renameMutation.isPending}
-        error={renameError}
-        onClose={() => {
-          setRenaming(null);
-          setRenameError(null);
-        }}
-        onRename={(conversation, nextTitle) => {
-          handleRename(conversation, nextTitle);
-        }}
-      />
-
-      <ConfirmDeleteDialog
-        conversation={deleting}
-        pending={deleteMutation.isPending}
-        error={deleteError}
-        onClose={() => {
-          setDeleting(null);
-          setDeleteError(null);
-        }}
-        onConfirm={(conversation) => {
-          handleDelete(conversation);
-        }}
-      />
-    </>
-  );
 }
 
 function guildNavIcon(to: string) {
@@ -217,9 +67,218 @@ function guildNavIcon(to: string) {
   }
 }
 
+function ToolNavIcon(props: { to: string }) {
+  if (props.to === "/explore") {
+    return <Compass className="size-4 shrink-0 text-scout-subtle" />;
+  }
+  if (props.to === "/players") {
+    return <Users className="size-4 shrink-0 text-scout-subtle" />;
+  }
+  if (props.to === "/challenges") {
+    return <Target className="size-3.5 shrink-0 text-scout-subtle" />;
+  }
+  if (props.to === "/bucks") {
+    return <Coins className="size-4 shrink-0 text-scout-subtle" />;
+  }
+  if (props.to.startsWith("/halls")) {
+    return <Trophy className="size-4 shrink-0 text-scout-subtle" />;
+  }
+  return null;
+}
+
+function ToolsNavigationSection(props: {
+  tools: readonly { label: string; to: string }[];
+  inHalls: boolean;
+  hallGuilds: readonly { id: string; name: string }[];
+}) {
+  if (props.tools.length === 0) return null;
+
+  return (
+    <section className="space-y-0.5 shrink-0" aria-label="Tools">
+      <p className="scout-app-sidebar-heading">Tools</p>
+      {props.tools.map((item) => {
+        const isHallItem = item.to.startsWith("/halls");
+        return (
+          <div key={item.to} className="space-y-0.5">
+            <NavLink
+              to={item.to}
+              end={item.to === "/explore"}
+              className="scout-app-sidebar-link flex items-center gap-2.5 px-2.5 py-2 text-sm"
+            >
+              <ToolNavIcon to={item.to} />
+              <span>{item.label}</span>
+            </NavLink>
+
+            {isHallItem && props.inHalls && props.hallGuilds.length > 1 ? (
+              <div className="pl-6 space-y-0.5" aria-label="Hall servers">
+                {props.hallGuilds.map((g) => (
+                  <NavLink
+                    key={g.id}
+                    to={`/halls/${g.id}`}
+                    className="scout-app-sidebar-link flex items-center gap-2 px-2.5 py-1.5 text-xs"
+                  >
+                    <span className="truncate">{g.name}</span>
+                  </NavLink>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        );
+      })}
+    </section>
+  );
+}
+
+function ChatsSection(props: {
+  inExplore: boolean;
+  exploreAvailable: boolean;
+  activeConversationId: string | null;
+}) {
+  const navigate = useNavigate();
+
+  if (!props.inExplore || !props.exploreAvailable) return null;
+
+  return (
+    <section
+      className="min-h-0 flex-1 flex flex-col overflow-hidden border-t border-scout-border/60 pt-2.5"
+      aria-label="Recent chats"
+    >
+      <div className="flex items-center justify-between px-2.5 pb-1 shrink-0">
+        <p className="scout-app-sidebar-heading !p-0 !m-0">Chats</p>
+        <button
+          type="button"
+          title="New chat"
+          aria-label="New chat"
+          className="flex size-6 items-center justify-center rounded text-scout-subtle transition-colors hover:bg-scout-hover hover:text-scout-ink"
+          onClick={() => {
+            void navigate("/explore");
+          }}
+        >
+          <SquarePen className="size-4" />
+        </button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <ExploreNavigationSection activeId={props.activeConversationId} />
+      </div>
+    </section>
+  );
+}
+
+function ServerManagementSection(props: {
+  guildId: string;
+  guildName: string | undefined;
+  guildItems: readonly GuildNavigationItem[];
+}) {
+  if (props.guildItems.length === 0) return null;
+
+  return (
+    <section
+      className="min-h-0 flex-1 flex flex-col overflow-hidden border-t border-scout-border/60 pt-2.5"
+      aria-label="Server management"
+    >
+      <p className="scout-app-sidebar-heading truncate">
+        {props.guildName ?? "Server"}
+      </p>
+      <div className="min-h-0 flex-1 overflow-y-auto space-y-0.5">
+        {props.guildItems.map((item) => {
+          const Icon = guildNavIcon(item.to);
+          return (
+            <NavLink
+              key={item.to}
+              to={`/g/${props.guildId}/${item.to}`}
+              className="scout-app-sidebar-link flex items-center gap-2.5 px-2.5 py-2 text-sm"
+            >
+              <Icon className="size-4 shrink-0 text-scout-subtle" />
+              <span>{item.label}</span>
+            </NavLink>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function WorkspaceSwitcherSection(props: {
+  guildId: string | undefined;
+  selectedGuild: { id: string; name: string } | undefined;
+  manageableGuilds: readonly { id: string; name: string }[] | undefined;
+}) {
+  const navigate = useNavigate();
+
+  const selectableGuilds = props.manageableGuilds ?? [];
+  if (selectableGuilds.length <= 1) {
+    return null;
+  }
+
+  const selectedGuild = props.selectedGuild;
+  const serverInitials = selectedGuild
+    ? selectedGuild.name.slice(0, 2).toUpperCase()
+    : null;
+  const serverName = selectedGuild ? selectedGuild.name : "Switch server";
+  const serverSubtitle = selectedGuild ? "Active server" : "No server selected";
+
+  return (
+    <section
+      className="scout-app-sidebar-section mt-auto shrink-0 border-t border-scout-border/60 pt-2 space-y-0.5"
+      aria-label="Workspace"
+    >
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="group flex w-full items-center justify-between gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm font-medium text-scout-ink transition-colors hover:bg-scout-hover"
+          >
+            <div className="flex min-w-0 items-center gap-2.5">
+              <div className="flex size-7 shrink-0 items-center justify-center rounded-md border border-scout-border/60 bg-scout-canvas text-xs font-semibold text-scout-ink">
+                {serverInitials ?? (
+                  <Server className="size-3.5 text-scout-subtle" />
+                )}
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium leading-tight text-scout-ink">
+                  {serverName}
+                </p>
+                <p className="truncate text-xs leading-tight text-scout-subtle">
+                  {serverSubtitle}
+                </p>
+              </div>
+            </div>
+            <ChevronsUpDown className="size-4 shrink-0 text-scout-subtle transition-colors group-hover:text-scout-ink" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-56">
+          <DropdownMenuLabel>Servers</DropdownMenuLabel>
+          {selectableGuilds.map((guild) => (
+            <DropdownMenuItem
+              key={guild.id}
+              onClick={() => {
+                void navigate(guildWorkspacePath(guild.id));
+              }}
+              className={`flex items-center justify-between gap-2 text-sm ${
+                guild.id === props.guildId
+                  ? "bg-scout-hover/70 font-semibold text-scout-ink"
+                  : ""
+              }`}
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <div className="flex size-6 shrink-0 items-center justify-center rounded border border-scout-border/60 bg-scout-canvas text-xs font-semibold text-scout-ink">
+                  {guild.name.slice(0, 2).toUpperCase()}
+                </div>
+                <span className="truncate">{guild.name}</span>
+              </div>
+              {guild.id === props.guildId && (
+                <Check className="ml-1 size-4 shrink-0 text-scout-primary" />
+              )}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </section>
+  );
+}
+
 export function AppNavigation() {
   const location = useLocation();
-  const navigate = useNavigate();
   const trpc = useTRPC();
   const guildId = guildIdFromAppPath(location.pathname);
   const guildsQuery = useQuery(
@@ -237,164 +296,67 @@ export function AppNavigation() {
   const bucksQuery = useQuery(
     trpc.bucks.status.queryOptions(undefined, { retry: 2 }),
   );
+  const hallQuery = useQuery(
+    trpc.hall.status.queryOptions(undefined, { retry: 2 }),
+  );
   const { perms } = usePermissions(guildId);
+
+  const hallGuilds =
+    hallQuery.data?.state === "available" ? hallQuery.data.guilds : [];
+  const inHalls = location.pathname.startsWith("/halls");
+  const hallMatchGuildId = inHalls
+    ? /^\/halls\/([^/]+)/.exec(location.pathname)?.[1]
+    : undefined;
+  const activeHallGuild = hallGuilds.find(
+    (guild) => guild.id === (guildId ?? hallMatchGuildId),
+  );
+  const hallTo = resolveHallTo(activeHallGuild, hallGuilds);
 
   const tools = consumerNavigationItems({
     exploreAvailable: exploreQuery.data?.enabled === true,
     profilesAvailable: profilesQuery.data?.state === "available",
     challengesAvailable: challengesQuery.data?.enabled === true,
     bucksAvailable: bucksQuery.data?.state === "available",
+    hallAvailable: hallQuery.data?.state === "available",
+    hallTo,
   });
+
   const selectedGuild = guildsQuery.data?.find((guild) => guild.id === guildId);
+
   const guildItems = visibleGuildNavigationItems(
     (permission) => perms.can(permission.resource, permission.action),
-    selectedGuild?.customNightsEnabled === true,
-    selectedGuild?.hallOfFameEnabled === true,
+    selectedGuild?.customNightsEnabled ?? false,
+    selectedGuild?.hallOfFameEnabled ?? false,
   );
 
   const activeConversationId = getActiveConversationId(location.pathname);
-  const exploreAvailable = exploreQuery.data?.enabled === true;
-  const inExplore = isExplorePath(location.pathname);
 
   return (
     <nav className="scout-app-sidebar-nav" aria-label="App navigation">
-      {tools.length === 0 ? null : (
-        <section className="space-y-0.5 shrink-0" aria-label="Tools">
-          <p className="scout-app-sidebar-heading">Tools</p>
-          {tools.map((item) => (
-            <NavLink
-              key={item.to}
-              to={item.to}
-              end={item.to === "/explore"}
-              className="scout-app-sidebar-link flex items-center gap-2.5 px-2.5 py-2 text-sm"
-            >
-              {item.to === "/explore" && (
-                <Compass className="size-4 shrink-0 text-scout-subtle" />
-              )}
-              {item.to === "/players" && (
-                <Users className="size-4 shrink-0 text-scout-subtle" />
-              )}
-              {item.to === "/challenges" && (
-                <Target className="size-3.5 shrink-0 text-scout-subtle" />
-              )}
-              {item.to === "/bucks" && (
-                <Coins className="size-4 shrink-0 text-scout-subtle" />
-              )}
-              <span>{item.label}</span>
-            </NavLink>
-          ))}
-        </section>
+      <ToolsNavigationSection
+        tools={tools}
+        inHalls={inHalls}
+        hallGuilds={hallGuilds}
+      />
+      <ChatsSection
+        inExplore={isExplorePath(location.pathname)}
+        exploreAvailable={exploreQuery.data?.enabled === true}
+        activeConversationId={activeConversationId}
+      />
+      {guildId !== undefined && (
+        <ServerManagementSection
+          guildId={guildId}
+          guildName={selectedGuild?.name}
+          guildItems={guildItems}
+        />
       )}
-
-      {inExplore && exploreAvailable && (
-        <section
-          className="min-h-0 flex-1 flex flex-col overflow-hidden border-t border-scout-border/60 pt-2.5"
-          aria-label="Recent chats"
-        >
-          <div className="flex items-center justify-between px-2.5 pb-1 shrink-0">
-            <p className="scout-app-sidebar-heading !p-0 !m-0">Chats</p>
-            <button
-              type="button"
-              title="New chat"
-              aria-label="New chat"
-              className="flex size-6 items-center justify-center rounded text-scout-subtle transition-colors hover:bg-scout-hover hover:text-scout-ink"
-              onClick={() => {
-                void navigate("/explore");
-              }}
-            >
-              <SquarePen className="size-4" />
-            </button>
-          </div>
-          <div className="min-h-0 flex-1 overflow-hidden">
-            <ExploreNavigationSection activeId={activeConversationId} />
-          </div>
-        </section>
+      {guildId !== undefined && (
+        <WorkspaceSwitcherSection
+          guildId={guildId}
+          selectedGuild={selectedGuild}
+          manageableGuilds={guildsQuery.data}
+        />
       )}
-
-      {guildId !== undefined && guildItems.length > 0 && (
-        <section
-          className="min-h-0 flex-1 flex flex-col overflow-hidden border-t border-scout-border/60 pt-2.5"
-          aria-label="Server management"
-        >
-          <p className="scout-app-sidebar-heading truncate">
-            {selectedGuild?.name ?? "Server"}
-          </p>
-          <div className="min-h-0 flex-1 overflow-y-auto space-y-0.5">
-            {guildItems.map((item) => {
-              const Icon = guildNavIcon(item.to);
-              return (
-                <NavLink
-                  key={item.to}
-                  to={`/g/${guildId}/${item.to}`}
-                  className="scout-app-sidebar-link flex items-center gap-2.5 px-2.5 py-2 text-sm"
-                >
-                  <Icon className="size-4 shrink-0 text-scout-subtle" />
-                  <span>{item.label}</span>
-                </NavLink>
-              );
-            })}
-          </div>
-        </section>
-      )}
-
-      <section
-        className="scout-app-sidebar-section mt-auto shrink-0 border-t border-scout-border/60 pt-2 space-y-0.5"
-        aria-label="Workspace"
-      >
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              className="group flex w-full items-center justify-between gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm font-medium text-scout-ink transition-colors hover:bg-scout-hover"
-            >
-              <div className="flex min-w-0 items-center gap-2.5">
-                <div className="flex size-7 shrink-0 items-center justify-center rounded-md border border-scout-border/60 bg-scout-canvas text-xs font-semibold text-scout-ink">
-                  {selectedGuild ? (
-                    selectedGuild.name.slice(0, 2).toUpperCase()
-                  ) : (
-                    <Server className="size-3.5 text-scout-subtle" />
-                  )}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium leading-tight text-scout-ink">
-                    {selectedGuild ? selectedGuild.name : "Switch server"}
-                  </p>
-                  <p className="truncate text-xs leading-tight text-scout-subtle">
-                    {selectedGuild ? "Active server" : "No server selected"}
-                  </p>
-                </div>
-              </div>
-              <ChevronsUpDown className="size-4 shrink-0 text-scout-subtle transition-colors group-hover:text-scout-ink" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="w-56">
-            <DropdownMenuLabel>Servers</DropdownMenuLabel>
-            {guildsQuery.data?.map((guild) => (
-              <DropdownMenuItem
-                key={guild.id}
-                onClick={() => {
-                  void navigate(guildWorkspacePath(guild.id));
-                }}
-                className={`flex items-center justify-between gap-2 text-sm ${
-                  guild.id === guildId
-                    ? "bg-scout-hover/70 font-semibold text-scout-ink"
-                    : ""
-                }`}
-              >
-                <div className="flex min-w-0 items-center gap-2">
-                  <div className="flex size-6 shrink-0 items-center justify-center rounded border border-scout-border/60 bg-scout-canvas text-xs font-semibold text-scout-ink">
-                    {guild.name.slice(0, 2).toUpperCase()}
-                  </div>
-                  <span className="truncate">{guild.name}</span>
-                </div>
-                {guild.id === guildId && (
-                  <Check className="ml-1 size-4 shrink-0 text-scout-primary" />
-                )}
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </section>
     </nav>
   );
 }

--- a/packages/scout-for-lol/packages/app/src/components/explore/explore-navigation-section.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore/explore-navigation-section.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router";
+import type { ExploreConversation } from "@scout-for-lol/data";
+import { useTRPC } from "#src/lib/query/trpc.ts";
+import { ExploreSidebar } from "#src/components/explore/explore-sidebar.tsx";
+import { useOptionalExploreRuns } from "#src/components/explore/explore-runs-context.ts";
+import { RenameConversationDialog } from "#src/components/dialogs/rename-conversation-dialog.tsx";
+import { ConfirmDeleteDialog } from "#src/components/dialogs/confirm-delete-dialog.tsx";
+import { analyticsMeta } from "#src/lib/analytics.ts";
+
+export function ExploreNavigationSection(props: { activeId: string | null }) {
+  const trpc = useTRPC();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const runs = useOptionalExploreRuns();
+  const [renaming, setRenaming] = useState<ExploreConversation | null>(null);
+  const [deleting, setDeleting] = useState<ExploreConversation | null>(null);
+
+  const conversationsQuery = useQuery({
+    ...trpc.explore.list.queryOptions(),
+    staleTime: 60_000,
+  });
+
+  const renameMutation = useMutation(
+    trpc.explore.rename.mutationOptions({
+      meta: analyticsMeta("explore_conversation_renamed"),
+    }),
+  );
+  const deleteMutation = useMutation(
+    trpc.explore.delete.mutationOptions({
+      meta: analyticsMeta("explore_conversation_deleted"),
+    }),
+  );
+
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const handleSelect = (id: string) => {
+    void navigate(`/explore/${id}`);
+  };
+
+  const handleNew = () => {
+    void navigate("/explore");
+  };
+
+  const handleStartRename = (conversation: ExploreConversation) => {
+    setRenameError(null);
+    setRenaming(conversation);
+  };
+
+  const handleStartDelete = (conversation: ExploreConversation) => {
+    setDeleteError(null);
+    setDeleting(conversation);
+  };
+
+  const handleRename = (
+    conversation: ExploreConversation,
+    nextTitle: string,
+  ) => {
+    setRenameError(null);
+    renameMutation.mutate(
+      {
+        conversationId: conversation.id,
+        title: nextTitle,
+      },
+      {
+        onSuccess: () => {
+          setRenaming(null);
+          void Promise.all([
+            queryClient.invalidateQueries({
+              queryKey: trpc.explore.list.queryKey(),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.explore.get.queryKey({
+                conversationId: conversation.id,
+              }),
+            }),
+          ]);
+        },
+        onError: (err: unknown) => {
+          setRenameError(err instanceof Error ? err.message : String(err));
+        },
+      },
+    );
+  };
+
+  const handleDelete = (conversation: ExploreConversation) => {
+    setDeleteError(null);
+    deleteMutation.mutate(
+      { conversationId: conversation.id },
+      {
+        onSuccess: () => {
+          setDeleting(null);
+          queryClient.removeQueries({
+            queryKey: trpc.explore.get.queryKey({
+              conversationId: conversation.id,
+            }),
+          });
+          void queryClient.invalidateQueries({
+            queryKey: trpc.explore.list.queryKey(),
+          });
+          if (props.activeId === conversation.id) {
+            void navigate("/explore", { replace: true });
+          }
+        },
+        onError: (err: unknown) => {
+          setDeleteError(err instanceof Error ? err.message : String(err));
+        },
+      },
+    );
+  };
+
+  const statusForConversation = runs?.status ?? (() => null);
+
+  return (
+    <>
+      <ExploreSidebar
+        conversations={conversationsQuery.data ?? []}
+        activeId={props.activeId}
+        onSelect={handleSelect}
+        onNew={handleNew}
+        onRename={handleStartRename}
+        onDelete={handleStartDelete}
+        statusForConversation={statusForConversation}
+        showNewButton={false}
+      />
+
+      <RenameConversationDialog
+        conversation={renaming}
+        pending={renameMutation.isPending}
+        error={renameError}
+        onClose={() => {
+          setRenaming(null);
+          setRenameError(null);
+        }}
+        onRename={(conversation, nextTitle) => {
+          handleRename(conversation, nextTitle);
+        }}
+      />
+
+      <ConfirmDeleteDialog
+        conversation={deleting}
+        pending={deleteMutation.isPending}
+        error={deleteError}
+        onClose={() => {
+          setDeleting(null);
+          setDeleteError(null);
+        }}
+        onConfirm={(conversation) => {
+          handleDelete(conversation);
+        }}
+      />
+    </>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/lib/routes/app-navigation.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/routes/app-navigation.ts
@@ -5,6 +5,8 @@ export type ConsumerNavigationAvailability = {
   profilesAvailable: boolean;
   challengesAvailable: boolean;
   bucksAvailable: boolean;
+  hallAvailable?: boolean;
+  hallTo?: string;
 };
 
 export function consumerNavigationItems(
@@ -13,11 +15,27 @@ export function consumerNavigationItems(
   return [
     ...(input.exploreAvailable ? [{ label: "Explore", to: "/explore" }] : []),
     ...(input.profilesAvailable ? [{ label: "Players", to: "/players" }] : []),
+    ...(input.hallAvailable === true
+      ? [{ label: "Hall of Fame", to: input.hallTo ?? "/halls" }]
+      : []),
     ...(input.challengesAvailable
       ? [{ label: "Challenges", to: "/challenges" }]
       : []),
     ...(input.bucksAvailable ? [{ label: "Bryan Bucks", to: "/bucks" }] : []),
   ];
+}
+
+export function resolveHallTo(
+  activeHallGuild: { id: string } | undefined,
+  hallGuilds: readonly { id: string }[],
+): string {
+  if (activeHallGuild !== undefined) {
+    return `/halls/${activeHallGuild.id}`;
+  }
+  if (hallGuilds.length === 1 && hallGuilds[0] !== undefined) {
+    return `/halls/${hallGuilds[0].id}`;
+  }
+  return "/halls";
 }
 
 export type GuildNavigationItem = {

--- a/packages/scout-for-lol/packages/app/src/router.test.ts
+++ b/packages/scout-for-lol/packages/app/src/router.test.ts
@@ -21,6 +21,7 @@ const KNOWN_URLS = [
   "/explore/s/some-share-token",
   "/players",
   "/players/42",
+  "/halls",
   "/halls/1",
   "/challenges",
   "/challenges/1b4e28ba-2fa1-41d2-883f-0016d3cca427",

--- a/packages/scout-for-lol/packages/app/src/router.tsx
+++ b/packages/scout-for-lol/packages/app/src/router.tsx
@@ -46,7 +46,7 @@ import { OnboardingWizard } from "#src/routes/onboarding-wizard.tsx";
 import { InstallLanding } from "#src/routes/install-landing.tsx";
 import { RequireSession } from "#src/routes/require-session.tsx";
 import { RootLayout } from "#src/routes/root-layout.tsx";
-import { HallOfFame } from "#src/routes/hall-of-fame.tsx";
+import { HallOfFame, HallPicker } from "#src/routes/hall-of-fame.tsx";
 import { HallSettings } from "#src/routes/hall-settings.tsx";
 import { ChallengeCatalog } from "#src/routes/challenges/challenge-catalog.tsx";
 import { ChallengeTemplate } from "#src/routes/challenges/challenge-template.tsx";
@@ -259,6 +259,11 @@ export const routes: RouteObject[] = [
               {
                 path: "champions/:championId",
                 element: <ConsumerChampion />,
+                errorElement: <RouteErrorPanel />,
+              },
+              {
+                path: "halls",
+                element: <HallPicker />,
                 errorElement: <RouteErrorPanel />,
               },
               {

--- a/packages/scout-for-lol/packages/app/src/routes/consumer/consumer-workspace.test.ts
+++ b/packages/scout-for-lol/packages/app/src/routes/consumer/consumer-workspace.test.ts
@@ -3,6 +3,7 @@ import {
   consumerNavigationItems,
   GUILD_NAVIGATION_ITEMS,
   guildWorkspacePath,
+  resolveHallTo,
   visibleGuildNavigationItems,
 } from "#src/lib/routes/app-navigation.ts";
 
@@ -55,12 +56,70 @@ describe("consumer navigation", () => {
       profilesAvailable: false,
       challengesAvailable: false,
       bucksAvailable: false,
+      hallAvailable: true,
+      expected: ["Hall of Fame"],
+    },
+    {
+      exploreAvailable: true,
+      profilesAvailable: true,
+      challengesAvailable: true,
+      bucksAvailable: true,
+      hallAvailable: true,
+      expected: [
+        "Explore",
+        "Players",
+        "Hall of Fame",
+        "Challenges",
+        "Bryan Bucks",
+      ],
+    },
+    {
+      exploreAvailable: false,
+      profilesAvailable: false,
+      challengesAvailable: false,
+      bucksAvailable: false,
       expected: [],
     },
   ])("shows only enabled member features", (input) => {
     expect(consumerNavigationItems(input).map((item) => item.label)).toEqual(
       input.expected,
     );
+  });
+
+  test("links Hall of Fame to custom path or /halls", () => {
+    expect(
+      consumerNavigationItems({
+        exploreAvailable: false,
+        profilesAvailable: false,
+        challengesAvailable: false,
+        bucksAvailable: false,
+        hallAvailable: true,
+      }),
+    ).toEqual([{ label: "Hall of Fame", to: "/halls" }]);
+
+    expect(
+      consumerNavigationItems({
+        exploreAvailable: false,
+        profilesAvailable: false,
+        challengesAvailable: false,
+        bucksAvailable: false,
+        hallAvailable: true,
+        hallTo: "/halls/123",
+      }),
+    ).toEqual([{ label: "Hall of Fame", to: "/halls/123" }]);
+  });
+
+  test("resolves Hall of Fame path based on active guild and guild count", () => {
+    expect(
+      resolveHallTo({ id: "guild-active" }, [{ id: "g1" }, { id: "g2" }]),
+    ).toBe("/halls/guild-active");
+    expect(resolveHallTo(undefined, [{ id: "solo-guild" }])).toBe(
+      "/halls/solo-guild",
+    );
+    expect(resolveHallTo(undefined, [{ id: "g1" }, { id: "g2" }])).toBe(
+      "/halls",
+    );
+    expect(resolveHallTo(undefined, [])).toBe("/halls");
   });
 });
 

--- a/packages/scout-for-lol/packages/app/src/routes/hall-of-fame.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/hall-of-fame.tsx
@@ -15,7 +15,7 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuTrigger,
-} from "@scout-for-lol/design-system/components/dropdown-menu";
+} from "@scout-for-lol/design-system/components/overlays/dropdown-menu";
 import {
   Table,
   TableBody,

--- a/packages/scout-for-lol/packages/app/src/routes/hall-of-fame.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/hall-of-fame.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "react-router";
+import { Link, Navigate, useNavigate } from "react-router";
+import { Check, ChevronsUpDown, Server } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -7,7 +8,14 @@ import {
   CardHeader,
   CardTitle,
 } from "@scout-for-lol/design-system/components/card";
-import { Badge } from "@scout-for-lol/design-system/components/badge";
+import { Button } from "@scout-for-lol/design-system/components/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@scout-for-lol/design-system/components/dropdown-menu";
 import {
   Table,
   TableBody,
@@ -24,21 +32,125 @@ function recordValue(value: number | null, precision: number): string {
   return value === null ? "—" : value.toFixed(precision);
 }
 
+function formatRecordDate(isoString: string): string {
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function HallPicker() {
+  const trpc = useTRPC();
+  const status = useQuery(
+    trpc.hall.status.queryOptions(undefined, { retry: 2 }),
+  );
+
+  if (status.isPending) {
+    return (
+      <div className="mx-auto max-w-5xl space-y-6 px-6 py-8 sm:px-8 sm:py-12">
+        <p className="text-sm text-scout-subtle">
+          Checking Hall of Fame availability…
+        </p>
+      </div>
+    );
+  }
+
+  if (status.isError) {
+    return (
+      <div className="mx-auto max-w-5xl space-y-6 px-6 py-8 sm:px-8 sm:py-12">
+        <ErrorPanel
+          title="Unable to check Hall of Fame"
+          message={status.error.message}
+          onRetry={() => {
+            void status.refetch();
+          }}
+        />
+      </div>
+    );
+  }
+
+  const guilds = status.data.state === "available" ? status.data.guilds : [];
+
+  if (guilds.length === 0) {
+    return (
+      <div className="mx-auto max-w-5xl space-y-6 px-6 py-8 sm:px-8 sm:py-12">
+        <Card>
+          <CardHeader>
+            <CardTitle>Hall of Fame unavailable</CardTitle>
+            <CardDescription>
+              Hall of Fame is not enabled in any Discord server you currently
+              share.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant="outline">
+              <Link to="/">Back to Scout</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (guilds.length === 1 && guilds[0] !== undefined) {
+    return <Navigate to={`/halls/${guilds[0].id}`} replace />;
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 px-6 py-8 sm:px-8 sm:py-12">
+      <header className="space-y-2">
+        <p className="text-sm font-medium text-primary">Guild records</p>
+        <h1 className="text-3xl font-semibold tracking-tight">Hall of Fame</h1>
+        <p className="max-w-2xl text-scout-subtle">
+          Select a server to view its single-game Hall of Fame records.
+        </p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {guilds.map((guild) => (
+          <Card key={guild.id} className="flex flex-col justify-between">
+            <CardHeader className="space-y-2">
+              <div className="flex size-10 items-center justify-center rounded-lg border border-scout-border/60 bg-scout-canvas text-sm font-semibold text-scout-ink">
+                {guild.name.slice(0, 2).toUpperCase()}
+              </div>
+              <CardTitle className="text-xl">{guild.name}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Button asChild className="w-full">
+                <Link to={`/halls/${guild.id}`}>View Hall of Fame</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function HallOfFame() {
   const { guildId } = useHallParams();
+  const navigate = useNavigate();
   const trpc = useTRPC();
   const hall = useQuery(trpc.hall.get.queryOptions({ guildId }));
+  const hallStatus = useQuery(
+    trpc.hall.status.queryOptions(undefined, { retry: 2 }),
+  );
 
   if (hall.isPending) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:py-12">
+      <div className="mx-auto max-w-5xl space-y-6 px-6 py-8 sm:px-8 sm:py-12">
         <p className="text-sm text-scout-subtle">Building the Hall…</p>
       </div>
     );
   }
   if (hall.isError) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:py-12">
+      <div className="mx-auto max-w-5xl space-y-6 px-6 py-8 sm:px-8 sm:py-12">
         <ErrorPanel
           title="Unable to load Hall of Fame"
           message={hall.error.message}
@@ -57,16 +169,55 @@ export function HallOfFame() {
     (entry) => entry.queueFamilyId,
   );
 
+  const availableGuilds =
+    hallStatus.data?.state === "available" ? hallStatus.data.guilds : [];
+  const currentGuild = availableGuilds.find((g) => g.id === guildId);
+
   return (
-    <div className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:py-12">
+    <div className="mx-auto max-w-5xl space-y-6 px-6 py-8 sm:px-8 sm:py-12">
       <header className="space-y-2">
-        <p className="text-sm font-medium text-primary">Guild records</p>
-        <h1 className="text-3xl font-semibold tracking-tight">Hall of Fame</h1>
-        <p className="max-w-2xl text-scout-subtle">
-          Best performances from completed, non-remake games Scout recorded
-          after each account began guild tracking. Customs and duels are never
-          included.
-        </p>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <p className="text-sm font-medium text-primary">
+              {currentGuild && availableGuilds.length > 1
+                ? `${currentGuild.name} records`
+                : "Guild records"}
+            </p>
+            <h1 className="text-3xl font-semibold tracking-tight">
+              Hall of Fame
+            </h1>
+          </div>
+          {availableGuilds.length > 1 && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm" className="gap-2">
+                  <Server className="size-3.5 text-scout-subtle" />
+                  <span>
+                    {currentGuild ? currentGuild.name : "Switch server"}
+                  </span>
+                  <ChevronsUpDown className="size-3.5 text-scout-subtle" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <DropdownMenuLabel>Servers</DropdownMenuLabel>
+                {availableGuilds.map((g) => (
+                  <DropdownMenuItem
+                    key={g.id}
+                    onClick={() => {
+                      void navigate(`/halls/${g.id}`);
+                    }}
+                    className="flex items-center justify-between gap-2"
+                  >
+                    <span className="truncate">{g.name}</span>
+                    {g.id === guildId && (
+                      <Check className="size-4 shrink-0 text-scout-primary" />
+                    )}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
       </header>
 
       {hall.data.settings.enabledQueueFamilies.map((familyId) => {
@@ -88,7 +239,8 @@ export function HallOfFame() {
                     <TableHead>Record</TableHead>
                     <TableHead>Value</TableHead>
                     <TableHead>Holder</TableHead>
-                    <TableHead>Status</TableHead>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Game</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -106,20 +258,73 @@ export function HallOfFame() {
                         <TableCell>
                           {entry.holders.length === 0
                             ? "—"
-                            : entry.holders
-                                .map((holder) => holder.playerAlias)
-                                .join(", ")}
+                            : entry.holders.map((holder, idx) => (
+                                <span
+                                  key={`${holder.playerId.toString()}-${holder.accountId.toString()}`}
+                                >
+                                  {idx > 0 && ", "}
+                                  <Link
+                                    to={`/players/${holder.playerId.toString()}`}
+                                    className="underline-offset-4 hover:underline"
+                                  >
+                                    {holder.playerAlias}
+                                  </Link>
+                                </span>
+                              ))}
                         </TableCell>
                         <TableCell>
-                          <Badge
-                            variant={
-                              entry.baselineStatus === "failed"
-                                ? "destructive"
-                                : "outline"
-                            }
-                          >
-                            {entry.baselineStatus}
-                          </Badge>
+                          {entry.evidence.length === 0 ? (
+                            <span className="text-scout-subtle">—</span>
+                          ) : entry.evidence.length === 1 &&
+                            entry.evidence[0] !== undefined ? (
+                            <span
+                              className="whitespace-nowrap text-sm text-scout-muted"
+                              title={new Date(
+                                entry.evidence[0].gameEndAt,
+                              ).toLocaleString()}
+                            >
+                              {formatRecordDate(entry.evidence[0].gameEndAt)}
+                            </span>
+                          ) : (
+                            <div className="flex flex-col gap-1 whitespace-nowrap text-sm text-scout-muted">
+                              {entry.evidence.map((ev) => (
+                                <span
+                                  key={`${ev.holder.playerId.toString()}-${ev.matchId}`}
+                                  title={new Date(
+                                    ev.gameEndAt,
+                                  ).toLocaleString()}
+                                  className="text-xs"
+                                >
+                                  {formatRecordDate(ev.gameEndAt)}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          {entry.evidence.length === 0 ? (
+                            <span className="text-scout-subtle">—</span>
+                          ) : entry.evidence.length === 1 &&
+                            entry.evidence[0] !== undefined ? (
+                            <Link
+                              to={`/players/${entry.evidence[0].holder.playerId.toString()}/matches/${encodeURIComponent(entry.evidence[0].matchId)}`}
+                              className="underline-offset-4 hover:underline text-primary"
+                            >
+                              View game
+                            </Link>
+                          ) : (
+                            <div className="flex flex-col gap-1">
+                              {entry.evidence.map((ev) => (
+                                <Link
+                                  key={`${ev.holder.playerId.toString()}-${ev.matchId}`}
+                                  to={`/players/${ev.holder.playerId.toString()}/matches/${encodeURIComponent(ev.matchId)}`}
+                                  className="underline-offset-4 hover:underline text-primary text-xs"
+                                >
+                                  {ev.holder.playerAlias}&apos;s game
+                                </Link>
+                              ))}
+                            </div>
+                          )}
                         </TableCell>
                       </TableRow>
                     );

--- a/packages/scout-for-lol/packages/app/src/routes/root-layout.test.ts
+++ b/packages/scout-for-lol/packages/app/src/routes/root-layout.test.ts
@@ -27,6 +27,9 @@ describe("RootLayout shell selection", () => {
 
   test("reads the selected guild from basename-relative router paths", () => {
     expect(guildIdFromAppPath("/g/123/reports")).toBe("123");
+    expect(guildIdFromAppPath("/halls/123")).toBeUndefined();
+    expect(guildIdFromAppPath("/duels/123")).toBeUndefined();
+    expect(guildIdFromAppPath("/halls")).toBeUndefined();
     expect(guildIdFromAppPath("/manage")).toBeUndefined();
   });
 

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/evaluate-match.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/evaluate-match.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import {
   HallQueueFamilyIdSchema,
   HallRecordEvidenceSchema,
@@ -16,6 +17,7 @@ import { prisma, type Db } from "#src/database/index.ts";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
 import { parseProgressionJson } from "#src/progression/json.ts";
 import { lockHallRecords } from "#src/progression/hall/baseline.ts";
+import { RETIRED_HALL_RECORD_IDS } from "#src/progression/hall/legacy-record-ids.ts";
 import { hallSettingsFromRow } from "#src/progression/hall/settings.ts";
 import {
   fetchProgressionMatches,
@@ -37,6 +39,38 @@ const HallBreakPayloadSchema = HallRecordEvidenceSchema.extend({
   holders: HallRecordHolderSchema.array(),
 });
 export const HallBreakOutboxPayloadSchema = HallBreakPayloadSchema.array();
+export type HallBreakOutboxPayload = z.infer<
+  typeof HallBreakOutboxPayloadSchema
+>;
+
+const RecordIdFieldSchema = z.object({ recordId: z.unknown() }).partial();
+
+function dropRetiredRecordIds(raw: unknown): unknown {
+  if (!Array.isArray(raw)) return raw;
+  return raw.filter((entry) => {
+    const parsed = RecordIdFieldSchema.safeParse(entry);
+    if (!parsed.success) return true;
+    const recordId = parsed.data.recordId;
+    return (
+      typeof recordId !== "string" || !RETIRED_HALL_RECORD_IDS.has(recordId)
+    );
+  });
+}
+
+/**
+ * Parse a queued Hall break-outbox payload, dropping any entry for a record
+ * id retired by a catalog rename (see {@link RETIRED_HALL_RECORD_IDS}) instead
+ * of failing on it. A pending/failed row queued before such a rename would
+ * otherwise be rejected by the narrowed enum forever. Any other unrecognized
+ * id still fails loudly through the schema below.
+ */
+export function parseHallBreakOutboxPayload(
+  payloadJson: string,
+): HallBreakOutboxPayload {
+  return HallBreakOutboxPayloadSchema.parse(
+    dropRetiredRecordIds(JSON.parse(payloadJson)),
+  );
+}
 
 function holderFor(account: TrackedAccount): HallRecordHolder {
   return HallRecordHolderSchema.parse({

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/legacy-record-ids.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/legacy-record-ids.ts
@@ -1,0 +1,13 @@
+/**
+ * Record ids retired from the competitive-progression catalog by a rename
+ * whose replacement measures something different (e.g. "largest_multikill"
+ * -> "pentakills": multikill size vs. pentakill count).
+ *
+ * Every persisted path that validates a Hall record id against the current
+ * catalog schema (guild settings, queued break-outbox payloads) must drop
+ * exactly these ids rather than relabel them, and must keep failing loudly on
+ * any other unrecognized id — that would be corrupt data, not a known rename.
+ */
+export const RETIRED_HALL_RECORD_IDS: ReadonlySet<string> = new Set([
+  "largest_multikill",
+]);

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/outbox.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/outbox.test.ts
@@ -27,10 +27,11 @@ describe("Hall record-break embeds", () => {
       }),
     );
 
-    const json = hallBreakEmbed(
-      JSON.stringify(payload),
-      "NA1_HALL_TEST",
-    ).toJSON();
+    const embed = hallBreakEmbed(JSON.stringify(payload), "NA1_HALL_TEST");
+    if (embed === null) {
+      throw new Error("Expected an embed for a payload with live record ids");
+    }
+    const json = embed.toJSON();
     const fields = json.fields ?? [];
     const totalLength =
       (json.title?.length ?? 0) +

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/outbox.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/outbox.ts
@@ -7,8 +7,7 @@ import {
 import { prisma } from "#src/database/index.ts";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
 import { send as sendChannelMessage } from "#src/league/discord/channel.ts";
-import { parseProgressionJson } from "#src/progression/json.ts";
-import { HallBreakOutboxPayloadSchema } from "#src/progression/hall/evaluate-match.ts";
+import { parseHallBreakOutboxPayload } from "#src/progression/hall/evaluate-match.ts";
 import { hallRecordBreakDeliveries } from "#src/metrics/progression.ts";
 import { loadProgressionOutboxRows } from "#src/progression/outbox.ts";
 import {
@@ -42,14 +41,17 @@ function truncateToLength(text: string, maxLength: number): string {
   return `${text.slice(0, maxLength - 3)}...`;
 }
 
+/**
+ * Builds the record-break embed, or `null` when every queued record referenced
+ * a Hall record id since retired by a catalog rename (see
+ * {@link parseHallBreakOutboxPayload}) — nothing left worth notifying about.
+ */
 export function hallBreakEmbed(
   payloadJson: string,
   matchId: string,
-): EmbedBuilder {
-  const records = parseProgressionJson(
-    payloadJson,
-    HallBreakOutboxPayloadSchema,
-  );
+): EmbedBuilder | null {
+  const records = parseHallBreakOutboxPayload(payloadJson);
+  if (records.length === 0) return null;
   const description = `Match ${escapeMarkdown(matchId)} set new guild records.`;
   const rawFields = records.map((record) => ({
     name: `${queueLabel(record.queueFamilyId)} · ${recordLabel(record.recordId)}`,
@@ -141,9 +143,23 @@ export async function deliverHallRecordBreakOutbox(): Promise<void> {
           lastError: null,
         },
       });
+      const embed = hallBreakEmbed(row.payloadJson, row.matchId);
+      if (embed === null) {
+        await completeScoutEffect(effectKey);
+        await prisma.hallRecordBreakOutbox.update({
+          where: { id: row.id },
+          data: {
+            deliveryStatus: "suppressed",
+            lastError:
+              "Every queued record referenced a Hall record id retired by a catalog rename",
+          },
+        });
+        hallRecordBreakDeliveries.inc({ status: "suppressed" });
+        continue;
+      }
       await sendChannelMessage(
         {
-          embeds: [hallBreakEmbed(row.payloadJson, row.matchId)],
+          embeds: [embed],
           allowedMentions: { parse: [] },
           nonce: discordNonce(row.id),
           enforceNonce: true,

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/settings.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/settings.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import {
   COMPETITIVE_PROGRESSION_CATALOG,
   COMPETITIVE_PROGRESSION_CATALOG_VERSION,
@@ -48,6 +49,18 @@ export function defaultHallSettings(guildId: string): HallSettings {
 }
 
 export function hallSettingsFromRow(row: HallSettingsRow): HallSettings {
+  const rawRecords = parseProgressionJson(
+    row.enabledRecords,
+    z.array(z.string()),
+  );
+  // A record id retired from the catalog (e.g. the "largest_multikill" ->
+  // "pentakills" rename) measures something different from its replacement,
+  // so a persisted legacy id is dropped rather than relabeled to the new id.
+  // The record simply falls out of the guild's enabled set until baselined
+  // again under a current id, instead of surfacing a stale or wrong value.
+  const enabledRecords = RecordArraySchema.parse(
+    rawRecords.filter((id) => HallRecordIdSchema.safeParse(id).success),
+  );
   return HallSettingsSchema.parse({
     guildId: row.guildId,
     catalogVersion: row.catalogVersion,
@@ -56,7 +69,7 @@ export function hallSettingsFromRow(row: HallSettingsRow): HallSettings {
       row.enabledQueueFamilies,
       QueueFamilyArraySchema,
     ),
-    enabledRecords: parseProgressionJson(row.enabledRecords, RecordArraySchema),
+    enabledRecords,
   });
 }
 

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/settings.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/settings.ts
@@ -19,19 +19,10 @@ import {
 } from "@scout-for-lol/temporal";
 import type { Db, ExtendedPrismaClient } from "#src/database/index.ts";
 import { parseProgressionJson } from "#src/progression/json.ts";
+import { RETIRED_HALL_RECORD_IDS } from "#src/progression/hall/legacy-record-ids.ts";
 
 const QueueFamilyArraySchema = HallQueueFamilyIdSchema.array();
 const RecordArraySchema = HallRecordIdSchema.array();
-
-/**
- * Record ids retired from the catalog by a rename whose replacement measures
- * something different (e.g. "largest_multikill" -> "pentakills": multikill
- * size vs. pentakill count). Dropped rather than relabeled so a guild never
- * shows a stale value under the new id. Any other unrecognized id still fails
- * loudly via {@link RecordArraySchema} — that is corrupt data, not a known
- * rename, and must not be silently swallowed.
- */
-const RETIRED_RECORD_IDS = new Set(["largest_multikill"]);
 
 type HallSettingsRow = {
   readonly guildId: string;
@@ -64,7 +55,7 @@ export function hallSettingsFromRow(row: HallSettingsRow): HallSettings {
     z.array(z.string()),
   );
   const enabledRecords = RecordArraySchema.parse(
-    rawRecords.filter((id) => !RETIRED_RECORD_IDS.has(id)),
+    rawRecords.filter((id) => !RETIRED_HALL_RECORD_IDS.has(id)),
   );
   return HallSettingsSchema.parse({
     guildId: row.guildId,

--- a/packages/scout-for-lol/packages/backend/src/progression/hall/settings.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/hall/settings.ts
@@ -23,6 +23,16 @@ import { parseProgressionJson } from "#src/progression/json.ts";
 const QueueFamilyArraySchema = HallQueueFamilyIdSchema.array();
 const RecordArraySchema = HallRecordIdSchema.array();
 
+/**
+ * Record ids retired from the catalog by a rename whose replacement measures
+ * something different (e.g. "largest_multikill" -> "pentakills": multikill
+ * size vs. pentakill count). Dropped rather than relabeled so a guild never
+ * shows a stale value under the new id. Any other unrecognized id still fails
+ * loudly via {@link RecordArraySchema} — that is corrupt data, not a known
+ * rename, and must not be silently swallowed.
+ */
+const RETIRED_RECORD_IDS = new Set(["largest_multikill"]);
+
 type HallSettingsRow = {
   readonly guildId: string;
   readonly catalogVersion: number;
@@ -53,13 +63,8 @@ export function hallSettingsFromRow(row: HallSettingsRow): HallSettings {
     row.enabledRecords,
     z.array(z.string()),
   );
-  // A record id retired from the catalog (e.g. the "largest_multikill" ->
-  // "pentakills" rename) measures something different from its replacement,
-  // so a persisted legacy id is dropped rather than relabeled to the new id.
-  // The record simply falls out of the guild's enabled set until baselined
-  // again under a current id, instead of surfacing a stale or wrong value.
   const enabledRecords = RecordArraySchema.parse(
-    rawRecords.filter((id) => HallRecordIdSchema.safeParse(id).success),
+    rawRecords.filter((id) => !RETIRED_RECORD_IDS.has(id)),
   );
   return HallSettingsSchema.parse({
     guildId: row.guildId,

--- a/packages/scout-for-lol/packages/backend/src/progression/progression-lake-reads.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/progression-lake-reads.ts
@@ -49,7 +49,7 @@ const ProgressionMatchRowSchema = z.strictObject({
   time_ccing_others: LakeIntSchema,
   longest_time_spent_living: LakeIntSchema,
   total_time_spent_dead: LakeIntSchema,
-  largest_multi_kill: LakeIntSchema,
+  penta_kills: LakeIntSchema,
   timeline_complete: z.boolean(),
 });
 
@@ -92,7 +92,7 @@ const MATCH_COLUMNS = [
   "m.time_ccing_others",
   "m.longest_time_spent_living",
   "m.total_time_spent_dead",
-  "m.largest_multi_kill",
+  "m.penta_kills",
 ].join(", ");
 
 function cursorPredicate(cursor: ProgressionMatchCursor | undefined): {

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/hall.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/hall.router.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/data";
+import {
+  addFlagOverride,
+  resetFlagOverrides,
+} from "#src/configuration/flags.ts";
+import { createOfflineTrpcHarness } from "#src/testing/test-trpc-caller.ts";
+
+const trpc = await createOfflineTrpcHarness("trpc-hall-test");
+const { prisma: db } = trpc;
+
+const guildId = DiscordGuildIdSchema.parse("100000000000000051");
+const otherGuildId = DiscordGuildIdSchema.parse("100000000000000052");
+const actor = DiscordAccountIdSchema.parse("300000000000000051");
+
+function caller() {
+  return trpc.authedCaller(actor);
+}
+
+describe("hall.router", () => {
+  beforeEach(() => {
+    resetFlagOverrides("hall_of_fame_enabled");
+    trpc.setMembership([
+      { guildId, asAdmin: false },
+      { guildId: otherGuildId, asAdmin: false },
+    ]);
+  });
+
+  afterAll(async () => {
+    resetFlagOverrides("hall_of_fame_enabled");
+    await db.$disconnect();
+  });
+
+  describe("hall.status", () => {
+    test("rejects an unauthenticated caller", async () => {
+      await expect(trpc.anonCaller().hall.status()).rejects.toMatchObject({
+        code: "UNAUTHORIZED",
+      });
+    });
+
+    test("returns feature_disabled when no shared guilds have Hall of Fame enabled", async () => {
+      const status = await caller().hall.status();
+      expect(status).toEqual({
+        state: "feature_disabled",
+        guilds: [],
+      });
+    });
+
+    test("returns available with only the enabled shared guilds", async () => {
+      addFlagOverride("hall_of_fame_enabled", true, { server: guildId });
+
+      const status = await caller().hall.status();
+      expect(status).toEqual({
+        state: "available",
+        guilds: [
+          {
+            id: guildId,
+            name: "test-guild",
+            icon: null,
+          },
+        ],
+      });
+    });
+
+    test("returns all enabled shared guilds for multi-guild players", async () => {
+      addFlagOverride("hall_of_fame_enabled", true, { server: guildId });
+      addFlagOverride("hall_of_fame_enabled", true, { server: otherGuildId });
+
+      const status = await caller().hall.status();
+      expect(status).toEqual({
+        state: "available",
+        guilds: [
+          {
+            id: guildId,
+            name: "test-guild",
+            icon: null,
+          },
+          {
+            id: otherGuildId,
+            name: "test-guild",
+            icon: null,
+          },
+        ],
+      });
+    });
+
+    test("returns no_shared_guild when member shares no guilds where Scout is installed", async () => {
+      trpc.setMembership([]);
+      const status = await caller().hall.status();
+      expect(status).toEqual({
+        state: "no_shared_guild",
+        guilds: [],
+      });
+    });
+  });
+
+  describe("hall.get", () => {
+    test("throws NOT_FOUND if Hall of Fame is disabled for the guild", async () => {
+      await expect(caller().hall.get({ guildId })).rejects.toMatchObject({
+        code: "NOT_FOUND",
+        message: "Hall of Fame is unavailable",
+      });
+    });
+
+    test("returns hall data when enabled for member", async () => {
+      addFlagOverride("hall_of_fame_enabled", true, { server: guildId });
+      const result = await caller().hall.get({ guildId });
+      expect(result.settings.guildId).toBe(guildId);
+      expect(result.catalog).toBeDefined();
+      expect(result.entries).toEqual([]);
+    });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/hall.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/hall.router.ts
@@ -22,11 +22,17 @@ import {
 } from "#src/trpc/guild-permission.ts";
 import { assertChannelInGuild } from "#src/trpc/guild-guard.ts";
 import { router, webProcedure } from "#src/trpc/trpc.ts";
+import { client as discordClient } from "#src/discord/client.ts";
+import { isDevGuildOverrideGuild } from "#src/lib/discord-rest.ts";
+import { fetchUserGuildsForRequest } from "#src/trpc/discord-upstream.ts";
 
 const GuildInputSchema = z.strictObject({ guildId: DiscordGuildIdSchema });
 
 async function assertHallEnabled(guildId: DiscordGuildId): Promise<void> {
-  if (!(await isPolicyEnabled("hall_of_fame_enabled", { server: guildId }))) {
+  if (
+    !(await isPolicyEnabled("hall_of_fame_enabled", { server: guildId })) &&
+    !isDevGuildOverrideGuild(guildId)
+  ) {
     throw new TRPCError({
       code: "NOT_FOUND",
       message: "Hall of Fame is unavailable",
@@ -35,6 +41,42 @@ async function assertHallEnabled(guildId: DiscordGuildId): Promise<void> {
 }
 
 export const hallRouter = router({
+  status: webProcedure.query(async ({ ctx }) => {
+    const userGuilds = await fetchUserGuildsForRequest(ctx.user);
+    const botGuildIds = new Set(discordClient.guilds.cache.map((g) => g.id));
+    const present = userGuilds.filter(
+      (g) => botGuildIds.has(g.id) || isDevGuildOverrideGuild(g.id),
+    );
+    if (present.length === 0) {
+      return { state: "no_shared_guild", guilds: [] } as const;
+    }
+    const evaluations = await Promise.all(
+      present.map(async (guild) => {
+        const guildId = DiscordGuildIdSchema.parse(guild.id);
+        const enabled =
+          (await isPolicyEnabled("hall_of_fame_enabled", {
+            server: guildId,
+          })) || isDevGuildOverrideGuild(guild.id);
+        return { guild, enabled };
+      }),
+    );
+    const enabledGuilds = evaluations.flatMap((evaluation) =>
+      evaluation.enabled ? [evaluation.guild] : [],
+    );
+
+    if (enabledGuilds.length === 0) {
+      return { state: "feature_disabled", guilds: [] } as const;
+    }
+
+    return {
+      state: "available",
+      guilds: enabledGuilds.map((g) => ({
+        id: g.id,
+        name: g.name,
+        icon: g.icon,
+      })),
+    } as const;
+  }),
   get: webProcedure.input(GuildInputSchema).query(async ({ ctx, input }) => {
     await assertHallEnabled(input.guildId);
     await resolveGuildPermissions(ctx.user, input.guildId);

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/hall.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/hall.router.ts
@@ -22,8 +22,8 @@ import {
 } from "#src/trpc/guild-permission.ts";
 import { assertChannelInGuild } from "#src/trpc/guild-guard.ts";
 import { router, webProcedure } from "#src/trpc/trpc.ts";
-import { client as discordClient } from "#src/discord/client.ts";
 import { isDevGuildOverrideGuild } from "#src/lib/discord-rest.ts";
+import { installedGuildIdsAmong } from "#src/lib/discord/installed-guilds.ts";
 import { fetchUserGuildsForRequest } from "#src/trpc/discord-upstream.ts";
 
 const GuildInputSchema = z.strictObject({ guildId: DiscordGuildIdSchema });
@@ -43,9 +43,11 @@ async function assertHallEnabled(guildId: DiscordGuildId): Promise<void> {
 export const hallRouter = router({
   status: webProcedure.query(async ({ ctx }) => {
     const userGuilds = await fetchUserGuildsForRequest(ctx.user);
-    const botGuildIds = new Set(discordClient.guilds.cache.map((g) => g.id));
+    const installedGuildIds = await installedGuildIdsAmong(
+      userGuilds.map((g) => g.id),
+    );
     const present = userGuilds.filter(
-      (g) => botGuildIds.has(g.id) || isDevGuildOverrideGuild(g.id),
+      (g) => installedGuildIds.has(g.id) || isDevGuildOverrideGuild(g.id),
     );
     if (present.length === 0) {
       return { state: "no_shared_guild", guilds: [] } as const;

--- a/packages/scout-for-lol/packages/data/competitive-progression-catalog.json
+++ b/packages/scout-for-lol/packages/data/competitive-progression-catalog.json
@@ -96,8 +96,8 @@
         "precision": 0
       },
       {
-        "id": "largest_multikill",
-        "label": "Largest multikill",
+        "id": "pentakills",
+        "label": "Most pentakills",
         "unit": "count",
         "precision": 0
       },

--- a/packages/scout-for-lol/packages/data/src/model/progression/catalog.ts
+++ b/packages/scout-for-lol/packages/data/src/model/progression/catalog.ts
@@ -23,7 +23,7 @@ export type HallQueueFamilyId = z.infer<typeof HallQueueFamilyIdSchema>;
 export const HallRecordIdSchema = z.enum([
   "kills",
   "assists",
-  "largest_multikill",
+  "pentakills",
   "champion_damage",
   "champion_damage_per_minute",
   "damage_taken",

--- a/packages/scout-for-lol/packages/data/src/model/progression/hall.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/progression/hall.test.ts
@@ -86,7 +86,7 @@ function matchRow(): MatchLakeRow {
     double_kills: 2,
     triple_kills: 1,
     quadra_kills: 0,
-    penta_kills: 0,
+    penta_kills: 2,
     largest_multi_kill: 3,
     killing_sprees: 2,
     first_blood_kill: true,
@@ -152,7 +152,7 @@ describe("Hall of Fame domain", () => {
     const expected = {
       kills: 14,
       assists: 17,
-      largest_multikill: 3,
+      pentakills: 2,
       champion_damage: 30_000,
       champion_damage_per_minute: 1000,
       damage_taken: 22_000,
@@ -230,5 +230,34 @@ describe("Hall of Fame domain", () => {
         candidate(holderTwo, 11),
       ),
     ).toMatchObject({ kind: "break", value: 11, holders: [holderTwo] });
+  });
+
+  test("pentakills record requires at least one pentakill", () => {
+    const zeroPenta: HallCandidate = {
+      queueFamilyId: "ranked_sr",
+      recordId: "pentakills",
+      value: 0,
+      holder: holderOne,
+      evidence: {
+        matchId: "match-penta-0",
+        gameEndAt: "2026-01-01T00:30:00.000Z",
+        value: 0,
+        holder: holderOne,
+      },
+    };
+    expect(compareHallCandidate(null, [], [], zeroPenta)).toEqual({
+      kind: "below",
+    });
+
+    const onePenta: HallCandidate = {
+      ...zeroPenta,
+      value: 1,
+      evidence: { ...zeroPenta.evidence, value: 1 },
+    };
+    expect(compareHallCandidate(null, [], [], onePenta)).toMatchObject({
+      kind: "break",
+      value: 1,
+      holders: [holderOne],
+    });
   });
 });

--- a/packages/scout-for-lol/packages/data/src/model/progression/hall.ts
+++ b/packages/scout-for-lol/packages/data/src/model/progression/hall.ts
@@ -90,8 +90,8 @@ export type HallRecordMatch = Pick<
   | "game_duration_seconds"
   | "gold_earned"
   | "kills"
-  | "largest_multi_kill"
   | "longest_time_spent_living"
+  | "penta_kills"
   | "time_ccing_others"
   | "total_damage_dealt_to_champions"
   | "total_damage_taken"
@@ -143,8 +143,8 @@ function rawHallRecordValue(
       return match.kills;
     case "assists":
       return match.assists;
-    case "largest_multikill":
-      return match.largest_multi_kill;
+    case "pentakills":
+      return match.penta_kills;
     case "champion_damage":
       return match.total_damage_dealt_to_champions;
     case "champion_damage_per_minute":
@@ -199,6 +199,9 @@ export function compareHallCandidate(
   currentEvidence: HallRecordEvidence[],
   candidate: HallCandidate,
 ): HallComparison {
+  if (candidate.recordId === "pentakills" && candidate.value <= 0) {
+    return { kind: "below" };
+  }
   if (currentValue !== null && candidate.value < currentValue) {
     return { kind: "below" };
   }


### PR DESCRIPTION
## Why

Players need a direct way to view single-game server records in Scout for League of Legends across their shared Discord servers, inspect the specific match evidence and dates for each record, and navigate between server Halls without exposing server administration controls or redundant selectors to single-guild players.

## What

- Add Hall of Fame entry to consumer sidebar navigation (`ToolsNavigationSection`) with multi-guild considerations (nested server sub-links only when belonging to >1 enabled guild).
- Add consumer routes `/halls` (landing with server selector cards or direct redirect) and `/halls/:guildId` (single-game records table).
- Isolate `guildIdFromAppPath` to `/^\/g\/([^/]+)/` so consumer tool routes do not mount `ServerManagementSection`.
- Hide `WorkspaceSwitcherSection` in the sidebar and the server dropdown in the Hall header when the user only has <= 1 guild.
- Standardize the Hall of Fame container to `mx-auto max-w-5xl space-y-6 px-6 py-8 sm:px-8 sm:py-12`, matching `/explore` and `/players`.
- Replace `largest_multikill` with `pentakills` ("Most pentakills") across catalog, backend lake reads, and comparators (requiring >= 1 pentakill).
- Add a "Date" column and link records to player match details (`/players/:id/matches/:matchId`).
- Hide internal `baselineStatus` from end users.
- Add backend `hallRouter.status` endpoint for discovering shared enabled guilds, and unit tests for `hall.router.ts`.

## Verification

- Focused unit tests:
  - `bun test src/routes/consumer/consumer-workspace.test.ts` (14 passing)
  - `bun test src/routes/root-layout.test.ts` (5 passing)
  - `bun test` in `@scout-for-lol/app` (520 passing)
  - `bun test` in `@scout-for-lol/data` (1,523 passing)
  - `bun test src/trpc/router/hall.router.test.ts` (7 passing)
- Lint and typecheck:
  - `bun run lint` in `@scout-for-lol/app` (346 modules clean)
  - `bunx turbo run build typecheck test lint --filter=@scout-for-lol/app --filter=@scout-for-lol/backend --filter=@scout-for-lol/data` (all tasks green)
  - `bunx lefthook run pre-commit` (all pre-commit safety & package-quality checks green)
- Live checks not run:
  - Production deployment and live Discord bot verification not run locally.