### PR TITLE
feat(scout-for-lol): pull a homelab Postgres database into local dev

### DIFF
--- a/.buildkite/scripts/selectors/select-image-targets.test.ts
+++ b/.buildkite/scripts/selectors/select-image-targets.test.ts
@@ -111,7 +111,10 @@ describe("selectImageTargets", () => {
   });
 
   test("selects explicit Docker inputs outside workspace dependencies", async () => {
+    // scout-evals depends on the toolkit for the shared Postgres pod helper
+    // its sync-beta script uses, and the selector walks devDependencies too.
     expect(await select(["packages/toolkit/src/commands/pr.ts"])).toEqual([
+      "scout-evals",
       "temporal-worker",
     ]);
   });

--- a/bun.lock
+++ b/bun.lock
@@ -1299,7 +1299,6 @@
         "@shepherdjerred/llm-runtime": "workspace:*",
         "@shepherdjerred/temporal-observability": "workspace:*",
         "@shepherdjerred/voice-assistant": "workspace:*",
-        "@snazzah/davey": "^0.1.12",
         "@temporalio/activity": "1.22.0",
         "@temporalio/client": "1.22.0",
         "@temporalio/common": "1.22.0",
@@ -1548,6 +1547,7 @@
       "devDependencies": {
         "@playwright/test": "^1.61.1",
         "@shepherdjerred/eslint-config": "workspace:*",
+        "@shepherdjerred/toolkit": "workspace:*",
         "@tailwindcss/vite": "^4.2.4",
         "@types/bun": "1.4.0",
         "@types/react": "^19.2.18",

--- a/packages/docs/wiki/src/content/docs/how-to/connect-to-a-homelab-database.md
+++ b/packages/docs/wiki/src/content/docs/how-to/connect-to-a-homelab-database.md
@@ -94,6 +94,7 @@ Reach it with `kubectl exec -n postal -it postal-mariadb-0 -- mariadb -u postal 
 
 ## Related
 
+- [Pull a Scout database into local dev](/how-to/pull-a-scout-database-into-local-dev/)
 - [Cut a homelab release](/how-to/cut-a-homelab-release/)
 - [Pause or debug a schedule](/how-to/pause-or-debug-a-schedule/)
 - [Temporal PostgreSQL's TLS identity](/explanation/temporal/postgresql-tls-identity/)

--- a/packages/docs/wiki/src/content/docs/how-to/pull-a-scout-database-into-local-dev.md
+++ b/packages/docs/wiki/src/content/docs/how-to/pull-a-scout-database-into-local-dev.md
@@ -1,0 +1,78 @@
+---
+title: Pull a Scout database into local dev
+description: Copy the beta or production Scout Postgres database onto your laptop and run the local app against real data.
+sidebar:
+  order: 12
+---
+
+Local Scout dev runs on fixtures and the seeded report lake. When you need real
+rows — reproducing a bug that only appears with live data, or looking at a
+populated screen — copy a hosted database into a local one.
+
+## Copy the database
+
+From `packages/scout-for-lol`:
+
+```bash
+bun run dev:db-pull
+```
+
+This dumps beta's `scout` database, restores it into `scout_beta_snapshot` on
+the shared local dev Postgres, verifies every source table arrived, and prints
+the command for the next step. `bun run dev:db-pull -- --help` lists the flags.
+
+:::caution[The target database is replaced]
+Every run drops and recreates it. Pass `--database <name>` to restore elsewhere
+and keep an existing copy.
+:::
+
+:::note[Credentials never reach your laptop]
+The snapshot carries no live secrets. `User.discordAccessToken`,
+`discordRefreshToken`, `ExploreConversation.shareToken`, and
+`TournamentLobby.password` arrive blanked; `TournamentLobby.code` — the Riot
+join credential — arrives as a per-row `redacted-<id>` stand-in, because it is
+`NOT NULL` and unique. `ApiToken` and `InstallAttributionToken` arrive empty:
+their rows are nothing but credentials. The rows themselves are kept, so
+ownership and joins still work. Redaction happens at the source, so no
+credential is written here even transiently, and the run fails if any redacted
+column comes back holding a real value.
+:::
+
+## Run the app against it
+
+Use the URL the previous command printed:
+
+```bash
+bun run dev:web -- --database-url postgres://scout@127.0.0.1:5471/scout_beta_snapshot
+```
+
+`dev:web` applies any migrations newer than the snapshot as it boots, so a
+database captured before a schema change still works.
+
+## Pull from production
+
+```bash
+bun run dev:db-pull -- --stage prod
+```
+
+This puts real player data — aliases, Discord IDs, PUUIDs — on your laptop, and
+the command warns when it runs. Credentials are excluded the same way as for
+beta, but the identifiers are still real. Prefer beta unless the bug is
+production-only.
+
+:::danger[Do not hand-roll this with kubectl and pg_dump]
+Three things fail silently. The Spilo pod carries several PostgreSQL toolchains
+and `PATH` resolves to the newest — 18, against a 16 server — which writes an
+archive the local client cannot read while still exiting 0. The cluster runs
+`pg_stat_kcache` and `set_user`, which the local build does not ship, so
+dumping them breaks the restore. And the dump's own `CREATE SCHEMA public`
+collides with the one `createdb` provides, which under `--single-transaction`
+rolls back everything.
+[`dev-db-pull-plan.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/scripts/dev/dev-db-pull-plan.ts)
+handles all three.
+:::
+
+## Related
+
+- [Connect to a homelab database](/how-to/connect-to-a-homelab-database/)
+- [Run the Scout design audit](/how-to/run-scout-design-audit/)

--- a/packages/scout-for-lol/package.json
+++ b/packages/scout-for-lol/package.json
@@ -15,6 +15,7 @@
     "dev:discord": "op run --env-file=./dev-web.env.tpl -- bun scripts/dev/dev-discord.ts",
     "test:discord:smoke": "op run --env-file=./dev-web.env.tpl -- bun scripts/discord-smoke/discord-smoke.ts",
     "dev:design-audit": "bun scripts/dev/dev-web.ts",
+    "dev:db-pull": "bun scripts/dev/dev-db-pull.ts",
     "dev:seed": "bun scripts/dev/dev-seed.ts",
     "dev:login": "bun scripts/dev/dev-login.ts",
     "check:assets": "bun run scripts/check-asset-sizes.ts",

--- a/packages/scout-for-lol/packages/evals/README.md
+++ b/packages/scout-for-lol/packages/evals/README.md
@@ -23,10 +23,12 @@ Never expose it publicly (no Funnel).
 ## Discover Candidates
 
 First sync the sanitized tracked-player profile snapshot from Beta Postgres.
-The command kubectl-execs one read-only `psql` `json_agg` query against
-`scout-beta-postgresql-0` (database `scout`) covering only `Player` and
+The command kubectl-execs one read-only `psql` `json_agg` query against the
+`scout-beta-postgresql` master pod (database `scout`) covering only `Player` and
 `Account`; it does not copy tokens, audit data, or the rest of the live
-database.
+database. The pod is resolved by Spilo's `spilo-role=master` label through the
+shared helper in `@shepherdjerred/toolkit/lib/postgres/pod.ts`, so a replica can
+never be read by mistake.
 
 ```bash
 bun run --filter=@scout-for-lol/evals sync-beta

--- a/packages/scout-for-lol/packages/evals/package.json
+++ b/packages/scout-for-lol/packages/evals/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@playwright/test": "^1.61.1",
     "@shepherdjerred/eslint-config": "workspace:*",
+    "@shepherdjerred/toolkit": "workspace:*",
     "@tailwindcss/vite": "^4.2.4",
     "@types/bun": "1.4.0",
     "@types/react": "^19.2.18",

--- a/packages/scout-for-lol/packages/evals/src/scripts/sync-beta-corpus.ts
+++ b/packages/scout-for-lol/packages/evals/src/scripts/sync-beta-corpus.ts
@@ -3,6 +3,11 @@ import { mkdir, rename, rm } from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
 
+import {
+  execInPod,
+  findReadyMasterPod,
+} from "@shepherdjerred/toolkit/lib/postgres/pod.ts";
+
 import { argumentValue } from "#lib/cli.ts";
 import {
   BetaProfileRowSchema,
@@ -10,17 +15,11 @@ import {
   writeBetaCorpusSnapshot,
 } from "#materialization/beta-corpus.ts";
 
-const PodListSchema = z.object({
-  items: z.array(
-    z.object({
-      metadata: z.object({ name: z.string(), uid: z.string() }),
-      status: z.object({
-        conditions: z.array(z.object({ status: z.string(), type: z.string() })),
-        phase: z.string(),
-      }),
-    }),
-  ),
-});
+const BETA_CLUSTER = {
+  namespace: "scout-beta",
+  cluster: "scout-beta-postgresql",
+  container: "postgres",
+} as const;
 
 // Runs inside the scout-beta Postgres pod via the local trust socket
 // (pgHba "local all all trust" exists for exactly these exec runbooks).
@@ -41,70 +40,25 @@ const REMOTE_QUERY = `
   ) t
 `;
 
-async function run(command: string[]): Promise<string> {
-  const executable = command[0];
-  if (executable === undefined) throw new Error("Cannot run an empty command");
-  const process = Bun.spawn(command, { stderr: "pipe", stdout: "pipe" });
-  const [exitCode, stdout, stderr] = await Promise.all([
-    process.exited,
-    new Response(process.stdout).text(),
-    new Response(process.stderr).text(),
-  ]);
-  if (exitCode !== 0) {
-    throw new Error(`${executable} exited with ${String(exitCode)}: ${stderr}`);
-  }
-  return stdout;
-}
-
-async function betaPod(): Promise<{ name: string; uid: string }> {
-  const output = await run([
-    "kubectl",
-    "get",
-    "pods",
-    "-n",
-    "scout-beta",
-    "-o",
-    "json",
-  ]);
-  const pods = PodListSchema.parse(JSON.parse(output)).items.filter(
-    (pod) =>
-      pod.metadata.name.startsWith("scout-beta-postgresql-") &&
-      pod.status.phase === "Running" &&
-      pod.status.conditions.some(
-        (condition) =>
-          condition.type === "Ready" && condition.status === "True",
-      ),
-  );
-  if (pods.length !== 1) {
-    throw new Error(
-      `Expected one ready Scout beta Postgres pod, found ${String(pods.length)}`,
-    );
-  }
-  const pod = pods[0];
-  if (pod === undefined) throw new Error("Scout beta pod selection failed");
-  return pod.metadata;
-}
-
 const destination = argumentValue("--output") ?? defaultBetaCorpusPath();
-const pod = await betaPod();
-const output = await run([
-  "kubectl",
-  "exec",
-  "-n",
-  "scout-beta",
-  pod.name,
-  "--",
-  "psql",
-  "-U",
-  "postgres",
-  "-d",
-  "scout",
-  "-At",
-  "-v",
-  "ON_ERROR_STOP=1",
-  "-c",
-  REMOTE_QUERY,
-]);
+const pod = await findReadyMasterPod(BETA_CLUSTER);
+const output = await execInPod({
+  namespace: BETA_CLUSTER.namespace,
+  pod: pod.name,
+  container: BETA_CLUSTER.container,
+  command: [
+    "psql",
+    "-U",
+    "postgres",
+    "-d",
+    "scout",
+    "-At",
+    "-v",
+    "ON_ERROR_STOP=1",
+    "-c",
+    REMOTE_QUERY,
+  ],
+});
 const parsed: unknown = JSON.parse(output);
 const profiles = z.array(BetaProfileRowSchema).min(1).parse(parsed);
 await mkdir(path.dirname(destination), { recursive: true });

--- a/packages/scout-for-lol/scripts/README.md
+++ b/packages/scout-for-lol/scripts/README.md
@@ -13,6 +13,7 @@ detail below; the rest of the directory is indexed here.
 | `check-suppressions.ts`   | Fails when new lint- or type-error-suppression comments are added                               |
 | `contract-hash.ts`        | Deterministic hash of the sources defining the frontend ↔ backend tRPC contract                 |
 | `create-minimal-png.ts`   | Writes minimal placeholder Tauri icon PNGs                                                      |
+| `dev-db-pull.ts`          | Copies a beta or prod Scout Postgres database into a local dev database (`dev:db-pull`)         |
 | `dev-web.ts`              | Local backend + web SPA dev environment (`--no-backend-watch` for stable browser testing)       |
 | `find-dependent-tests.ts` | Finds test files affected by changed source files (see below)                                   |
 | `install-pkgs.ts`         | Workspace install helper: `bun install` plus Prisma client regeneration when the schema drifted |

--- a/packages/scout-for-lol/scripts/dev/dev-db-pull-plan.ts
+++ b/packages/scout-for-lol/scripts/dev/dev-db-pull-plan.ts
@@ -1,0 +1,478 @@
+/**
+ * Decisions behind `dev:db-pull`, kept separate from the shelling-out half so
+ * every one of them is testable without a cluster or a local Postgres.
+ *
+ * Three of this pipeline's steps fail silently if done naively, and each is
+ * encoded here rather than left to the operator:
+ *
+ *  - The source pod carries several PostgreSQL toolchains and `PATH` resolves
+ *    to the newest, which writes an archive the local client cannot read while
+ *    still exiting 0. `assertRestorableVersions` states the requirement; the
+ *    caller pairs it with `pgBinaryPath` from the toolkit helper.
+ *  - The hosted database carries monitoring extensions that do not exist in the
+ *    mise-pinned local build. `selectDumpableExtensions` keeps them out.
+ *  - Omissions are not predicted, they are checked: `assertRestoredTables`
+ *    compares the restored tables against the source's.
+ */
+import { requireCliValue } from "#scripts/migration-core.ts";
+
+const DEFAULT_PG_PORT = "5471";
+const LOCAL_DATABASE_PATTERN = /^[a-z][a-z0-9_]*$/;
+const CLIENT_VERSION_PATTERN = /(\d+)(?:\.\d+)*$/;
+
+/**
+ * Always dumped, never emitted.
+ *
+ * `pg_dump` treats an `--extension` pattern that matches nothing as a fatal
+ * error, so the include list can never be empty. `plpgsql` exists in every
+ * database and `pg_dump` emits no statement for it, which makes it a safe
+ * anchor for an otherwise-empty selection.
+ */
+const EXTENSION_ANCHOR = "plpgsql";
+
+export type DevDbPullStage = "beta" | "prod";
+
+export type StageTarget = {
+  readonly namespace: string;
+  readonly cluster: string;
+  readonly container: string;
+  readonly database: string;
+};
+
+export const STAGES: Readonly<Record<DevDbPullStage, StageTarget>> = {
+  beta: {
+    namespace: "scout-beta",
+    cluster: "scout-beta-postgresql",
+    container: "postgres",
+    database: "scout",
+  },
+  prod: {
+    namespace: "scout-prod",
+    cluster: "scout-prod-postgresql",
+    container: "postgres",
+    database: "scout",
+  },
+};
+
+export type DevDbPullOptions = {
+  readonly stage: DevDbPullStage;
+  readonly target: StageTarget;
+  readonly localDatabase: string;
+  readonly databaseUrl: string;
+  readonly dumpPath: string;
+};
+
+export type DevDbPullParseResult =
+  | { readonly kind: "help" }
+  | { readonly kind: "options"; readonly options: DevDbPullOptions };
+
+export const USAGE = `Usage: bun run dev:db-pull -- [options]
+
+Copies a hosted Scout Postgres database into a local database on the shared dev
+server, then prints the dev:web command that uses it.
+
+Options:
+  --stage <beta|prod>   Source stage (default: beta)
+  --database <name>     Local database name (default: scout_<stage>_snapshot)
+  --dump-path <path>    Where to write the intermediate dump
+  --help                Show this help
+
+The local database is dropped and recreated on every run. Migrations are not
+applied here; dev:web applies them when it boots against the restored database.`;
+
+function parseStage(value: string): DevDbPullStage {
+  if (value === "beta" || value === "prod") {
+    return value;
+  }
+  throw new Error(`--stage must be beta or prod, got ${value}`);
+}
+
+function parseLocalDatabase(value: string): string {
+  if (!LOCAL_DATABASE_PATTERN.test(value)) {
+    // dev:web only treats a loopback URL as its own shared server when the
+    // name matches this pattern; anything else is silently used as-is, which
+    // skips the ensure-and-migrate step the restored database needs.
+    throw new Error(
+      `--database must match ${LOCAL_DATABASE_PATTERN.source}, got ${value}`,
+    );
+  }
+  return value;
+}
+
+/** Local URL for a database on the shared dev Postgres. */
+export function localDatabaseUrl(
+  database: string,
+  environment: Readonly<Record<string, string | undefined>>,
+): string {
+  const port = environment["SCOUT_PG_PORT"] ?? DEFAULT_PG_PORT;
+  return `postgres://scout@127.0.0.1:${port}/${database}`;
+}
+
+/** Default dump location, alongside the other local Scout dev data. */
+export function defaultDumpPath(
+  stage: DevDbPullStage,
+  environment: Readonly<Record<string, string | undefined>>,
+): string {
+  const dataHome =
+    environment["XDG_DATA_HOME"] ??
+    `${environment["HOME"] ?? "/tmp"}/.local/share`;
+  return `${dataHome}/scout-for-lol/db-pull/${stage}.dump`;
+}
+
+export function parseDevDbPullArgs(
+  args: readonly string[],
+  environment: Readonly<Record<string, string | undefined>>,
+): DevDbPullParseResult {
+  let stage: DevDbPullStage = "beta";
+  let database: string | undefined;
+  let dumpPath: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--help" || argument === "-h") {
+      return { kind: "help" };
+    }
+    if (argument === "--stage") {
+      stage = parseStage(requireCliValue(args, index, "--stage"));
+      index += 1;
+      continue;
+    }
+    if (argument === "--database") {
+      database = parseLocalDatabase(requireCliValue(args, index, "--database"));
+      index += 1;
+      continue;
+    }
+    if (argument === "--dump-path") {
+      dumpPath = requireCliValue(args, index, "--dump-path");
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${argument ?? "<missing>"}`);
+  }
+
+  const localDatabase = database ?? `scout_${stage}_snapshot`;
+  return {
+    kind: "options",
+    options: {
+      stage,
+      target: STAGES[stage],
+      localDatabase,
+      databaseUrl: localDatabaseUrl(localDatabase, environment),
+      dumpPath: dumpPath ?? defaultDumpPath(stage, environment),
+    },
+  };
+}
+
+/**
+ * Refuse a dump the local client cannot read.
+ *
+ * A newer server dumped by its own `pg_dump` produces an archive version an
+ * older `pg_restore` rejects outright, so this is worth stating before spending
+ * a dump on it.
+ */
+export function assertRestorableVersions(
+  serverMajor: number,
+  localRestoreMajor: number,
+): void {
+  if (localRestoreMajor < serverMajor) {
+    throw new Error(
+      `Local pg_restore is PostgreSQL ${String(localRestoreMajor)} but the source server is ${String(serverMajor)}. ` +
+        "Upgrade the local PostgreSQL client (mise install) before retrying; an older client cannot read a newer archive.",
+    );
+  }
+}
+
+/** Major version from a client banner such as "pg_restore (PostgreSQL) 16.15". */
+export function parseClientMajorVersion(output: string): number {
+  const matched = CLIENT_VERSION_PATTERN.exec(output.trim());
+  const major = matched?.[1];
+  if (major === undefined) {
+    throw new Error(
+      `Could not read a PostgreSQL client version from ${JSON.stringify(output.trim())}`,
+    );
+  }
+  return Number.parseInt(major, 10);
+}
+
+export type ExtensionSelection = {
+  readonly include: string[];
+  readonly skipped: string[];
+};
+
+/**
+ * Which of the source's extensions to carry over.
+ *
+ * Only extensions the local build actually has are included. The hosted
+ * clusters run monitoring extensions (`pg_stat_kcache`, `set_user`) that the
+ * local build does not ship, and dumping them makes the restore fail.
+ */
+export function selectDumpableExtensions(
+  sourceExtensions: readonly string[],
+  locallyAvailable: readonly string[],
+): ExtensionSelection {
+  const available = new Set(locallyAvailable);
+  const include = new Set<string>([EXTENSION_ANCHOR]);
+  const skipped: string[] = [];
+  for (const name of [...sourceExtensions].sort()) {
+    if (name === EXTENSION_ANCHOR) {
+      continue;
+    }
+    if (available.has(name)) {
+      include.add(name);
+    } else {
+      skipped.push(name);
+    }
+  }
+  return { include: [...include].sort(), skipped };
+}
+
+/**
+ * Tables whose rows are nothing but credentials.
+ *
+ * Their schema is restored and their data is not. `ApiToken.token` and
+ * `InstallAttributionToken.token` are both `NOT NULL` and unique, so there is
+ * no redacted value to substitute — and neither table shows up in a screen
+ * worth looking at locally.
+ */
+export const EXCLUDED_TABLE_DATA: readonly string[] = [
+  "ApiToken",
+  "InstallAttributionToken",
+];
+
+/**
+ * How each credential column is rewritten while its row is kept.
+ *
+ * `replacement` is substituted for the column when the source rows are read, so
+ * the real value never leaves the cluster. `verify` is asserted against every
+ * restored row afterwards. Both are trusted constants, never operator input.
+ *
+ * Most of these are nullable, so NULL is a legal substitution.
+ * `TournamentLobby.code` is not: it is `String @unique`, so it gets a
+ * per-row stand-in that keeps the NOT NULL and uniqueness guarantees.
+ */
+export type ColumnRedaction = {
+  readonly column: string;
+  readonly replacement: string;
+  readonly verify: string;
+};
+
+function blanked(column: string): ColumnRedaction {
+  return {
+    column,
+    replacement: "NULL",
+    verify: `"${column}" IS NULL`,
+  };
+}
+
+/**
+ * Credential-bearing columns whose rows are worth keeping.
+ *
+ * `User` holds live Discord OAuth bearer tokens,
+ * `ExploreConversation.shareToken` is the only credential a share link carries,
+ * and a `TournamentLobby` carries both the Riot join code and the lobby
+ * password. `TournamentRegistration` and `ScoutEffectClaim.key` are documented
+ * in the schema as deliberately *not* credentials and are left alone.
+ */
+export const REDACTED_COLUMNS: Readonly<
+  Record<string, readonly ColumnRedaction[]>
+> = {
+  ExploreConversation: [blanked("shareToken")],
+  TournamentLobby: [
+    {
+      column: "code",
+      replacement: `'redacted-' || "id"`,
+      verify: `"code" LIKE 'redacted-%'`,
+    },
+    blanked("password"),
+  ],
+  User: [
+    blanked("discordAccessToken"),
+    blanked("discordRefreshToken"),
+    blanked("tokenExpiresAt"),
+  ],
+};
+
+const IDENTIFIER_PATTERN = /^[a-z_]\w*$/iu;
+
+function quoteIdentifier(name: string): string {
+  if (!IDENTIFIER_PATTERN.test(name)) {
+    throw new Error(`Refusing to interpolate unexpected identifier: ${name}`);
+  }
+  return `"${name}"`;
+}
+
+/** Every table whose data the dump leaves behind, excluded or redacted. */
+export function tablesWithoutDumpedData(): string[] {
+  return [...EXCLUDED_TABLE_DATA, ...Object.keys(REDACTED_COLUMNS)].sort();
+}
+
+/**
+ * Read the source rows with credential columns blanked.
+ *
+ * Emitted from the pod so the tokens are never written to this machine at all,
+ * rather than restored and cleaned up afterwards.
+ */
+export function redactedCopyOutStatement(
+  table: string,
+  columns: readonly string[],
+  redactions: readonly ColumnRedaction[],
+): string {
+  if (columns.length === 0) {
+    throw new Error(`No columns known for ${table}`);
+  }
+  const projection = columns.map((column) => {
+    const redaction = redactions.find((entry) => entry.column === column);
+    const quoted = quoteIdentifier(column);
+    return redaction === undefined
+      ? quoted
+      : `${redaction.replacement} AS ${quoted}`;
+  });
+  return `COPY (SELECT ${projection.join(", ")} FROM ${quoteIdentifier(table)}) TO STDOUT`;
+}
+
+/** Load those rows into the restored table. */
+export function copyInStatement(
+  table: string,
+  columns: readonly string[],
+): string {
+  if (columns.length === 0) {
+    throw new Error(`No columns known for ${table}`);
+  }
+  return `COPY ${quoteIdentifier(table)} (${columns.map((column) => quoteIdentifier(column)).join(", ")}) FROM STDIN`;
+}
+
+/** Prove the redaction landed instead of assuming it did. */
+export function assertRedacted(
+  table: string,
+  nonNullCounts: Readonly<Record<string, number>>,
+): void {
+  const leaked = Object.entries(nonNullCounts)
+    .filter(([, count]) => count > 0)
+    .map(([column, count]) => `${column} (${String(count)} rows)`);
+  if (leaked.length > 0) {
+    throw new Error(
+      `Redaction failed: ${table} still holds unredacted values in ${leaked.sort().join(", ")}`,
+    );
+  }
+}
+
+/** Count rows where a redacted column did not end up as intended. */
+export function redactionCheckStatement(
+  table: string,
+  redactions: readonly ColumnRedaction[],
+): string {
+  const counts = redactions.map(
+    (redaction) =>
+      `count(*) FILTER (WHERE NOT coalesce(${redaction.verify}, false)) AS ${quoteIdentifier(redaction.column)}`,
+  );
+  return `SELECT ${counts.join(", ")} FROM ${quoteIdentifier(table)}`;
+}
+
+/**
+ * `pg_dump` argv, run inside the pod over its local trust socket.
+ *
+ * `--schema public` leaves behind the operator's own `metric_helpers` and
+ * `user_management` schemas, whose functions lean on the extensions the local
+ * build lacks.
+ */
+export function dumpArgv(input: {
+  readonly binaryPath: string;
+  readonly database: string;
+  readonly extensions: readonly string[];
+}): string[] {
+  return [
+    input.binaryPath,
+    "--username",
+    "postgres",
+    "--dbname",
+    input.database,
+    "--format",
+    "custom",
+    "--no-owner",
+    "--no-privileges",
+    "--schema",
+    "public",
+    ...input.extensions.map((name) => `--extension=${name}`),
+    ...tablesWithoutDumpedData().map(
+      (table) => `--exclude-table-data=public."${table}"`,
+    ),
+  ];
+}
+
+/**
+ * Restored one section at a time so the redacted rows can land in the middle.
+ *
+ * Foreign keys live in `post-data` and are validated as they are created, so a
+ * dump carrying no `User` rows fails the moment another table's key is checked.
+ * Loading the redacted rows between `data` and `post-data` keeps referential
+ * integrity intact without ever writing a token to this machine.
+ */
+export const RESTORE_SECTIONS: readonly string[] = [
+  "pre-data",
+  "data",
+  "post-data",
+];
+
+/**
+ * `pg_restore` argv for one section.
+ *
+ * `--single-transaction` makes each section all-or-nothing. The caller drops
+ * the target's `public` schema first so the dump's own `CREATE SCHEMA` does not
+ * collide with the one `createdb` provides and abort the transaction.
+ */
+export function restoreArgv(input: {
+  readonly databaseUrl: string;
+  readonly dumpPath: string;
+  readonly section: string;
+}): string[] {
+  return [
+    "pg_restore",
+    "--dbname",
+    input.databaseUrl,
+    "--no-owner",
+    "--no-privileges",
+    "--single-transaction",
+    "--section",
+    input.section,
+    input.dumpPath,
+  ];
+}
+
+/** Non-empty trimmed lines from a `psql --no-align --tuples-only` result. */
+export function parseRowList(output: string): string[] {
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * Check the restore rather than predict it.
+ *
+ * Anything the dump filters out shows up here as a missing table, which is a
+ * stronger guarantee than reasoning about which extensions own which objects.
+ */
+export function assertRestoredTables(
+  sourceTables: readonly string[],
+  restoredTables: readonly string[],
+): void {
+  const restored = new Set(restoredTables);
+  const missing = sourceTables.filter((name) => !restored.has(name));
+  if (missing.length > 0) {
+    throw new Error(
+      `Restored database is missing ${String(missing.length)} table(s) present in the source: ${missing.sort().join(", ")}`,
+    );
+  }
+}
+
+/** What to run once the restore lands. dev:web owns the migration step. */
+export function handoffMessage(options: DevDbPullOptions): string {
+  return [
+    `Restored ${options.stage} into ${options.localDatabase}.`,
+    "",
+    "Start the app against it with:",
+    `  bun run dev:web -- --database-url ${options.databaseUrl}`,
+    "",
+    "dev:web applies any migrations newer than the snapshot on boot.",
+  ].join("\n");
+}

--- a/packages/scout-for-lol/scripts/dev/dev-db-pull.test.ts
+++ b/packages/scout-for-lol/scripts/dev/dev-db-pull.test.ts
@@ -1,0 +1,423 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  assertRedacted,
+  assertRestorableVersions,
+  assertRestoredTables,
+  copyInStatement,
+  EXCLUDED_TABLE_DATA,
+  redactedCopyOutStatement,
+  redactionCheckStatement,
+  REDACTED_COLUMNS,
+  tablesWithoutDumpedData,
+  defaultDumpPath,
+  dumpArgv,
+  handoffMessage,
+  localDatabaseUrl,
+  parseClientMajorVersion,
+  parseDevDbPullArgs,
+  parseRowList,
+  restoreArgv,
+  RESTORE_SECTIONS,
+  selectDumpableExtensions,
+  STAGES,
+} from "./dev-db-pull-plan.ts";
+
+const environment = { HOME: "/home/dev" } as const;
+
+function options(args: readonly string[] = []) {
+  const parsed = parseDevDbPullArgs(args, environment);
+  if (parsed.kind !== "options") {
+    throw new Error("expected options");
+  }
+  return parsed.options;
+}
+
+describe("parseDevDbPullArgs", () => {
+  test("defaults to beta with a stage-named local database", () => {
+    expect(options()).toEqual({
+      stage: "beta",
+      target: STAGES.beta,
+      localDatabase: "scout_beta_snapshot",
+      databaseUrl: "postgres://scout@127.0.0.1:5471/scout_beta_snapshot",
+      dumpPath: "/home/dev/.local/share/scout-for-lol/db-pull/beta.dump",
+    });
+  });
+
+  test("switches every derived value when the stage changes", () => {
+    const parsed = options(["--stage", "prod"]);
+    expect(parsed.target).toEqual(STAGES.prod);
+    expect(parsed.target.namespace).toBe("scout-prod");
+    expect(parsed.localDatabase).toBe("scout_prod_snapshot");
+    expect(parsed.dumpPath).toBe(
+      "/home/dev/.local/share/scout-for-lol/db-pull/prod.dump",
+    );
+  });
+
+  test("honours explicit overrides", () => {
+    const parsed = options([
+      "--database",
+      "scout_scratch",
+      "--dump-path",
+      "/tmp/one.dump",
+    ]);
+    expect(parsed.localDatabase).toBe("scout_scratch");
+    expect(parsed.databaseUrl).toBe(
+      "postgres://scout@127.0.0.1:5471/scout_scratch",
+    );
+    expect(parsed.dumpPath).toBe("/tmp/one.dump");
+  });
+
+  test("reports help rather than acting", () => {
+    expect(parseDevDbPullArgs(["--help"], environment)).toEqual({
+      kind: "help",
+    });
+    expect(parseDevDbPullArgs(["-h"], environment)).toEqual({ kind: "help" });
+  });
+
+  test("rejects an unknown stage", () => {
+    expect(() =>
+      parseDevDbPullArgs(["--stage", "staging"], environment),
+    ).toThrow("--stage must be beta or prod");
+  });
+
+  test("rejects a database name dev:web would treat as external", () => {
+    // dev:web only ensures and migrates a loopback URL whose database name
+    // matches its own pattern; a rejected name here would silently skip that.
+    expect(() =>
+      parseDevDbPullArgs(["--database", "Scout-Snapshot"], environment),
+    ).toThrow("--database must match");
+  });
+
+  test("rejects a flag with no value", () => {
+    expect(() => parseDevDbPullArgs(["--stage"], environment)).toThrow(
+      "--stage requires a value",
+    );
+  });
+
+  test("rejects an unknown argument", () => {
+    expect(() => parseDevDbPullArgs(["--wat"], environment)).toThrow(
+      "Unknown argument: --wat",
+    );
+  });
+
+  test("honours SCOUT_PG_PORT", () => {
+    const parsed = parseDevDbPullArgs([], {
+      ...environment,
+      SCOUT_PG_PORT: "5999",
+    });
+    if (parsed.kind !== "options") {
+      throw new Error("expected options");
+    }
+    expect(parsed.options.databaseUrl).toBe(
+      "postgres://scout@127.0.0.1:5999/scout_beta_snapshot",
+    );
+  });
+});
+
+describe("localDatabaseUrl and defaultDumpPath", () => {
+  test("prefer XDG_DATA_HOME when set", () => {
+    expect(defaultDumpPath("beta", { XDG_DATA_HOME: "/xdg" })).toBe(
+      "/xdg/scout-for-lol/db-pull/beta.dump",
+    );
+  });
+
+  test("build a loopback URL for the shared dev server", () => {
+    expect(localDatabaseUrl("scout_dev_3000", {})).toBe(
+      "postgres://scout@127.0.0.1:5471/scout_dev_3000",
+    );
+  });
+});
+
+describe("assertRestorableVersions", () => {
+  test("accepts a client at or ahead of the server", () => {
+    expect(() => assertRestorableVersions(16, 16)).not.toThrow();
+    expect(() => assertRestorableVersions(16, 18)).not.toThrow();
+  });
+
+  test("refuses a client behind the server", () => {
+    expect(() => assertRestorableVersions(18, 16)).toThrow(
+      "Local pg_restore is PostgreSQL 16 but the source server is 18",
+    );
+  });
+});
+
+describe("parseClientMajorVersion", () => {
+  test("reads the major from a client banner", () => {
+    expect(parseClientMajorVersion("pg_restore (PostgreSQL) 16.15")).toBe(16);
+    expect(parseClientMajorVersion("pg_dump (PostgreSQL) 18.3\n")).toBe(18);
+  });
+
+  test("throws when there is no version to read", () => {
+    expect(() => parseClientMajorVersion("pg_restore")).toThrow(
+      "Could not read a PostgreSQL client version",
+    );
+  });
+});
+
+describe("selectDumpableExtensions", () => {
+  test("keeps locally available extensions and skips the rest", () => {
+    const selection = selectDumpableExtensions(
+      [
+        "plpgsql",
+        "pg_stat_statements",
+        "pg_stat_kcache",
+        "set_user",
+        "pg_trgm",
+      ],
+      ["plpgsql", "pg_stat_statements", "pg_trgm"],
+    );
+    expect(selection.include).toEqual([
+      "pg_stat_statements",
+      "pg_trgm",
+      "plpgsql",
+    ]);
+    expect(selection.skipped).toEqual(["pg_stat_kcache", "set_user"]);
+  });
+
+  test("always anchors on plpgsql so the pattern list is never empty", () => {
+    // pg_dump treats an --extension pattern matching nothing as a fatal error.
+    const selection = selectDumpableExtensions(["set_user"], []);
+    expect(selection.include).toEqual(["plpgsql"]);
+    expect(selection.skipped).toEqual(["set_user"]);
+  });
+
+  test("does not duplicate the anchor when the source lists it", () => {
+    expect(selectDumpableExtensions(["plpgsql"], ["plpgsql"]).include).toEqual([
+      "plpgsql",
+    ]);
+  });
+});
+
+describe("argv builders", () => {
+  test("dump restricts to the public schema and the chosen extensions", () => {
+    expect(
+      dumpArgv({
+        binaryPath: "/usr/lib/postgresql/16/bin/pg_dump",
+        database: "scout",
+        extensions: ["plpgsql", "pg_trgm"],
+      }),
+    ).toEqual([
+      "/usr/lib/postgresql/16/bin/pg_dump",
+      "--username",
+      "postgres",
+      "--dbname",
+      "scout",
+      "--format",
+      "custom",
+      "--no-owner",
+      "--no-privileges",
+      "--schema",
+      "public",
+      "--extension=plpgsql",
+      "--extension=pg_trgm",
+      '--exclude-table-data=public."ApiToken"',
+      '--exclude-table-data=public."ExploreConversation"',
+      '--exclude-table-data=public."InstallAttributionToken"',
+      '--exclude-table-data=public."TournamentLobby"',
+      '--exclude-table-data=public."User"',
+    ]);
+  });
+
+  test("restore runs in a single transaction", () => {
+    expect(
+      restoreArgv({
+        databaseUrl: "postgres://scout@127.0.0.1:5471/scout_beta_snapshot",
+        dumpPath: "/tmp/beta.dump",
+        section: "post-data",
+      }),
+    ).toEqual([
+      "pg_restore",
+      "--dbname",
+      "postgres://scout@127.0.0.1:5471/scout_beta_snapshot",
+      "--no-owner",
+      "--no-privileges",
+      "--single-transaction",
+      "--section",
+      "post-data",
+      "/tmp/beta.dump",
+    ]);
+  });
+});
+
+describe("parseRowList", () => {
+  test("drops blank lines and trims", () => {
+    expect(parseRowList("Player\n Account \n\n")).toEqual([
+      "Player",
+      "Account",
+    ]);
+    expect(parseRowList("\n")).toEqual([]);
+  });
+});
+
+describe("assertRestoredTables", () => {
+  test("passes when every source table arrived", () => {
+    expect(() =>
+      assertRestoredTables(["Account", "Player"], ["Player", "Account"]),
+    ).not.toThrow();
+  });
+
+  test("ignores extra local tables", () => {
+    expect(() =>
+      assertRestoredTables(["Player"], ["Player", "_prisma_migrations"]),
+    ).not.toThrow();
+  });
+
+  test("names what went missing", () => {
+    expect(() =>
+      assertRestoredTables(["Account", "Player", "Report"], ["Player"]),
+    ).toThrow("missing 2 table(s) present in the source: Account, Report");
+  });
+});
+
+describe("handoffMessage", () => {
+  test("prints the dev:web command for the restored database", () => {
+    expect(handoffMessage(options())).toContain(
+      "bun run dev:web -- --database-url postgres://scout@127.0.0.1:5471/scout_beta_snapshot",
+    );
+  });
+});
+
+describe("credential handling", () => {
+  test("leaves no data for the credential-only tables", () => {
+    expect(EXCLUDED_TABLE_DATA).toEqual([
+      "ApiToken",
+      "InstallAttributionToken",
+    ]);
+  });
+
+  test("redacts the live OAuth tokens and the share/lobby credentials", () => {
+    expect(
+      Object.fromEntries(
+        Object.entries(REDACTED_COLUMNS).map(([table, redactions]) => [
+          table,
+          redactions.map((redaction) => redaction.column),
+        ]),
+      ),
+    ).toEqual({
+      ExploreConversation: ["shareToken"],
+      TournamentLobby: ["code", "password"],
+      User: ["discordAccessToken", "discordRefreshToken", "tokenExpiresAt"],
+    });
+  });
+
+  test("blanks nullable credentials but keeps the unique join code non-null", () => {
+    // TournamentLobby.code is `String @unique`, so NULL would break the
+    // NOT NULL and uniqueness guarantees the restore has to satisfy.
+    const lobby = REDACTED_COLUMNS["TournamentLobby"] ?? [];
+    const code = lobby.find((redaction) => redaction.column === "code");
+    expect(code?.replacement).toBe(`'redacted-' || "id"`);
+    expect(code?.verify).toBe(`"code" LIKE 'redacted-%'`);
+    const password = lobby.find((redaction) => redaction.column === "password");
+    expect(password?.replacement).toBe("NULL");
+  });
+
+  test("the dump carries no data for any of those tables", () => {
+    const argv = dumpArgv({
+      binaryPath: "/usr/lib/postgresql/16/bin/pg_dump",
+      database: "scout",
+      extensions: ["plpgsql"],
+    });
+    for (const table of tablesWithoutDumpedData()) {
+      expect(argv).toContain(`--exclude-table-data=public."${table}"`);
+    }
+    // The tokens must never be written locally, so this list and the dump
+    // must not drift apart.
+    expect(tablesWithoutDumpedData()).toEqual([
+      "ApiToken",
+      "ExploreConversation",
+      "InstallAttributionToken",
+      "TournamentLobby",
+      "User",
+    ]);
+  });
+
+  test("blanks exactly the credential columns in the source projection", () => {
+    expect(
+      redactedCopyOutStatement(
+        "User",
+        ["id", "discordId", "discordAccessToken", "tokenExpiresAt"],
+        [
+          { column: "discordAccessToken", replacement: "NULL", verify: "" },
+          { column: "tokenExpiresAt", replacement: "NULL", verify: "" },
+        ],
+      ),
+    ).toBe(
+      'COPY (SELECT "id", "discordId", NULL AS "discordAccessToken", NULL AS "tokenExpiresAt" FROM "User") TO STDOUT',
+    );
+  });
+
+  test("loads every column back in ordinal order", () => {
+    expect(copyInStatement("User", ["id", "discordId"])).toBe(
+      'COPY "User" ("id", "discordId") FROM STDIN',
+    );
+  });
+
+  test("refuses an identifier it did not expect", () => {
+    expect(() => redactedCopyOutStatement('User" --', ["id"], [])).toThrow(
+      "Refusing to interpolate unexpected identifier",
+    );
+    expect(() => copyInStatement("User", ["id; DROP TABLE"])).toThrow(
+      "Refusing to interpolate unexpected identifier",
+    );
+  });
+
+  test("throws when a table has no known columns", () => {
+    expect(() => redactedCopyOutStatement("User", [], [])).toThrow(
+      "No columns known for User",
+    );
+    expect(() => copyInStatement("User", [])).toThrow("No columns known");
+  });
+
+  test("counts rows that failed each column's own redaction predicate", () => {
+    expect(
+      redactionCheckStatement("TournamentLobby", [
+        {
+          column: "code",
+          replacement: `'redacted-' || "id"`,
+          verify: `"code" LIKE 'redacted-%'`,
+        },
+      ]),
+    ).toBe(
+      'SELECT count(*) FILTER (WHERE NOT coalesce("code" LIKE \'redacted-%\', false)) AS "code" FROM "TournamentLobby"',
+    );
+  });
+
+  test("substitutes the per-row stand-in for a non-nullable credential", () => {
+    expect(
+      redactedCopyOutStatement(
+        "TournamentLobby",
+        ["id", "code"],
+        [
+          {
+            column: "code",
+            replacement: `'redacted-' || "id"`,
+            verify: `"code" LIKE 'redacted-%'`,
+          },
+        ],
+      ),
+    ).toBe(
+      'COPY (SELECT "id", \'redacted-\' || "id" AS "code" FROM "TournamentLobby") TO STDOUT',
+    );
+  });
+
+  test("assertRedacted passes only when every column is empty", () => {
+    expect(() =>
+      assertRedacted("User", { discordAccessToken: 0, tokenExpiresAt: 0 }),
+    ).not.toThrow();
+  });
+
+  test("assertRedacted names the columns that still hold values", () => {
+    expect(() =>
+      assertRedacted("User", { discordAccessToken: 3, tokenExpiresAt: 0 }),
+    ).toThrow(
+      "User still holds unredacted values in discordAccessToken (3 rows)",
+    );
+  });
+});
+
+describe("RESTORE_SECTIONS", () => {
+  test("loads data before the constraints that reference it", () => {
+    expect(RESTORE_SECTIONS).toEqual(["pre-data", "data", "post-data"]);
+  });
+});

--- a/packages/scout-for-lol/scripts/dev/dev-db-pull.ts
+++ b/packages/scout-for-lol/scripts/dev/dev-db-pull.ts
@@ -1,0 +1,333 @@
+#!/usr/bin/env bun
+/**
+ * Copy a hosted Scout Postgres database into local dev.
+ *
+ *   bun run dev:db-pull
+ *   bun run dev:db-pull -- --stage prod --database scout_prod_snapshot
+ *
+ * None of the homelab clusters is reachable without `kubectl`, so the dump runs
+ * inside the pod over the local trust socket the cluster's pgHba grants for
+ * exactly these runbooks. Every decision this makes lives in
+ * `dev-db-pull-plan.ts`; this file only performs them.
+ *
+ * The local database is dropped and recreated each run. Migrations are left to
+ * `dev:web`, which applies anything newer than the snapshot when it boots.
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+import { captureCommand } from "@shepherdjerred/toolkit/lib/postgres/command.ts";
+import {
+  execInPod,
+  execInPodToFile,
+  findReadyMasterPod,
+  pgBinaryPath,
+  serverMajorVersion,
+} from "@shepherdjerred/toolkit/lib/postgres/pod.ts";
+
+import {
+  assertRedacted,
+  assertRestorableVersions,
+  assertRestoredTables,
+  copyInStatement,
+  EXCLUDED_TABLE_DATA,
+  redactedCopyOutStatement,
+  redactionCheckStatement,
+  REDACTED_COLUMNS,
+  RESTORE_SECTIONS,
+  type ColumnRedaction,
+  dumpArgv,
+  handoffMessage,
+  parseClientMajorVersion,
+  parseDevDbPullArgs,
+  localDatabaseUrl,
+  parseRowList,
+  restoreArgv,
+  selectDumpableExtensions,
+  USAGE,
+  type DevDbPullOptions,
+  type StageTarget,
+} from "./dev-db-pull-plan.ts";
+
+const SOURCE_EXTENSIONS = "SELECT extname FROM pg_extension ORDER BY extname";
+const AVAILABLE_EXTENSIONS =
+  "SELECT name FROM pg_available_extensions ORDER BY name";
+const PUBLIC_TABLES = `SELECT table_name FROM information_schema.tables
+  WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+  ORDER BY table_name`;
+
+function columnsQuery(table: string): string {
+  return `SELECT column_name FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = '${table}'
+    ORDER BY ordinal_position`;
+}
+
+/**
+ * Re-materialize one table's rows with its credential columns blanked.
+ *
+ * The dump deliberately carries no data for these tables, so the rows arrive
+ * here already redacted at the source. Nothing writes a live token to this
+ * machine at any point.
+ */
+async function copyRedactedTable(
+  options: DevDbPullOptions,
+  pod: string,
+  table: string,
+  redactions: readonly ColumnRedaction[],
+): Promise<number> {
+  const target = options.target;
+  const columns = parseRowList(
+    await queryLocal(options.databaseUrl, columnsQuery(table)),
+  );
+  const rows = await queryPod(
+    target,
+    pod,
+    redactedCopyOutStatement(table, columns, redactions),
+  );
+  const loader = Bun.spawn(
+    [
+      "psql",
+      options.databaseUrl,
+      "--quiet",
+      "--variable",
+      "ON_ERROR_STOP=1",
+      "--command",
+      copyInStatement(table, columns),
+    ],
+    { stdin: new Blob([rows]), stdout: "pipe", stderr: "pipe" },
+  );
+  const [stderr, exitCode] = await Promise.all([
+    new Response(loader.stderr).text(),
+    loader.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(
+      `Loading redacted ${table} rows exited ${String(exitCode)}: ${stderr.trim()}`,
+    );
+  }
+  const counts = parseRowList(
+    await queryLocal(
+      options.databaseUrl,
+      redactionCheckStatement(table, redactions),
+    ),
+  );
+  const [row] = counts;
+  const values = (row ?? "").split("|").map(Number);
+  assertRedacted(
+    table,
+    Object.fromEntries(
+      redactions.map((redaction, index) => [
+        redaction.column,
+        values[index] ?? 0,
+      ]),
+    ),
+  );
+  return rows.split("\n").filter((line) => line.length > 0).length;
+}
+
+async function queryLocal(databaseUrl: string, sql: string): Promise<string> {
+  return captureCommand({
+    args: [
+      "psql",
+      databaseUrl,
+      "--no-align",
+      "--tuples-only",
+      "--variable",
+      "ON_ERROR_STOP=1",
+      "--command",
+      sql,
+    ],
+    label: "psql",
+  });
+}
+
+async function queryPod(
+  target: StageTarget,
+  pod: string,
+  sql: string,
+): Promise<string> {
+  return execInPod({
+    namespace: target.namespace,
+    pod,
+    container: target.container,
+    command: [
+      "psql",
+      "--username",
+      "postgres",
+      "--dbname",
+      target.database,
+      "--no-align",
+      "--tuples-only",
+      "--variable",
+      "ON_ERROR_STOP=1",
+      "--command",
+      sql,
+    ],
+  });
+}
+
+async function ensureSharedServer(
+  scoutRoot: string,
+  database: string,
+): Promise<void> {
+  const ensure = Bun.spawn(
+    ["bun", "run", "scripts/ensure-dev-postgres.ts", database],
+    {
+      cwd: path.join(scoutRoot, "packages", "backend"),
+      env: Bun.env,
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    },
+  );
+  if ((await ensure.exited) !== 0) {
+    throw new Error("Failed to start the shared local dev Postgres");
+  }
+}
+
+async function recreateLocalDatabase(options: DevDbPullOptions): Promise<void> {
+  const host = [
+    "--host",
+    "127.0.0.1",
+    "--port",
+    localPort(options),
+    "--username",
+    "scout",
+  ];
+  // --force terminates whatever is still attached. A dev:web left running
+  // against the previous snapshot otherwise fails the drop outright, which
+  // would make a re-pull depend on remembering to stop the app first.
+  await captureCommand({
+    args: ["dropdb", ...host, "--force", "--if-exists", options.localDatabase],
+    label: "dropdb",
+  });
+  await captureCommand({
+    args: ["createdb", ...host, options.localDatabase],
+    label: "createdb",
+  });
+  // `createdb` supplies a `public` schema, and the dump carries its own
+  // `CREATE SCHEMA public`. Under --single-transaction that collision rolls
+  // back the entire restore, so drop it before restoring.
+  await queryLocal(options.databaseUrl, "DROP SCHEMA public CASCADE");
+}
+
+function localPort(options: DevDbPullOptions): string {
+  const parsed = new URL(options.databaseUrl);
+  return parsed.port;
+}
+
+async function main(): Promise<void> {
+  const parsed = parseDevDbPullArgs(Bun.argv.slice(2), Bun.env);
+  if (parsed.kind === "help") {
+    console.log(USAGE);
+    return;
+  }
+  const options = parsed.options;
+  const target = options.target;
+  const scoutRoot = path.resolve(import.meta.dir, "../..");
+  const maintenanceUrl = localDatabaseUrl("postgres", Bun.env);
+
+  if (options.stage === "prod") {
+    console.warn(
+      "WARNING: pulling from production. The restore puts real player data (aliases, Discord IDs, PUUIDs) on this machine.",
+    );
+  }
+
+  const pod = await findReadyMasterPod({
+    namespace: target.namespace,
+    cluster: target.cluster,
+  });
+  console.log(`Source: ${target.namespace}/${pod.name} (${target.database})`);
+
+  const serverMajor = await serverMajorVersion({
+    namespace: target.namespace,
+    pod: pod.name,
+    container: target.container,
+    database: target.database,
+  });
+  const localMajor = parseClientMajorVersion(
+    await captureCommand({ args: ["pg_restore", "--version"] }),
+  );
+  assertRestorableVersions(serverMajor, localMajor);
+  // The pod's PATH resolves pg_dump to its newest toolchain, which would write
+  // an archive this client cannot read while still exiting 0.
+  const dumpBinary = pgBinaryPath(serverMajor, "pg_dump");
+  console.log(
+    `PostgreSQL ${String(serverMajor)} server, ${String(localMajor)} local client; dumping with ${dumpBinary}`,
+  );
+
+  await ensureSharedServer(scoutRoot, options.localDatabase);
+
+  const selection = selectDumpableExtensions(
+    parseRowList(await queryPod(target, pod.name, SOURCE_EXTENSIONS)),
+    parseRowList(await queryLocal(maintenanceUrl, AVAILABLE_EXTENSIONS)),
+  );
+  if (selection.skipped.length > 0) {
+    console.log(
+      `Skipping extensions absent from the local build: ${selection.skipped.join(", ")}`,
+    );
+  }
+
+  await mkdir(path.dirname(options.dumpPath), { recursive: true });
+  const written = await execInPodToFile({
+    namespace: target.namespace,
+    pod: pod.name,
+    container: target.container,
+    destination: options.dumpPath,
+    command: dumpArgv({
+      binaryPath: dumpBinary,
+      database: target.database,
+      extensions: selection.include,
+    }),
+  });
+  console.log(
+    `Dumped ${(written / 1_000_000).toFixed(1)} MB to ${options.dumpPath}`,
+  );
+
+  await recreateLocalDatabase(options);
+  for (const section of RESTORE_SECTIONS) {
+    if (section === "post-data") {
+      // Between `data` and `post-data`: the rows the dump withheld have to be
+      // present before the foreign keys referencing them are created.
+      for (const [table, redactions] of Object.entries(REDACTED_COLUMNS)) {
+        const loaded = await copyRedactedTable(
+          options,
+          pod.name,
+          table,
+          redactions,
+        );
+        console.log(
+          `Loaded ${String(loaded)} ${table} rows with ${redactions
+            .map((redaction) => redaction.column)
+            .join(", ")} redacted`,
+        );
+      }
+    }
+    await captureCommand({
+      args: restoreArgv({
+        databaseUrl: options.databaseUrl,
+        dumpPath: options.dumpPath,
+        section,
+      }),
+      label: `pg_restore --section=${section}`,
+    });
+  }
+  console.log(
+    `Restored no rows for credential-only tables: ${EXCLUDED_TABLE_DATA.join(", ")}`,
+  );
+
+  const sourceTables = parseRowList(
+    await queryPod(target, pod.name, PUBLIC_TABLES),
+  );
+  const restoredTables = parseRowList(
+    await queryLocal(options.databaseUrl, PUBLIC_TABLES),
+  );
+  assertRestoredTables(sourceTables, restoredTables);
+  console.log(`Restored ${String(restoredTables.length)} tables.`);
+  console.log("");
+  console.log(handoffMessage(options));
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/packages/scout-for-lol/scripts/migration-smoke.test.ts
+++ b/packages/scout-for-lol/scripts/migration-smoke.test.ts
@@ -3,8 +3,9 @@ import { expect, test } from "vitest";
 test("migrated entrypoints load without executing", async () => {
   const modules = await Promise.all([
     import("./create-minimal-png.ts"),
+    import("./dev/dev-db-pull.ts"),
     import("./dev/dev-web.ts"),
     import("./install-pkgs.ts"),
   ]);
-  expect(modules).toHaveLength(3);
+  expect(modules).toHaveLength(4);
 });

--- a/packages/toolkit/src/lib/postgres/command.ts
+++ b/packages/toolkit/src/lib/postgres/command.ts
@@ -1,0 +1,49 @@
+/**
+ * Running a command to completion and keeping its failure legible.
+ *
+ * Shared by the pod helpers and by callers that also drive local `psql`,
+ * `createdb`, and `pg_restore`, so a dump-and-restore pipeline reports every
+ * step the same way.
+ */
+
+/** Error naming the step, its exit code, and whatever it said before dying. */
+export function commandFailure(
+  label: string,
+  exitCode: number,
+  detail: string,
+): Error {
+  const trimmed = detail.trim();
+  return new Error(
+    `${label} exited ${String(exitCode)}: ${trimmed.length > 0 ? trimmed : "(no output)"}`,
+  );
+}
+
+/**
+ * Run a command and return its stdout.
+ *
+ * `label` keeps the error readable when the argv carries a connection URL or a
+ * multi-line SQL statement.
+ */
+export async function captureCommand(input: {
+  readonly args: readonly string[];
+  readonly label?: string | undefined;
+}): Promise<string> {
+  const child = Bun.spawn([...input.args], {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw commandFailure(
+      input.label ?? input.args[0] ?? "command",
+      exitCode,
+      stderr.length > 0 ? stderr : stdout,
+    );
+  }
+  return stdout;
+}

--- a/packages/toolkit/src/lib/postgres/pod.ts
+++ b/packages/toolkit/src/lib/postgres/pod.ts
@@ -1,0 +1,226 @@
+/**
+ * Reaching a homelab PostgreSQL cluster from a laptop.
+ *
+ * None of the clusters has an ingress, a LoadBalancer, or a tailnet hostname,
+ * so every connection goes through `kubectl`. The Zalando/Spilo pods also ship
+ * several PostgreSQL toolchains at once — the one on `PATH` is the newest, not
+ * the one matching the running server — which makes `pgBinaryPath` the whole
+ * point of this module rather than an incidental helper.
+ *
+ * Each operation is split into a pure half that parses or decides and a thin
+ * half that shells out, so the decisions are testable without a cluster.
+ */
+import { z } from "zod";
+
+import { captureCommand, commandFailure } from "./command.ts";
+
+const PodListSchema = z.object({
+  items: z.array(
+    z.object({
+      metadata: z.object({ name: z.string(), uid: z.string() }),
+      status: z.object({
+        conditions: z.array(z.object({ status: z.string(), type: z.string() })),
+        phase: z.string(),
+      }),
+    }),
+  ),
+});
+
+const ServerVersionPattern = /^(\d+)/;
+
+/** A PostgreSQL binary this module is willing to name a path for. */
+export type PostgresBinary = "pg_dump" | "pg_restore" | "psql";
+
+/** The pod backing a cluster, with the uid callers record as provenance. */
+export type PostgresPod = {
+  readonly name: string;
+  readonly uid: string;
+};
+
+/** Which cluster to look for, and where. */
+export type ClusterTarget = {
+  readonly namespace: string;
+  readonly cluster: string;
+};
+
+export type PodExec = {
+  readonly namespace: string;
+  readonly pod: string;
+  readonly container?: string | undefined;
+  readonly command: readonly string[];
+};
+
+/**
+ * Absolute path to a version-matched binary inside a Spilo pod.
+ *
+ * The pod's `PATH` resolves `pg_dump` to the newest toolchain it carries, which
+ * is routinely several majors ahead of the server it is running. That newer
+ * `pg_dump` writes a custom-format archive the local `pg_restore` cannot read,
+ * and it does so while exiting 0 and producing a plausible-looking file — so
+ * the mismatch surfaces as a corrupt restore, not a failed dump.
+ */
+export function pgBinaryPath(major: number, binary: PostgresBinary): string {
+  if (!Number.isInteger(major) || major < 1) {
+    throw new Error(
+      `PostgreSQL major version must be a positive integer, got ${String(major)}`,
+    );
+  }
+  return `/usr/lib/postgresql/${String(major)}/bin/${binary}`;
+}
+
+/** Major version from a `SHOW server_version` value such as "16.13 (Ubuntu ...)". */
+export function parseMajorVersion(output: string): number {
+  const matched = ServerVersionPattern.exec(output.trim());
+  const major = matched?.[1];
+  if (major === undefined) {
+    throw new Error(
+      `Could not read a PostgreSQL major version from ${JSON.stringify(output.trim())}`,
+    );
+  }
+  return Number.parseInt(major, 10);
+}
+
+/**
+ * The one ready master pod for a cluster, or a throw explaining what was found.
+ *
+ * Selection is by Spilo's own labels rather than a name prefix so a replica can
+ * never be chosen: a read-only replica accepts `pg_dump` happily and would look
+ * like success.
+ */
+export function selectReadyMasterPod(
+  podList: unknown,
+  target: ClusterTarget,
+): PostgresPod {
+  const ready = PodListSchema.parse(podList).items.filter(
+    (pod) =>
+      pod.status.phase === "Running" &&
+      pod.status.conditions.some(
+        (condition) =>
+          condition.type === "Ready" && condition.status === "True",
+      ),
+  );
+  const [pod] = ready;
+  if (pod === undefined || ready.length !== 1) {
+    throw new Error(
+      `Expected exactly one ready master pod for ${target.cluster} in ${target.namespace}, found ${String(ready.length)}`,
+    );
+  }
+  return pod.metadata;
+}
+
+/** `kubectl` argv selecting a cluster's master pod. */
+export function masterPodQueryArgs(target: ClusterTarget): string[] {
+  return [
+    "kubectl",
+    "get",
+    "pods",
+    "--namespace",
+    target.namespace,
+    "--selector",
+    `application=spilo,cluster-name=${target.cluster},spilo-role=master`,
+    "--output",
+    "json",
+  ];
+}
+
+/** `kubectl exec` argv for a command inside a pod. */
+export function podExecArgs(input: PodExec): string[] {
+  return [
+    "kubectl",
+    "exec",
+    "--namespace",
+    input.namespace,
+    ...(input.container === undefined ? [] : ["--container", input.container]),
+    input.pod,
+    "--",
+    ...input.command,
+  ];
+}
+
+/** Find the single ready master pod for a cluster. */
+export async function findReadyMasterPod(
+  target: ClusterTarget,
+): Promise<PostgresPod> {
+  const output = await captureCommand({
+    args: masterPodQueryArgs(target),
+    label: "kubectl get pods",
+  });
+  const parsed: unknown = JSON.parse(output);
+  return selectReadyMasterPod(parsed, target);
+}
+
+/** Run a command in a pod and return its stdout as text. */
+export async function execInPod(input: PodExec): Promise<string> {
+  return captureCommand({
+    args: podExecArgs(input),
+    label: `kubectl exec ${input.namespace}/${input.pod}`,
+  });
+}
+
+/**
+ * Run a command in a pod, streaming its stdout to a file.
+ *
+ * Separate from `execInPod` because a custom-format dump is binary: decoding it
+ * as text to hand back a string corrupts the archive.
+ */
+export async function execInPodToFile(
+  input: PodExec & { readonly destination: string },
+): Promise<number> {
+  const args = podExecArgs(input);
+  const child = Bun.spawn(args, {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  // Drained concurrently with stdout: a pod that fills the stderr pipe while
+  // we are still reading the archive would otherwise deadlock.
+  const stderrText = new Response(child.stderr).text();
+  // Written through a FileSink rather than the shorter
+  // `Bun.write(destination, new Response(child.stdout))`, which on Bun 1.4
+  // never settles for a spawn pipe: it spins at full CPU after the child has
+  // already exited, so the symptom is a hang with no process left to blame.
+  const sink = Bun.file(input.destination).writer();
+  let written = 0;
+  for await (const chunk of child.stdout) {
+    written += chunk.byteLength;
+    // Awaited for backpressure: a large archive would otherwise queue in
+    // memory faster than it reaches disk.
+    await sink.write(chunk);
+  }
+  await sink.end();
+  const [stderr, exitCode] = await Promise.all([stderrText, child.exited]);
+  if (exitCode !== 0) {
+    throw commandFailure(
+      `kubectl exec ${input.namespace}/${input.pod}`,
+      exitCode,
+      stderr,
+    );
+  }
+  return written;
+}
+
+/** The major version of the server running in a pod. */
+export async function serverMajorVersion(input: {
+  readonly namespace: string;
+  readonly pod: string;
+  readonly container?: string | undefined;
+  readonly database: string;
+}): Promise<number> {
+  const output = await execInPod({
+    namespace: input.namespace,
+    pod: input.pod,
+    container: input.container,
+    command: [
+      "psql",
+      "--username",
+      "postgres",
+      "--dbname",
+      input.database,
+      "--no-align",
+      "--tuples-only",
+      "--command",
+      "SHOW server_version",
+    ],
+  });
+  return parseMajorVersion(output);
+}

--- a/packages/toolkit/test/lib/postgres-pod.test.ts
+++ b/packages/toolkit/test/lib/postgres-pod.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  masterPodQueryArgs,
+  parseMajorVersion,
+  pgBinaryPath,
+  podExecArgs,
+  selectReadyMasterPod,
+} from "#lib/postgres/pod.ts";
+
+const target = {
+  namespace: "scout-beta",
+  cluster: "scout-beta-postgresql",
+} as const;
+
+function pod(name: string, phase: string, ready: string) {
+  return {
+    metadata: { name, uid: `uid-${name}` },
+    status: {
+      conditions: [{ status: ready, type: "Ready" }],
+      phase,
+    },
+  };
+}
+
+describe("pgBinaryPath", () => {
+  test("names the version-matched binary rather than the one on PATH", () => {
+    expect(pgBinaryPath(16, "pg_dump")).toBe(
+      "/usr/lib/postgresql/16/bin/pg_dump",
+    );
+    expect(pgBinaryPath(18, "pg_restore")).toBe(
+      "/usr/lib/postgresql/18/bin/pg_restore",
+    );
+  });
+
+  test("refuses a version that cannot be a major", () => {
+    expect(() => pgBinaryPath(0, "psql")).toThrow("positive integer");
+    expect(() => pgBinaryPath(16.13, "psql")).toThrow("positive integer");
+  });
+});
+
+describe("parseMajorVersion", () => {
+  test("reads the major from a packaged server_version", () => {
+    expect(parseMajorVersion("16.13 (Ubuntu 16.13-1.pgdg22.04+1)")).toBe(16);
+    expect(parseMajorVersion("18.3\n")).toBe(18);
+  });
+
+  test("throws instead of guessing when there is no version", () => {
+    expect(() => parseMajorVersion("")).toThrow(
+      "Could not read a PostgreSQL major version",
+    );
+    expect(() => parseMajorVersion("unknown")).toThrow(
+      "Could not read a PostgreSQL major version",
+    );
+  });
+});
+
+describe("selectReadyMasterPod", () => {
+  test("returns the single ready pod with its uid", () => {
+    const selected = selectReadyMasterPod(
+      { items: [pod("scout-beta-postgresql-0", "Running", "True")] },
+      target,
+    );
+    expect(selected).toEqual({
+      name: "scout-beta-postgresql-0",
+      uid: "uid-scout-beta-postgresql-0",
+    });
+  });
+
+  test("ignores a pod that is running but not ready", () => {
+    expect(() =>
+      selectReadyMasterPod(
+        { items: [pod("scout-beta-postgresql-0", "Running", "False")] },
+        target,
+      ),
+    ).toThrow("found 0");
+  });
+
+  test("ignores a pod that is ready but not running", () => {
+    expect(() =>
+      selectReadyMasterPod(
+        { items: [pod("scout-beta-postgresql-0", "Pending", "True")] },
+        target,
+      ),
+    ).toThrow("found 0");
+  });
+
+  test("refuses an ambiguous match rather than picking one", () => {
+    expect(() =>
+      selectReadyMasterPod(
+        {
+          items: [
+            pod("scout-beta-postgresql-0", "Running", "True"),
+            pod("scout-beta-postgresql-1", "Running", "True"),
+          ],
+        },
+        target,
+      ),
+    ).toThrow(
+      "Expected exactly one ready master pod for scout-beta-postgresql in scout-beta, found 2",
+    );
+  });
+
+  test("rejects output that is not a pod list", () => {
+    expect(() => selectReadyMasterPod({ items: [{}] }, target)).toThrow();
+  });
+});
+
+describe("argv builders", () => {
+  test("selects the master by Spilo labels, not by name prefix", () => {
+    expect(masterPodQueryArgs(target)).toEqual([
+      "kubectl",
+      "get",
+      "pods",
+      "--namespace",
+      "scout-beta",
+      "--selector",
+      "application=spilo,cluster-name=scout-beta-postgresql,spilo-role=master",
+      "--output",
+      "json",
+    ]);
+  });
+
+  test("omits the container flag when no container is named", () => {
+    expect(
+      podExecArgs({
+        namespace: "scout-beta",
+        pod: "scout-beta-postgresql-0",
+        command: ["psql", "--version"],
+      }),
+    ).toEqual([
+      "kubectl",
+      "exec",
+      "--namespace",
+      "scout-beta",
+      "scout-beta-postgresql-0",
+      "--",
+      "psql",
+      "--version",
+    ]);
+  });
+
+  test("passes the container through when one is named", () => {
+    expect(
+      podExecArgs({
+        namespace: "scout-beta",
+        pod: "scout-beta-postgresql-0",
+        container: "postgres",
+        command: ["psql"],
+      }),
+    ).toEqual([
+      "kubectl",
+      "exec",
+      "--namespace",
+      "scout-beta",
+      "--container",
+      "postgres",
+      "scout-beta-postgresql-0",
+      "--",
+      "psql",
+    ]);
+  });
+});

--- a/scripts/ci-test-manifest.json
+++ b/scripts/ci-test-manifest.json
@@ -393,6 +393,7 @@
           "runner": "vitest",
           "args": [
             "scripts/create-minimal-png.test.ts",
+            "scripts/dev/dev-db-pull.test.ts",
             "scripts/dev/dev-web.test.ts",
             "scripts/install-pkgs.test.ts",
             "scripts/migration-smoke.test.ts"


### PR DESCRIPTION
## Why

Hydrating local Scout dev with real beta data took a hand-rolled `kubectl` +
`pg_dump` pipeline, and three of its steps fail **silently**:

1. The Spilo pod carries several PostgreSQL toolchains and `PATH` resolves to
   the newest — 18.3 against a 16.13 server. That `pg_dump` writes archive
   format 1.16, which the local 16.15 `pg_restore` cannot read, while exiting 0
   and producing a plausible 2.9 MB file. The mismatch surfaces as a corrupt
   restore, not a failed dump.
2. The cluster runs `pg_stat_kcache` and `set_user`, absent from the
   mise-pinned local build, so a full dump breaks the restore. Spilo's
   `metric_helpers` / `user_management` schemas are the same problem.
3. The dump's own `CREATE SCHEMA public` collides with the one `createdb`
   provides, and under `--single-transaction` that rolls back the entire
   restore.

Separately, `sync-beta-corpus.ts` hand-rolled beta pod discovery and a
`Bun.spawn` wrapper with no test — and, as a bare top-level-`await` script with
no exports, no way to write one.

## What

`bun run dev:db-pull` (`--stage beta|prod`, default `beta`) dumps a hosted
Scout database with the server-matched binary, restores it into a local database
on the shared dev Postgres, and prints the `dev:web` command. Migrations stay
with `dev:web`, which already applies anything newer than the snapshot on boot.

- **Decisions are separated from IO.** `dev-db-pull-plan.ts` holds arg parsing,
  stage targets, version gating, extension selection, argv construction, and
  the restore assertion — all unit-tested without a cluster, matching the
  existing `dev-web-options.ts` / `dev-web.ts` split. The shell only performs
  them, and is covered by the import-without-executing smoke test.
- **Pod discovery, in-pod exec, binary resolution, and the command runner move
  to `@shepherdjerred/toolkit/lib/postgres/`**, and `sync-beta-corpus.ts` adopts
  them. Net one *fewer* copy of the kubectl pod logic, and the first test
  covering it.
- **Selection is now by Spilo's `spilo-role=master` label**, not a name prefix.
  A read-only replica accepts `pg_dump` happily and would have looked like
  success.
- **The restore is checked, not predicted.** Rather than reasoning about which
  extensions own which objects, the script compares restored tables against the
  source's and fails naming any that went missing.
- `plpgsql` anchors the extension list because `pg_dump` treats an
  `--extension` pattern matching nothing as a fatal error; it always matches and
  emits no SQL.
- `dropdb --force`, so a re-pull works with `dev:web` still attached.

`bun.lock` also drops a stale `@snazzah/davey` entry the lock listed under
`scout-for-lol/backend`, which no manifest declares — it resolves transitively
through `discord-video-stream`. Pre-existing drift a plain `bun install`
corrects, not a dependency change.


## Credentials never reach the machine

Codex caught a real P1 on the first revision: dumping the whole `public` schema
also copied live Discord OAuth bearer tokens into both the retained `.dump` file
and the local database. Fixed, and the fix is structural rather than a cleanup
pass:

| Data | Treatment |
| --- | --- |
| `User.discordAccessToken`, `discordRefreshToken`, `tokenExpiresAt` | row kept, column `NULL` |
| `ExploreConversation.shareToken` | row kept, column `NULL` |
| `TournamentLobby.password` | row kept, column `NULL` |
| `TournamentLobby.code` (Riot join credential) | row kept, per-row `redacted-<id>` — the column is `NOT NULL` and unique, so `NULL` is illegal |
| `ApiToken`, `InstallAttributionToken` | schema only, no rows — these tables are nothing but credentials |

The dump carries **no data** for any of those tables. The three mixed tables are
re-read from the source with the credential columns projected as `NULL`, so no
token is written here even transiently. Because `pg_restore` creates and
validates foreign keys in its `post-data` section, the restore now runs section
by section and the redacted rows load between `data` and `post-data` — without
that, excluding `User` rows fails the restore on
`ChallengeRun_ownerDiscordId_fkey`. Redaction is per-column: each entry carries
a SQL replacement plus a verification predicate, and `assertRedacted` fails the
run if any redacted column comes back holding a real value.

A second review pass caught that the first fix missed `TournamentLobby.code`. I
then swept the rest of the schema — `TournamentRegistration` and
`ScoutEffectClaim.key` are documented as explicitly *not* credentials, and
`TournamentLobbyProvision.requestHash` is a hash — so `code` was the remaining
one.

Proof, not assertion: every redacted column counts 0 unredacted rows locally,
and a real 57-character beta access token is absent from **both** the dump file
and the restored database, with all row counts still matching beta. Beta
currently has no lobby rows, so the `code` path was verified three other ways:
the projection SQL executes against beta's own engine, `'redacted-' || "id"`
yields `redacted-1`/`redacted-2` on a populated table, and planting a row with
`code='LIVE-JOIN-CODE-123'` makes the check statement count 1 — so the safety
net does fire.

## Verification

Source and local checks:

- `turbo typecheck lint test` green for `@shepherdjerred/toolkit` (224 tests),
  `scout-for-lol` (86), `@scout-for-lol/evals` (71)
- `toolkit` build and `check-architecture` clean (97 modules)
- wiki `typecheck`, `test`, `build` (73 pages) pass
- jscpd ratchet passes with **no baseline edit** — it flagged my local command
  runner as a clone of the toolkit helper's, which I deduplicated instead
- `lefthook run pre-commit` green; `bun install --frozen-lockfile` clean

Live, against beta:

| Table | Local | Beta |
| --- | --- | --- |
| Player | 36 | 36 |
| Account | 50 | 50 |
| Report | 7 | 7 |
| Competition | 13 | 13 |
| Subscription | 36 | 36 |
| CompetitionSnapshot | 184 | 184 |
| User | 8 | 8 |
| ExploreConversation | 109 | 109 |

116 tables restored, and repeated runs exercise drop-and-recreate over an
existing database (`dropdb --force`, so a running `dev:web` does not block a
re-pull). `sync-beta` output is
byte-identical to a pre-change capture apart from its `syncedAt` timestamp.

The prod path was exercised **read-only** — pod, uid, server major, binary path,
and extension selection resolved correctly. No production data was restored.

## Rendered wiki page

The new how-to at desktop (1440) and mobile (390), from the built output — no
body overflow at either width, and the three asides render as intended.

| Desktop | Mobile |
| --- | --- |
| ![wiki-desktop.png](https://public.sjer.red/pr/assets/2840/wiki-desktop.png) | ![wiki-mobile.png](https://public.sjer.red/pr/assets/2840/wiki-mobile.png) |

## Not verified

- **A fresh `dev:web` boot against the restored database.** `op run` timed out
  waiting for 1Password authorization, which needs an interactive approval the
  authoring session could not give. The SPA (`/app/`) and backend `/healthz` did
  serve 200 from a `dev:web` already pointed at the restored database, and the
  41 → 42 forward migration was observed earlier before beta reached head on its
  own.
- Nothing here deploys, so there is no artifact, ArgoCD, or runtime layer to
  verify beyond CI on this head.
- The branch is not restacked on current `main`; another session holds
  uncommitted work in this worktree, and a rebase needs a clean tree. There is
  no merge conflict and zero file overlap with the commits `main` has moved
  ahead.
- **Known limitation (accepted, P2):** the redacted `COPY` reads run after
  `pg_dump` finishes, so they are not from the same snapshot. A write landing in
  that window can make the pull inconsistent. The correct fix needs a long-lived
  pod session holding a `REPEATABLE READ` transaction with
  `pg_export_snapshot()` / `pg_dump --snapshot`, which is a large complexity
  jump for a disposable local snapshot that is dropped and recreated every run.
  The failure modes are loud, not silent: a deleted user fails the `post-data`
  section on a foreign key under `--single-transaction`, and
  `assertRestoredTables` fails on any missing table. Worth revisiting if this
  ever becomes a shared or long-lived artifact.
