### PR TITLE
feat(scout-for-lol): track Riot API rate-limit usage and retry more upstream errors

### DIFF
--- a/packages/homelab/src/cdk8s/grafana/scout/scout-dashboard-api-competition-rows.ts
+++ b/packages/homelab/src/cdk8s/grafana/scout/scout-dashboard-api-competition-rows.ts
@@ -171,11 +171,41 @@ export function addApiAndCompetitionRows(
       .gridPos({ x: 0, y: 89, w: 24, h: 8 }),
   );
 
+  // Riot API App Rate Limit Usage
+  builder.withPanel(
+    new timeseries.PanelBuilder()
+      .title("Riot API App Rate Limit Usage")
+      .description(
+        "Fraction of Riot's app-wide rate limit consumed, per window (X-App-Rate-Limit-Count / X-App-Rate-Limit)",
+      )
+      .datasource(prometheusDatasource)
+      .withTarget(
+        new prometheus.DataqueryBuilder()
+          .expr(
+            `riot_api_app_rate_limit_count{${buildFilter()}} / riot_api_app_rate_limit_limit{${buildFilter()}}`,
+          )
+          .legendFormat("{{environment}} - {{window_seconds}}s"),
+      )
+      .unit("percentunit")
+      .lineWidth(2)
+      .fillOpacity(10)
+      .thresholds(
+        new dashboard.ThresholdsConfigBuilder()
+          .mode(dashboard.ThresholdsMode.Absolute)
+          .steps([
+            { value: 0, color: "green" },
+            { value: 0.7, color: "yellow" },
+            { value: 0.9, color: "red" },
+          ]),
+      )
+      .gridPos({ x: 0, y: 97, w: 24, h: 8 }),
+  );
+
   // Row 6: Competition leaderboard chart
   builder.withRow(
     new dashboard.RowBuilder("Competition leaderboard chart").gridPos({
       x: 0,
-      y: 97,
+      y: 105,
       w: 24,
       h: 1,
     }),
@@ -206,7 +236,7 @@ export function addApiAndCompetitionRows(
       .unit("s")
       .lineWidth(2)
       .fillOpacity(5)
-      .gridPos({ x: 0, y: 98, w: 12, h: 8 }),
+      .gridPos({ x: 0, y: 106, w: 12, h: 8 }),
   );
 
   // Render outcome rate (success / error / skipped)
@@ -236,7 +266,7 @@ export function addApiAndCompetitionRows(
             { value: 0.1, color: "red" },
           ]),
       )
-      .gridPos({ x: 12, y: 98, w: 12, h: 8 }),
+      .gridPos({ x: 12, y: 106, w: 12, h: 8 }),
   );
 
   // PNG size distribution — catches blank-render regressions and pathological growth
@@ -264,7 +294,7 @@ export function addApiAndCompetitionRows(
       .unit("bytes")
       .lineWidth(2)
       .fillOpacity(5)
-      .gridPos({ x: 0, y: 106, w: 12, h: 8 }),
+      .gridPos({ x: 0, y: 114, w: 12, h: 8 }),
   );
 
   // S3 snapshot fetch latency
@@ -285,6 +315,6 @@ export function addApiAndCompetitionRows(
       .unit("s")
       .lineWidth(2)
       .fillOpacity(10)
-      .gridPos({ x: 12, y: 106, w: 12, h: 8 }),
+      .gridPos({ x: 12, y: 114, w: 12, h: 8 }),
   );
 }

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout-temporal-rules.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout-temporal-rules.ts
@@ -1,0 +1,149 @@
+import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { escapePrometheusTemplate } from "./shared.ts";
+
+// Extracted from scout.ts (which is at the max-lines limit) to keep the
+// "scout-temporal" rule group's definition alongside the rest of Scout's
+// alert rules without exceeding the file-length ESLint cap.
+export function getScoutTemporalRuleGroup(): PrometheusRuleSpecGroups {
+  return {
+    name: "scout-temporal",
+    rules: [
+      {
+        alert: "ScoutTemporalDisconnected",
+        annotations: {
+          summary: "Scout's embedded Temporal supervisor is disconnected",
+          message: escapePrometheusTemplate(
+            "Scout {{ $labels.environment }} has rejected durable starts because its Temporal supervisor has been disconnected for five minutes. Legacy execution must remain stopped; restore Temporal connectivity.",
+          ),
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          '(min by (environment) (scout_temporal_connected{environment=~"beta|prod"}) == 0) or absent(scout_temporal_connected{environment="beta"}) or absent(scout_temporal_connected{environment="prod"})',
+        ),
+        for: "5m",
+        labels: { severity: "critical" },
+      },
+      {
+        alert: "ScoutTemporalWorkerMissing",
+        annotations: {
+          summary: "A Scout Temporal task-queue worker is missing",
+          message:
+            "Scout must expose workflow, realtime, interactive, background, and lake Workers after Discord readiness. Inspect the embedded Worker supervisor before changing concurrency.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          '(count by (environment) (scout_temporal_workers{environment=~"beta|prod"} == 1) < 5) or absent(scout_temporal_workers{environment="beta"}) or absent(scout_temporal_workers{environment="prod"})',
+        ),
+        for: "5m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalActivityFailing",
+        annotations: {
+          summary: "Scout Temporal Activities are failing",
+          message: escapePrometheusTemplate(
+            "Scout queue {{ $labels.task_queue }} has failed Activities in the last 30 minutes. Inspect the Workflow history and effect claims before retrying manually.",
+          ),
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          'sum by (task_queue) (increase(activity_task_fail{task_queue=~"scout-(beta|prod).*"}[30m])) > 0',
+        ),
+        for: "10m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalTaskScheduleToStartHigh",
+        annotations: {
+          summary: "Scout Temporal tasks are waiting for a Worker",
+          message:
+            "Scout task p95 schedule-to-start latency has exceeded ten seconds. Inspect the affected task queue and embedded Worker resources before tuning concurrency.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          'histogram_quantile(0.95, sum by (task_queue, le) (rate(task_schedule_to_start_latency_bucket{task_queue=~"scout-(beta|prod).*"}[5m]))) > 10000',
+        ),
+        for: "5m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalDurabilityMetricsUnknown",
+        annotations: {
+          summary: "Scout Temporal durability metrics are unavailable",
+          message:
+            "Scout could not query report outbox or interactive projection state. Restore the Scout database metric query before relying on the age and drift alerts.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          '(scout_temporal_report_outbox_oldest_timestamp_seconds < 0) or (scout_temporal_stale_product_projections < 0) or absent(scout_temporal_report_outbox_oldest_timestamp_seconds{environment="beta"}) or absent(scout_temporal_report_outbox_oldest_timestamp_seconds{environment="prod"}) or absent(scout_temporal_stale_product_projections{environment="beta"}) or absent(scout_temporal_stale_product_projections{environment="prod"})',
+        ),
+        for: "5m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalReportOutboxStale",
+        annotations: {
+          summary: "Scout's report Schedule outbox is stale",
+          message: escapePrometheusTemplate(
+            "Scout {{ $labels.environment }} has an unprocessed report Schedule outbox row older than five minutes. Inspect the singleton reconciler Workflow and Temporal Schedule.",
+          ),
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          "scout_temporal_report_outbox_oldest_timestamp_seconds > 0 and (time() - scout_temporal_report_outbox_oldest_timestamp_seconds) > 300",
+        ),
+        for: "5m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalReportScheduleDrift",
+        annotations: {
+          summary: "Scout report Schedules differ from product state",
+          message:
+            "The report Schedule audit found a missing, drifted, orphaned, or ownership-mismatched Schedule. Unknown ownership mismatches are deliberately not deleted.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          "scout_temporal_report_schedule_drift > 0 or scout_temporal_report_schedule_orphans > 0",
+        ),
+        for: "5m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalProductProjectionStale",
+        annotations: {
+          summary: "Scout product execution state is stale",
+          message:
+            "An Explore or report-AI projection has remained active beyond its 40-minute execution budget. Temporal remains authoritative; reconcile the product row from Workflow state.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          "scout_temporal_stale_product_projections > 0",
+        ),
+        for: "5m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalProviderAttemptInterrupted",
+        annotations: {
+          summary: "Scout salvaged an ambiguous provider attempt",
+          message: escapePrometheusTemplate(
+            "Scout interrupted {{ $value }} {{ $labels.kind }} provider attempt(s) rather than risk duplicate model spend. Inspect persisted partial output and the original Worker interruption.",
+          ),
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          "sum by (kind) (increase(scout_temporal_interrupted_provider_attempts_total[30m])) > 0",
+        ),
+        for: "1m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalDuplicateEffectClaim",
+        annotations: {
+          summary: "Scout retried an ambiguous or mismatched external effect",
+          message: escapePrometheusTemplate(
+            "Scout observed {{ $value }} duplicate {{ $labels.kind }} effect claim(s) with outcome {{ $labels.outcome }}. Verify the stable Discord nonce or storage key prevented a duplicate effect.",
+          ),
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          'sum by (kind, outcome) (increase(scout_temporal_duplicate_effect_claims_total{outcome=~"ambiguous_retry|kind_mismatch"}[30m])) > 0',
+        ),
+        for: "1m",
+        labels: { severity: "warning" },
+      },
+    ],
+  };
+}

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.test.ts
@@ -48,6 +48,27 @@ describe("Scout Temporal alert rules", () => {
   });
 });
 
+describe("Scout Riot API alert rules", () => {
+  const riotApi = getScoutRuleGroups().find(
+    (group) => group.name === "scout-riot-api",
+  );
+
+  test("covers error rate and app rate limit usage", () => {
+    if (riotApi?.rules === undefined) {
+      throw new Error("Missing scout-riot-api rule group");
+    }
+    const alerts = new Set(riotApi.rules.map((rule) => rule.alert));
+    expect(alerts).toEqual(
+      new Set([
+        "ScoutRiotApiErrorRateHigh",
+        "ScoutRiotApiErrorRateCritical",
+        "ScoutRiotApiAppRateLimitHigh",
+        "ScoutRiotApiAppRateLimitCritical",
+      ]),
+    );
+  });
+});
+
 describe("Scout bot-health alert rules", () => {
   const botHealth = getScoutRuleGroups().find(
     (group) => group.name === "scout-bot-health",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts
@@ -2,6 +2,7 @@ import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/gen
 import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
 import { escapePrometheusTemplate } from "./shared.ts";
 import { SCOUT_TRPC_NON_FAULT_CODES } from "./scout-alert-constants.ts";
+import { getScoutTemporalRuleGroup } from "./scout-temporal-rules.ts";
 
 /**
  * tRPC result codes that are ordinary traffic on a public web surface rather
@@ -18,148 +19,6 @@ import { SCOUT_TRPC_NON_FAULT_CODES } from "./scout-alert-constants.ts";
  * alert meant to catch it. These rules use absolute counts over a window
  * instead, sized to what "obviously wrong" looks like at this scale.
  */
-function getScoutTemporalRuleGroup(): PrometheusRuleSpecGroups {
-  return {
-    name: "scout-temporal",
-    rules: [
-      {
-        alert: "ScoutTemporalDisconnected",
-        annotations: {
-          summary: "Scout's embedded Temporal supervisor is disconnected",
-          message: escapePrometheusTemplate(
-            "Scout {{ $labels.environment }} has rejected durable starts because its Temporal supervisor has been disconnected for five minutes. Legacy execution must remain stopped; restore Temporal connectivity.",
-          ),
-        },
-        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          '(min by (environment) (scout_temporal_connected{environment=~"beta|prod"}) == 0) or absent(scout_temporal_connected{environment="beta"}) or absent(scout_temporal_connected{environment="prod"})',
-        ),
-        for: "5m",
-        labels: { severity: "critical" },
-      },
-      {
-        alert: "ScoutTemporalWorkerMissing",
-        annotations: {
-          summary: "A Scout Temporal task-queue worker is missing",
-          message:
-            "Scout must expose workflow, realtime, interactive, background, and lake Workers after Discord readiness. Inspect the embedded Worker supervisor before changing concurrency.",
-        },
-        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          '(count by (environment) (scout_temporal_workers{environment=~"beta|prod"} == 1) < 5) or absent(scout_temporal_workers{environment="beta"}) or absent(scout_temporal_workers{environment="prod"})',
-        ),
-        for: "5m",
-        labels: { severity: "warning" },
-      },
-      {
-        alert: "ScoutTemporalActivityFailing",
-        annotations: {
-          summary: "Scout Temporal Activities are failing",
-          message: escapePrometheusTemplate(
-            "Scout queue {{ $labels.task_queue }} has failed Activities in the last 30 minutes. Inspect the Workflow history and effect claims before retrying manually.",
-          ),
-        },
-        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          'sum by (task_queue) (increase(activity_task_fail{task_queue=~"scout-(beta|prod).*"}[30m])) > 0',
-        ),
-        for: "10m",
-        labels: { severity: "warning" },
-      },
-      {
-        alert: "ScoutTemporalTaskScheduleToStartHigh",
-        annotations: {
-          summary: "Scout Temporal tasks are waiting for a Worker",
-          message:
-            "Scout task p95 schedule-to-start latency has exceeded ten seconds. Inspect the affected task queue and embedded Worker resources before tuning concurrency.",
-        },
-        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          'histogram_quantile(0.95, sum by (task_queue, le) (rate(task_schedule_to_start_latency_bucket{task_queue=~"scout-(beta|prod).*"}[5m]))) > 10000',
-        ),
-        for: "5m",
-        labels: { severity: "warning" },
-      },
-      {
-        alert: "ScoutTemporalDurabilityMetricsUnknown",
-        annotations: {
-          summary: "Scout Temporal durability metrics are unavailable",
-          message:
-            "Scout could not query report outbox or interactive projection state. Restore the Scout database metric query before relying on the age and drift alerts.",
-        },
-        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          '(scout_temporal_report_outbox_oldest_timestamp_seconds < 0) or (scout_temporal_stale_product_projections < 0) or absent(scout_temporal_report_outbox_oldest_timestamp_seconds{environment="beta"}) or absent(scout_temporal_report_outbox_oldest_timestamp_seconds{environment="prod"}) or absent(scout_temporal_stale_product_projections{environment="beta"}) or absent(scout_temporal_stale_product_projections{environment="prod"})',
-        ),
-        for: "5m",
-        labels: { severity: "warning" },
-      },
-      {
-        alert: "ScoutTemporalReportOutboxStale",
-        annotations: {
-          summary: "Scout's report Schedule outbox is stale",
-          message: escapePrometheusTemplate(
-            "Scout {{ $labels.environment }} has an unprocessed report Schedule outbox row older than five minutes. Inspect the singleton reconciler Workflow and Temporal Schedule.",
-          ),
-        },
-        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          "scout_temporal_report_outbox_oldest_timestamp_seconds > 0 and (time() - scout_temporal_report_outbox_oldest_timestamp_seconds) > 300",
-        ),
-        for: "5m",
-        labels: { severity: "warning" },
-      },
-      {
-        alert: "ScoutTemporalReportScheduleDrift",
-        annotations: {
-          summary: "Scout report Schedules differ from product state",
-          message:
-            "The report Schedule audit found a missing, drifted, orphaned, or ownership-mismatched Schedule. Unknown ownership mismatches are deliberately not deleted.",
-        },
-        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          "scout_temporal_report_schedule_drift > 0 or scout_temporal_report_schedule_orphans > 0",
-        ),
-        for: "5m",
-        labels: { severity: "warning" },
-      },
-      {
-        alert: "ScoutTemporalProductProjectionStale",
-        annotations: {
-          summary: "Scout product execution state is stale",
-          message:
-            "An Explore or report-AI projection has remained active beyond its 40-minute execution budget. Temporal remains authoritative; reconcile the product row from Workflow state.",
-        },
-        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          "scout_temporal_stale_product_projections > 0",
-        ),
-        for: "5m",
-        labels: { severity: "warning" },
-      },
-      {
-        alert: "ScoutTemporalProviderAttemptInterrupted",
-        annotations: {
-          summary: "Scout salvaged an ambiguous provider attempt",
-          message: escapePrometheusTemplate(
-            "Scout interrupted {{ $value }} {{ $labels.kind }} provider attempt(s) rather than risk duplicate model spend. Inspect persisted partial output and the original Worker interruption.",
-          ),
-        },
-        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          "sum by (kind) (increase(scout_temporal_interrupted_provider_attempts_total[30m])) > 0",
-        ),
-        for: "1m",
-        labels: { severity: "warning" },
-      },
-      {
-        alert: "ScoutTemporalDuplicateEffectClaim",
-        annotations: {
-          summary: "Scout retried an ambiguous or mismatched external effect",
-          message: escapePrometheusTemplate(
-            "Scout observed {{ $value }} duplicate {{ $labels.kind }} effect claim(s) with outcome {{ $labels.outcome }}. Verify the stable Discord nonce or storage key prevented a duplicate effect.",
-          ),
-        },
-        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          'sum by (kind, outcome) (increase(scout_temporal_duplicate_effect_claims_total{outcome=~"ambiguous_retry|kind_mismatch"}[30m])) > 0',
-        ),
-        for: "1m",
-        labels: { severity: "warning" },
-      },
-    ],
-  };
-}
 
 export function getScoutRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
@@ -195,6 +54,38 @@ export function getScoutRuleGroups(): PrometheusRuleSpecGroups[] {
             "sum by (environment, source) (rate(riot_api_errors_total[15m])) * 60 > 10",
           ),
           for: "15m",
+          labels: {
+            severity: "critical",
+          },
+        },
+        {
+          alert: "ScoutRiotApiAppRateLimitHigh",
+          annotations: {
+            summary: "Riot API app rate limit usage is elevated",
+            message: escapePrometheusTemplate(
+              "Scout {{ $labels.environment }} is using {{ $value | humanizePercentage }} of its Riot app rate limit for the {{ $labels.window_seconds }}s window.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "riot_api_app_rate_limit_count / riot_api_app_rate_limit_limit > 0.7",
+          ),
+          for: "5m",
+          labels: {
+            severity: "warning",
+          },
+        },
+        {
+          alert: "ScoutRiotApiAppRateLimitCritical",
+          annotations: {
+            summary: "Riot API app rate limit usage is critically high",
+            message: escapePrometheusTemplate(
+              "Scout {{ $labels.environment }} is using {{ $value | humanizePercentage }} of its Riot app rate limit for the {{ $labels.window_seconds }}s window. Requests may start being throttled with 429s.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "riot_api_app_rate_limit_count / riot_api_app_rate_limit_limit > 0.9",
+          ),
+          for: "5m",
           labels: {
             severity: "critical",
           },

--- a/packages/scout-for-lol/packages/backend/src/league/api/client/rate-limit-headers.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/api/client/rate-limit-headers.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+import { parseAppRateLimitWindows } from "./rate-limit-headers.ts";
+
+describe("parseAppRateLimitWindows", () => {
+  test("parses a multi-window header and zips by window, not position", () => {
+    const headers = new Headers({
+      "X-App-Rate-Limit": "20:1,100:120",
+      // Deliberately listed in a different order than the limit header.
+      "X-App-Rate-Limit-Count": "45:120,3:1",
+    });
+
+    expect(parseAppRateLimitWindows(headers)).toEqual([
+      { windowSeconds: 1, count: 3, limit: 20 },
+      { windowSeconds: 120, count: 45, limit: 100 },
+    ]);
+  });
+
+  test("parses a single-window header", () => {
+    const headers = new Headers({
+      "X-App-Rate-Limit": "20:1",
+      "X-App-Rate-Limit-Count": "5:1",
+    });
+
+    expect(parseAppRateLimitWindows(headers)).toEqual([
+      { windowSeconds: 1, count: 5, limit: 20 },
+    ]);
+  });
+
+  test("skips malformed/non-numeric entries instead of throwing", () => {
+    const headers = new Headers({
+      "X-App-Rate-Limit": "20:1,abc:xyz,100:120",
+      "X-App-Rate-Limit-Count": "3:1,45:120",
+    });
+
+    expect(() => parseAppRateLimitWindows(headers)).not.toThrow();
+    expect(parseAppRateLimitWindows(headers)).toEqual([
+      { windowSeconds: 1, count: 3, limit: 20 },
+      { windowSeconds: 120, count: 45, limit: 100 },
+    ]);
+  });
+
+  test("returns an empty array when either header is missing", () => {
+    const onlyLimit = new Headers({ "X-App-Rate-Limit": "20:1" });
+    const onlyCount = new Headers({ "X-App-Rate-Limit-Count": "5:1" });
+    const neither = new Headers();
+
+    expect(parseAppRateLimitWindows(onlyLimit)).toEqual([]);
+    expect(parseAppRateLimitWindows(onlyCount)).toEqual([]);
+    expect(parseAppRateLimitWindows(neither)).toEqual([]);
+  });
+
+  test("drops unmatched windows present in only one header", () => {
+    const headers = new Headers({
+      "X-App-Rate-Limit": "20:1,100:120,500:600",
+      "X-App-Rate-Limit-Count": "3:1,45:120,9:10",
+    });
+
+    expect(parseAppRateLimitWindows(headers)).toEqual([
+      { windowSeconds: 1, count: 3, limit: 20 },
+      { windowSeconds: 120, count: 45, limit: 100 },
+    ]);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/league/api/client/rate-limit-headers.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/api/client/rate-limit-headers.ts
@@ -1,0 +1,80 @@
+/**
+ * Parses Riot's `X-App-Rate-Limit` / `X-App-Rate-Limit-Count` response
+ * headers into structured per-window rate-limit accounting.
+ *
+ * Both headers share the same comma-separated `N:W` format, e.g.
+ * `"20:1,100:120"` means 20 requests per 1-second window AND 100 requests
+ * per 120-second window. `X-App-Rate-Limit` carries the ceiling for each
+ * window; `X-App-Rate-Limit-Count` carries the current usage.
+ *
+ * `X-Method-Rate-Limit*` headers are intentionally not handled here.
+ */
+
+export type AppRateLimitWindow = {
+  windowSeconds: number;
+  count: number;
+  limit: number;
+};
+
+function parseRateLimitPairs(
+  header: string,
+): { value: number; windowSeconds: number }[] {
+  const pairs: { value: number; windowSeconds: number }[] = [];
+
+  for (const entry of header.split(",")) {
+    const [rawValue, rawWindowSeconds] = entry.split(":");
+    if (rawValue === undefined || rawWindowSeconds === undefined) {
+      continue;
+    }
+
+    const value = Number(rawValue.trim());
+    const windowSeconds = Number(rawWindowSeconds.trim());
+    if (!Number.isFinite(value) || !Number.isFinite(windowSeconds)) {
+      continue;
+    }
+
+    pairs.push({ value, windowSeconds });
+  }
+
+  return pairs;
+}
+
+/**
+ * Parses Riot's app rate-limit ceiling and usage headers into per-window
+ * accounting, matching windows by their window-seconds key rather than by
+ * array position (Riot does not guarantee the two headers list windows in
+ * the same order).
+ */
+export function parseAppRateLimitWindows(
+  headers: Headers,
+): AppRateLimitWindow[] {
+  const limitHeader = headers.get("x-app-rate-limit");
+  const countHeader = headers.get("x-app-rate-limit-count");
+  if (limitHeader === null || countHeader === null) {
+    return [];
+  }
+
+  const limits = parseRateLimitPairs(limitHeader);
+  const counts = parseRateLimitPairs(countHeader);
+
+  const countsByWindow = new Map<number, number>();
+  for (const count of counts) {
+    countsByWindow.set(count.windowSeconds, count.value);
+  }
+
+  const windows: AppRateLimitWindow[] = [];
+  for (const limit of limits) {
+    const count = countsByWindow.get(limit.windowSeconds);
+    if (count === undefined) {
+      continue;
+    }
+
+    windows.push({
+      windowSeconds: limit.windowSeconds,
+      count,
+      limit: limit.value,
+    });
+  }
+
+  return windows;
+}

--- a/packages/scout-for-lol/packages/backend/src/league/api/client/rate-limiter.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/api/client/rate-limiter.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test, vi } from "vitest";
+import {
+  riotApiAppRateLimitCount,
+  riotApiAppRateLimitLimit,
+} from "#src/metrics/riot-rate-limit.ts";
 import { RiotHttpError } from "./errors.ts";
 import { RateLimiter } from "./rate-limiter.ts";
 
@@ -271,20 +275,40 @@ describe("RateLimiter retries", () => {
     },
   );
 
-  test("retains exponential 503 backoff without a global cooldown", async () => {
+  test.each([502, 503, 504, 520, 522, 524])(
+    "retains exponential %i backoff without a global cooldown",
+    async (status) => {
+      const { runtime, sleeps } = createAdvancingRuntime();
+      const limiter = new RateLimiter({ maxRetries: 2 }, runtime);
+      let calls = 0;
+
+      await limiter.execute("https://example.test/unavailable", async () => {
+        calls += 1;
+        return calls <= 2
+          ? new Response("unavailable", { status })
+          : new Response("ok");
+      });
+
+      expect(calls).toBe(3);
+      expect(sleeps).toEqual([1000, 2000]);
+    },
+  );
+
+  test("does not retry a genuinely non-retryable status", async () => {
     const { runtime, sleeps } = createAdvancingRuntime();
     const limiter = new RateLimiter({ maxRetries: 2 }, runtime);
     let calls = 0;
 
-    await limiter.execute("https://example.test/unavailable", async () => {
-      calls += 1;
-      return calls <= 2
-        ? new Response("unavailable", { status: 503 })
-        : new Response("ok");
-    });
+    const error = await captureRiotError(
+      limiter.execute("https://example.test/not-found", async () => {
+        calls += 1;
+        return new Response("not found", { status: 404 });
+      }),
+    );
 
-    expect(calls).toBe(3);
-    expect(sleeps).toEqual([1000, 2000]);
+    expect(calls).toBe(1);
+    expect(sleeps).toEqual([]);
+    expect(error.status).toBe(404);
   });
 
   test("throws the final 429 with its diagnostic body after retries", async () => {
@@ -302,5 +326,78 @@ describe("RateLimiter retries", () => {
     expect(sleeps).toEqual([1000]);
     expect(error.status).toBe(429);
     expect(error.body).toEqual({ message: "still limited" });
+  });
+});
+
+describe("RateLimiter app rate-limit gauges", () => {
+  test("updates gauges from response headers on a successful response", async () => {
+    const { runtime } = createAdvancingRuntime();
+    const limiter = new RateLimiter({ maxRetries: 0 }, runtime);
+
+    await limiter.execute(
+      "https://example.test/gauges-success",
+      async () =>
+        new Response("ok", {
+          status: 200,
+          headers: {
+            "X-App-Rate-Limit": "20:1,100:120",
+            "X-App-Rate-Limit-Count": "7:1,42:120",
+          },
+        }),
+    );
+
+    const countMetric = await riotApiAppRateLimitCount.get();
+    const limitMetric = await riotApiAppRateLimitLimit.get();
+
+    expect(
+      countMetric.values.find((value) => value.labels.window_seconds === "1")
+        ?.value,
+    ).toBe(7);
+    expect(
+      limitMetric.values.find((value) => value.labels.window_seconds === "1")
+        ?.value,
+    ).toBe(20);
+    expect(
+      countMetric.values.find((value) => value.labels.window_seconds === "120")
+        ?.value,
+    ).toBe(42);
+    expect(
+      limitMetric.values.find((value) => value.labels.window_seconds === "120")
+        ?.value,
+    ).toBe(100);
+  });
+
+  test("records headers from every attempt, so a retried request's gauges reflect the final response", async () => {
+    const { runtime } = createAdvancingRuntime();
+    const limiter = new RateLimiter({ maxRetries: 1 }, runtime);
+    let calls = 0;
+
+    await limiter.execute("https://example.test/gauges-retry", async () => {
+      calls += 1;
+      if (calls === 1) {
+        return new Response("unavailable", {
+          status: 503,
+          headers: {
+            "X-App-Rate-Limit": "20:1",
+            "X-App-Rate-Limit-Count": "19:1",
+          },
+        });
+      }
+      return new Response("ok", {
+        status: 200,
+        headers: {
+          "X-App-Rate-Limit": "20:1",
+          "X-App-Rate-Limit-Count": "3:1",
+        },
+      });
+    });
+
+    expect(calls).toBe(2);
+
+    const countMetric = await riotApiAppRateLimitCount.get();
+    expect(
+      countMetric.values.find((value) => value.labels.window_seconds === "1")
+        ?.value,
+    ).toBe(3);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/league/api/client/rate-limiter.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/api/client/rate-limiter.test.ts
@@ -327,6 +327,47 @@ describe("RateLimiter retries", () => {
     expect(error.status).toBe(429);
     expect(error.body).toEqual({ message: "still limited" });
   });
+
+  test("does not retry an upstream outage when retryUpstreamErrors is false", async () => {
+    const { runtime, sleeps } = createAdvancingRuntime();
+    const limiter = new RateLimiter({ maxRetries: 2 }, runtime);
+    let calls = 0;
+
+    const error = await captureRiotError(
+      limiter.execute(
+        "https://example.test/non-idempotent",
+        async () => {
+          calls += 1;
+          return new Response("bad gateway", { status: 502 });
+        },
+        { retryUpstreamErrors: false },
+      ),
+    );
+
+    expect(calls).toBe(1);
+    expect(sleeps).toEqual([]);
+    expect(error.status).toBe(502);
+  });
+
+  test("still retries 429 when retryUpstreamErrors is false", async () => {
+    const { runtime } = createAdvancingRuntime();
+    const limiter = new RateLimiter({ maxRetries: 1 }, runtime);
+    let calls = 0;
+
+    const response = await limiter.execute(
+      "https://example.test/non-idempotent-429",
+      async () => {
+        calls += 1;
+        return calls === 1
+          ? new Response("limited", { status: 429 })
+          : new Response("ok");
+      },
+      { retryUpstreamErrors: false },
+    );
+
+    expect(calls).toBe(2);
+    expect(response.ok).toBe(true);
+  });
 });
 
 describe("RateLimiter app rate-limit gauges", () => {

--- a/packages/scout-for-lol/packages/backend/src/league/api/client/rate-limiter.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/api/client/rate-limiter.ts
@@ -23,6 +23,16 @@ export type RateLimiterOptions = {
 export type RateLimitedRequestOptions = {
   /** Override automatic retries for one request without bypassing the limiter. */
   maxRetries?: number | undefined;
+  /**
+   * Whether to retry expected upstream outages (502/503/504/520/522/524).
+   * Default: true. Set to false for non-idempotent requests (e.g. a POST
+   * that mints a resource): Riot may have already processed the request
+   * even though its response was lost, so retrying could duplicate the
+   * side effect. 429 retries are unaffected by this option — Riot's rate
+   * limiter rejects those before the request reaches any handler, so
+   * retrying a 429 is always safe regardless of method.
+   */
+  retryUpstreamErrors?: boolean | undefined;
 };
 
 type RateLimiterRuntime = {
@@ -183,11 +193,14 @@ export class RateLimiter {
       }
 
       const status = response.status;
+      const retryUpstreamErrors = options.retryUpstreamErrors ?? true;
 
       // 429 (Rate Limit Exceeded) and expected upstream outages
-      // (502/503/504/520/522/524) are retried with backoff.
+      // (502/503/504/520/522/524) are retried with backoff. Upstream-outage
+      // retries can be disabled per request for non-idempotent calls.
       const isRetryableStatus =
-        status === 429 || isExpectedUpstreamError(status);
+        status === 429 ||
+        (retryUpstreamErrors && isExpectedUpstreamError(status));
       if (isRetryableStatus && attempts <= maxRetries) {
         if (status === 429) {
           logger.info(

--- a/packages/scout-for-lol/packages/backend/src/league/api/client/rate-limiter.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/api/client/rate-limiter.ts
@@ -1,11 +1,22 @@
-import { RiotHttpError } from "./errors.ts";
+import { createLogger } from "#src/logger.ts";
+import {
+  riotApiAppRateLimitCount,
+  riotApiAppRateLimitLimit,
+} from "#src/metrics/riot-rate-limit.ts";
+import { isExpectedUpstreamError, RiotHttpError } from "./errors.ts";
+import { parseAppRateLimitWindows } from "./rate-limit-headers.ts";
+
+const logger = createLogger("rate-limiter");
 
 export type RequestExecutor = () => Promise<Response>;
 
 export type RateLimiterOptions = {
   /** Maximum number of concurrent in-flight requests. Default: 5. */
   concurrency?: number | undefined;
-  /** Maximum retry attempts on 429 / 503. Default: 3. */
+  /**
+   * Maximum retry attempts on 429 and expected upstream outages
+   * (502/503/504/520/522/524). Default: 3.
+   */
   maxRetries?: number | undefined;
 };
 
@@ -132,6 +143,13 @@ export class RateLimiter {
     try {
       await this.waitForCooldown();
       const response = await executeRequest();
+
+      for (const window of parseAppRateLimitWindows(response.headers)) {
+        const labels = { window_seconds: window.windowSeconds.toString() };
+        riotApiAppRateLimitCount.set(labels, window.count);
+        riotApiAppRateLimitLimit.set(labels, window.limit);
+      }
+
       if (response.status === 429) {
         // Establish the shared cooldown before releasing the semaphore slot so
         // queued calls cannot start during Riot's Retry-After window.
@@ -144,7 +162,8 @@ export class RateLimiter {
   }
 
   /**
-   * Execute an HTTP request with concurrency management and automatic retry on 429 / 503.
+   * Execute an HTTP request with concurrency management and automatic retry
+   * on 429 and expected upstream outages (502/503/504/520/522/524).
    */
   public async execute(
     url: string,
@@ -165,15 +184,23 @@ export class RateLimiter {
 
       const status = response.status;
 
-      // 429: Rate Limit Exceeded
-      if (status === 429 && attempts <= maxRetries) {
-        continue;
-      }
+      // 429 (Rate Limit Exceeded) and expected upstream outages
+      // (502/503/504/520/522/524) are retried with backoff.
+      const isRetryableStatus =
+        status === 429 || isExpectedUpstreamError(status);
+      if (isRetryableStatus && attempts <= maxRetries) {
+        if (status === 429) {
+          logger.info(
+            `429 from Riot API (attempt ${attempts.toString()}/${maxRetries.toString()}) for ${url}; cooldown extended via Retry-After`,
+          );
+          continue;
+        }
 
-      // 503: Service Unavailable (Riot API server overload / temporary outage)
-      if (status === 503 && attempts <= maxRetries) {
         const baseDelayMs = 1000 * 2 ** (attempts - 1);
         const delayMs = baseDelayMs + this.runtime.random() * 300;
+        logger.warn(
+          `${status.toString()} from Riot API (expected upstream outage, attempt ${attempts.toString()}/${maxRetries.toString()}) for ${url}; retrying in ${delayMs.toFixed(0)}ms`,
+        );
         await this.runtime.sleep(delayMs);
         continue;
       }

--- a/packages/scout-for-lol/packages/backend/src/league/api/tournament/http.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/api/tournament/http.ts
@@ -46,20 +46,27 @@ export async function tournamentFetch(
   }
   const href = url.toString();
 
-  const response = await rateLimiter.execute(href, () =>
-    fetch(href, {
-      method: request.method,
-      headers: {
-        "X-Riot-Token": configuration.riotApiToken,
-        Accept: "application/json",
+  const response = await rateLimiter.execute(
+    href,
+    () =>
+      fetch(href, {
+        method: request.method,
+        headers: {
+          "X-Riot-Token": configuration.riotApiToken,
+          Accept: "application/json",
+          ...(request.body === undefined
+            ? {}
+            : { "Content-Type": "application/json" }),
+        },
         ...(request.body === undefined
           ? {}
-          : { "Content-Type": "application/json" }),
-      },
-      ...(request.body === undefined
-        ? {}
-        : { body: JSON.stringify(request.body) }),
-    }),
+          : { body: JSON.stringify(request.body) }),
+      }),
+    // POST/PUT tournament calls mint or mutate resources (e.g. minting
+    // tournament codes) and are not safe to retry on an ambiguous upstream
+    // outage — Riot may have already processed the request even though its
+    // response was lost. Only GET is idempotent enough to retry blindly.
+    { retryUpstreamErrors: request.method === "GET" },
   );
 
   // 204 and an empty body are legal for the code-update endpoint.

--- a/packages/scout-for-lol/packages/backend/src/metrics/riot-rate-limit.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/riot-rate-limit.ts
@@ -1,0 +1,24 @@
+import { Gauge } from "prom-client";
+import { registry } from "#src/metrics/registry.ts";
+
+/**
+ * Current request count within the active Riot app rate-limit window, parsed
+ * from the `X-App-Rate-Limit-Count` response header.
+ */
+export const riotApiAppRateLimitCount = new Gauge({
+  name: "riot_api_app_rate_limit_count",
+  help: "Current request count within the active Riot app rate-limit window",
+  labelNames: ["window_seconds"] as const,
+  registers: [registry],
+});
+
+/**
+ * Configured Riot app rate-limit ceiling for the current window, parsed from
+ * the `X-App-Rate-Limit` response header.
+ */
+export const riotApiAppRateLimitLimit = new Gauge({
+  name: "riot_api_app_rate_limit_limit",
+  help: "Configured Riot app rate-limit ceiling for the current window",
+  labelNames: ["window_seconds"] as const,
+  registers: [registry],
+});


### PR DESCRIPTION
## Why

Scout's only signal for "how close am I to Riot's app rate limit (500 req/10s,
30000 req/10min)?" was its own outbound request counter, not Riot's actual
accounting — it can't see other consumers of the same key and has no
visibility into Riot's real-time bucket state. Separately, the rate limiter
only retried on 429/503 with zero logging, even though 502/504/520/522/524
were already classified elsewhere as "expected upstream outages."

## What

- New `rate-limit-headers.ts` parses Riot's `X-App-Rate-Limit` /
  `X-App-Rate-Limit-Count` response headers into per-window `{count, limit}`
  pairs, zipped by window value (not array position).
- Two new gauges (`riot_api_app_rate_limit_count` / `_limit`) recorded on
  every response inside `RateLimiter`, so both the main Riot client and the
  tournament API's separate limiter instance are covered automatically.
- `RateLimiter.execute()` now retries all of `EXPECTED_UPSTREAM_STATUS_CODES`
  (502/503/504/520/522/524) in addition to 429, with the same
  exponential-backoff-with-jitter previously reserved for 503 alone. Every
  retry decision is now logged (previously silent).
- New Grafana panel ("Riot API App Rate Limit Usage") and two Prometheus
  alerts (warning at 70%, critical at 90% of the app rate limit) added to the
  existing Riot API dashboard row and alert group.
- Extracted `scout-temporal-rules.ts` and `riot-rate-limit.ts` to keep the
  edited files under this repo's 500-effective-line ESLint cap, following the
  existing sibling-file extraction convention (mirrors `platform/temporal.ts`).

## Test plan

- [x] `bunx turbo run build typecheck test lint --filter=@scout-for-lol/backend` — 3734 tests passed
- [x] `bunx turbo run build typecheck test lint --filter=@homelab/cdk8s` — 710 tests passed, cdk8s synth clean
- [ ] Live Prometheus data / Grafana panel rendering after ArgoCD deploys this (needs a live Riot API response to populate the new gauges) — not yet verified