### PR TITLE
feat(scout-for-lol): dual-write v1 match facts

### DIFF
--- a/packages/scout-for-lol/packages/backend/README.md
+++ b/packages/scout-for-lol/packages/backend/README.md
@@ -59,6 +59,48 @@ bun run temporal:requeue-work -- \
 `db:generate` must run after schema changes and before typecheck/test; from the
 Scout root, `mise run generate` does the same thing.
 
+## Durable match facts
+
+`src/durable/match/` holds the typed services the per-match pipeline calls.
+Each one runs an injected v1 operation — archive, settlement, progression,
+delivery, workflow start — and then records what that operation did in the
+durable tables (`MatchObservation`, `MatchTrackedAccount`,
+`MatchProcessingReceipt`, `MatchNotificationIntent`, `ScoutWorkflowStart`).
+
+The pipeline remains authoritative for behaviour. Every durable write is
+fail-open: it can never throw into the pipeline, so a recorder outage cannot
+stall ingestion or suppress a report. `ScoutEffectClaim` is still the
+at-most-once Discord delivery guard; a notification intent is a record of what
+that guard let through, keyed by the same string so the two describe the same
+send.
+
+Receipt evidence names things by durable identity — Discord message ids, ledger
+row ids, object key plus content digest — never by a count or a local path, so
+a reader can go find what the receipt attests to. No evidence carries a money
+amount; the identities locate the ledger rows and the amounts live there under
+the storable Bucks brands. The `raw-archive` and `lake-staging` receipt kinds
+belong to the receipted lake projection in `report-lake/`, which records them
+from the writer that knows the artifact's key and digest.
+
+Two metrics carry the parity signal, both defined once in
+`src/metrics/durable.ts` — prom-client throws at import time on a duplicate
+metric name, so a second definition site takes the process down on boot rather
+than at the first `inc()`:
+
+- `scout_durable_dualwrite_records_total{write_kind, outcome}` — facts
+  recorded, by repository answer (`applied`, `already-applied`, `adopted`,
+  `conflict`).
+- `scout_durable_dualwrite_failures_total{write_kind}` — writes that failed and
+  were swallowed. Non-zero means the durable record is behind what the pipeline
+  actually did. These failures deliberately do not reach Sentry: an outage
+  would raise one event per write per channel per match and bury the errors
+  that actually stop work.
+
+Both are per-write counters incremented by whichever runtime role executed the
+write, so a parity dashboard joins across roles rather than reading one
+process. Neither is derived from a database sweep, so neither belongs in
+`getMetrics()`'s `databaseMetricSweepsEnabled()` block.
+
 ## Beta Customs operations
 
 Scout Customs reuses this process's Discord gateway client, OAuth client

--- a/packages/scout-for-lol/packages/backend/architecture-fixtures/durable-imports-betting.ts
+++ b/packages/scout-for-lol/packages/backend/architecture-fixtures/durable-imports-betting.ts
@@ -1,0 +1,4 @@
+// Deliberate violation of durable-services-take-their-dependencies-as-arguments.
+import "#src/betting/markets/postmatch-hook.ts";
+
+export const illegalDurableDependency = true;

--- a/packages/scout-for-lol/packages/backend/architecture.config.ts
+++ b/packages/scout-for-lol/packages/backend/architecture.config.ts
@@ -55,6 +55,7 @@ const layers = [
   "configuration",
   "database",
   "discord",
+  "durable",
   "explore",
   "http",
   "league",
@@ -171,6 +172,22 @@ export default defineArchitecture({
         "utils",
         "configuration",
       ),
+    },
+    {
+      name: "durable-services-take-their-dependencies-as-arguments",
+      comment:
+        "`durable/` holds the typed match services the v1 pipeline calls: they run an injected " +
+        "operation and record what it did in the durable tables, whose repositories and row " +
+        "codecs sit under `database/durable/`. Every feature they coordinate — settlement, " +
+        "progression, delivery, workflow starts — arrives as a callback, so the layer stays " +
+        "callable from a Temporal Activity, a backfill script or a test without dragging a " +
+        "Discord client or a Riot fetcher in behind it. Importing a feature slice directly is " +
+        "what would end that, so only the persistence and metric layers are reachable from " +
+        "here. Note the name is about durability, not about the `application` RUNTIME ROLE in " +
+        "`configuration/runtime-role.ts`: these services run under whichever role executes the " +
+        "write, which is usually a worker.",
+      from: "durable",
+      to: everythingExcept("durable", "database", "metrics"),
     },
     {
       name: "analytics-reads-the-database-and-nothing-else",

--- a/packages/scout-for-lol/packages/backend/src/durable/match/archive-facts.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/archive-facts.ts
@@ -1,0 +1,238 @@
+import type { Db } from "#src/database/index.ts";
+import {
+  S3ObjectKeySchema,
+  Sha256DigestSchema,
+  type IsoInstant,
+  type RiotMatchId,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import { LeaguePuuidSchema } from "@scout-for-lol/domain/identity/league-account.ts";
+import {
+  AccountIdSchema,
+  PlayerIdSchema,
+} from "@scout-for-lol/domain/identity/database-ids.ts";
+import { observeMatch } from "#src/database/durable/observation-repository.ts";
+import { recordTrackedAccounts } from "#src/database/durable/tracked-account-repository.ts";
+import type { MatchTrackedAccountRecord } from "#src/database/durable/tracked-account-row.ts";
+import type { StoredArtifactReference } from "#src/database/durable/observation-row.ts";
+import {
+  recordDurableWrite,
+  resolveDurableIdentity,
+  type DurableFacts,
+} from "#src/durable/match/durable-facts.ts";
+import {
+  isoInstantFromEpochMs,
+  platformRouteOf,
+  toIsoInstant,
+  toRiotMatchId,
+} from "#src/durable/match/match-identity.ts";
+
+/**
+ * The archive-request service: the typed boundary around v1's authoritative
+ * archive step, which writes the canonical raw match to the object store and
+ * stages it into the derived report lake.
+ *
+ * The service runs the v1 archive exactly as before and records what it
+ * observed afterwards. Ordering matters: the durable facts are written only
+ * once the archive has actually succeeded, so a match with an observation row
+ * is a match whose raw payload really is canonical. A failure in `archive`
+ * propagates untouched — it is the cursor gate, and swallowing it would lose
+ * the match.
+ *
+ * What this service does NOT write is the `raw-archive` and `lake-staging`
+ * receipts. Those belong to the receipted lake projection, which records them
+ * from the writers that produce the artifact and therefore know its object key
+ * and content digest. Here we only place the observation those receipts hang
+ * off, and stamp the observation's artifact reference when the archive hands
+ * one back.
+ */
+
+/**
+ * What the v1 archive step reports back about one match.
+ *
+ * `artifact` is the raw payload's durable identity — object key plus content
+ * digest. Today's v1 writer returns neither, so it is absent and the
+ * observation's artifact columns stay NULL, which is exactly what NULL means
+ * there. A writer that does return a descriptor passes it through and the
+ * observation carries the identity instead.
+ */
+export type MatchArchiveOutcome = {
+  readonly staged: boolean;
+  readonly stored: boolean;
+  readonly artifact?: { readonly key: string; readonly digest: string };
+};
+
+export type ArchivedMatchFacts = {
+  /** v1's loose match id; parsed to a RiotMatchId inside the boundary. */
+  readonly matchId: string;
+  /** Riot's `info.gameCreation`, epoch milliseconds. */
+  readonly gameCreation: number;
+  /** Every tracked account seen in the match, by PUUID. */
+  readonly trackedPuuids: readonly string[];
+  /** v1's ingest source label, e.g. `postmatch_live`. */
+  readonly source: string;
+};
+
+/**
+ * Snapshot the registration behind each tracked PUUID.
+ *
+ * A PUUID can be registered in several guilds, so it has several `Account`
+ * rows, while the association's grain is one row per (match, PUUID). The
+ * lowest account id is the deterministic representative of that PUUID's
+ * registration; a PUUID with no row at all stays NULL, which is exactly what
+ * the column means.
+ */
+async function registrationsByPuuid(
+  db: Db,
+  puuids: readonly string[],
+): Promise<Map<string, { accountId: number; playerId: number }>> {
+  const accounts = await db.account.findMany({
+    where: { puuid: { in: [...puuids] } },
+    select: { id: true, playerId: true, puuid: true },
+    orderBy: { id: "asc" },
+  });
+  const byPuuid = new Map<string, { accountId: number; playerId: number }>();
+  for (const account of accounts) {
+    if (byPuuid.has(account.puuid)) continue;
+    byPuuid.set(account.puuid, {
+      accountId: account.id,
+      playerId: account.playerId,
+    });
+  }
+  return byPuuid;
+}
+
+async function trackedAccountRecords(
+  db: Db,
+  matchId: RiotMatchId,
+  puuids: readonly string[],
+): Promise<MatchTrackedAccountRecord[]> {
+  const registrations = await registrationsByPuuid(db, puuids);
+  return puuids.map((puuid) => {
+    const registration = registrations.get(puuid);
+    return {
+      matchId,
+      puuid: LeaguePuuidSchema.parse(puuid),
+      playerId:
+        registration === undefined
+          ? null
+          : PlayerIdSchema.parse(registration.playerId),
+      accountId:
+        registration === undefined
+          ? null
+          : AccountIdSchema.parse(registration.accountId),
+      cursorAdvancedAt: null,
+    };
+  });
+}
+
+/**
+ * The raw payload's durable identity, parsed. NULL when the archive writer
+ * returned none — never a key reconstructed from the layout convention, which
+ * would be evidence of nothing.
+ */
+function artifactReference(
+  artifact: MatchArchiveOutcome["artifact"],
+): StoredArtifactReference | null {
+  if (artifact === undefined) return null;
+  return {
+    key: S3ObjectKeySchema.parse(artifact.key),
+    digest: Sha256DigestSchema.parse(artifact.digest),
+  };
+}
+
+type ObservationArgs = {
+  facts: DurableFacts;
+  matchId: RiotMatchId;
+  match: ArchivedMatchFacts;
+  observedAt: IsoInstant;
+  artifact: StoredArtifactReference | null;
+};
+
+async function recordObservation(args: ObservationArgs): Promise<void> {
+  const { facts, matchId, match } = args;
+  await recordDurableWrite(facts, "observation", async (db) =>
+    observeMatch(db, {
+      matchId,
+      platformRoute: platformRouteOf(matchId),
+      // The normal per-match pipeline runs every downstream effect, so the
+      // policy is FULL even for a silent backfill: suppressing the Discord
+      // report does not make the match archive-only.
+      policy: "FULL",
+      owner: { kind: "legacy-v1" },
+      // Born FULL, so there is no promotion to record.
+      promotion: null,
+      gameCreatedAt: isoInstantFromEpochMs(match.gameCreation),
+      observedAt: args.observedAt,
+      // The timeline is fetched conditionally and by a different path, so this
+      // service never has its identity to record.
+      artifacts: { match: args.artifact, timeline: null },
+    }),
+  );
+
+  await recordDurableWrite(facts, "tracked-accounts", async (db) => {
+    const records = await trackedAccountRecords(
+      db,
+      matchId,
+      match.trackedPuuids,
+    );
+    const written = await recordTrackedAccounts(db, records);
+    // The repository counts rows rather than answering with an outcome: a
+    // batch that wrote nothing new is the association already being recorded.
+    return { outcome: written.recorded > 0 ? "applied" : "already-applied" };
+  });
+}
+
+/**
+ * Record that this pipeline saw the match and which accounts it tracked in it,
+ * without attesting to an archive.
+ *
+ * This is the path for a match whose archive effect was already completed by
+ * an earlier run: v1 skips the archive entirely, so there is no fresh artifact
+ * identity to stamp, but the observation and the account associations are
+ * still true — and the cursor advance that follows needs them to exist.
+ */
+export async function recordObservedMatch(args: {
+  facts: DurableFacts;
+  match: ArchivedMatchFacts;
+}): Promise<void> {
+  const matchId = resolveDurableIdentity(() =>
+    toRiotMatchId(args.match.matchId),
+  );
+  if (matchId === null) return;
+  await recordObservation({
+    facts: args.facts,
+    matchId,
+    match: args.match,
+    observedAt: toIsoInstant(args.facts.now()),
+    artifact: null,
+  });
+}
+
+/**
+ * Run v1's authoritative archive for one match and record what it did.
+ *
+ * The returned value is `archive`'s own, unchanged, so the caller's gate logic
+ * reads exactly as it did before this bridge existed.
+ */
+export async function requestMatchArchive(args: {
+  facts: DurableFacts;
+  match: ArchivedMatchFacts;
+  archive: () => Promise<MatchArchiveOutcome>;
+}): Promise<MatchArchiveOutcome> {
+  const outcome = await args.archive();
+  const matchId = resolveDurableIdentity(() =>
+    toRiotMatchId(args.match.matchId),
+  );
+  if (matchId === null) return outcome;
+  const artifact = resolveDurableIdentity(() =>
+    artifactReference(outcome.artifact),
+  );
+  await recordObservation({
+    facts: args.facts,
+    matchId,
+    match: args.match,
+    observedAt: toIsoInstant(args.facts.now()),
+    artifact,
+  });
+  return outcome;
+}

--- a/packages/scout-for-lol/packages/backend/src/durable/match/delivery-intents.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/delivery-intents.ts
@@ -1,0 +1,322 @@
+import { createHash } from "node:crypto";
+import {
+  DiscordMessageIdSchema,
+  NotificationIntentKeySchema,
+  type RiotMatchId,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/domain/identity/discord.ts";
+import {
+  NotificationAttemptNonceSchema,
+  type NotificationAttemptNonce,
+  type NotificationFailure,
+} from "@scout-for-lol/domain/notifications/intent.ts";
+import {
+  beginSend,
+  confirmDelivered,
+  markReady,
+  recordFailure,
+} from "@scout-for-lol/domain/notifications/intent-transitions.ts";
+import { recordReceipt } from "#src/database/durable/receipt-repository.ts";
+import {
+  transitionIntent,
+  upsertIntent,
+} from "#src/database/durable/intent-repository.ts";
+import {
+  recordDurableWrite,
+  resolveDurableIdentity,
+  type DurableFacts,
+} from "#src/durable/match/durable-facts.ts";
+import {
+  toIsoInstant,
+  toRiotMatchId,
+} from "#src/durable/match/match-identity.ts";
+import {
+  buildMatchReceipt,
+  deliveryEvidence,
+  deliveryEvidenceCodec,
+  MATCH_RECEIPT_KINDS,
+  type DeliveredMessage,
+} from "#src/durable/match/receipt-evidence.ts";
+
+/**
+ * The notification-intent service: a durable record of every Discord send the
+ * v1 pipeline performs for a match.
+ *
+ * This wave RECORDS; it does not guard. On the post-match path the existing
+ * `ScoutEffectClaim` rows remain the authoritative at-most-once delivery
+ * guard, and the intent key is deliberately the same string as that claim's
+ * effect key, so a later wave can promote the intent to the guard without
+ * re-keying anything already stored. The attempt nonce uses the same recipe
+ * for the same reason, and `deliverToChannels` now calls this helper rather
+ * than repeating the hash inline, so the nonce Discord sees under
+ * `enforceNonce` and the nonce the intent records cannot disagree.
+ *
+ * The pre-match path has no effect claim and sends no nonce to Discord — the
+ * ActiveGame row is what stops a second detection from re-notifying — so its
+ * keys and nonces are durable identifiers only, built the same way so both
+ * paths read alike.
+ */
+
+/**
+ * Discord's `nonce` field is limited to 25 characters, which is where the
+ * slice comes from; base64url keeps it to characters Discord accepts.
+ */
+export function deliveryAttemptNonce(effectKey: string): string {
+  return createHash("sha256")
+    .update(effectKey)
+    .digest("base64url")
+    .slice(0, 25);
+}
+
+export type ChannelDeliveryEvent =
+  | { kind: "prepared"; channelId: string }
+  | { kind: "send-started"; channelId: string }
+  | { kind: "delivered"; channelId: string; messageId: string }
+  | { kind: "failed"; channelId: string; permissionError: boolean };
+
+export type ChannelDeliveryRecorder = (
+  event: ChannelDeliveryEvent,
+) => Promise<void>;
+
+/**
+ * v1 distinguishes exactly one send failure from all the others: a Discord
+ * permission error. That maps cleanly onto the domain's terminal
+ * `permission-denied`; everything else is recorded as the generic retryable
+ * class, because v1 has no finer taxonomy to record and guessing one would
+ * put invented evidence in the table.
+ */
+function failureOf(permissionError: boolean): NotificationFailure {
+  return permissionError
+    ? { classification: "terminal", reason: "permission-denied" }
+    : { classification: "retryable", reason: "service-unavailable" };
+}
+
+type RecorderConfig = {
+  facts: DurableFacts;
+  matchId: RiotMatchId;
+  /**
+   * The shared prefix of the delivery's effect keys — `postmatch-discord:<id>`
+   * or `prematch-discord:<id>`. One intent key per channel is built from it.
+   */
+  keyPrefix: string;
+  /** Sending after this instant is a conflict; the intent is stale. */
+  freshnessDeadline: Date;
+};
+
+function intentKeyFor(config: RecorderConfig, channelId: string): string {
+  return `${config.keyPrefix}:${channelId}`;
+}
+
+function attemptNonceFor(
+  config: RecorderConfig,
+  channelId: string,
+): NotificationAttemptNonce {
+  return NotificationAttemptNonceSchema.parse(
+    deliveryAttemptNonce(intentKeyFor(config, channelId)),
+  );
+}
+
+async function createIntent(
+  config: RecorderConfig,
+  channelId: string,
+): Promise<void> {
+  const key = NotificationIntentKeySchema.parse(
+    intentKeyFor(config, channelId),
+  );
+  // A re-delivery after an ambiguous claim upserts the same key with a fresh
+  // creation instant, which the repository answers with `intent-differs`. That
+  // is the intended outcome: the stored intent is the one that counts, and the
+  // transitions below then move that original row.
+  await recordDurableWrite(config.facts, "intent-created", async (db) =>
+    upsertIntent(db, {
+      matchId: config.matchId,
+      intent: {
+        key,
+        target: {
+          kind: "channel",
+          channelId: DiscordChannelIdSchema.parse(channelId),
+        },
+        freshnessDeadline: toIsoInstant(config.freshnessDeadline),
+        createdAt: toIsoInstant(config.facts.now()),
+        attemptCount: 0,
+        state: { kind: "pending" },
+      },
+    }),
+  );
+  await recordDurableWrite(config.facts, "intent-ready", async (db) =>
+    transitionIntent(db, { intentKey: key, transition: markReady }),
+  );
+}
+
+async function applyIntentTransition(
+  config: RecorderConfig,
+  channelId: string,
+  kind: "intent-send-started" | "intent-delivered" | "intent-failed",
+  transition: Parameters<typeof transitionIntent>[1]["transition"],
+): Promise<void> {
+  const key = NotificationIntentKeySchema.parse(
+    intentKeyFor(config, channelId),
+  );
+  await recordDurableWrite(config.facts, kind, async (db) =>
+    transitionIntent(db, { intentKey: key, transition }),
+  );
+}
+
+/**
+ * Build a recorder for one delivery pass.
+ *
+ * The recorder remembers which channels actually began a send, so a failure
+ * raised before the send — a claim lookup that threw, say — is not recorded as
+ * a failed attempt that never happened.
+ */
+export function createChannelDeliveryRecorder(
+  config: RecorderConfig,
+): ChannelDeliveryRecorder {
+  const started = new Set<string>();
+  return async (event) => {
+    switch (event.kind) {
+      case "prepared":
+        await createIntent(config, event.channelId);
+        return;
+      case "send-started": {
+        started.add(event.channelId);
+        const nonce = attemptNonceFor(config, event.channelId);
+        await applyIntentTransition(
+          config,
+          event.channelId,
+          "intent-send-started",
+          (intent) =>
+            beginSend(intent, {
+              attemptNonce: nonce,
+              startedAt: toIsoInstant(config.facts.now()),
+            }),
+        );
+        return;
+      }
+      case "delivered": {
+        const nonce = attemptNonceFor(config, event.channelId);
+        await applyIntentTransition(
+          config,
+          event.channelId,
+          "intent-delivered",
+          (intent) =>
+            confirmDelivered(intent, {
+              attemptNonce: nonce,
+              messageId: DiscordMessageIdSchema.parse(event.messageId),
+              deliveredAt: toIsoInstant(config.facts.now()),
+            }),
+        );
+        return;
+      }
+      case "failed": {
+        if (!started.has(event.channelId)) return;
+        const nonce = attemptNonceFor(config, event.channelId);
+        await applyIntentTransition(
+          config,
+          event.channelId,
+          "intent-failed",
+          (intent) =>
+            recordFailure(intent, {
+              attemptNonce: nonce,
+              failure: failureOf(event.permissionError),
+            }),
+        );
+        return;
+      }
+      default: {
+        const exhaustive: never = event;
+        return exhaustive;
+      }
+    }
+  };
+}
+
+/**
+ * Build a delivery recorder for one match, or `null` when the v1 match id
+ * cannot be a durable identity — in which case the delivery runs exactly as it
+ * did before, unrecorded, and the parity metric carries the loss.
+ */
+export function tryCreateChannelDeliveryRecorder(args: {
+  facts: DurableFacts;
+  matchId: string;
+  keyPrefix: string;
+  freshnessDeadline: Date;
+}): ChannelDeliveryRecorder | null {
+  const matchId = resolveDurableIdentity(() => toRiotMatchId(args.matchId));
+  if (matchId === null) return null;
+  return createChannelDeliveryRecorder({
+    facts: args.facts,
+    matchId,
+    keyPrefix: args.keyPrefix,
+    freshnessDeadline: args.freshnessDeadline,
+  });
+}
+
+/**
+ * Group the Discord messages this delivery produced by the guild they landed
+ * in. Built from the channels that were targeted and came back with a message
+ * id, so a delivery receipt's evidence describes delivery rather than intent,
+ * and names each message by the id Discord itself will answer for.
+ */
+export function deliveredMessagesByGuild(
+  channels: readonly { channel: string; serverId: string }[],
+  messageIdsByChannel: ReadonlyMap<string, string>,
+): Map<string, DeliveredMessage[]> {
+  const byGuild = new Map<string, DeliveredMessage[]>();
+  for (const { channel, serverId } of channels) {
+    const messageId = messageIdsByChannel.get(channel);
+    if (messageId === undefined) continue;
+    byGuild.set(serverId, [
+      ...(byGuild.get(serverId) ?? []),
+      { channelId: channel, messageId },
+    ]);
+  }
+  return byGuild;
+}
+
+/**
+ * Record one delivery receipt per guild that received the match's message.
+ *
+ * Receipt scope is global, guild or account, so a per-channel receipt is not
+ * representable; the guild is the audience the receipt describes, and the
+ * evidence names every message delivered inside it. The intents carry the same
+ * message ids per channel, so the two can be reconciled against each other and
+ * against Discord.
+ */
+export async function recordDeliveryReceipts(args: {
+  facts: DurableFacts;
+  kind: "reportDelivery" | "prematchDelivery";
+  matchId: string;
+  messagesByGuild: ReadonlyMap<string, readonly DeliveredMessage[]>;
+}): Promise<void> {
+  const matchId = resolveDurableIdentity(() => toRiotMatchId(args.matchId));
+  if (matchId === null) return;
+  const writeKind =
+    args.kind === "reportDelivery"
+      ? "receipt-report-delivery"
+      : "receipt-prematch-delivery";
+  const recordedAt = toIsoInstant(args.facts.now());
+
+  for (const [guildId, delivered] of args.messagesByGuild) {
+    await recordDurableWrite(args.facts, writeKind, async (db) =>
+      recordReceipt(
+        db,
+        buildMatchReceipt({
+          matchId,
+          kind: MATCH_RECEIPT_KINDS[args.kind],
+          scope: {
+            kind: "guild",
+            guildId: DiscordGuildIdSchema.parse(guildId),
+          },
+          recordedAt,
+          evidence: deliveryEvidenceCodec.serialize(
+            deliveryEvidence(delivered),
+          ),
+        }),
+      ),
+    );
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/durable/match/dualwrite.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/dualwrite.integration.test.ts
@@ -1,0 +1,519 @@
+import { afterAll, describe, expect, test } from "vitest";
+import {
+  NotificationIntentKeySchema,
+  type NotificationIntentKey,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+  testPuuid,
+} from "#src/testing/test-ids.ts";
+import {
+  getObservation,
+  getProcessingState,
+} from "#src/database/durable/observation-repository.ts";
+import { listReceipts } from "#src/database/durable/receipt-repository.ts";
+import { listTrackedAccounts } from "#src/database/durable/tracked-account-repository.ts";
+import { getIntent } from "#src/database/durable/intent-repository.ts";
+import { getWorkflowStart } from "#src/database/durable/workflow-start-repository.ts";
+import { scoutDurableDualwriteFailuresTotal } from "#src/metrics/durable.ts";
+import type { DurableFacts } from "#src/durable/match/durable-facts.ts";
+import {
+  recordObservedMatch,
+  requestMatchArchive,
+} from "#src/durable/match/archive-facts.ts";
+import { commitMatchSettlement } from "#src/durable/match/settlement-facts.ts";
+import {
+  recordCursorAdvanced,
+  runMatchProgressionStage,
+} from "#src/durable/match/progression-facts.ts";
+import {
+  createChannelDeliveryRecorder,
+  deliveredMessagesByGuild,
+  deliveryAttemptNonce,
+  recordDeliveryReceipts,
+} from "#src/durable/match/delivery-intents.ts";
+import { withRecordedWorkflowStart } from "#src/durable/match/workflow-start-facts.ts";
+import {
+  deliveryEvidenceCodec,
+  settlementEvidenceCodec,
+  type SettlementEvidence,
+} from "#src/durable/match/receipt-evidence.ts";
+import { toRiotMatchId } from "#src/durable/match/match-identity.ts";
+
+const { prisma } = createTestDatabase("durable-dualwrite");
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+const NOW = new Date("2026-09-12T10:00:00.000Z");
+const GAME_CREATION = Date.parse("2026-09-12T09:00:00.000Z");
+const FRESHNESS_DEADLINE = new Date("2026-09-12T12:00:00.000Z");
+
+const REGISTERED_PUUID = testPuuid("registered");
+const UNREGISTERED_PUUID = testPuuid("stranger");
+const OWNER_ID = testAccountId("9000");
+const GUILD_ONE = testGuildId("9001");
+const GUILD_TWO = testGuildId("9002");
+const CHANNEL_ONE = testChannelId("9001");
+const CHANNEL_TWO = testChannelId("9002");
+const MESSAGE_ID = "300000000000000001";
+
+const facts: DurableFacts = { db: prisma, now: () => NOW };
+
+function matchId(gameId: number): string {
+  return `NA1_${String(gameId)}`;
+}
+
+/** The intent key one channel's send is recorded under. */
+function intentKey(
+  keyPrefix: string,
+  channelId: string,
+): NotificationIntentKey {
+  return NotificationIntentKeySchema.parse(`${keyPrefix}:${channelId}`);
+}
+
+/**
+ * A client whose durable tables are unreachable. Every other model still
+ * works, so a test can prove the v1 path is unaffected while the durable
+ * writes fail.
+ */
+function databaseWithBrokenDurableTables(): ExtendedPrismaClient {
+  return new Proxy(prisma, {
+    get(target, property) {
+      if (typeof property === "string" && property.startsWith("match")) {
+        throw new Error("durable table is unreachable");
+      }
+      return Reflect.get(target, property);
+    },
+  });
+}
+
+async function failureCount(writeKind: string): Promise<number> {
+  const metric = await scoutDurableDualwriteFailuresTotal.get();
+  return (
+    metric.values.find((value) => value.labels.write_kind === writeKind)
+      ?.value ?? 0
+  );
+}
+
+async function seedRegisteredAccount(): Promise<{
+  playerId: number;
+  accountId: number;
+}> {
+  const player = await prisma.player.create({
+    data: {
+      alias: "registered",
+      serverId: GUILD_ONE,
+      creatorDiscordId: OWNER_ID,
+      createdTime: NOW,
+      updatedTime: NOW,
+    },
+  });
+  const account = await prisma.account.create({
+    data: {
+      alias: "registered",
+      puuid: REGISTERED_PUUID,
+      region: "AMERICA_NORTH",
+      playerId: player.id,
+      serverId: GUILD_ONE,
+      creatorDiscordId: OWNER_ID,
+      createdTime: NOW,
+      updatedTime: NOW,
+    },
+  });
+  return { playerId: player.id, accountId: account.id };
+}
+
+const SETTLEMENT_EVIDENCE: SettlementEvidence = {
+  closedBetIds: [11, 12],
+  settledBetIds: [21],
+  resolvedDareIds: [31, 32],
+  settledParlayGuildIds: [GUILD_TWO],
+  earnedDiscordIds: [OWNER_ID],
+};
+
+describe("a v1 match-processing pass", () => {
+  test("records the observation and the tracked accounts", async () => {
+    const registration = await seedRegisteredAccount();
+    const id = matchId(9001);
+
+    const archived = await requestMatchArchive({
+      facts,
+      match: {
+        matchId: id,
+        gameCreation: GAME_CREATION,
+        trackedPuuids: [REGISTERED_PUUID, UNREGISTERED_PUUID],
+        source: "postmatch_live",
+      },
+      archive: async () => ({ staged: true, stored: true }),
+    });
+
+    // The v1 caller gets its own value back untouched; the gate still reads
+    // exactly as it did before the bridge existed.
+    expect(archived).toEqual({ staged: true, stored: true });
+
+    const state = await getProcessingState(prisma, {
+      matchId: toRiotMatchId(id),
+    });
+    expect(state?.policy).toBe("FULL");
+    expect(state?.owner).toEqual({ kind: "legacy-v1" });
+    expect(state?.promotion).toBeNull();
+
+    const tracked = await listTrackedAccounts(prisma, {
+      matchId: toRiotMatchId(id),
+    });
+    expect(tracked).toHaveLength(2);
+    expect(tracked.find((row) => row.puuid === REGISTERED_PUUID)).toMatchObject(
+      {
+        playerId: registration.playerId,
+        accountId: registration.accountId,
+        cursorAdvancedAt: null,
+      },
+    );
+    expect(
+      tracked.find((row) => row.puuid === UNREGISTERED_PUUID),
+    ).toMatchObject({ playerId: null, accountId: null });
+
+    // `raw-archive` and `lake-staging` belong to the receipted lake
+    // projection, which records them from the writer that knows the object
+    // key and digest. This service places only the observation they hang off.
+    expect(state?.receipts).toEqual([]);
+  });
+
+  test("stamps the observation with the artifact identity when the archive returns one", async () => {
+    const id = matchId(9005);
+    const key = "games/2026/09/12/NA1_9005/match.json";
+    const digest = "b".repeat(64);
+
+    await requestMatchArchive({
+      facts,
+      match: {
+        matchId: id,
+        gameCreation: GAME_CREATION,
+        trackedPuuids: [REGISTERED_PUUID],
+        source: "postmatch_live",
+      },
+      archive: async () => ({
+        staged: true,
+        stored: true,
+        artifact: { key, digest },
+      }),
+    });
+
+    const observation = await getObservation(prisma, {
+      matchId: toRiotMatchId(id),
+    });
+    expect(observation?.artifacts.match).toEqual({ key, digest });
+    expect(observation?.artifacts.timeline).toBeNull();
+  });
+
+  test("records the observation alone when the archive was already completed", async () => {
+    const id = matchId(9004);
+    await recordObservedMatch({
+      facts,
+      match: {
+        matchId: id,
+        gameCreation: GAME_CREATION,
+        trackedPuuids: [REGISTERED_PUUID],
+        source: "postmatch_live",
+      },
+    });
+
+    const state = await getProcessingState(prisma, {
+      matchId: toRiotMatchId(id),
+    });
+    expect(state?.owner).toEqual({ kind: "legacy-v1" });
+    expect(
+      await listTrackedAccounts(prisma, { matchId: toRiotMatchId(id) }),
+    ).toHaveLength(1);
+
+    const observation = await getObservation(prisma, {
+      matchId: toRiotMatchId(id),
+    });
+    // No archive ran this pass, so there is no artifact identity to stamp.
+    expect(observation?.artifacts.match).toBeNull();
+  });
+
+  test("records the settlement receipt naming the ledger rows it moved", async () => {
+    const id = matchId(9002);
+    const settled = await commitMatchSettlement({
+      facts,
+      matchId: id,
+      settle: async () => ({ announced: true }),
+      evidence: () => SETTLEMENT_EVIDENCE,
+    });
+    expect(settled).toEqual({ announced: true });
+
+    const receipts = await listReceipts(prisma, { matchId: toRiotMatchId(id) });
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0]?.receipt.scope).toEqual({ kind: "global" });
+    expect(
+      settlementEvidenceCodec.parse(
+        JSON.parse(receipts[0]?.evidence ?? "null"),
+      ),
+    ).toEqual(SETTLEMENT_EVIDENCE);
+  });
+
+  test("records the progression receipt and each account's cursor advance", async () => {
+    const id = matchId(9003);
+    await requestMatchArchive({
+      facts,
+      match: {
+        matchId: id,
+        gameCreation: GAME_CREATION,
+        trackedPuuids: [REGISTERED_PUUID],
+        source: "postmatch_live",
+      },
+      archive: async () => ({ staged: true, stored: true }),
+    });
+
+    await runMatchProgressionStage({
+      facts,
+      matchId: id,
+      evidence: { participantCount: 10, trackedAccountCount: 1 },
+      advance: async () => "progressed",
+    });
+    await recordCursorAdvanced({ facts, matchId: id, puuid: REGISTERED_PUUID });
+
+    const receipts = await listReceipts(prisma, { matchId: toRiotMatchId(id) });
+    expect(receipts.map((entry) => entry.receipt.kind)).toContain(
+      "progression",
+    );
+
+    const tracked = await listTrackedAccounts(prisma, {
+      matchId: toRiotMatchId(id),
+    });
+    expect(tracked[0]?.cursorAdvancedAt).toBe(NOW.toISOString());
+  });
+});
+
+describe("the fail-open boundary", () => {
+  test("a broken durable repository leaves the v1 pass unaffected", async () => {
+    const id = matchId(9010);
+    const before = await failureCount("observation");
+
+    const archived = await requestMatchArchive({
+      facts: { db: databaseWithBrokenDurableTables(), now: () => NOW },
+      match: {
+        matchId: id,
+        gameCreation: GAME_CREATION,
+        trackedPuuids: [REGISTERED_PUUID],
+        source: "postmatch_live",
+      },
+      archive: async () => ({ staged: true, stored: false }),
+    });
+
+    // v1's own result is returned, and nothing about the pass changed.
+    expect(archived).toEqual({ staged: true, stored: false });
+    expect(await failureCount("observation")).toBe(before + 1);
+    expect(
+      await getProcessingState(prisma, { matchId: toRiotMatchId(id) }),
+    ).toBeNull();
+  });
+
+  test("a match id that cannot be a durable identity is counted, not thrown", async () => {
+    const before = await failureCount("match-identity");
+    const settled = await commitMatchSettlement({
+      facts,
+      matchId: "not-a-riot-match-id",
+      settle: async () => "settled anyway",
+      evidence: () => SETTLEMENT_EVIDENCE,
+    });
+    expect(settled).toBe("settled anyway");
+    expect(await failureCount("match-identity")).toBe(before + 1);
+  });
+});
+
+describe("notification intents", () => {
+  test("records a delivered send through its whole lifecycle", async () => {
+    const id = matchId(9020);
+    const keyPrefix = `postmatch-discord:${id}`;
+    const record = createChannelDeliveryRecorder({
+      facts,
+      matchId: toRiotMatchId(id),
+      keyPrefix,
+      freshnessDeadline: FRESHNESS_DEADLINE,
+    });
+
+    await record({ kind: "prepared", channelId: CHANNEL_ONE });
+    await record({ kind: "send-started", channelId: CHANNEL_ONE });
+    await record({
+      kind: "delivered",
+      channelId: CHANNEL_ONE,
+      messageId: MESSAGE_ID,
+    });
+
+    const stored = await getIntent(prisma, {
+      intentKey: intentKey(keyPrefix, CHANNEL_ONE),
+    });
+    expect(stored?.intent.target).toEqual({
+      kind: "channel",
+      channelId: CHANNEL_ONE,
+    });
+    expect(stored?.intent.attemptCount).toBe(1);
+    expect(stored?.intent.state).toEqual({
+      kind: "delivered",
+      messageId: MESSAGE_ID,
+      deliveredAt: NOW.toISOString(),
+    });
+  });
+
+  test("the recorded attempt nonce is the one v1 sends to Discord", async () => {
+    const id = matchId(9021);
+    const keyPrefix = `postmatch-discord:${id}`;
+    const effectKey = `${keyPrefix}:${CHANNEL_ONE}`;
+    const record = createChannelDeliveryRecorder({
+      facts,
+      matchId: toRiotMatchId(id),
+      keyPrefix,
+      freshnessDeadline: FRESHNESS_DEADLINE,
+    });
+
+    await record({ kind: "prepared", channelId: CHANNEL_ONE });
+    await record({ kind: "send-started", channelId: CHANNEL_ONE });
+
+    const stored = await getIntent(prisma, {
+      intentKey: NotificationIntentKeySchema.parse(effectKey),
+    });
+    expect(stored?.intent.state).toEqual({
+      kind: "sending",
+      attemptNonce: deliveryAttemptNonce(effectKey),
+      startedAt: NOW.toISOString(),
+    });
+  });
+
+  test("records a permission failure as a terminal denial", async () => {
+    const id = matchId(9022);
+    const keyPrefix = `prematch-discord:${id}`;
+    const record = createChannelDeliveryRecorder({
+      facts,
+      matchId: toRiotMatchId(id),
+      keyPrefix,
+      freshnessDeadline: FRESHNESS_DEADLINE,
+    });
+
+    await record({ kind: "prepared", channelId: CHANNEL_ONE });
+    await record({ kind: "send-started", channelId: CHANNEL_ONE });
+    await record({
+      kind: "failed",
+      channelId: CHANNEL_ONE,
+      permissionError: true,
+    });
+
+    const stored = await getIntent(prisma, {
+      intentKey: intentKey(keyPrefix, CHANNEL_ONE),
+    });
+    expect(stored?.intent.state).toEqual({ kind: "permission-denied" });
+    expect(stored?.intent.lastFailure).toEqual({
+      classification: "terminal",
+      reason: "permission-denied",
+    });
+  });
+
+  test("a failure raised before the send records no attempt", async () => {
+    const id = matchId(9023);
+    const keyPrefix = `postmatch-discord:${id}`;
+    const record = createChannelDeliveryRecorder({
+      facts,
+      matchId: toRiotMatchId(id),
+      keyPrefix,
+      freshnessDeadline: FRESHNESS_DEADLINE,
+    });
+
+    await record({ kind: "prepared", channelId: CHANNEL_ONE });
+    await record({
+      kind: "failed",
+      channelId: CHANNEL_ONE,
+      permissionError: false,
+    });
+
+    const stored = await getIntent(prisma, {
+      intentKey: intentKey(keyPrefix, CHANNEL_ONE),
+    });
+    expect(stored?.intent.state).toEqual({ kind: "ready" });
+    expect(stored?.intent.attemptCount).toBe(0);
+  });
+
+  test("records one delivery receipt per guild, naming the messages it delivered", async () => {
+    const id = matchId(9024);
+    // CHANNEL_TWO was targeted but came back without a message id, so its
+    // guild received nothing and gets no receipt.
+    const messages = deliveredMessagesByGuild(
+      [
+        { channel: CHANNEL_ONE, serverId: GUILD_ONE },
+        { channel: CHANNEL_TWO, serverId: GUILD_TWO },
+      ],
+      new Map([[CHANNEL_ONE, MESSAGE_ID]]),
+    );
+    expect([...messages.keys()]).toEqual([GUILD_ONE]);
+
+    await recordDeliveryReceipts({
+      facts,
+      kind: "reportDelivery",
+      matchId: id,
+      messagesByGuild: messages,
+    });
+
+    const receipts = await listReceipts(prisma, { matchId: toRiotMatchId(id) });
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0]?.receipt.kind).toBe("report-delivery");
+    expect(receipts[0]?.receipt.scope).toEqual({
+      kind: "guild",
+      guildId: GUILD_ONE,
+    });
+    // The evidence names the Discord message, so the receipt can be checked
+    // against Discord rather than merely counted.
+    expect(
+      deliveryEvidenceCodec.parse(JSON.parse(receipts[0]?.evidence ?? "null")),
+    ).toEqual({
+      deliveries: [{ channelId: CHANNEL_ONE, messageId: MESSAGE_ID }],
+    });
+  });
+});
+
+describe("workflow starts", () => {
+  test("records the request before the start and the acceptance after", async () => {
+    const requestedWorkflowId = "scout-detached-work-parlay-9030";
+    const observed: string[] = [];
+
+    const handle = await withRecordedWorkflowStart({
+      facts,
+      request: {
+        requestedWorkflowId,
+        workflowType: "scoutDetachedWork",
+        requestSource: "detached-work:parlay-generation",
+        requestedBy: null,
+        input: { workId: "parlay:NA1_9030" },
+      },
+      start: async () => {
+        const pending = await getWorkflowStart(prisma, {
+          requestedWorkflowId,
+        });
+        observed.push(pending?.acceptance === null ? "requested" : "accepted");
+        return { firstExecutionRunId: "run-9030" };
+      },
+      runIdOf: (started) => started.firstExecutionRunId,
+    });
+
+    expect(handle).toEqual({ firstExecutionRunId: "run-9030" });
+    // The request row already existed while the start was in flight.
+    expect(observed).toEqual(["requested"]);
+
+    const stored = await getWorkflowStart(prisma, { requestedWorkflowId });
+    expect(stored?.workflowType).toBe("scoutDetachedWork");
+    expect(stored?.inputPayload).toEqual({
+      kind: "scoutDetachedWork",
+      version: 1,
+      data: { workId: "parlay:NA1_9030" },
+    });
+    expect(stored?.acceptance).toEqual({
+      acceptedAt: NOW.toISOString(),
+      runId: "run-9030",
+    });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/durable/match/durable-facts.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/durable-facts.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+import type { Db } from "#src/database/index.ts";
+import { createLogger } from "#src/logger.ts";
+import {
+  scoutDurableDualwriteFailuresTotal,
+  scoutDurableDualwriteRecordsTotal,
+} from "#src/metrics/durable.ts";
+
+/**
+ * The fail-open boundary every durable dual-write goes through.
+ *
+ * This wave makes Postgres the operational RECORD of what the v1 pipeline
+ * does, while v1 remains authoritative for behaviour. That asymmetry is the
+ * whole contract of this module: a durable write that throws must never reach
+ * the pipeline, because the pipeline's own error handling is what decides
+ * whether a cursor advances or a report is retried. A broken recorder would
+ * otherwise be able to block ingestion, which is exactly the failure mode the
+ * durable tables exist to remove.
+ *
+ * Swallowing is not silence. Every failure logs loudly and increments
+ * `scout_durable_dualwrite_failures_total{write_kind}`, so parity loss is
+ * visible in the place the acceptance checks will look.
+ */
+
+const logger = createLogger("durable-dualwrite");
+
+/**
+ * Every durable write the bridge performs, spelled out so the metric's
+ * `write_kind` label can never grow unbounded. A new dual-write site adds a
+ * member here rather than passing a free-form string.
+ */
+export const DURABLE_WRITE_KINDS = [
+  "match-identity",
+  "observation",
+  "tracked-accounts",
+  "cursor-advanced",
+  "receipt-settlement",
+  "receipt-report-delivery",
+  "receipt-prematch-delivery",
+  "receipt-progression",
+  "intent-created",
+  "intent-ready",
+  "intent-send-started",
+  "intent-delivered",
+  "intent-failed",
+  "workflow-start-requested",
+  "workflow-start-accepted",
+] as const;
+
+export type DurableWriteKind = (typeof DURABLE_WRITE_KINDS)[number];
+
+/**
+ * The answers the durable repositories give. Parsed rather than trusted so a
+ * repository that grows a new outcome shows up as a loud dual-write failure
+ * instead of quietly widening a Prometheus label.
+ */
+const DurableWriteOutcomeSchema = z.enum([
+  "applied",
+  "already-applied",
+  "adopted",
+  "conflict",
+]);
+
+/**
+ * What a durable write needs: the database handle to write through, and the
+ * clock to stamp facts with. Both are injected so a caller already inside a v1
+ * transaction can pass that transaction's client, and so tests can pin time.
+ */
+export type DurableFacts = {
+  readonly db: Db;
+  readonly now: () => Date;
+};
+
+/**
+ * Failures are reported through the log and the metric, never through Sentry.
+ *
+ * Sentry is where the pipeline's own broken invariants go, and a recorder that
+ * cannot reach its tables is not one of those: a durable outage would raise an
+ * event per write per channel per match, drowning the errors that actually
+ * stop work. `scout_durable_dualwrite_failures_total` is the signal an alert
+ * watches, and it stays legible under exactly the outage that produces it.
+ */
+function reportDurableWriteFailure(
+  kind: DurableWriteKind,
+  error: unknown,
+): void {
+  scoutDurableDualwriteFailuresTotal.inc({ write_kind: kind });
+  logger.error(
+    `❌ Durable dual-write ${kind} failed; the authoritative v1 pipeline continues unaffected`,
+    error,
+  );
+}
+
+/**
+ * Run one durable write behind the fail-open boundary.
+ *
+ * `write` returns the repository's own answer, which is what the records
+ * counter reports. Identity parsing belongs INSIDE `write` so a malformed v1
+ * value is counted as this write's failure rather than escaping to the
+ * pipeline.
+ */
+export async function recordDurableWrite(
+  facts: DurableFacts,
+  kind: DurableWriteKind,
+  write: (db: Db) => Promise<{ outcome: string }>,
+): Promise<void> {
+  try {
+    const result = await write(facts.db);
+    const outcome = DurableWriteOutcomeSchema.parse(result.outcome);
+    scoutDurableDualwriteRecordsTotal.inc({ write_kind: kind, outcome });
+  } catch (error) {
+    reportDurableWriteFailure(kind, error);
+  }
+}
+
+/**
+ * Parse a branded identity out of a looser v1 value behind the same fail-open
+ * boundary. `null` means "record nothing for this match": the durable facts
+ * are keyed by that identity, so without it there is nothing truthful to
+ * write. No record is counted, because resolving an identity is not itself a
+ * recorded fact — only the failure is.
+ */
+export function resolveDurableIdentity<T>(resolve: () => T): T | null {
+  try {
+    return resolve();
+  } catch (error) {
+    reportDurableWriteFailure("match-identity", error);
+    return null;
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/durable/match/live-facts.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/live-facts.ts
@@ -1,0 +1,15 @@
+import { prisma } from "#src/database/index.ts";
+import type { DurableFacts } from "#src/durable/match/durable-facts.ts";
+
+/**
+ * The recorder the running pipeline uses: the process's Prisma client and the
+ * wall clock.
+ *
+ * It lives apart from the services so that importing a service never pulls the
+ * database singleton in behind it — a caller already holding a transaction
+ * client passes that instead, and a test passes its own client and a pinned
+ * clock.
+ */
+export function liveDurableFacts(): DurableFacts {
+  return { db: prisma, now: () => new Date() };
+}

--- a/packages/scout-for-lol/packages/backend/src/durable/match/match-identity.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/match-identity.ts
@@ -1,0 +1,44 @@
+import {
+  IsoInstantSchema,
+  RiotMatchIdSchema,
+  type IsoInstant,
+  type RiotMatchId,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  PlatformRouteSchema,
+  type PlatformRoute,
+} from "@scout-for-lol/domain/identity/routes.ts";
+
+/**
+ * Identity conversions between the v1 pipeline's loose values and the durable
+ * tables' branded ones.
+ *
+ * v1's `MatchId` is an unvalidated branded string and its instants are `Date`s;
+ * the durable tables take {@link RiotMatchId} and {@link IsoInstant}. Every
+ * conversion here parses rather than casts, and every call sits inside the
+ * dual-write fail-open boundary, so a v1 value that cannot be a durable
+ * identity is recorded as a parity failure instead of breaking the pipeline.
+ */
+
+export function toRiotMatchId(value: string): RiotMatchId {
+  return RiotMatchIdSchema.parse(value);
+}
+
+/**
+ * The platform prefix of a Riot match id. `MatchObservationRecordSchema` also
+ * cross-checks the two, so a route derived any other way would be rejected —
+ * deriving it from the id is the only way they can agree by construction.
+ */
+export function platformRouteOf(matchId: RiotMatchId): PlatformRoute {
+  const [platform] = matchId.split("_");
+  return PlatformRouteSchema.parse(platform);
+}
+
+export function toIsoInstant(value: Date): IsoInstant {
+  return IsoInstantSchema.parse(value.toISOString());
+}
+
+/** Riot reports game creation as epoch milliseconds. */
+export function isoInstantFromEpochMs(epochMs: number): IsoInstant {
+  return toIsoInstant(new Date(epochMs));
+}

--- a/packages/scout-for-lol/packages/backend/src/durable/match/progression-facts.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/progression-facts.ts
@@ -1,0 +1,81 @@
+import { LeaguePuuidSchema } from "@scout-for-lol/domain/identity/league-account.ts";
+import { recordReceipt } from "#src/database/durable/receipt-repository.ts";
+import { markTrackedAccountCursorAdvanced } from "#src/database/durable/tracked-account-repository.ts";
+import {
+  recordDurableWrite,
+  resolveDurableIdentity,
+  type DurableFacts,
+} from "#src/durable/match/durable-facts.ts";
+import {
+  toIsoInstant,
+  toRiotMatchId,
+} from "#src/durable/match/match-identity.ts";
+import {
+  buildMatchReceipt,
+  MATCH_RECEIPT_KINDS,
+  progressionEvidenceCodec,
+} from "#src/durable/match/receipt-evidence.ts";
+
+/**
+ * The progression-stage service and the cursor-advance record.
+ *
+ * Both live here because they are one step in the v1 flow: progression is the
+ * last durable hook before a match stops being re-processed, and the cursor
+ * advance immediately follows it inside the same advisory lock. Recording the
+ * cursor advance next to v1's own `updateLastProcessedMatch` — rather than in
+ * its own pass — is what makes the durable row a faithful record of when the
+ * match stopped being replayable.
+ *
+ * v1 advances cursors through the global client rather than the advisory
+ * lock's transaction client, so these writes do the same. Moving them into
+ * that transaction would change when the cursor write becomes visible, which
+ * is a behaviour change this wave must not make.
+ */
+
+export async function runMatchProgressionStage<T>(args: {
+  facts: DurableFacts;
+  /** v1's loose match id; parsed to a RiotMatchId inside the boundary. */
+  matchId: string;
+  evidence: { participantCount: number; trackedAccountCount: number };
+  advance: () => Promise<T>;
+}): Promise<T> {
+  const advanced = await args.advance();
+  const matchId = resolveDurableIdentity(() => toRiotMatchId(args.matchId));
+  if (matchId === null) return advanced;
+
+  await recordDurableWrite(args.facts, "receipt-progression", async (db) =>
+    recordReceipt(
+      db,
+      buildMatchReceipt({
+        matchId,
+        kind: MATCH_RECEIPT_KINDS.progression,
+        scope: { kind: "global" },
+        recordedAt: toIsoInstant(args.facts.now()),
+        evidence: progressionEvidenceCodec.serialize(args.evidence),
+      }),
+    ),
+  );
+  return advanced;
+}
+
+/**
+ * Record that this match advanced one tracked account's processing cursor.
+ * The repository guard is monotonic, so a delayed retry can never rewind an
+ * advance that already moved past this match.
+ */
+export async function recordCursorAdvanced(args: {
+  facts: DurableFacts;
+  matchId: string;
+  puuid: string;
+}): Promise<void> {
+  const matchId = resolveDurableIdentity(() => toRiotMatchId(args.matchId));
+  if (matchId === null) return;
+
+  await recordDurableWrite(args.facts, "cursor-advanced", async (db) =>
+    markTrackedAccountCursorAdvanced(db, {
+      matchId,
+      puuid: LeaguePuuidSchema.parse(args.puuid),
+      advancedAt: toIsoInstant(args.facts.now()),
+    }),
+  );
+}

--- a/packages/scout-for-lol/packages/backend/src/durable/match/receipt-evidence.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/receipt-evidence.ts
@@ -1,0 +1,189 @@
+import { z } from "zod";
+import { defineVersionedCodec } from "@scout-for-lol/domain/codec/versioned.ts";
+import {
+  DiscordMessageIdSchema,
+  type IsoInstant,
+  type RiotMatchId,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  DiscordAccountIdSchema,
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/domain/identity/discord.ts";
+import {
+  ReceiptKindSchema,
+  type ReceiptKind,
+  type ReceiptScope,
+} from "@scout-for-lol/domain/match-processing/states.ts";
+import type { MatchProcessingReceiptRecord } from "#src/database/durable/receipt-row.ts";
+
+/**
+ * The closed set of receipt kinds the v1 dual-write bridge records, and the
+ * versioned evidence each one carries.
+ *
+ * The domain deliberately leaves {@link ReceiptKindSchema} open — it is a
+ * kebab-case brand, not an enum — because receipt kinds belong to the pipeline
+ * that produces them, not to the shared contracts. This module is that
+ * pipeline's declaration for the effects the per-match flow owns.
+ *
+ * `raw-archive` and `lake-staging` are deliberately ABSENT. The receipted lake
+ * projection owns those two kinds and records them from the writers that
+ * actually produce the artifact, which is the only place the object key and
+ * content digest exist. Recording them here as well would put two different
+ * evidence shapes behind one receipt identity, and the second writer would
+ * lose to `receipt-evidence-mismatch`.
+ *
+ * Evidence identifies what happened by DURABLE identity — Discord message ids,
+ * ledger row ids — never by a count, a local path, or a build id, so a reader
+ * can go find the thing the receipt attests to. It is also always what the v1
+ * call site actually observed; nothing here is reconstructed after the fact.
+ * No evidence carries a money amount: the identities are enough to find the
+ * ledger rows, and the amounts live there under their own storable brands.
+ */
+
+export const MATCH_RECEIPT_KINDS = {
+  /** Markets, parlays and Dares settled for the match; balances moved. */
+  settlement: ReceiptKindSchema.parse("settlement"),
+  /** The visible post-match report reached a guild. */
+  reportDelivery: ReceiptKindSchema.parse("report-delivery"),
+  /** The pre-match notification reached a guild. */
+  prematchDelivery: ReceiptKindSchema.parse("prematch-delivery"),
+  /** Competitive progression ran for the match, before cursors advanced. */
+  progression: ReceiptKindSchema.parse("progression"),
+} as const satisfies Record<string, ReceiptKind>;
+
+/** A BucksBet or BucksDareV2 primary key — the ledger's own row identity. */
+const LedgerRowIdSchema = z.int().positive();
+
+/**
+ * Settlement evidence names the ledger rows the commit touched, keeping market
+ * settlement and Dare resolution apart. They are different products with
+ * different semantics — a Dare moves balances between two people, a market
+ * settles a pool — and the Scout boundaries forbid collapsing them.
+ *
+ * Weekly parlays carry no per-bet row id out of the settle call, so they are
+ * identified by the guild whose parlay settled; earnings are identified by the
+ * account awarded, which together with the receipt's match id names the ledger
+ * rows exactly. Every list is sorted and deduplicated so a replay of the same
+ * commit produces byte-identical evidence.
+ */
+export const settlementEvidenceCodec = defineVersionedCodec({
+  kind: "settlement-evidence",
+  version: 1,
+  schema: z.strictObject({
+    closedBetIds: z.array(LedgerRowIdSchema),
+    settledBetIds: z.array(LedgerRowIdSchema),
+    resolvedDareIds: z.array(LedgerRowIdSchema),
+    settledParlayGuildIds: z.array(DiscordGuildIdSchema),
+    earnedDiscordIds: z.array(DiscordAccountIdSchema),
+  }),
+});
+
+/**
+ * Delivery evidence names the Discord messages that exist because of this
+ * match, so the receipt can be checked against Discord itself. Sorted by
+ * channel so a replay produces byte-identical evidence.
+ */
+export const deliveryEvidenceCodec = defineVersionedCodec({
+  kind: "delivery-evidence",
+  version: 1,
+  schema: z.strictObject({
+    deliveries: z.array(
+      z.strictObject({
+        channelId: DiscordChannelIdSchema,
+        messageId: DiscordMessageIdSchema,
+      }),
+    ),
+  }),
+});
+
+/**
+ * The progression stage returns nothing identifying — a challenge-run revision
+ * id never leaves `processCompetitiveProgressionMatch` — so this receipt
+ * records the shape of the input it ran over rather than inventing an identity
+ * for an effect it cannot see.
+ */
+export const progressionEvidenceCodec = defineVersionedCodec({
+  kind: "progression-evidence",
+  version: 1,
+  schema: z.strictObject({
+    participantCount: z.int().nonnegative(),
+    trackedAccountCount: z.int().nonnegative(),
+  }),
+});
+
+export type SettlementEvidence = Parameters<
+  typeof settlementEvidenceCodec.serialize
+>[0];
+export type DeliveryEvidence = Parameters<
+  typeof deliveryEvidenceCodec.serialize
+>[0];
+export type ProgressionEvidence = Parameters<
+  typeof progressionEvidenceCodec.serialize
+>[0];
+
+/** One delivered Discord message, before it is parsed into evidence. */
+export type DeliveredMessage = { channelId: string; messageId: string };
+
+/**
+ * Parse and canonicalize a guild's delivered messages. Sorting here rather
+ * than at each call site is what makes a replayed delivery's evidence compare
+ * equal instead of conflicting.
+ */
+export function deliveryEvidence(
+  delivered: readonly DeliveredMessage[],
+): DeliveryEvidence {
+  const deliveries = delivered
+    .map((entry) => ({
+      channelId: DiscordChannelIdSchema.parse(entry.channelId),
+      messageId: DiscordMessageIdSchema.parse(entry.messageId),
+    }))
+    .toSorted((left, right) => left.channelId.localeCompare(right.channelId));
+  return { deliveries };
+}
+
+/** Sort and deduplicate an identity list so replayed evidence compares equal. */
+export function canonicalIdentities<T extends string | number>(
+  values: readonly T[],
+): T[] {
+  return [...new Set(values)].toSorted((left, right) =>
+    String(left).localeCompare(String(right)),
+  );
+}
+
+/**
+ * The receipt table's `evidence` column: the codec envelope, serialized. Kept
+ * here so every producer writes the same wire form the reader expects.
+ */
+export function serializeEvidence(envelope: {
+  kind: string;
+  version: number;
+  data: unknown;
+}): string {
+  return JSON.stringify(envelope);
+}
+
+/**
+ * Build one receipt record. Every receipt this bridge writes is version 1;
+ * the version is part of a receipt's identity, so bumping it is how a future
+ * wave records the same fact under a changed meaning without colliding with
+ * the rows already stored.
+ */
+export function buildMatchReceipt(args: {
+  matchId: RiotMatchId;
+  kind: ReceiptKind;
+  scope: ReceiptScope;
+  recordedAt: IsoInstant;
+  evidence: { kind: string; version: number; data: unknown };
+}): MatchProcessingReceiptRecord {
+  return {
+    matchId: args.matchId,
+    receipt: {
+      kind: args.kind,
+      version: 1,
+      scope: args.scope,
+      recordedAt: args.recordedAt,
+    },
+    evidence: serializeEvidence(args.evidence),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/durable/match/settlement-facts.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/settlement-facts.ts
@@ -1,0 +1,56 @@
+import { recordReceipt } from "#src/database/durable/receipt-repository.ts";
+import {
+  recordDurableWrite,
+  resolveDurableIdentity,
+  type DurableFacts,
+} from "#src/durable/match/durable-facts.ts";
+import {
+  toIsoInstant,
+  toRiotMatchId,
+} from "#src/durable/match/match-identity.ts";
+import {
+  buildMatchReceipt,
+  MATCH_RECEIPT_KINDS,
+  settlementEvidenceCodec,
+  type SettlementEvidence,
+} from "#src/durable/match/receipt-evidence.ts";
+
+/**
+ * The settlement-commit service, which is also the Dare resolution boundary.
+ *
+ * Both happen in the same v1 call: closing pools, settling markets and
+ * parlays, awarding earnings, and resolving Dares all commit together before
+ * anything is announced. The receipt therefore covers the whole commit, and
+ * its evidence keeps the counts separate — a Dare resolution and a market
+ * settlement are different products and must not be collapsed into one number.
+ *
+ * The receipt is recorded only after the commit returns. A settlement that
+ * throws leaves no receipt, which is correct: nothing was committed, and the
+ * next pass re-settles.
+ */
+
+export async function commitMatchSettlement<T>(args: {
+  facts: DurableFacts;
+  /** v1's loose match id; parsed to a RiotMatchId inside the boundary. */
+  matchId: string;
+  settle: () => Promise<T>;
+  evidence: (settled: T) => SettlementEvidence;
+}): Promise<T> {
+  const settled = await args.settle();
+  const matchId = resolveDurableIdentity(() => toRiotMatchId(args.matchId));
+  if (matchId === null) return settled;
+
+  await recordDurableWrite(args.facts, "receipt-settlement", async (db) =>
+    recordReceipt(
+      db,
+      buildMatchReceipt({
+        matchId,
+        kind: MATCH_RECEIPT_KINDS.settlement,
+        scope: { kind: "global" },
+        recordedAt: toIsoInstant(args.facts.now()),
+        evidence: settlementEvidenceCodec.serialize(args.evidence(settled)),
+      }),
+    ),
+  );
+  return settled;
+}

--- a/packages/scout-for-lol/packages/backend/src/durable/match/workflow-start-facts.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/workflow-start-facts.ts
@@ -1,0 +1,80 @@
+import {
+  WorkflowRunIdSchema,
+  type WorkflowRunId,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import type { DiscordAccountId } from "@scout-for-lol/domain/identity/discord.ts";
+import {
+  recordWorkflowStartAccepted,
+  requestWorkflowStart,
+} from "#src/database/durable/workflow-start-repository.ts";
+import {
+  recordDurableWrite,
+  type DurableFacts,
+} from "#src/durable/match/durable-facts.ts";
+import { toIsoInstant } from "#src/durable/match/match-identity.ts";
+
+/**
+ * The workflow-start request service.
+ *
+ * v1 asks Temporal to start work and finds out whether it was accepted; this
+ * records both halves. The request row is written BEFORE the start call, so a
+ * crash between the two leaves durable evidence that a start was intended —
+ * which is the whole point of the table. Acceptance is recorded afterwards,
+ * carrying the run id when the client surfaced one.
+ *
+ * Ordering is the only thing this adds to v1: the start call itself, its
+ * arguments, and its error handling are untouched.
+ */
+
+export type WorkflowStartRequest = {
+  /** Temporal's business key — the workflow id v1 asked for. */
+  readonly requestedWorkflowId: string;
+  /** The registered workflow name; also the input envelope's kind. */
+  readonly workflowType: string;
+  /** Where the request came from, e.g. `prematch-parlay-generation`. */
+  readonly requestSource: string;
+  /** The operator who asked, or null for a system request. */
+  readonly requestedBy: DiscordAccountId | null;
+  /** The workflow input, wrapped in a version-1 envelope of `workflowType`. */
+  readonly input: unknown;
+};
+
+function toRunId(value: string | undefined): WorkflowRunId | null {
+  return value === undefined ? null : WorkflowRunIdSchema.parse(value);
+}
+
+export async function withRecordedWorkflowStart<T>(args: {
+  facts: DurableFacts;
+  request: WorkflowStartRequest;
+  start: () => Promise<T>;
+  /** Reads the run id out of the client's answer, when it carries one. */
+  runIdOf: (started: T) => string | undefined;
+}): Promise<T> {
+  const requestedAt = toIsoInstant(args.facts.now());
+  await recordDurableWrite(args.facts, "workflow-start-requested", async (db) =>
+    requestWorkflowStart(db, {
+      requestedWorkflowId: args.request.requestedWorkflowId,
+      workflowType: args.request.workflowType,
+      requestedBy: args.request.requestedBy,
+      requestSource: args.request.requestSource,
+      inputPayload: {
+        kind: args.request.workflowType,
+        version: 1,
+        data: args.request.input,
+      },
+      requestedAt,
+      acceptance: null,
+    }),
+  );
+
+  const started = await args.start();
+
+  await recordDurableWrite(args.facts, "workflow-start-accepted", async (db) =>
+    recordWorkflowStartAccepted(db, {
+      requestedWorkflowId: args.request.requestedWorkflowId,
+      acceptedAt: toIsoInstant(args.facts.now()),
+      runId: toRunId(args.runIdOf(started)),
+    }),
+  );
+  return started;
+}

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.ts
@@ -1,11 +1,14 @@
 import * as Sentry from "@sentry/bun";
-import { createHash } from "node:crypto";
 import {
   claimScoutEffect,
   completeScoutEffectWithResult,
   recordScoutEffectFailure,
   requireCompletedScoutEffectResult,
 } from "#src/temporal/effect-claims.ts";
+import {
+  deliveryAttemptNonce,
+  type ChannelDeliveryRecorder,
+} from "#src/durable/match/delivery-intents.ts";
 import {
   filtersPass,
   DiscordGuildIdSchema,
@@ -43,10 +46,75 @@ export function channelsPassingQueueFilter(
   );
 }
 
+/** No durable record kept for this delivery; the send is unchanged either way. */
+const RECORD_NOTHING: ChannelDeliveryRecorder = () => Promise.resolve();
+
+function isPermissionError(error: unknown): boolean {
+  return error instanceof ChannelSendError && error.permissionError;
+}
+
+/**
+ * Send one rendered message to a channel, falling back to a plain send when
+ * the channel denies replies.
+ *
+ * A reply requires Read Message History. Without it the report itself is still
+ * deliverable wherever plain sending is allowed, so a reply-permission failure
+ * retries as a normal message rather than losing the report.
+ */
+async function sendWithReplyFallback(params: {
+  message: MessageCreateOptions;
+  replyToMessageId: string | undefined;
+  nonce: string | undefined;
+  channel: DiscordChannelId;
+  guildId: DiscordGuildId;
+}): Promise<Awaited<ReturnType<typeof send>>> {
+  const idempotency =
+    params.nonce === undefined
+      ? {}
+      : { nonce: params.nonce, enforceNonce: true };
+  const replied: MessageCreateOptions =
+    params.replyToMessageId === undefined
+      ? params.message
+      : {
+          ...params.message,
+          reply: {
+            messageReference: params.replyToMessageId,
+            // If the prematch message was deleted, still deliver the
+            // postmatch report as a normal message.
+            failIfNotExists: false,
+          },
+        };
+  try {
+    return await send(
+      { ...replied, ...idempotency },
+      params.channel,
+      params.guildId,
+    );
+  } catch (error) {
+    if (
+      params.replyToMessageId === undefined ||
+      !(error instanceof ChannelSendError) ||
+      !isReplyPermissionError(error)
+    ) {
+      throw error;
+    }
+    return await send(
+      { ...params.message, ...idempotency },
+      params.channel,
+      params.guildId,
+    );
+  }
+}
+
 /**
  * Send a rendered message to each channel, tolerating per-channel failures:
  * missing-permission errors are logged and skipped, anything else is reported
  * to Sentry, so one bad channel never blocks the rest.
+ *
+ * `recordDelivery` is the durable notification-intent recorder. It observes
+ * the send; it never gates it — the `ScoutEffectClaim` below remains the
+ * at-most-once guard — and every one of its writes is fail-open, so a
+ * recorder outage cannot stop a message going out.
  */
 export async function deliverToChannels(params: {
   message: MessageCreateOptions;
@@ -55,12 +123,14 @@ export async function deliverToChannels(params: {
   sentryTags: Record<string, string>;
   replyToMessageIds?: ReadonlyMap<string, string>;
   effectKeyPrefix?: string;
+  recordDelivery?: ChannelDeliveryRecorder | undefined;
 }): Promise<{
   deliveredGuildIds: Set<DiscordGuildId>;
   messageIdsByChannel: Map<DiscordChannelId, string>;
 }> {
   const deliveredGuildIds = new Set<DiscordGuildId>();
   const messageIdsByChannel = new Map<DiscordChannelId, string>();
+  const recordDelivery = params.recordDelivery ?? RECORD_NOTHING;
   for (const { channel, serverId } of params.channels) {
     const effectKey =
       params.effectKeyPrefix === undefined
@@ -74,6 +144,9 @@ export async function deliverToChannels(params: {
           kind: "discord-channel-message",
         });
         if (claim === "completed") {
+          // An earlier run already sent this message and already recorded its
+          // intent; replaying the lifecycle here would only conflict with the
+          // delivered row that run wrote.
           const messageId = await requireCompletedScoutEffectResult(effectKey);
           deliveredGuildIds.add(DiscordGuildIdSchema.parse(serverId));
           messageIdsByChannel.set(channel, messageId);
@@ -81,64 +154,36 @@ export async function deliverToChannels(params: {
         }
         effectClaimed = true;
       }
-      const replyToMessageId = params.replyToMessageIds?.get(channel);
-      const message: MessageCreateOptions =
-        replyToMessageId === undefined
-          ? params.message
-          : {
-              ...params.message,
-              reply: {
-                messageReference: replyToMessageId,
-                // If the prematch message was deleted, still deliver the
-                // postmatch report as a normal message.
-                failIfNotExists: false,
-              },
-            };
-      const nonce =
-        effectKey === undefined
-          ? undefined
-          : createHash("sha256")
-              .update(effectKey)
-              .digest("base64url")
-              .slice(0, 25);
-      const idempotentMessage: MessageCreateOptions = {
-        ...message,
-        ...(nonce === undefined ? {} : { nonce, enforceNonce: true }),
-      };
+      await recordDelivery({ kind: "prepared", channelId: channel });
       const guildId = DiscordGuildIdSchema.parse(serverId);
-      let sentMessage;
-      try {
-        sentMessage = await send(idempotentMessage, channel, guildId);
-      } catch (error) {
-        if (
-          replyToMessageId !== undefined &&
-          error instanceof ChannelSendError &&
-          isReplyPermissionError(error)
-        ) {
-          // A reply requires Read Message History. Retry as a normal message
-          // when that permission is missing; the post-match report itself is
-          // still deliverable in channels where sending is allowed.
-          sentMessage = await send(
-            {
-              ...params.message,
-              ...(nonce === undefined ? {} : { nonce, enforceNonce: true }),
-            },
-            channel,
-            guildId,
-          );
-        } else {
-          throw error;
-        }
-      }
+      await recordDelivery({ kind: "send-started", channelId: channel });
+      const sentMessage = await sendWithReplyFallback({
+        message: params.message,
+        replyToMessageId: params.replyToMessageIds?.get(channel),
+        nonce:
+          effectKey === undefined ? undefined : deliveryAttemptNonce(effectKey),
+        channel,
+        guildId,
+      });
       if (effectKey !== undefined) {
         await completeScoutEffectWithResult(effectKey, sentMessage.id);
       }
       deliveredGuildIds.add(guildId);
       messageIdsByChannel.set(channel, sentMessage.id);
+      await recordDelivery({
+        kind: "delivered",
+        channelId: channel,
+        messageId: sentMessage.id,
+      });
     } catch (error) {
       if (effectKey !== undefined && effectClaimed) {
         await recordScoutEffectFailure(effectKey, error);
       }
+      await recordDelivery({
+        kind: "failed",
+        channelId: channel,
+        permissionError: isPermissionError(error),
+      });
       if (error instanceof ChannelSendError && error.permissionError) {
         logger.warn(
           `${params.logPrefix} ⚠️  Permission error for channel ${channel}: ${error.message}`,

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling-effects.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling-effects.ts
@@ -8,6 +8,11 @@ import {
   completeScoutEffect,
   recordScoutEffectFailure,
 } from "#src/temporal/effect-claims.ts";
+import { liveDurableFacts } from "#src/durable/match/live-facts.ts";
+import {
+  recordObservedMatch,
+  requestMatchArchive,
+} from "#src/durable/match/archive-facts.ts";
 
 const logger = createLogger("postmatch-match-history-polling");
 
@@ -20,25 +25,52 @@ export async function persistAuthoritativeMatch(input: {
   silent: boolean;
 }): Promise<void> {
   const effectKey = `raw-match-s3:${input.matchId}`;
+  const source = input.silent ? "postmatch_silent_backfill" : "postmatch_live";
+  const observed = {
+    matchId: input.matchId,
+    gameCreation: input.matchData.info.gameCreation,
+    trackedPuuids: input.trackedPlayers.map(
+      (player) => player.league.leagueAccount.puuid,
+    ),
+    source,
+  };
   let claimed = false;
   try {
     const claim = await claimScoutEffect({
       key: effectKey,
       kind: "raw-match-s3",
     });
-    if (claim !== "execute") return;
-    claimed = true;
-    const ingest = await recordMatchForReportStore({
-      match: input.matchData,
-      source: input.silent ? "postmatch_silent_backfill" : "postmatch_live",
-      trackedPlayerAliases: input.trackedPlayers.map((player) => player.alias),
-    });
-    if (!ingest.staged) {
-      throw new Error(
-        `Report lake staging failed for ${input.matchId}; cursor advancement is blocked.`,
-      );
+    if (claim !== "execute") {
+      // An earlier run already archived this match, so there is no fresh
+      // archive outcome to attest to — but the match and its tracked accounts
+      // are still facts, and the cursor advance ahead needs their rows.
+      await recordObservedMatch({ facts: liveDurableFacts(), match: observed });
+      return;
     }
-    await completeScoutEffect(effectKey);
+    claimed = true;
+    // The durable observation and its archive receipts are written only after
+    // the whole gate below has passed, so an observation row always means the
+    // raw payload really did become canonical.
+    await requestMatchArchive({
+      facts: liveDurableFacts(),
+      match: observed,
+      archive: async () => {
+        const ingest = await recordMatchForReportStore({
+          match: input.matchData,
+          source,
+          trackedPlayerAliases: input.trackedPlayers.map(
+            (player) => player.alias,
+          ),
+        });
+        if (!ingest.staged) {
+          throw new Error(
+            `Report lake staging failed for ${input.matchId}; cursor advancement is blocked.`,
+          );
+        }
+        await completeScoutEffect(effectKey);
+        return ingest;
+      },
+    });
   } catch (error) {
     if (claimed) await recordScoutEffectFailure(effectKey, error);
     logger.error(

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
@@ -49,6 +49,13 @@ import {
   type MatchPollAccount,
 } from "#src/league/tasks/postmatch/match-discovery-selection.ts";
 import { withChallengeProgressionLock } from "#src/progression/challenges/locking.ts";
+import { liveDurableFacts } from "#src/durable/match/live-facts.ts";
+import { commitMatchSettlement } from "#src/durable/match/settlement-facts.ts";
+import {
+  recordCursorAdvanced,
+  runMatchProgressionStage,
+} from "#src/durable/match/progression-facts.ts";
+import { settlementEvidenceOf } from "#src/league/tasks/postmatch/settlement-evidence.ts";
 
 const logger = createLogger("postmatch-match-history-polling");
 
@@ -145,6 +152,11 @@ export async function processMatchAndUpdatePlayers(
     silent,
   });
 
+  // The durable recorder for this match's facts. v1 stays authoritative for
+  // every decision below; each recorded fact is fail-open behind its own
+  // boundary, so a recorder outage cannot stall ingestion.
+  const facts = liveDurableFacts();
+
   // After the S3 gate and OUTSIDE `!silent`: Bucks are owed for the game even
   // when the ordinary match report is suppressed. See settleAndAwardBucks.
   const {
@@ -152,10 +164,16 @@ export async function processMatchAndUpdatePlayers(
     prefetchedTimeline,
     prefetchedPlayers,
     prefetchedRankChanges,
-  } = await settleBucksWithDareTimelineV2({
-    matchData,
-    trackedPlayers: allTrackedPlayers,
-    prismaClient: prisma,
+  } = await commitMatchSettlement({
+    facts,
+    matchId,
+    settle: async () =>
+      await settleBucksWithDareTimelineV2({
+        matchData,
+        trackedPlayers: allTrackedPlayers,
+        prismaClient: prisma,
+      }),
+    evidence: (settled) => settlementEvidenceOf(settled.bucks),
   });
   let postmatchMessageIds = await deliverVisiblePostmatchReport({
     silent,
@@ -215,10 +233,20 @@ export async function processMatchAndUpdatePlayers(
   await withChallengeProgressionLock(
     matchData.metadata.participants,
     async () => {
-      await processCompetitiveProgressionMatch({
-        match: matchData,
-        timeline: prefetchedTimeline,
-        trackedPlayers: allTrackedPlayers,
+      await runMatchProgressionStage({
+        facts,
+        matchId,
+        evidence: {
+          participantCount: matchData.metadata.participants.length,
+          trackedAccountCount: allTrackedPlayers.length,
+        },
+        advance: async () => {
+          await processCompetitiveProgressionMatch({
+            match: matchData,
+            timeline: prefetchedTimeline,
+            trackedPlayers: allTrackedPlayers,
+          });
+        },
       });
 
       // Mark as processed
@@ -236,6 +264,7 @@ export async function processMatchAndUpdatePlayers(
           undefined,
           matchCreationTime,
         );
+        await recordCursorAdvanced({ facts, matchId, puuid: playerPuuid });
       }
     },
   );

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-delivery.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-delivery.ts
@@ -24,6 +24,12 @@ import {
   channelsPassingQueueFilter,
   deliverToChannels,
 } from "#src/league/tasks/notification-filters.ts";
+import { liveDurableFacts } from "#src/durable/match/live-facts.ts";
+import {
+  deliveredMessagesByGuild,
+  recordDeliveryReceipts,
+  tryCreateChannelDeliveryRecorder,
+} from "#src/durable/match/delivery-intents.ts";
 
 const logger = createLogger("postmatch-report-delivery");
 const MAX_DISCORD_ALERT_AGE_MS = 3 * 60 * 60 * 1000;
@@ -92,15 +98,37 @@ export async function deliverPostmatchReport(input: {
     logger.info(`[processMatch] ⚠️  No message generated for match ${matchId}`);
     return new Map();
   }
+  const facts = liveDurableFacts();
+  const effectKeyPrefix = `postmatch-discord:${matchId}`;
   const delivery = await deliverToChannels({
     message,
     channels: deliverChannels,
     logPrefix: "[processMatch]",
     sentryTags: { matchId },
     replyToMessageIds: await getPrematchMessageIdsForMatchIdOrEmpty(matchId),
-    effectKeyPrefix: `postmatch-discord:${matchId}`,
+    effectKeyPrefix,
+    recordDelivery:
+      tryCreateChannelDeliveryRecorder({
+        facts,
+        matchId,
+        keyPrefix: effectKeyPrefix,
+        // v1's own staleness rule: a report older than this is never sent, so
+        // it is exactly the instant after which the intent is stale.
+        freshnessDeadline: new Date(
+          input.matchData.info.gameCreation + MAX_DISCORD_ALERT_AGE_MS,
+        ),
+      }) ?? undefined,
   });
   await recordCoreOutputsDelivered(delivery.deliveredGuildIds, "postmatch");
   await recordPostmatchMessageIds(matchId, delivery.messageIdsByChannel);
+  await recordDeliveryReceipts({
+    facts,
+    kind: "reportDelivery",
+    matchId,
+    messagesByGuild: deliveredMessagesByGuild(
+      deliverChannels,
+      delivery.messageIdsByChannel,
+    ),
+  });
   return delivery.messageIdsByChannel;
 }

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/settlement-evidence.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/settlement-evidence.ts
@@ -1,0 +1,57 @@
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/domain/identity/discord.ts";
+import type { settleAndAwardBucks } from "#src/betting/markets/postmatch-hook.ts";
+import {
+  canonicalIdentities,
+  type SettlementEvidence,
+} from "#src/durable/match/receipt-evidence.ts";
+
+/**
+ * Translate one match's Bucks settlement result into the durable receipt's
+ * evidence.
+ *
+ * This mapping lives here, not in the application layer, because it reads
+ * betting's own result types; the services take evidence already shaped and so
+ * stay independent of the feature slices they record.
+ *
+ * Receipt evidence names durable identities rather than counts, so a reader
+ * can go find the bets, Dares and awards the commit moved. No money amount is
+ * recorded: these identities locate the ledger rows, and the amounts live
+ * there under the storable Bucks brands that bound them to their columns.
+ */
+
+type BucksPostmatchResult = Awaited<ReturnType<typeof settleAndAwardBucks>>;
+
+export function settlementEvidenceOf(
+  bucks: BucksPostmatchResult,
+): SettlementEvidence {
+  return {
+    closedBetIds: canonicalIdentities(
+      bucks.closures.flatMap((pool) =>
+        pool.positions.map((position) => position.betId),
+      ),
+    ),
+    settledBetIds: canonicalIdentities(
+      bucks.settlements.flatMap((summary) =>
+        summary.bets.map((bet) => bet.betId),
+      ),
+    ),
+    resolvedDareIds: canonicalIdentities(
+      bucks.dareSettlements.map((summary) => summary.dareId),
+    ),
+    // A weekly parlay settlement carries no per-bet row id out of the settle
+    // call, so the guild whose parlay settled is its durable identity.
+    settledParlayGuildIds: canonicalIdentities(
+      bucks.parlaySettlements.map((summary) =>
+        DiscordGuildIdSchema.parse(summary.serverId),
+      ),
+    ),
+    earnedDiscordIds: canonicalIdentities(
+      bucks.earnings.map((award) =>
+        DiscordAccountIdSchema.parse(award.discordId),
+      ),
+    ),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-queries.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-queries.ts
@@ -8,8 +8,9 @@ import * as Sentry from "@sentry/bun";
 const logger = createLogger("prematch-active-game-queries");
 
 // Keep reply metadata through the full postmatch alert window, which is three
-// hours from match creation.
-const ACTIVE_GAME_TTL_MS = 3 * 60 * 60 * 1000;
+// hours from match creation. Exported because it is also the freshness horizon
+// of a pre-match notification intent: past it the game is no longer tracked.
+export const ACTIVE_GAME_TTL_MS = 3 * 60 * 60 * 1000;
 
 const TrackedPuuidsSchema = z.array(z.string());
 /** Discord channel ID -> message ID, for both prematch and postmatch refs. */

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/prematch-notification.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/prematch-notification.ts
@@ -41,6 +41,14 @@ import {
 } from "#src/betting/markets/prematch-hook.ts";
 import { PrematchNotificationPostDeliveryError } from "#src/league/tasks/prematch/prematch-notification-errors.ts";
 import { recordPrematchOutputs } from "#src/league/tasks/prematch/prematch-output-recording.ts";
+import { liveDurableFacts } from "#src/durable/match/live-facts.ts";
+import {
+  deliveredMessagesByGuild,
+  recordDeliveryReceipts,
+  tryCreateChannelDeliveryRecorder,
+  type ChannelDeliveryRecorder,
+} from "#src/durable/match/delivery-intents.ts";
+import { ACTIVE_GAME_TTL_MS } from "#src/league/tasks/prematch/active-game-queries.ts";
 import type { MessageCreateOptions } from "discord.js";
 import type { LoadingScreenData } from "@scout-for-lol/data/index.ts";
 
@@ -179,6 +187,14 @@ type PrematchDeliveryChannel = Awaited<
   ReturnType<typeof getChannelsSubscribedToPlayers>
 >[number];
 
+/**
+ * Deliver the pre-match message to each subscribed channel.
+ *
+ * `recordDelivery` writes the durable notification intent for each send. There
+ * is no effect claim on this path — the ActiveGame row is what stops a second
+ * detection from re-notifying — so the intent is purely a record here, exactly
+ * as it is on the post-match path.
+ */
 async function deliverPrematchMessages(input: {
   channels: PrematchDeliveryChannel[];
   gameInfo: RawCurrentGameInfo;
@@ -188,6 +204,7 @@ async function deliverPrematchMessages(input: {
   prematchMessageContent: string;
   loadingScreenAttachment: AttachmentBuilder | undefined;
   loadingScreenEmbed: EmbedBuilder | undefined;
+  recordDelivery: ChannelDeliveryRecorder | undefined;
 }): Promise<{
   sentMessageIds: Map<string, string>;
   deliveredGuildIds: Set<DiscordGuildId>;
@@ -213,7 +230,17 @@ async function deliverPrematchMessages(input: {
         fallbackEmbed: () =>
           buildFallbackPrematchEmbed(input.gameInfo, input.trackedPlayers),
       });
+      await input.recordDelivery?.({ kind: "prepared", channelId: channel });
+      await input.recordDelivery?.({
+        kind: "send-started",
+        channelId: channel,
+      });
       const sentMessage = await send(message, channel, guildId);
+      await input.recordDelivery?.({
+        kind: "delivered",
+        channelId: channel,
+        messageId: sentMessage.id,
+      });
       sentMessageIds.set(channel, sentMessage.id);
       deliveredGuildIds.add(guildId);
       if (betsOpen) {
@@ -223,6 +250,12 @@ async function deliverPrematchMessages(input: {
         ]);
       }
     } catch (error) {
+      await input.recordDelivery?.({
+        kind: "failed",
+        channelId: channel,
+        permissionError:
+          error instanceof ChannelSendError && error.permissionError,
+      });
       if (error instanceof ChannelSendError && error.permissionError) {
         logger.warn(
           `[sendPrematchNotification] ⚠️  Permission error for channel ${channel}: ${error.message}`,
@@ -437,6 +470,10 @@ export async function sendPrematchNotification(
       ? prematchMessageContent
       : "";
 
+  // The platform-qualified match id the completed game will carry, so a
+  // pre-match intent and the post-match facts describe the same match.
+  const prematchMatchId = `${gameInfo.platformId}_${gameInfo.gameId.toString()}`;
+  const facts = liveDurableFacts();
   const delivery = await deliverPrematchMessages({
     channels: deliverChannels,
     gameInfo,
@@ -446,6 +483,24 @@ export async function sendPrematchNotification(
     prematchMessageContent,
     loadingScreenAttachment,
     loadingScreenEmbed,
+    recordDelivery:
+      tryCreateChannelDeliveryRecorder({
+        facts,
+        matchId: prematchMatchId,
+        keyPrefix: `prematch-discord:${prematchMatchId}`,
+        // The ActiveGame row's own lifetime: past it the game is no longer
+        // tracked, so a pre-match send would be about a game already over.
+        freshnessDeadline: new Date(detectedAt.getTime() + ACTIVE_GAME_TTL_MS),
+      }) ?? undefined,
+  });
+  await recordDeliveryReceipts({
+    facts,
+    kind: "prematchDelivery",
+    matchId: prematchMatchId,
+    messagesByGuild: deliveredMessagesByGuild(
+      deliverChannels,
+      delivery.sentMessageIds,
+    ),
   });
 
   try {

--- a/packages/scout-for-lol/packages/backend/src/metrics/durable.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/durable.ts
@@ -1,0 +1,32 @@
+import { Counter } from "prom-client";
+import { registry } from "#src/metrics/registry.ts";
+
+/**
+ * Parity instrumentation for the durable dual-write bridge.
+ *
+ * THIS IS THE SINGLE DEFINITION SITE for these metrics. prom-client throws at
+ * import time when two modules register the same metric name on the shared
+ * registry, which takes the process down on boot rather than at the first
+ * `inc()`. Every producer — the match services here, the receipted lake
+ * projection — imports these symbols; nobody declares a second counter with
+ * the same name.
+ *
+ * Both are per-write counters incremented inline by whichever runtime role
+ * executed the write, so a parity dashboard joins across roles rather than
+ * reading one process. Neither is derived from a database sweep, so neither
+ * belongs in `getMetrics()`'s `databaseMetricSweepsEnabled()` block.
+ */
+
+export const scoutDurableDualwriteFailuresTotal = new Counter({
+  name: "scout_durable_dualwrite_failures_total",
+  help: "Durable dual-write side-effects that failed without failing the v1 path, by write kind.",
+  labelNames: ["write_kind"] as const,
+  registers: [registry],
+});
+
+export const scoutDurableDualwriteRecordsTotal = new Counter({
+  name: "scout_durable_dualwrite_records_total",
+  help: "Durable facts recorded alongside the v1 pipeline, by write kind and repository outcome.",
+  labelNames: ["write_kind", "outcome"] as const,
+  registers: [registry],
+});

--- a/packages/scout-for-lol/packages/backend/src/temporal/starts.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/starts.ts
@@ -3,6 +3,7 @@ import {
   WorkflowIdConflictPolicy,
   WorkflowIdReusePolicy,
   type WorkflowHandle,
+  type WorkflowHandleWithFirstExecutionRunId,
   type WorkflowStartOptions,
 } from "@temporalio/client";
 import type { Client } from "@temporalio/client";
@@ -136,10 +137,15 @@ export async function startScoutInitialHistory(
   );
 }
 
+/**
+ * Returns the narrower handle the client actually produces: `start` carries
+ * the first execution's run id, which the durable workflow-start record stores
+ * as its acceptance evidence.
+ */
 export async function startScoutDetachedWork(
   client: Client,
   input: ScoutDetachedWorkInput,
-): Promise<WorkflowHandle> {
+): Promise<WorkflowHandleWithFirstExecutionRunId> {
   return await client.workflow.start(SCOUT_WORKFLOW_NAMES.detachedWork, {
     ...IDEMPOTENT_START_POLICIES,
     workflowId: scoutDetachedWorkWorkflowId(

--- a/packages/scout-for-lol/packages/backend/src/temporal/work-store.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/work-store.ts
@@ -7,6 +7,8 @@ import {
 } from "@scout-for-lol/data";
 import {
   DETACHED_WORK_MAX_ATTEMPTS,
+  SCOUT_WORKFLOW_NAMES,
+  scoutDetachedWorkWorkflowId,
   type ScoutDetachedWorkInput,
 } from "@scout-for-lol/temporal";
 import { classifyLlmProviderIssue } from "#src/alerts/provider-metrics.ts";
@@ -14,6 +16,8 @@ import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import configuration from "#src/configuration.ts";
 import { createLogger } from "#src/logger.ts";
 import type { StartParlayGenerationInput } from "#src/betting/parlays/parlay-generation-types.ts";
+import { liveDurableFacts } from "#src/durable/match/live-facts.ts";
+import { withRecordedWorkflowStart } from "#src/durable/match/workflow-start-facts.ts";
 import { currentScoutTemporalSupervisor } from "./runtime.ts";
 import { startScoutDetachedWork } from "./starts.ts";
 
@@ -59,7 +63,25 @@ async function requestStart(input: ScoutDetachedWorkInput): Promise<void> {
     return;
   }
   try {
-    await startScoutDetachedWork(supervisor.client(), input);
+    // The durable request row is written before the start call, so a crash
+    // between the two still leaves evidence that a start was intended.
+    await withRecordedWorkflowStart({
+      facts: liveDurableFacts(),
+      request: {
+        requestedWorkflowId: scoutDetachedWorkWorkflowId(
+          input.stage,
+          input.kind,
+          input.workId,
+        ),
+        workflowType: SCOUT_WORKFLOW_NAMES.detachedWork,
+        requestSource: `detached-work:${input.kind}`,
+        requestedBy: null,
+        input,
+      },
+      start: async () =>
+        await startScoutDetachedWork(supervisor.client(), input),
+      runIdOf: (handle) => handle.firstExecutionRunId,
+    });
   } catch (error) {
     logger.warn(
       "Temporal work persisted but its immediate start was not accepted",


### PR DESCRIPTION
## Why

The durable pipeline (SJ-186 / SJ-190) needs Postgres to start recording what v1 actually does — match ownership, processing receipts, notification intents, workflow-start handoff — while v1 remains byte-identical and fully authoritative. This bridge is what Wave 4's V2 workflows take over from, and what the acceptance parity comparison reads.

## What

- **New application service layer** `src/application/match/` with its own enforced architecture boundary (services take `Db`+clock as arguments; import only `database/` and `metrics/`; negative fixture proves it): durable identity resolution (v1 MatchId → branded RiotMatchId), six closed receipt kinds with versioned evidence codecs, and archive/settlement/progression/delivery/workflow-start services.
- **Wired into v1 call sites** with zero behavior change: observation + tracked accounts + archive receipts inside the existing S3 effect gate; settlement receipt covering settlement AND Dare resolution (separated counts); progression + cursor advancement; post-match and prematch **notification intents carrying v1's own deterministic nonce** (`ScoutEffectClaim` remains the authoritative delivery guard — the intent is the durable record this wave); detached-work start requests recorded requested→accepted.
- **Fail-open discipline**: a durable write failure logs + increments `scout_durable_dualwrite_failures_total{write_kind}` and never touches the v1 result — deliberately without Sentry (an existing integration test pins that this path emits no captureException; a durable outage would otherwise bury real errors at one event per write per channel per match). `scout_durable_dualwrite_records_total{write_kind,outcome}` parses repository outcomes so an unknown answer fails loudly rather than minting a label.
- **Honest limits**: observation artifact references stay NULL until the receipted archival (PR 7) returns real descriptors — no fabricated keys; transaction shapes match v1 exactly (no invented transactions on the cursor or S3-gate paths, so visibility semantics are unchanged).

## Verification

- `bunx turbo run typecheck test lint --filter=@scout-for-lol/backend` — 20/20 tasks; **403 files / 3823 tests**; `architecture: 1246 modules clean` including the new boundary; prettier + directory-count clean.
- New 12-test integration suite over the test-template DB: simulated v1 pass (observation/tracked-accounts/receipts), already-completed claim path, settlement evidence, progression + cursor, **fail-open with broken durable tables (v1 result unchanged, no rows, metric +1)**, unparseable match id, intent lifecycle delivered + terminal permission failure, nonce agreement with v1's Discord nonce, pre-send failure recording no attempt, per-guild delivery receipts, workflow-start ordering.
- **Every pre-existing test unchanged and green — they are the behavior pin.**
- Not run: Buildkite exact-head, images, deployment, live behavior.

Part of SJ-190 (Wave 3 of the Scout durable-architecture program, SJ-186).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qRdG6fzJr3THzYzAJwTZB