### PR TITLE
feat(scout-for-lol): add receipted match projection

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1168,10 +1168,6 @@
       "clones": 1,
       "tokens": 76
     },
-    "packages/scout-for-lol/packages/backend/src/storage/s3-helpers.ts|packages/scout-for-lol/packages/backend/src/storage/s3-prematch.ts": {
-      "clones": 2,
-      "tokens": 161
-    },
     "packages/scout-for-lol/packages/backend/src/storage/s3-leaderboard-image.ts|packages/scout-for-lol/packages/backend/src/storage/s3-leaderboard.ts": {
       "clones": 1,
       "tokens": 79
@@ -1190,7 +1186,7 @@
     },
     "packages/scout-for-lol/packages/backend/src/storage/s3-prematch-data.no-bucket.test.ts|packages/scout-for-lol/packages/backend/src/storage/s3-prematch-data.test.ts": {
       "clones": 1,
-      "tokens": 143
+      "tokens": 86
     },
     "packages/scout-for-lol/packages/backend/src/storage/s3-query.integration.test.ts|packages/scout-for-lol/packages/backend/src/storage/s3-query.integration.test.ts": {
       "clones": 2,

--- a/packages/docs/wiki/src/content/docs/explanation/scout-report-lake.md
+++ b/packages/docs/wiki/src/content/docs/explanation/scout-report-lake.md
@@ -88,6 +88,97 @@ state, settle Bryan Bucks, award earnings, or fabricate per-match rank deltas.
 The live poller resumes only after the fixed snapshot is stored and its newest
 ID becomes the cursor, so a game completed during import is notified once.
 
+### Every archived capture is content-addressed
+
+Each raw match, timeline, and prematch payload is hashed with SHA-256 before it
+is uploaded, in
+[object-integrity.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/storage/object-integrity.ts). The digest is stored on the object as user metadata and returned to
+the caller as an artifact descriptor: the key that was written, the digest, the
+byte count, the content type, and the capture instant. Because a descriptor
+carries the key the put actually used rather than one recomputed afterwards, it
+cannot describe an object that is not there.
+
+The write path verifies less than it may appear to. The AWS SDK sends a request
+checksum the server recomputes and rejects on mismatch, so transit corruption
+fails the put itself; Scout additionally compares the returned ETag against its
+own MD5 of the body, which independently confirms that the bytes the server
+acknowledged are the bytes it sent (`assertPutIntegrity`, same module). Nothing re-reads the object. Durable
+replication, later overwrites, and read-time integrity are all outside what a
+write can establish — the recorded digest is what makes them checkable later,
+which is the reason for recording it.
+
+### The timeline partition cutover
+
+Every asset for a game belongs under one `games/yyyy/MM/dd/{matchId}/` prefix,
+and since 2026-09-12 timelines are keyed by the match's `gameCreation` so they
+land beside the match payload, per
+[archiveTimelineToS3](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/storage/s3.ts). Before that they were keyed by the moment they
+were uploaded, which was usually — but not reliably — the day the game was
+played, so a game's own assets could end up split across two prefixes.
+
+Nothing rewrites the objects already filed under the old layout, and nothing
+needs to. Both the fold and the rebuild enumerate the whole `games/` prefix and
+take a match's identity from the parsed payload, never from its key, so a reader
+cannot tell which layout it is looking at. What it does need is deduplication —
+a match retried across the cutover has a surviving object in each layout, and
+[rebuild-sources.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/report-lake/rebuild-sources.ts) keeps the newest so the
+rebuild is reproducible.
+
+### Receipted ingest is a second door, not a replacement
+
+The durable architecture adds a receipted entry point alongside the boolean one:
+the same staging and archival primitives underneath, the opposite failure
+contract on top. A caller that asks for a receipted write is asking for a
+durable claim that the projection happened, so a staging failure throws and
+records nothing rather than returning `false`
+([receipted-staging.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/report-lake/receipted-staging.ts),
+[receipted-archive.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/report-lake/receipted-archive.ts)). A receipt that might not
+correspond to a real staging file would be worse than no receipt, because the
+value of the table is that a row in it can be trusted without re-deriving the
+fact it attests to.
+
+The receipt write itself is the one fail-open step. Refusing an archive because
+its bookkeeping row could not be inserted would trade a bookkeeping problem for a
+data-loss one, so a broken receipt write is logged and metered while the v1 write
+stands.
+
+Two counters record that, and keeping them apart is what makes either usable
+(defined in [metrics/durable.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/metrics/durable.ts), applied in
+[durable-receipts.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/report-lake/durable-receipts.ts)).
+`scout_durable_dualwrite_failures_total` counts only writes that THREW: the
+recorder is broken and the stored state is unknown, which is worth paging on.
+`scout_durable_dualwrite_records_total` counts every write that completed,
+labelled by the repository's answer, so a conflict — a definite result where the
+row exists, the first writer's evidence was kept, and two producers disagree — is
+visible as drift without contaminating the alert. Collapsing a conflict into the
+failures counter would make it fire on benign retries and stop meaning "the
+recorder is broken". Both are recorded inline by whichever role performed the
+write, so they arrive from the ingest worker roles rather than from
+`application`; neither is one of the database-sweeping collectors only
+`application` serves ([sweep-policy.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/metrics/sweep-policy.ts)), so a
+dashboard over the pair joins across roles.
+
+### A receipt identifies content, never a location
+
+Receipt evidence names artifacts by content digest and by the S3 object they
+derive from, shaped by
+[durable-receipts.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/report-lake/durable-receipts.ts). It never names a local path or a build id, and that rule is what
+lets any role read a receipt another role wrote.
+
+The reason is the split topology. Staging files live on one role's
+read-write-once volume, so a receipt naming `matches-recent/NA1_1.jsonl` would be
+a claim no other role could evaluate, and it would quietly become false the day
+the lake moved to a shared store. A lake-staging receipt therefore records the
+source object key, the digest of the bytes the rows were derived from, and how
+many staging relations the capture writes. All three are true from anywhere, and
+together they let a reader re-derive the projection and check it rather than take
+the receipt's word for it. A staging run cannot be receipted at all without
+knowing the object it projected, which is why the source descriptor is a required
+argument rather than an optional one. Each artifact kind also gets its own
+receipt kind, because all three share one match id and a receipt's identity is
+`(kind, version, scope)` within a match — one kind per family would make a
+game's match and timeline the same receipt.
+
 ```mermaid
 sequenceDiagram
   accTitle: Ingest write contract

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-standard.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-standard.ts
@@ -92,11 +92,13 @@ export async function persistTimelineForProgression(
   timeline: RawTimeline,
   playersInMatch: PlayerConfigEntry[],
   matchId: MatchId,
+  matchData: RawMatch,
 ): Promise<void> {
   const staged = await recordTimelineForReportStore({
     timeline,
     source: "timeline_progression",
     trackedPlayerAliases: playersInMatch.map((player) => player.alias),
+    gameCreatedAt: new Date(matchData.info.gameCreation),
   });
   requireTimelineStaging("required", staged, matchId);
 }
@@ -116,6 +118,7 @@ async function stageFetchedTimeline(
     readonly source?: "timeline_progression";
     readonly playersInMatch: PlayerConfigEntry[];
     readonly matchId: MatchId;
+    readonly matchData: RawMatch;
   },
   timeline: RawTimeline,
 ): Promise<void> {
@@ -134,6 +137,7 @@ async function stageFetchedTimeline(
           ? "timeline_dare_v2"
           : "timeline_live"),
       trackedPlayerAliases,
+      gameCreatedAt: new Date(options.matchData.info.gameCreation),
     });
     requireTimelineStaging(options.persistence, staged, options.matchId);
   } catch (error) {

--- a/packages/scout-for-lol/packages/backend/src/metrics/durable.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/durable.ts
@@ -1,0 +1,32 @@
+import { Counter } from "prom-client";
+import { registry } from "#src/metrics/registry.ts";
+
+/**
+ * Parity instrumentation for the durable dual-write bridge.
+ *
+ * THIS IS THE SINGLE DEFINITION SITE for these metrics. prom-client throws at
+ * import time when two modules register the same metric name on the shared
+ * registry, which takes the process down on boot rather than at the first
+ * `inc()`. Every producer — the match services here, the receipted lake
+ * projection — imports these symbols; nobody declares a second counter with
+ * the same name.
+ *
+ * Both are per-write counters incremented inline by whichever runtime role
+ * executed the write, so a parity dashboard joins across roles rather than
+ * reading one process. Neither is derived from a database sweep, so neither
+ * belongs in `getMetrics()`'s `databaseMetricSweepsEnabled()` block.
+ */
+
+export const scoutDurableDualwriteFailuresTotal = new Counter({
+  name: "scout_durable_dualwrite_failures_total",
+  help: "Durable dual-write side-effects that failed without failing the v1 path, by write kind.",
+  labelNames: ["write_kind"] as const,
+  registers: [registry],
+});
+
+export const scoutDurableDualwriteRecordsTotal = new Counter({
+  name: "scout_durable_dualwrite_records_total",
+  help: "Durable facts recorded alongside the v1 pipeline, by write kind and repository outcome.",
+  labelNames: ["write_kind", "outcome"] as const,
+  registers: [registry],
+});

--- a/packages/scout-for-lol/packages/backend/src/progression/postmatch.ts
+++ b/packages/scout-for-lol/packages/backend/src/progression/postmatch.ts
@@ -66,6 +66,7 @@ export async function processCompetitiveProgressionMatch(input: {
         timeline,
         input.trackedPlayers,
         matchId,
+        input.match,
       );
     }
     timelinePersisted = required || timeline !== undefined;

--- a/packages/scout-for-lol/packages/backend/src/report-lake/durable-receipts.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/durable-receipts.ts
@@ -1,0 +1,218 @@
+import { z } from "zod";
+import type { Db } from "#src/database/index.ts";
+import { prisma } from "#src/database/index.ts";
+import { recordReceipt } from "#src/database/durable/receipt-repository.ts";
+import type { MatchProcessingReceiptRecord } from "#src/database/durable/receipt-row.ts";
+import { createLogger } from "#src/logger.ts";
+import {
+  scoutDurableDualwriteFailuresTotal,
+  scoutDurableDualwriteRecordsTotal,
+} from "#src/metrics/durable.ts";
+import { defineVersionedCodec } from "@scout-for-lol/domain/codec/versioned.ts";
+import {
+  ArtifactDescriptorSchema,
+  type ArtifactKind,
+} from "@scout-for-lol/domain/artifacts/descriptors.ts";
+import {
+  IsoInstantSchema,
+  RiotMatchIdSchema,
+  type RiotMatchId,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  ReceiptKindSchema,
+  type ReceiptKind,
+} from "@scout-for-lol/domain/match-processing/states.ts";
+import type { RawCurrentGameInfo } from "@scout-for-lol/data";
+
+const logger = createLogger("report-lake-durable-receipts");
+
+/**
+ * Receipt plumbing shared by the receipted staging and archive entry points.
+ *
+ * A receipt is the durable answer to "did this actually happen?", so its
+ * evidence has to survive a schema change as well as the fact does. Both kinds
+ * therefore serialize through a versioned envelope rather than raw JSON: a
+ * reader that meets a version it cannot migrate rejects it loudly instead of
+ * silently reading the wrong shape.
+ *
+ * The domain deliberately does not enumerate receipt kinds — they belong to the
+ * workflows that emit them — so the kinds this feature owns are named here.
+ */
+
+/**
+ * Receipt kinds are per ARTIFACT KIND, not per family.
+ *
+ * A receipt's identity is `(kind, version, scope)` within one match, and all
+ * three artifacts of a game share that match id — a prematch snapshot is keyed
+ * by the very id MatchV5 later assigns. So a single `raw-archive` kind would
+ * make the match, its timeline and its prematch snapshot the SAME receipt:
+ * archiving the timeline after the match would not record a second fact, it
+ * would collide with the first and be reported as a conflict. A normal ingest
+ * could never receipt all of its inputs.
+ *
+ * Splitting the kind is what makes them distinct facts. `ReceiptKind` is a
+ * branded kebab-case string precisely so waves can name their own kinds, and
+ * "the match payload was archived" genuinely is a different claim from "its
+ * timeline was archived". The evidence codecs stay shared across each family:
+ * the shape of the claim does not change with the artifact it describes.
+ */
+const RAW_ARCHIVE_RECEIPT_KINDS = {
+  match: ReceiptKindSchema.parse("raw-archive-match"),
+  timeline: ReceiptKindSchema.parse("raw-archive-timeline"),
+  prematch: ReceiptKindSchema.parse("raw-archive-prematch"),
+} as const satisfies Record<ArtifactKind, ReceiptKind>;
+
+const LAKE_STAGING_RECEIPT_KINDS = {
+  match: ReceiptKindSchema.parse("lake-staging-match"),
+  timeline: ReceiptKindSchema.parse("lake-staging-timeline"),
+  prematch: ReceiptKindSchema.parse("lake-staging-prematch"),
+} as const satisfies Record<ArtifactKind, ReceiptKind>;
+
+/** The canonical object store holds this artifact. */
+export function rawArchiveReceiptKind(artifact: ArtifactKind): ReceiptKind {
+  return RAW_ARCHIVE_RECEIPT_KINDS[artifact];
+}
+
+/** The lake projection for this artifact reached its staging files. */
+export function lakeStagingReceiptKind(artifact: ArtifactKind): ReceiptKind {
+  return LAKE_STAGING_RECEIPT_KINDS[artifact];
+}
+
+/** Every receipt kind this feature owns, for cross-checking against others. */
+export const RECEIPTED_LAKE_RECEIPT_KINDS: readonly ReceiptKind[] = [
+  ...Object.values(RAW_ARCHIVE_RECEIPT_KINDS),
+  ...Object.values(LAKE_STAGING_RECEIPT_KINDS),
+];
+
+export const RECEIPT_VERSION = 1;
+
+/**
+ * What a lake-staging receipt attests to, identified by CONTENT rather than by
+ * location.
+ *
+ * The staging files themselves live on a role's own RWO volume, so their
+ * absolute paths are meaningless to any other role and would be meaningless to
+ * every role if the lake ever moved to a shared store. A receipt that named
+ * them would be a claim no reader could evaluate. Instead the evidence names
+ * the S3 object the rows were derived from and the digest of the exact bytes
+ * that produced them: both are true from anywhere, and together they let a
+ * reader re-derive the projection and check it.
+ *
+ * `fileCount` is the shape of the projection — how many staging relations this
+ * capture writes — which is a property of the capture, not of a filesystem.
+ */
+export type LakeStagingEvidence = z.infer<typeof LakeStagingEvidenceSchema>;
+export const LakeStagingEvidenceSchema = z.strictObject({
+  objectKind: ArtifactDescriptorSchema.shape.kind,
+  sourceObjectKey: ArtifactDescriptorSchema.shape.key,
+  digest: ArtifactDescriptorSchema.shape.digest,
+  fileCount: z.number().int().positive(),
+});
+
+export const lakeStagingEvidenceCodec = defineVersionedCodec({
+  kind: "lake-staging-evidence",
+  version: RECEIPT_VERSION,
+  schema: LakeStagingEvidenceSchema,
+});
+
+export const rawArchiveEvidenceCodec = defineVersionedCodec({
+  kind: "raw-archive-evidence",
+  version: RECEIPT_VERSION,
+  schema: ArtifactDescriptorSchema,
+});
+
+/**
+ * The Riot match id a prematch snapshot will belong to.
+ *
+ * Receipts are keyed by match id, and a spectator snapshot is captured before
+ * MatchV5 knows about the game — but the id is not unknown, it is simply not
+ * assembled yet: Riot builds it from exactly the platform and game id the
+ * spectator payload already carries.
+ */
+export function prematchReceiptMatchId(
+  gameInfo: RawCurrentGameInfo,
+): RiotMatchId {
+  return receiptMatchId(`${gameInfo.platformId}_${gameInfo.gameId.toString()}`);
+}
+
+export function receiptMatchId(matchId: string): RiotMatchId {
+  return RiotMatchIdSchema.parse(matchId);
+}
+
+export function buildReceipt(args: {
+  matchId: RiotMatchId;
+  kind: ReceiptKind;
+  evidence: unknown;
+  recordedAt: Date;
+}): MatchProcessingReceiptRecord {
+  return {
+    matchId: args.matchId,
+    receipt: {
+      kind: args.kind,
+      version: RECEIPT_VERSION,
+      scope: { kind: "global" },
+      recordedAt: IsoInstantSchema.parse(args.recordedAt.toISOString()),
+    },
+    evidence: JSON.stringify(args.evidence),
+  };
+}
+
+/**
+ * What the durable recorder was able to say about this fact.
+ *
+ * `conflict` is deliberately NOT collapsed into `failed`. They are different
+ * operational conditions: `failed` means the write did not happen and the
+ * stored state is unknown, while `conflict` is a definite answer from a
+ * successful write — the row is there, the first writer's evidence was kept,
+ * and two producers disagree about the fact.
+ */
+export type ReceiptRecordOutcome = "recorded" | "conflict" | "failed";
+
+/**
+ * Record a receipt without letting its failure fail the write it describes.
+ *
+ * The v1 archive and staging paths are the ones with user-visible consequences:
+ * refusing an archive because the row recording it could not be inserted trades
+ * a bookkeeping problem for a data-loss one. So a broken receipt write is logged
+ * and metered and nothing else.
+ *
+ * The two counters answer different questions, and keeping them apart is what
+ * makes either usable. {@link scoutDurableDualwriteFailuresTotal} counts only
+ * THROWN writes — the recorder itself is broken and the stored state is unknown,
+ * which is worth paging on. {@link scoutDurableDualwriteRecordsTotal} counts
+ * every completed write by its repository outcome, so a `conflict` stays visible
+ * as drift without contaminating the alert.
+ *
+ * Conflicts are a permanent feature of this table, not a transitional one: a
+ * producer whose v1 operation is one-shot genuinely observes different evidence
+ * on a replay, and reporting that honestly is better than fabricating agreement.
+ * So a `conflict` must never reach the failures counter, whatever the
+ * repository's replay equality happens to compare at the time.
+ */
+export async function recordReceiptFailOpen(args: {
+  record: MatchProcessingReceiptRecord;
+  writeKind: string;
+  db?: Db;
+}): Promise<ReceiptRecordOutcome> {
+  try {
+    const outcome = await recordReceipt(args.db ?? prisma, args.record);
+    scoutDurableDualwriteRecordsTotal.inc({
+      write_kind: args.writeKind,
+      outcome: outcome.outcome,
+    });
+    if (outcome.outcome === "conflict") {
+      logger.warn(
+        `Receipt ${args.record.receipt.kind} for ${args.record.matchId} disagrees with the recorded one (${outcome.reason}); the first writer's evidence stands`,
+      );
+      return "conflict";
+    }
+    return "recorded";
+  } catch (error) {
+    logger.error(
+      `Failed to record ${args.record.receipt.kind} receipt for ${args.record.matchId}; the v1 write stands`,
+      error,
+    );
+    scoutDurableDualwriteFailuresTotal.inc({ write_kind: args.writeKind });
+    return "failed";
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/report-lake/rebuild-sources.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/rebuild-sources.ts
@@ -140,6 +140,23 @@ function timelineWriterRows(writers: TimelineRebuildWriters): number {
   );
 }
 
+/**
+ * TIMELINE PARTITION CUTOVER (2026-09-12). Timeline objects written before this
+ * date are keyed by their UPLOAD day; those written after are keyed by the
+ * match's `gameCreation` day, so that every asset for a game shares one prefix
+ * (see `storage/s3.ts`). Both layouts sit under `games/yyyy/MM/dd/{matchId}/`
+ * and this rebuild enumerates that whole prefix, classifying by the
+ * `/timeline.json` suffix and taking match identity from the parsed payload —
+ * never from the key. Reading both layouts therefore needed no listing change.
+ * What it DID need is deduplication, because a match can have a surviving
+ * object in each layout; see {@link dedupeTimelineCandidates}.
+ *
+ * `lastModified` is the accurate observation time and is preferred whenever S3
+ * supplies it. The key-derived fallback is the day the object was filed, which
+ * means the upload day under the old layout and the game day under the new one.
+ * Both are day-resolution approximations of when the timeline was seen, which
+ * is all this value is used for.
+ */
 function timelineObservedAt(key: string, lastModified: Date | undefined): Date {
   if (lastModified !== undefined) return lastModified;
   const keyDate = /games\/(\d{4})\/(\d{2})\/(\d{2})\//.exec(key);
@@ -150,6 +167,55 @@ function timelineObservedAt(key: string, lastModified: Date | undefined): Date {
     throw new Error(`Timeline object key has no stable date: ${key}`);
   }
   return new Date(`${year}-${month}-${day}T00:00:00.000Z`);
+}
+
+/**
+ * The match id segment of `games/yyyy/MM/dd/{matchId}/timeline.json`.
+ *
+ * Used only to GROUP candidate objects before fetching them, never to decide
+ * what a payload is; the winning object's identity still comes from its parsed
+ * `metadata.matchId`.
+ */
+function timelineKeyMatchId(key: string): string {
+  return key.split("/").at(-2) ?? key;
+}
+
+/**
+ * Pick one object per match from the cutover's two layouts.
+ *
+ * The partition cutover means a match whose timeline was written before it and
+ * retried after it has TWO surviving objects — one under the upload day, one
+ * under the game day — and both are valid, parseable timelines for the same
+ * match. Replaying both would emit two sets of rows for one match, and which
+ * set a query saw would depend on file order. Newest wins: a retry exists
+ * because something about the first attempt was unsatisfactory.
+ *
+ * Ranking uses the same instant as {@link timelineObservedAt}, so an object S3
+ * gives no `LastModified` for is ranked by the day its key files it under
+ * rather than being dropped. Ties break on the key so the result is a total
+ * order and the rebuild is reproducible.
+ */
+function dedupeTimelineCandidates(
+  candidates: readonly { key: string; observedAt: Date }[],
+): { key: string; observedAt: Date }[] {
+  const newestByMatch = new Map<string, { key: string; observedAt: Date }>();
+  for (const candidate of candidates) {
+    const matchId = timelineKeyMatchId(candidate.key);
+    const existing = newestByMatch.get(matchId);
+    if (
+      existing === undefined ||
+      candidate.observedAt.getTime() > existing.observedAt.getTime() ||
+      (candidate.observedAt.getTime() === existing.observedAt.getTime() &&
+        candidate.key > existing.key)
+    ) {
+      newestByMatch.set(matchId, candidate);
+    }
+  }
+  return [...newestByMatch.values()].toSorted(
+    (left, right) =>
+      right.observedAt.getTime() - left.observedAt.getTime() ||
+      left.key.localeCompare(right.key),
+  );
 }
 
 /** Replay only already-retained timeline objects into the normalized lake. */
@@ -166,6 +232,7 @@ export async function populateTimelinesFromS3(options: {
   }) => void;
 }): Promise<number> {
   let skipped = 0;
+  const emitted = new Set<string>();
   const batch: { key: string; observedAt: Date }[] = [];
   const flush = async (): Promise<void> => {
     const timelines = await Promise.all(
@@ -196,6 +263,11 @@ export async function populateTimelinesFromS3(options: {
         reportLakeCompactionSkippedTotal.inc({ table: "timeline_coverage" });
         continue;
       }
+      // Second line of defence behind the key-level dedupe: two objects under
+      // different key match ids can still parse to the same payload match id.
+      // Candidates arrive newest-first, so the first one seen is the winner.
+      if (emitted.has(result.timeline.metadata.matchId)) continue;
+      emitted.add(result.timeline.metadata.matchId);
       const flattened = flattenTimeline(result.timeline, result.observedAt);
       for (const row of flattened.events) options.writers.events.write(row);
       for (const row of flattened.eventParticipants) {
@@ -216,6 +288,10 @@ export async function populateTimelinesFromS3(options: {
     });
   };
 
+  // Enumerate the whole prefix before fetching anything. Deduping needs to see
+  // every candidate for a match, and the listing is metadata-only — it is the
+  // GETs that cost, and this is what stops us paying for a loser twice.
+  const candidates: { key: string; observedAt: Date }[] = [];
   for await (const ref of enumerateRawObjects(
     options.client,
     options.bucket,
@@ -223,10 +299,14 @@ export async function populateTimelinesFromS3(options: {
     options,
   )) {
     if (classifyRawObjectKey(ref.key) !== "timeline") continue;
-    batch.push({
+    candidates.push({
       key: ref.key,
       observedAt: timelineObservedAt(ref.key, ref.lastModified),
     });
+  }
+
+  for (const candidate of dedupeTimelineCandidates(candidates)) {
+    batch.push(candidate);
     if (batch.length >= REBUILD_S3_CONCURRENCY) await flush();
   }
   if (batch.length > 0) await flush();

--- a/packages/scout-for-lol/packages/backend/src/report-lake/rebuild-timeline-layouts.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/rebuild-timeline-layouts.test.ts
@@ -1,0 +1,279 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  GetObjectCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { mockClient } from "aws-sdk-client-mock";
+import { z } from "zod";
+import { RawTimelineSchema, type RawTimeline } from "@scout-for-lol/data";
+import { NdjsonFileWriter } from "#src/report-lake/ndjson-writer.ts";
+import { populateTimelinesFromS3 } from "#src/report-lake/rebuild-sources.ts";
+
+/**
+ * The timeline partition cutover (2026-09-12) left two layouts in the bucket:
+ * objects written before it sit under their UPLOAD day, objects written after
+ * sit under the match's gameCreation day. This pins the property that makes the
+ * rebuild indifferent to which one it meets — it enumerates the whole `games/`
+ * prefix and takes match identity from the payload, never from the key.
+ */
+
+const s3Mock = mockClient(S3Client);
+
+// Same match, same payload, filed under two different days. Under the OLD
+// layout this object was keyed by the day it was fetched; under the NEW one it
+// is keyed by the day the game was created.
+const OLD_LAYOUT_KEY = "games/2026/08/01/NA1_1111111111/timeline.json";
+const NEW_LAYOUT_KEY = "games/2026/09/12/NA1_2222222222/timeline.json";
+
+let tempDir: string;
+
+function timelineFixture(matchId: string, gameId: number): RawTimeline {
+  return RawTimelineSchema.parse({
+    metadata: { dataVersion: "2", matchId, participants: ["puuid-1"] },
+    info: {
+      frameInterval: 60_000,
+      gameId,
+      participants: [{ participantId: 1, puuid: "puuid-1" }],
+      frames: [
+        {
+          timestamp: 0,
+          events: [{ type: "PAUSE_END", timestamp: 0 }],
+          participantFrames: {},
+        },
+      ],
+    },
+  });
+}
+
+function seedTimelines(
+  objects: { key: string; body: string; lastModified?: Date }[],
+): void {
+  s3Mock.reset();
+  s3Mock.on(ListObjectsV2Command, { Prefix: "games/" }).resolves({
+    Contents: objects.map((object) => ({
+      Key: object.key,
+      ...(object.lastModified === undefined
+        ? {}
+        : { LastModified: object.lastModified }),
+    })),
+  });
+  for (const object of objects) {
+    s3Mock.on(GetObjectCommand, { Key: object.key }).callsFake(() => ({
+      Body: { transformToString: () => Promise.resolve(object.body) },
+      $metadata: {},
+    }));
+  }
+}
+
+const CoverageRowSchema = z.object({
+  match_id: z.string(),
+  frame_interval_ms: z.number(),
+});
+
+async function runRebuild(): Promise<{
+  foldedIds: Set<string>;
+  coverageRows: number;
+  coverage: z.infer<typeof CoverageRowSchema>[];
+}> {
+  const writers = {
+    events: new NdjsonFileWriter(path.join(tempDir, "events.ndjson")),
+    eventParticipants: new NdjsonFileWriter(
+      path.join(tempDir, "event-participants.ndjson"),
+    ),
+    participantFrames: new NdjsonFileWriter(
+      path.join(tempDir, "participant-frames.ndjson"),
+    ),
+    coverage: new NdjsonFileWriter(path.join(tempDir, "coverage.ndjson")),
+  };
+  const foldedIds = new Set<string>();
+  await populateTimelinesFromS3({
+    client: new S3Client({}),
+    bucket: "test-bucket",
+    writers,
+    foldedIds,
+  });
+  const coverageRows = writers.coverage.rows;
+  await Promise.all([
+    writers.events.close(),
+    writers.eventParticipants.close(),
+    writers.participantFrames.close(),
+    writers.coverage.close(),
+  ]);
+  const coverageText = await Bun.file(writers.coverage.filePath).text();
+  const coverage = coverageText
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line): unknown => JSON.parse(line))
+    .map((row) => CoverageRowSchema.parse(row));
+  return { foldedIds, coverageRows, coverage };
+}
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(path.join(tmpdir(), "rebuild-timeline-layouts-"));
+});
+
+afterEach(async () => {
+  s3Mock.reset();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("timeline rebuild across both partition layouts", () => {
+  test("reads timelines filed under the old upload-date prefix", async () => {
+    seedTimelines([
+      {
+        key: OLD_LAYOUT_KEY,
+        body: JSON.stringify(timelineFixture("NA1_1111111111", 1_111_111_111)),
+      },
+    ]);
+
+    const { foldedIds } = await runRebuild();
+
+    expect([...foldedIds]).toEqual(["NA1_1111111111"]);
+  });
+
+  test("reads timelines filed under the new game-date prefix", async () => {
+    seedTimelines([
+      {
+        key: NEW_LAYOUT_KEY,
+        body: JSON.stringify(timelineFixture("NA1_2222222222", 2_222_222_222)),
+      },
+    ]);
+
+    const { foldedIds } = await runRebuild();
+
+    expect([...foldedIds]).toEqual(["NA1_2222222222"]);
+  });
+
+  test("reads both layouts in one pass", async () => {
+    seedTimelines([
+      {
+        key: OLD_LAYOUT_KEY,
+        body: JSON.stringify(timelineFixture("NA1_1111111111", 1_111_111_111)),
+      },
+      {
+        key: NEW_LAYOUT_KEY,
+        body: JSON.stringify(timelineFixture("NA1_2222222222", 2_222_222_222)),
+      },
+    ]);
+
+    const { foldedIds, coverageRows } = await runRebuild();
+
+    expect([...foldedIds].toSorted()).toEqual([
+      "NA1_1111111111",
+      "NA1_2222222222",
+    ]);
+    expect(coverageRows).toBe(2);
+  });
+
+  test("takes match identity from the payload, not the key's date", async () => {
+    // A payload deliberately filed under a date prefix that has nothing to do
+    // with its match: the rebuild must still fold it under its real match id.
+    seedTimelines([
+      {
+        key: "games/1999/12/31/NA1_9999999999/timeline.json",
+        body: JSON.stringify(timelineFixture("NA1_2222222222", 2_222_222_222)),
+      },
+    ]);
+
+    const { foldedIds } = await runRebuild();
+
+    expect([...foldedIds]).toEqual(["NA1_2222222222"]);
+  });
+
+  test("keeps only the newest object when one match survives in both layouts", async () => {
+    // The cutover's real hazard: a timeline written pre-cutover under its
+    // upload day, then retried post-cutover under its game day. Both parse, so
+    // replaying both would emit two sets of rows for one match.
+    const body = JSON.stringify(
+      timelineFixture("NA1_3333333333", 3_333_333_333),
+    );
+    seedTimelines([
+      {
+        key: "games/2026/08/01/NA1_3333333333/timeline.json",
+        body,
+        lastModified: new Date("2026-08-01T10:00:00.000Z"),
+      },
+      {
+        key: "games/2026/09/12/NA1_3333333333/timeline.json",
+        body,
+        lastModified: new Date("2026-09-12T10:00:00.000Z"),
+      },
+    ]);
+
+    const { foldedIds, coverageRows } = await runRebuild();
+
+    expect([...foldedIds]).toEqual(["NA1_3333333333"]);
+    expect(coverageRows).toBe(1);
+  });
+
+  test("the newer object wins, whichever layout it happens to sit in", async () => {
+    // Same pair, recency reversed: the OLD-layout object is the newer write, so
+    // it must win. The tie-break is LastModified, never the layout and never
+    // the listing order.
+    const newer = timelineFixture("NA1_4444444444", 4_444_444_444);
+    newer.info.frameInterval = 15_000;
+    const older = timelineFixture("NA1_4444444444", 4_444_444_444);
+    older.info.frameInterval = 60_000;
+    seedTimelines([
+      {
+        key: "games/2026/08/01/NA1_4444444444/timeline.json",
+        body: JSON.stringify(newer),
+        lastModified: new Date("2026-09-20T10:00:00.000Z"),
+      },
+      {
+        key: "games/2026/09/12/NA1_4444444444/timeline.json",
+        body: JSON.stringify(older),
+        lastModified: new Date("2026-09-12T10:00:00.000Z"),
+      },
+    ]);
+
+    const { coverageRows, coverage } = await runRebuild();
+
+    expect(coverageRows).toBe(1);
+    expect(coverage).toHaveLength(1);
+    expect(coverage[0]?.frame_interval_ms).toBe(15_000);
+  });
+
+  test("dedupes on the payload's match id even when the keys disagree", async () => {
+    // Two objects under different key match ids that both parse to the same
+    // match. Key-level grouping cannot catch this, so the payload guard must.
+    const body = JSON.stringify(
+      timelineFixture("NA1_2222222222", 2_222_222_222),
+    );
+    seedTimelines([
+      {
+        key: "games/1999/12/31/NA1_9999999999/timeline.json",
+        body,
+        lastModified: new Date("2026-08-01T10:00:00.000Z"),
+      },
+      {
+        key: NEW_LAYOUT_KEY,
+        body,
+        lastModified: new Date("2026-09-12T10:00:00.000Z"),
+      },
+    ]);
+
+    const { foldedIds, coverageRows } = await runRebuild();
+
+    expect([...foldedIds]).toEqual(["NA1_2222222222"]);
+    expect(coverageRows).toBe(1);
+  });
+
+  test("falls back to the key's date only when S3 omits LastModified", async () => {
+    seedTimelines([
+      {
+        key: NEW_LAYOUT_KEY,
+        body: JSON.stringify(timelineFixture("NA1_2222222222", 2_222_222_222)),
+        lastModified: new Date("2026-09-13T08:00:00.000Z"),
+      },
+    ]);
+
+    const { foldedIds } = await runRebuild();
+
+    expect([...foldedIds]).toEqual(["NA1_2222222222"]);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/report-lake/receipted-archive.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/receipted-archive.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  loadRawMatchFixture,
+  rawCurrentGameInfoFixture,
+  rawTimelineFixture,
+} from "#src/testing/raw-capture-fixtures.ts";
+import {
+  ArtifactDescriptorSchema,
+  ArtifactKindSchema,
+} from "@scout-for-lol/domain/artifacts/descriptors.ts";
+import { matchProcessingReceiptIdentityKey } from "@scout-for-lol/domain/match-processing/states.ts";
+import {
+  MatchProcessingReceiptRecordSchema,
+  type MatchProcessingReceiptRecord,
+} from "#src/database/durable/receipt-row.ts";
+import {
+  getValidatedPutCommand,
+  mockFailedPut,
+  mockSuccessfulPut,
+  resetS3TestState,
+  s3Mock,
+  setS3TestBucket,
+} from "#src/storage/s3-test-helpers.ts";
+
+const mocks = vi.hoisted(() => ({
+  recordReceipt: vi.fn(),
+}));
+
+vi.mock("#src/database/index.ts", () => ({ prisma: {} }));
+vi.mock("#src/database/durable/receipt-repository.ts", () => ({
+  recordReceipt: mocks.recordReceipt,
+}));
+
+const ARTIFACT_KINDS = ArtifactKindSchema.options;
+
+const {
+  RECEIPTED_LAKE_RECEIPT_KINDS,
+  lakeStagingReceiptKind,
+  rawArchiveEvidenceCodec,
+  rawArchiveReceiptKind,
+} = await import("#src/report-lake/durable-receipts.ts");
+const {
+  archiveMatchReceipted,
+  archivePrematchReceipted,
+  archiveTimelineReceipted,
+} = await import("#src/report-lake/receipted-archive.ts");
+
+function recordedReceipt(callIndex = 0): MatchProcessingReceiptRecord {
+  const call: unknown = mocks.recordReceipt.mock.calls[callIndex]?.[1];
+  if (call === undefined) throw new Error("no receipt was recorded");
+  return MatchProcessingReceiptRecordSchema.parse(call);
+}
+
+/**
+ * The `(kind, version, scope)` identity `recordReceipt` enforces as unique
+ * within one match. Two receipts sharing it are the same receipt, so this is
+ * what has to differ between a match and its timeline.
+ */
+function receiptIdentity(record: MatchProcessingReceiptRecord): string {
+  return matchProcessingReceiptIdentityKey({
+    kind: record.receipt.kind,
+    version: record.receipt.version,
+    scope: record.receipt.scope,
+  });
+}
+
+beforeEach(() => {
+  resetS3TestState();
+  mocks.recordReceipt.mockReset();
+  mocks.recordReceipt.mockResolvedValue({ outcome: "applied" });
+});
+
+afterEach(resetS3TestState);
+
+describe("receipted match archival", () => {
+  test("records a raw-archive receipt carrying the stored descriptor", async () => {
+    const match = await loadRawMatchFixture();
+    mockSuccessfulPut();
+
+    const result = await archiveMatchReceipted(match, []);
+
+    expect(result.status).toBe("archived");
+    if (result.status !== "archived") throw new Error("expected an archive");
+    expect(result.receipt).toBe("recorded");
+
+    const receipt = recordedReceipt();
+    expect(receipt.matchId).toBe(match.metadata.matchId);
+    expect(receipt.receipt.kind).toBe("raw-archive-match");
+    expect(receipt.receipt.scope).toEqual({ kind: "global" });
+    if (receipt.evidence === null) throw new Error("receipt had no evidence");
+    expect(rawArchiveEvidenceCodec.parse(JSON.parse(receipt.evidence))).toEqual(
+      ArtifactDescriptorSchema.parse(result.artifact),
+    );
+  });
+
+  test("the receipted descriptor points at the object that was really written", async () => {
+    const match = await loadRawMatchFixture();
+    mockSuccessfulPut();
+
+    const result = await archiveMatchReceipted(match, []);
+
+    if (result.status !== "archived") throw new Error("expected an archive");
+    expect(result.artifact.key).toBe(getValidatedPutCommand().input.Key);
+    expect(getValidatedPutCommand().input.Metadata?.["sha256"]).toBe(
+      result.artifact.digest,
+    );
+  });
+
+  test("a failed receipt write does not fail the archive", async () => {
+    const match = await loadRawMatchFixture();
+    mockSuccessfulPut();
+    mocks.recordReceipt.mockRejectedValue(new Error("database is down"));
+
+    const result = await archiveMatchReceipted(match, []);
+
+    expect(result.status).toBe("archived");
+    if (result.status !== "archived") throw new Error("expected an archive");
+    expect(result.receipt).toBe("failed");
+    expect(s3Mock.calls()).toHaveLength(1);
+  });
+
+  test("a failed archive throws and records nothing", async () => {
+    const match = await loadRawMatchFixture();
+    mockFailedPut("S3 upload failed");
+
+    await expect(archiveMatchReceipted(match, [])).rejects.toThrow(
+      `Failed to save match ${match.metadata.matchId} to S3`,
+    );
+    expect(mocks.recordReceipt).not.toHaveBeenCalled();
+  });
+
+  test("records nothing when there is no bucket to archive into", async () => {
+    const match = await loadRawMatchFixture();
+    setS3TestBucket(undefined);
+    mockSuccessfulPut();
+
+    await expect(archiveMatchReceipted(match, [])).resolves.toEqual({
+      status: "skipped_no_bucket",
+    });
+    expect(mocks.recordReceipt).not.toHaveBeenCalled();
+  });
+});
+
+describe("receipted timeline archival", () => {
+  test("receipts the timeline against its own match id", async () => {
+    const timeline = rawTimelineFixture("NA1_5370969615");
+    mockSuccessfulPut();
+
+    const result = await archiveTimelineReceipted(
+      timeline,
+      [],
+      new Date("2026-01-01T00:00:00.000Z"),
+    );
+
+    if (result.status !== "archived") throw new Error("expected an archive");
+    expect(result.artifact.kind).toBe("timeline");
+    expect(recordedReceipt().matchId).toBe("NA1_5370969615");
+  });
+});
+
+describe("a full ingest receipts every one of its artifacts", () => {
+  test("match and timeline record two distinct receipt identities", async () => {
+    // All three artifacts of a game share one match id, so a single
+    // `raw-archive` kind would make them the SAME receipt and the second
+    // archive of a normal ingest would land as a conflict.
+    const match = await loadRawMatchFixture();
+    const timeline = rawTimelineFixture(match.metadata.matchId);
+    mockSuccessfulPut();
+
+    await archiveMatchReceipted(match, []);
+    await archiveTimelineReceipted(
+      timeline,
+      [],
+      new Date(match.info.gameCreation),
+    );
+
+    expect(mocks.recordReceipt).toHaveBeenCalledTimes(2);
+    const forMatch = recordedReceipt(0);
+    const forTimeline = recordedReceipt(1);
+
+    expect(forMatch.matchId).toBe(forTimeline.matchId);
+    expect(forMatch.receipt.kind).toBe("raw-archive-match");
+    expect(forTimeline.receipt.kind).toBe("raw-archive-timeline");
+    expect(receiptIdentity(forMatch)).not.toBe(receiptIdentity(forTimeline));
+  });
+
+  test("a prematch snapshot is a third distinct identity for the same match", async () => {
+    const gameInfo = rawCurrentGameInfoFixture();
+    mockSuccessfulPut();
+
+    await archivePrematchReceipted(gameInfo, []);
+
+    const receipt = recordedReceipt();
+    expect(receipt.matchId).toBe("NA1_5500000001");
+    expect(receipt.receipt.kind).toBe("raw-archive-prematch");
+  });
+
+  test("every artifact kind maps to its own receipt kind", () => {
+    const kinds = ARTIFACT_KINDS.map((kind) => rawArchiveReceiptKind(kind));
+
+    expect(new Set(kinds).size).toBe(ARTIFACT_KINDS.length);
+    expect(kinds).toEqual([
+      "raw-archive-match",
+      "raw-archive-timeline",
+      "raw-archive-prematch",
+    ]);
+  });
+
+  test("staging kinds are distinct from archive kinds for the same artifact", () => {
+    for (const kind of ARTIFACT_KINDS) {
+      expect(lakeStagingReceiptKind(kind)).not.toBe(
+        rawArchiveReceiptKind(kind),
+      );
+    }
+    expect(new Set(RECEIPTED_LAKE_RECEIPT_KINDS).size).toBe(
+      ARTIFACT_KINDS.length * 2,
+    );
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/report-lake/receipted-archive.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/receipted-archive.ts
@@ -1,0 +1,138 @@
+import type {
+  RawCurrentGameInfo,
+  RawMatch,
+  RawTimeline,
+} from "@scout-for-lol/data";
+import type { Db } from "#src/database/index.ts";
+import type { ArtifactDescriptor } from "@scout-for-lol/domain/artifacts/descriptors.ts";
+import {
+  rawArchiveReceiptKind,
+  buildReceipt,
+  prematchReceiptMatchId,
+  rawArchiveEvidenceCodec,
+  receiptMatchId,
+  recordReceiptFailOpen,
+  type ReceiptRecordOutcome,
+} from "#src/report-lake/durable-receipts.ts";
+import {
+  archiveMatchToS3,
+  archiveTimelineToS3,
+  savePrematchDataToS3,
+} from "#src/storage/s3.ts";
+
+/**
+ * The receipted entry point into raw S3 archival.
+ *
+ * S3 is the canonical raw store, so these functions do not soften the archive
+ * itself: a failed put throws exactly as it did before, and no receipt is
+ * written for an object that does not exist. What they add is the durable claim
+ * — the descriptor of what was stored, content-addressed by the digest of the
+ * exact bytes uploaded, recorded against the match the capture belongs to.
+ *
+ * The receipt write is the one part that is fail-open, and deliberately so; see
+ * `recordReceiptFailOpen`. The no-bucket path stays the dev/test no-op it has
+ * always been, and records nothing, because nothing was archived.
+ *
+ * These live under `report-lake/` rather than `storage/` for an architectural
+ * reason: `architecture.config.ts` forbids `storage/` and `report-store/` from
+ * importing `database/`, since a persistence adapter that reaches into another
+ * one cannot be used from a script or a fixture without dragging it along. The
+ * lake layer is already the one that composes the object store, the staging
+ * files and the database, so the composition belongs here.
+ */
+
+export type ReceiptedArchiveResult =
+  | {
+      status: "archived";
+      artifact: ArtifactDescriptor;
+      /**
+       * What the durable recorder said. `failed` means the object is in S3 but
+       * the durable record of it is not; `conflict` means a receipt for this
+       * identity already exists carrying different evidence. Either way the
+       * object is archived and the caller has succeeded.
+       */
+      receipt: ReceiptRecordOutcome;
+    }
+  | { status: "skipped_no_bucket" };
+
+type ReceiptOptions = {
+  /** Supply a transaction client to record the receipt atomically with others. */
+  db?: Db;
+  /** Injectable so tests need no wall clock; defaults to now. */
+  now?: Date;
+};
+
+async function receiptArchived(args: {
+  matchId: string;
+  artifact: ArtifactDescriptor;
+  options: ReceiptOptions;
+}): Promise<ReceiptedArchiveResult> {
+  const receipt = await recordReceiptFailOpen({
+    record: buildReceipt({
+      matchId: receiptMatchId(args.matchId),
+      kind: rawArchiveReceiptKind(args.artifact.kind),
+      evidence: rawArchiveEvidenceCodec.serialize(args.artifact),
+      recordedAt: args.options.now ?? new Date(),
+    }),
+    writeKind: "raw-archive",
+    ...(args.options.db === undefined ? {} : { db: args.options.db }),
+  });
+  return { status: "archived", artifact: args.artifact, receipt };
+}
+
+export async function archiveMatchReceipted(
+  match: RawMatch,
+  trackedPlayerAliases: string[],
+  options: ReceiptOptions = {},
+): Promise<ReceiptedArchiveResult> {
+  const result = await archiveMatchToS3(match, trackedPlayerAliases);
+  if (result.status === "skipped_no_bucket") {
+    return { status: "skipped_no_bucket" };
+  }
+  return receiptArchived({
+    matchId: match.metadata.matchId,
+    artifact: result.artifact,
+    options,
+  });
+}
+
+export async function archiveTimelineReceipted(
+  timeline: RawTimeline,
+  trackedPlayerAliases: string[],
+  gameCreatedAt: Date,
+  options: ReceiptOptions = {},
+): Promise<ReceiptedArchiveResult> {
+  const result = await archiveTimelineToS3(
+    timeline,
+    trackedPlayerAliases,
+    gameCreatedAt,
+  );
+  if (result.status === "skipped_no_bucket") {
+    return { status: "skipped_no_bucket" };
+  }
+  return receiptArchived({
+    matchId: timeline.metadata.matchId,
+    artifact: result.artifact,
+    options,
+  });
+}
+
+export async function archivePrematchReceipted(
+  gameInfo: RawCurrentGameInfo,
+  trackedPlayerAliases: string[],
+  options: ReceiptOptions = {},
+): Promise<ReceiptedArchiveResult> {
+  const result = await savePrematchDataToS3(
+    gameInfo.gameId,
+    gameInfo,
+    trackedPlayerAliases,
+  );
+  if (result.status === "skipped_no_bucket" || result.artifact === undefined) {
+    return { status: "skipped_no_bucket" };
+  }
+  return receiptArchived({
+    matchId: prematchReceiptMatchId(gameInfo),
+    artifact: result.artifact,
+    options,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/report-lake/receipted-staging.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/receipted-staging.test.ts
@@ -1,0 +1,322 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  artifactDescriptorFixture,
+  loadRawMatchFixture,
+  rawCurrentGameInfoFixture,
+  rawTimelineFixture,
+} from "#src/testing/raw-capture-fixtures.ts";
+import {
+  MatchProcessingReceiptRecordSchema,
+  type MatchProcessingReceiptRecord,
+} from "#src/database/durable/receipt-row.ts";
+import { MATCHES_STAGING_DIR } from "#src/report-lake/paths.ts";
+import type { Counter } from "prom-client";
+import {
+  scoutDurableDualwriteFailuresTotal,
+  scoutDurableDualwriteRecordsTotal,
+} from "#src/metrics/durable.ts";
+
+const mocks = vi.hoisted(() => ({
+  recordReceipt: vi.fn(),
+}));
+
+// The repository is mocked rather than exercised so these tests state the
+// wrapper's contract — what it records, and what it refuses to record — without
+// a Postgres connection. `receipt-repository.integration.test.ts` owns the
+// repository's own behaviour.
+vi.mock("#src/database/index.ts", () => ({ prisma: {} }));
+vi.mock("#src/database/durable/receipt-repository.ts", () => ({
+  recordReceipt: mocks.recordReceipt,
+}));
+
+const { lakeStagingEvidenceCodec } =
+  await import("#src/report-lake/durable-receipts.ts");
+const {
+  ReceiptedStagingError,
+  stageMatchReceipted,
+  stagePrematchReceipted,
+  stageTimelineReceipted,
+} = await import("#src/report-lake/receipted-staging.ts");
+
+let lakeDir: string;
+
+function recordedReceipt(callIndex = 0): MatchProcessingReceiptRecord {
+  const call: unknown = mocks.recordReceipt.mock.calls[callIndex]?.[1];
+  if (call === undefined) throw new Error("no receipt was recorded");
+  // Parsed, not asserted: this doubles as a check that the wrapper hands the
+  // repository a record the row codec would actually accept.
+  return MatchProcessingReceiptRecordSchema.parse(call);
+}
+
+async function counterValue(
+  counter: Counter,
+  labels: Record<string, string>,
+): Promise<number> {
+  const collected = await counter.get();
+  const match = collected.values.find((value) =>
+    Object.entries(labels).every(([key, want]) => value.labels[key] === want),
+  );
+  return match?.value ?? 0;
+}
+
+function failuresFor(writeKind: string): Promise<number> {
+  return counterValue(scoutDurableDualwriteFailuresTotal, {
+    write_kind: writeKind,
+  });
+}
+
+function recordsFor(writeKind: string, outcome: string): Promise<number> {
+  return counterValue(scoutDurableDualwriteRecordsTotal, {
+    write_kind: writeKind,
+    outcome,
+  });
+}
+
+/**
+ * Make the lake scaffold impossible to create by occupying a staging directory
+ * path with a plain file, so `mkdir` fails with EEXIST and the underlying
+ * `write*StagingFile` returns false — the real failure mode, not a stubbed one.
+ */
+async function blockStagingScaffold(): Promise<void> {
+  await Bun.write(path.join(lakeDir, MATCHES_STAGING_DIR), "not a directory");
+}
+
+function parsedEvidence(callIndex = 0): unknown {
+  const evidence = recordedReceipt(callIndex).evidence;
+  if (evidence === null) throw new Error("receipt carried no evidence");
+  return lakeStagingEvidenceCodec.parse(JSON.parse(evidence));
+}
+
+beforeEach(async () => {
+  mocks.recordReceipt.mockReset();
+  mocks.recordReceipt.mockResolvedValue({ outcome: "applied" });
+  lakeDir = await mkdtemp(path.join(tmpdir(), "receipted-staging-"));
+});
+
+afterEach(async () => {
+  await rm(lakeDir, { recursive: true, force: true });
+});
+
+describe("receipted match staging", () => {
+  test("identifies the projection by source object and digest", async () => {
+    const match = await loadRawMatchFixture();
+    const source = artifactDescriptorFixture("match");
+
+    const result = await stageMatchReceipted(lakeDir, match, { source });
+
+    expect(result.receipt).toBe("recorded");
+    expect(mocks.recordReceipt).toHaveBeenCalledTimes(1);
+    const receipt = recordedReceipt();
+    expect(receipt.matchId).toBe(match.metadata.matchId);
+    expect(receipt.receipt.kind).toBe("lake-staging-match");
+    expect(receipt.receipt.scope).toEqual({ kind: "global" });
+    expect(parsedEvidence()).toEqual({
+      objectKind: "match",
+      sourceObjectKey: source.key,
+      digest: source.digest,
+      fileCount: 3,
+    });
+    expect(result.files).toHaveLength(3);
+  });
+
+  test("keeps local staging paths out of the receipt entirely", async () => {
+    const match = await loadRawMatchFixture();
+
+    const result = await stageMatchReceipted(lakeDir, match, {
+      source: artifactDescriptorFixture("match"),
+    });
+
+    // The paths exist and are returned to the caller, but a receipt that named
+    // them would be a claim about one role's RWO volume.
+    expect(result.files.every((file) => file.startsWith(lakeDir))).toBe(true);
+    const serialized = recordedReceipt().evidence ?? "";
+    expect(serialized).not.toContain(lakeDir);
+    for (const file of result.files) {
+      expect(serialized).not.toContain(file);
+    }
+  });
+
+  test("refuses to receipt staging against a mismatched artifact kind", async () => {
+    const match = await loadRawMatchFixture();
+
+    await expect(
+      stageMatchReceipted(lakeDir, match, {
+        source: artifactDescriptorFixture("timeline"),
+      }),
+    ).rejects.toThrow("does not describe what was staged");
+    expect(mocks.recordReceipt).not.toHaveBeenCalled();
+  });
+
+  test("throws typed and records nothing when staging fails", async () => {
+    const match = await loadRawMatchFixture();
+    await blockStagingScaffold();
+
+    await expect(
+      stageMatchReceipted(lakeDir, match, {
+        source: artifactDescriptorFixture("match"),
+      }),
+    ).rejects.toBeInstanceOf(ReceiptedStagingError);
+    expect(mocks.recordReceipt).not.toHaveBeenCalled();
+  });
+
+  test("names the object kind and match on the typed error", async () => {
+    const match = await loadRawMatchFixture();
+    await blockStagingScaffold();
+
+    await expect(
+      stageMatchReceipted(lakeDir, match, {
+        source: artifactDescriptorFixture("match"),
+      }),
+    ).rejects.toThrow(match.metadata.matchId);
+  });
+
+  test("succeeds when the receipt write fails, reporting the gap", async () => {
+    const match = await loadRawMatchFixture();
+    mocks.recordReceipt.mockRejectedValue(new Error("database is down"));
+
+    const result = await stageMatchReceipted(lakeDir, match, {
+      source: artifactDescriptorFixture("match"),
+    });
+
+    expect(result.receipt).toBe("failed");
+    expect(result.files).toHaveLength(3);
+  });
+
+  test("reports a conflicting replay as a conflict, never as a failure", async () => {
+    const match = await loadRawMatchFixture();
+    mocks.recordReceipt.mockResolvedValue({
+      outcome: "conflict",
+      reason: "receipt-evidence-mismatch",
+    });
+
+    // A conflict is a definite answer from a write that SUCCEEDED, so it must
+    // stay out of the failures counter that alerts on a broken recorder —
+    // otherwise every benign retry pages someone.
+    await expect(
+      stageMatchReceipted(lakeDir, match, {
+        source: artifactDescriptorFixture("match"),
+      }),
+    ).resolves.toMatchObject({
+      receipt: "conflict",
+    });
+  });
+
+  test("keeps conflicts out of the failures counter and thrown writes in it", async () => {
+    const match = await loadRawMatchFixture();
+    const source = artifactDescriptorFixture("match");
+    const before = await failuresFor("lake-staging");
+
+    mocks.recordReceipt.mockResolvedValue({
+      outcome: "conflict",
+      reason: "receipt-evidence-mismatch",
+    });
+    await stageMatchReceipted(lakeDir, match, { source });
+    expect(await failuresFor("lake-staging")).toBe(before);
+
+    mocks.recordReceipt.mockRejectedValue(new Error("database is down"));
+    await stageMatchReceipted(lakeDir, match, { source });
+    expect(await failuresFor("lake-staging")).toBe(before + 1);
+  });
+
+  test("counts every completed write on the records counter by outcome", async () => {
+    const match = await loadRawMatchFixture();
+    const source = artifactDescriptorFixture("match");
+    const before = await recordsFor("lake-staging", "conflict");
+
+    mocks.recordReceipt.mockResolvedValue({
+      outcome: "conflict",
+      reason: "receipt-evidence-mismatch",
+    });
+    await stageMatchReceipted(lakeDir, match, { source });
+
+    expect(await recordsFor("lake-staging", "conflict")).toBe(before + 1);
+  });
+
+  test("reports an idempotent replay as recorded", async () => {
+    const match = await loadRawMatchFixture();
+    mocks.recordReceipt.mockResolvedValue({ outcome: "already-applied" });
+
+    await expect(
+      stageMatchReceipted(lakeDir, match, {
+        source: artifactDescriptorFixture("match"),
+      }),
+    ).resolves.toMatchObject({
+      receipt: "recorded",
+    });
+  });
+
+  test("staging a match and its timeline records two distinct identities", async () => {
+    // Staging shares the collision hazard archival has: one match id covers all
+    // three artifacts, so a single `lake-staging` kind would make the timeline's
+    // projection the same receipt as the match's.
+    const match = await loadRawMatchFixture();
+    const timeline = rawTimelineFixture(match.metadata.matchId);
+
+    await stageMatchReceipted(lakeDir, match, {
+      source: artifactDescriptorFixture("match"),
+    });
+    await stageTimelineReceipted(
+      lakeDir,
+      timeline,
+      new Date("2026-09-12T00:00:00.000Z"),
+      { source: artifactDescriptorFixture("timeline") },
+    );
+
+    expect(mocks.recordReceipt).toHaveBeenCalledTimes(2);
+    const forMatch = recordedReceipt(0);
+    const forTimeline = recordedReceipt(1);
+    expect(forMatch.matchId).toBe(forTimeline.matchId);
+    expect(forMatch.receipt.kind).toBe("lake-staging-match");
+    expect(forTimeline.receipt.kind).toBe("lake-staging-timeline");
+  });
+});
+
+describe("receipted timeline staging", () => {
+  test("counts all four timeline tables as the projection's shape", async () => {
+    const timeline = rawTimelineFixture("NA1_5370969615");
+    const source = artifactDescriptorFixture("timeline");
+
+    const result = await stageTimelineReceipted(
+      lakeDir,
+      timeline,
+      new Date("2026-09-12T00:00:00.000Z"),
+      { source },
+    );
+
+    expect(result.receipt).toBe("recorded");
+    expect(result.files).toHaveLength(4);
+    expect(parsedEvidence()).toEqual({
+      objectKind: "timeline",
+      sourceObjectKey: source.key,
+      digest: source.digest,
+      fileCount: 4,
+    });
+    expect(recordedReceipt().matchId).toBe("NA1_5370969615");
+  });
+});
+
+describe("receipted prematch staging", () => {
+  test("keys the receipt by the match id the snapshot will belong to", async () => {
+    const gameInfo = rawCurrentGameInfoFixture();
+    const source = artifactDescriptorFixture("prematch");
+
+    const result = await stagePrematchReceipted(
+      lakeDir,
+      gameInfo,
+      new Date("2026-09-12T00:00:00.000Z"),
+      { source },
+    );
+
+    expect(result.receipt).toBe("recorded");
+    expect(recordedReceipt().matchId).toBe("NA1_5500000001");
+    expect(parsedEvidence()).toEqual({
+      objectKind: "prematch",
+      sourceObjectKey: source.key,
+      digest: source.digest,
+      fileCount: 1,
+    });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/report-lake/receipted-staging.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/receipted-staging.ts
@@ -1,0 +1,191 @@
+import type {
+  RawCurrentGameInfo,
+  RawMatch,
+  RawTimeline,
+} from "@scout-for-lol/data";
+import type { Db } from "#src/database/index.ts";
+import type { ArtifactDescriptor } from "@scout-for-lol/domain/artifacts/descriptors.ts";
+import {
+  lakeStagingReceiptKind,
+  buildReceipt,
+  lakeStagingEvidenceCodec,
+  prematchReceiptMatchId,
+  receiptMatchId,
+  recordReceiptFailOpen,
+  type LakeStagingEvidence,
+  type ReceiptRecordOutcome,
+} from "#src/report-lake/durable-receipts.ts";
+import {
+  matchStagingFilePath,
+  matchTeamBanStagingFilePath,
+  matchTeamStagingFilePath,
+  prematchStagingFilePath,
+  timelineStagingFilePath,
+  writeMatchStagingFile,
+  writePrematchStagingFile,
+  writeTimelineStagingFiles,
+} from "#src/report-lake/staging.ts";
+
+/**
+ * The receipted entry point into lake staging.
+ *
+ * This is a SECOND door onto the same `write*StagingFile` functions, not a
+ * replacement for the first. The legacy boolean callers keep their exact
+ * semantics — best-effort for timeline, prematch and rank history; a `false`
+ * match staging result still blocks cursor advancement — because the contract
+ * that staging must never fail ingest is what makes the nightly rebuild the
+ * safety net rather than a second source of truth.
+ *
+ * What changes on this path is who is allowed to be vague. A caller that asked
+ * for a RECEIPTED write is asking for a durable claim that the projection
+ * happened, so a failure here throws {@link ReceiptedStagingError} and records
+ * nothing. A receipt that might or might not correspond to a real staging file
+ * would be worse than no receipt at all: the point of the table is that a row
+ * in it can be trusted without re-deriving the fact it attests to.
+ */
+
+export class ReceiptedStagingError extends Error {
+  readonly objectKind: LakeStagingEvidence["objectKind"];
+  readonly matchId: string;
+
+  constructor(args: {
+    objectKind: LakeStagingEvidence["objectKind"];
+    matchId: string;
+  }) {
+    super(
+      `Report lake staging failed for ${args.objectKind} ${args.matchId}; no receipt was recorded.`,
+    );
+    this.name = "ReceiptedStagingError";
+    this.objectKind = args.objectKind;
+    this.matchId = args.matchId;
+  }
+}
+
+export type ReceiptedStagingResult = {
+  /**
+   * Absolute paths of the staging files this run wrote, for the immediate
+   * caller's own logging. They are deliberately NOT in the receipt: they name
+   * a location on one role's RWO volume, and a receipt has to stay true for
+   * readers that cannot see it.
+   */
+  files: readonly string[];
+  /**
+   * What the durable recorder said. `failed` means the staging files exist but
+   * the durable record of them does not; `conflict` means a receipt for this
+   * identity already exists carrying different evidence. Either way the staging
+   * files are written and the caller has succeeded.
+   */
+  receipt: ReceiptRecordOutcome;
+};
+
+type ReceiptOptions = {
+  /**
+   * The archived S3 object these staging rows were derived from. Required,
+   * because a staging receipt that could not name its source would be a claim
+   * about a filesystem rather than about the data.
+   */
+  source: ArtifactDescriptor;
+  /** Supply a transaction client to record the receipt atomically with others. */
+  db?: Db;
+  /** Injectable so tests need no wall clock; defaults to now. */
+  now?: Date;
+};
+
+async function receiptStagedFiles(args: {
+  objectKind: LakeStagingEvidence["objectKind"];
+  matchId: string;
+  staged: boolean;
+  files: readonly string[];
+  options: ReceiptOptions;
+}): Promise<ReceiptedStagingResult> {
+  if (!args.staged) {
+    throw new ReceiptedStagingError({
+      objectKind: args.objectKind,
+      matchId: args.matchId,
+    });
+  }
+  if (args.options.source.kind !== args.objectKind) {
+    throw new Error(
+      `Refusing to receipt ${args.objectKind} staging for ${args.matchId} against a ${args.options.source.kind} artifact: the source descriptor does not describe what was staged`,
+    );
+  }
+  const evidence = lakeStagingEvidenceCodec.serialize({
+    objectKind: args.objectKind,
+    sourceObjectKey: args.options.source.key,
+    digest: args.options.source.digest,
+    fileCount: args.files.length,
+  });
+  const receipt = await recordReceiptFailOpen({
+    record: buildReceipt({
+      matchId: receiptMatchId(args.matchId),
+      kind: lakeStagingReceiptKind(args.objectKind),
+      evidence,
+      recordedAt: args.options.now ?? new Date(),
+    }),
+    writeKind: "lake-staging",
+    ...(args.options.db === undefined ? {} : { db: args.options.db }),
+  });
+  return { files: args.files, receipt };
+}
+
+export async function stageMatchReceipted(
+  lakeDir: string,
+  match: RawMatch,
+  options: ReceiptOptions,
+): Promise<ReceiptedStagingResult> {
+  const matchId = match.metadata.matchId;
+  const staged = await writeMatchStagingFile(lakeDir, match);
+  return receiptStagedFiles({
+    objectKind: "match",
+    matchId,
+    staged,
+    files: [
+      matchStagingFilePath(lakeDir, matchId),
+      matchTeamStagingFilePath(lakeDir, matchId),
+      matchTeamBanStagingFilePath(lakeDir, matchId),
+    ],
+    options,
+  });
+}
+
+export async function stageTimelineReceipted(
+  lakeDir: string,
+  timeline: RawTimeline,
+  observedAt: Date,
+  options: ReceiptOptions,
+): Promise<ReceiptedStagingResult> {
+  const matchId = timeline.metadata.matchId;
+  const staged = await writeTimelineStagingFiles(lakeDir, timeline, observedAt);
+  return receiptStagedFiles({
+    objectKind: "timeline",
+    matchId,
+    staged,
+    // Every timeline table is listed, including any the flattener emitted no
+    // rows for. The receipt describes the projection this capture defines, and
+    // "this match produced no events" is part of that projection, not a gap.
+    files: [
+      timelineStagingFilePath(lakeDir, "timeline_events", matchId),
+      timelineStagingFilePath(lakeDir, "timeline_event_participants", matchId),
+      timelineStagingFilePath(lakeDir, "timeline_participant_frames", matchId),
+      timelineStagingFilePath(lakeDir, "timeline_coverage", matchId),
+    ],
+    options,
+  });
+}
+
+export async function stagePrematchReceipted(
+  lakeDir: string,
+  gameInfo: RawCurrentGameInfo,
+  observedAt: Date,
+  options: ReceiptOptions,
+): Promise<ReceiptedStagingResult> {
+  const dedupeKey = `${gameInfo.platformId}:${gameInfo.gameId.toString()}`;
+  const staged = await writePrematchStagingFile(lakeDir, gameInfo, observedAt);
+  return receiptStagedFiles({
+    objectKind: "prematch",
+    matchId: prematchReceiptMatchId(gameInfo),
+    staged,
+    files: [prematchStagingFilePath(lakeDir, dedupeKey)],
+    options,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/report-store/live-ingest.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-store/live-ingest.ts
@@ -26,6 +26,12 @@ type TimelineIngestOptions = {
   timeline: RawTimeline;
   source: string;
   trackedPlayerAliases: string[];
+  /**
+   * The match's `info.gameCreation`. It partitions the timeline's S3 key onto
+   * the same day as the match payload, so the caller must supply the match's
+   * own timestamp rather than letting the upload time stand in for it.
+   */
+  gameCreatedAt: Date;
 };
 
 type PrematchIngestOptions = {
@@ -98,6 +104,7 @@ export async function recordTimelineForReportStore(
     const staged = await ingestTimeline(
       options.timeline,
       options.trackedPlayerAliases,
+      options.gameCreatedAt,
     );
     recordSuccess("timeline", options.source);
     logger.info(

--- a/packages/scout-for-lol/packages/backend/src/report-store/store.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-store/store.ts
@@ -41,8 +41,9 @@ export async function ingestMatch(
 export async function ingestTimeline(
   timeline: RawTimeline,
   trackedPlayerAliases: string[],
+  gameCreatedAt: Date,
 ): Promise<boolean> {
-  await saveTimelineToS3(timeline, trackedPlayerAliases);
+  await saveTimelineToS3(timeline, trackedPlayerAliases, gameCreatedAt);
   return writeTimelineStagingFiles(resolveLakeDir(), timeline, new Date());
 }
 

--- a/packages/scout-for-lol/packages/backend/src/storage/object-integrity.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/object-integrity.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+import { Sha256DigestSchema } from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  SHA256_METADATA_KEY,
+  assertPutIntegrity,
+  computeSha256Digest,
+  verifyPutEtag,
+} from "#src/storage/object-integrity.ts";
+
+const BODY = new TextEncoder().encode("the exact bytes we uploaded");
+// RFC 1321 test vector, so the ETag comparison is pinned against a value that
+// does not come from the same implementation it is checking.
+const EMPTY_MD5 = "d41d8cd98f00b204e9800998ecf8427e";
+
+describe("content addressing", () => {
+  test("computes a digest that parses through the domain brand", () => {
+    const digest = computeSha256Digest(BODY);
+
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+    expect(Sha256DigestSchema.parse(digest)).toBe(digest);
+  });
+
+  test("is the published SHA-256 of the empty input", () => {
+    expect(computeSha256Digest(new Uint8Array())).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+  });
+
+  test("distinguishes bodies that differ by one byte", () => {
+    const other = new TextEncoder().encode("the exact bytes we uploaded!");
+
+    expect(computeSha256Digest(BODY)).not.toBe(computeSha256Digest(other));
+  });
+
+  test("names the metadata key S3 carries the digest under", () => {
+    expect(SHA256_METADATA_KEY).toBe("sha256");
+  });
+});
+
+describe("ETag verification", () => {
+  test("verifies a quoted single-part ETag that matches the body", () => {
+    expect(
+      verifyPutEtag({ body: new Uint8Array(), etag: `"${EMPTY_MD5}"` }),
+    ).toEqual({ outcome: "verified" });
+  });
+
+  test("verifies an unquoted single-part ETag", () => {
+    expect(verifyPutEtag({ body: new Uint8Array(), etag: EMPTY_MD5 })).toEqual({
+      outcome: "verified",
+    });
+  });
+
+  test("reports a mismatch when the server stored different bytes", () => {
+    const verification = verifyPutEtag({ body: BODY, etag: EMPTY_MD5 });
+
+    expect(verification.outcome).toBe("mismatch");
+  });
+
+  test("skips when the server returned no ETag", () => {
+    expect(verifyPutEtag({ body: BODY, etag: undefined })).toEqual({
+      outcome: "skipped",
+      reason: "no-etag",
+    });
+  });
+
+  test("skips a multipart ETag instead of failing it", () => {
+    expect(verifyPutEtag({ body: BODY, etag: `"${EMPTY_MD5}-4"` })).toEqual({
+      outcome: "skipped",
+      reason: "multipart-etag",
+    });
+  });
+});
+
+describe("put integrity assertion", () => {
+  test("throws on a mismatch, naming the key", () => {
+    expect(() =>
+      assertPutIntegrity({
+        body: BODY,
+        etag: EMPTY_MD5,
+        errorContext: "match",
+        key: "games/2026/09/12/NA1_1/match.json",
+      }),
+    ).toThrow("games/2026/09/12/NA1_1/match.json");
+  });
+
+  test("accepts a skipped check, because a skip is not evidence of corruption", () => {
+    expect(() =>
+      assertPutIntegrity({
+        body: BODY,
+        etag: undefined,
+        errorContext: "match",
+        key: "games/2026/09/12/NA1_1/match.json",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/storage/object-integrity.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/object-integrity.ts
@@ -1,0 +1,214 @@
+import { PutObjectCommand, type S3Client } from "@aws-sdk/client-s3";
+import { z } from "zod";
+import {
+  IsoInstantSchema,
+  S3ObjectKeySchema,
+  Sha256DigestSchema,
+  type IsoInstant,
+  type S3ObjectKey,
+  type Sha256Digest,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import { createLogger } from "#src/logger.ts";
+import { sendPutWithRetry } from "#src/storage/s3-put-retry.ts";
+import { validateS3Metadata } from "#src/storage/s3-metadata.ts";
+
+const logger = createLogger("storage-object-integrity");
+
+/**
+ * Content addressing for raw archive objects.
+ *
+ * Every raw match/timeline/prematch payload is hashed before it is uploaded,
+ * the digest travels with the object as user metadata, and the same digest is
+ * handed back to the caller as part of the artifact descriptor. That makes a
+ * stored object verifiable later — a reader can re-hash the body it fetched and
+ * compare — without a read-back GET on the write path.
+ *
+ * WHAT THE WRITE PATH VERIFIES, EXACTLY:
+ *
+ * - VERIFIED by the SDK, not by us: transit integrity. @aws-sdk/client-s3 sends
+ *   a request checksum the server recomputes and rejects on mismatch, so a
+ *   corrupted or truncated body fails the put itself. That is the primary
+ *   guarantee, and it is why nothing here re-reads the object.
+ * - VERIFIED here, as confirmation: that the body the server acknowledged is
+ *   the body we sent. A single-part PutObject returns an ETag that is the MD5
+ *   of the stored body, so comparing it against the MD5 we computed locally
+ *   independently confirms the SDK's checksum. SeaweedFS follows S3 here for
+ *   single-part puts.
+ * - NOT VERIFIED: that the object is still intact at read time, that it was
+ *   durably replicated, or that a later overwrite preserved the content. Those
+ *   are read-time and storage-layer properties; the recorded digest is what
+ *   makes them checkable, not the write.
+ * - NOT VERIFIED: multipart uploads. A multipart ETag is a digest of part
+ *   digests plus a `-N` suffix, not the body's MD5, so it cannot be compared.
+ *   The archive path only issues single-part puts, but the check degrades to a
+ *   skip rather than a false alarm if that ever changes.
+ * - NOT DONE AT ALL: a read-back GET per write. It would double the request
+ *   volume on the ingest hot path to re-prove what the checksum already proved.
+ *
+ * MD5 is used only because it is the algorithm S3 defines for the ETag. The
+ * content address recorded in the descriptor and the receipt is SHA-256.
+ */
+
+/** The S3 user-metadata key carrying an object's SHA-256 content address. */
+export const SHA256_METADATA_KEY = "sha256";
+
+export function computeSha256Digest(body: Uint8Array): Sha256Digest {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(body);
+  return Sha256DigestSchema.parse(hasher.digest("hex"));
+}
+
+function computeMd5Hex(body: Uint8Array): string {
+  const hasher = new Bun.CryptoHasher("md5");
+  hasher.update(body);
+  return hasher.digest("hex");
+}
+
+export type EtagVerification =
+  | { outcome: "verified" }
+  | { outcome: "skipped"; reason: "no-etag" | "multipart-etag" }
+  | { outcome: "mismatch"; expectedMd5: string; returnedEtag: string };
+
+/**
+ * Compare a PutObject's returned ETag against the MD5 of the body we uploaded.
+ *
+ * A missing ETag or a multipart ETag is a skip, not a failure: neither is
+ * evidence that the bytes differ. Only a well-formed single-part ETag that
+ * disagrees with our own MD5 is a mismatch, and that is a genuine integrity
+ * failure the caller must not paper over.
+ */
+export function verifyPutEtag(args: {
+  body: Uint8Array;
+  etag: string | undefined;
+}): EtagVerification {
+  if (args.etag === undefined) {
+    return { outcome: "skipped", reason: "no-etag" };
+  }
+  const normalized = args.etag.replaceAll('"', "");
+  if (!/^[0-9a-f]{32}$/.test(normalized)) {
+    return { outcome: "skipped", reason: "multipart-etag" };
+  }
+  const expectedMd5 = computeMd5Hex(args.body);
+  return normalized === expectedMd5
+    ? { outcome: "verified" }
+    : { outcome: "mismatch", expectedMd5, returnedEtag: normalized };
+}
+
+/**
+ * Fail the upload when the server acknowledged different bytes than we sent.
+ *
+ * A mismatch is not a transient condition to retry past: the object under that
+ * key is not the payload the caller believes it archived, and S3 is the
+ * canonical raw store. Throwing here means the ingest path treats it exactly
+ * like a failed put — no receipt, no cursor advance — instead of recording a
+ * digest that describes bytes nobody has.
+ */
+export function assertPutIntegrity(args: {
+  body: Uint8Array;
+  etag: string | undefined;
+  errorContext: string;
+  key: string;
+}): void {
+  const verification = verifyPutEtag({ body: args.body, etag: args.etag });
+  if (verification.outcome === "mismatch") {
+    throw new Error(
+      `S3 stored a different body than we uploaded for ${args.errorContext} at ${args.key}: ` +
+        `expected MD5 ${verification.expectedMd5}, server returned ETag ${verification.returnedEtag}`,
+    );
+  }
+  if (verification.outcome === "skipped") {
+    logger.debug(
+      `[S3Storage] ETag integrity check skipped for ${args.key} (${verification.reason})`,
+    );
+  }
+}
+
+/**
+ * What one completed PutObject actually stored.
+ *
+ * This is the artifact descriptor minus its `kind`: the caller knows whether it
+ * archived a match, a timeline or a prematch snapshot, and the put does not.
+ * `key` is the key that was really written, not a recomputed one, so a
+ * descriptor built from this can never describe an object that is not there.
+ */
+export type StoredObject = {
+  key: S3ObjectKey;
+  digest: Sha256Digest;
+  bytes: number;
+  contentType: string;
+  capturedAt: IsoInstant;
+  url: string;
+};
+
+/**
+ * Content-address a body, PUT it, confirm what came back, and describe it.
+ *
+ * The match-keyed and prematch-keyed writers differ only in how they build a key
+ * and what they log. Everything from "encode the body" to "return a descriptor"
+ * is one procedure, and it lives here so the digest, the metadata key, the retry
+ * and the integrity check cannot drift apart between the two.
+ */
+export async function putContentAddressedObject(args: {
+  client: S3Client;
+  bucket: string;
+  key: string;
+  body: string | Uint8Array;
+  contentType: string;
+  metadata: Record<string, string>;
+  errorContext: string;
+  retryContext: string;
+  logDetails?: Record<string, unknown>;
+}): Promise<StoredObject> {
+  const StringSchema = z.string();
+  const BytesSchema = z.instanceof(Uint8Array);
+
+  // Try to validate as string first, then bytes.
+  const stringResult = StringSchema.safeParse(args.body);
+  const bodyBuffer: Uint8Array = stringResult.success
+    ? new TextEncoder().encode(stringResult.data)
+    : BytesSchema.parse(args.body);
+  const sizeBytes = bodyBuffer.length;
+  const digest = computeSha256Digest(bodyBuffer);
+
+  logger.info(`[S3Storage] 📝 Upload details:`, {
+    bucket: args.bucket,
+    key: args.key,
+    sizeBytes,
+    digest,
+    ...args.logDetails,
+  });
+
+  const capturedAt = new Date().toISOString();
+  const command = new PutObjectCommand({
+    Bucket: args.bucket,
+    Key: args.key,
+    Body: bodyBuffer,
+    ContentType: args.contentType,
+    Metadata: validateS3Metadata({
+      ...args.metadata,
+      [SHA256_METADATA_KEY]: digest,
+      uploadedAt: capturedAt,
+    }),
+  });
+
+  const output = await sendPutWithRetry(
+    args.client,
+    command,
+    args.retryContext,
+  );
+  assertPutIntegrity({
+    body: bodyBuffer,
+    etag: output.ETag,
+    errorContext: args.errorContext,
+    key: args.key,
+  });
+
+  return {
+    key: S3ObjectKeySchema.parse(args.key),
+    digest,
+    bytes: sizeBytes,
+    contentType: args.contentType,
+    capturedAt: IsoInstantSchema.parse(capturedAt),
+    url: `s3://${args.bucket}/${args.key}`,
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/storage/pipeline-s3.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/pipeline-s3.ts
@@ -79,7 +79,6 @@ async function saveStageTrace(params: {
     logEmoji: "🔬",
     logMessage: `Saving pipeline trace ${stageNumber}-${stageName}`,
     errorContext: `pipeline trace ${stageName}`,
-    returnUrl: false,
     additionalLogDetails: {
       queueType,
       model: trace.model.model,
@@ -127,7 +126,6 @@ async function saveImageGenerationTrace(params: {
     logEmoji: "🖼️",
     logMessage: "Saving pipeline image generation trace",
     errorContext: "pipeline image generation trace",
-    returnUrl: false,
     additionalLogDetails: {
       queueType,
       model: trace.model,
@@ -166,7 +164,6 @@ async function saveFinalReview(params: {
     logEmoji: "📝",
     logMessage: "Saving final review text",
     errorContext: "final review text",
-    returnUrl: false,
     additionalLogDetails: {
       queueType,
       reviewerName: context.reviewerName,
@@ -194,7 +191,7 @@ async function saveFinalImage(params: {
     bytes[i] = binaryString.codePointAt(i) ?? 0;
   }
 
-  return saveToS3({
+  const stored = await saveToS3({
     matchId,
     assetType: "ai-pipeline/final-image",
     extension: "png",
@@ -210,12 +207,12 @@ async function saveFinalImage(params: {
     logEmoji: "✨",
     logMessage: "Saving final review image",
     errorContext: "final review image",
-    returnUrl: true,
     additionalLogDetails: {
       queueType,
       imageSizeBytes: bytes.length,
     },
   });
+  return stored?.url;
 }
 
 /**
@@ -440,7 +437,7 @@ export async function savePipelineDebugToS3(params: {
 
   const body = JSON.stringify(debugData, null, 2);
 
-  return saveToS3({
+  const stored = await saveToS3({
     matchId,
     assetType: "ai-pipeline/debug",
     extension: "json",
@@ -455,11 +452,11 @@ export async function savePipelineDebugToS3(params: {
     logEmoji: "🔍",
     logMessage: "Saving pipeline debug data",
     errorContext: "pipeline debug data",
-    returnUrl: true,
     additionalLogDetails: {
       queueType,
       reviewerName: output.context.reviewerName,
       playerName: output.context.playerName,
     },
   });
+  return stored?.url;
 }

--- a/packages/scout-for-lol/packages/backend/src/storage/s3-archive.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3-archive.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  loadRawMatchFixture,
+  rawTimelineFixture,
+} from "#src/testing/raw-capture-fixtures.ts";
+import { Sha256DigestSchema } from "@scout-for-lol/domain/identity/brands.ts";
+import { ArtifactDescriptorSchema } from "@scout-for-lol/domain/artifacts/descriptors.ts";
+import {
+  archiveMatchToS3,
+  archiveTimelineToS3,
+  saveMatchToS3,
+} from "#src/storage/s3.ts";
+import {
+  getValidatedPutCommand,
+  mockSuccessfulPut,
+  resetS3TestState,
+  s3Mock,
+  setS3TestBucket,
+} from "#src/storage/s3-test-helpers.ts";
+
+function sha256OfPutBody(callIndex = 0): string {
+  const command = getValidatedPutCommand(callIndex);
+  const body = command.input.Body;
+  const bytes =
+    body instanceof Uint8Array ? body : new TextEncoder().encode(body);
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(bytes);
+  return hasher.digest("hex");
+}
+
+beforeEach(resetS3TestState);
+afterEach(resetS3TestState);
+
+describe("archived match descriptors", () => {
+  test("stores the payload digest as object metadata", async () => {
+    const match = await loadRawMatchFixture();
+    mockSuccessfulPut();
+
+    await archiveMatchToS3(match, []);
+
+    const command = getValidatedPutCommand();
+    expect(command.input.Metadata?.["sha256"]).toBe(sha256OfPutBody());
+  });
+
+  test("returns a descriptor whose digest parses through the domain brand", async () => {
+    const match = await loadRawMatchFixture();
+    mockSuccessfulPut();
+
+    const result = await archiveMatchToS3(match, []);
+
+    if (result.status !== "saved") throw new Error("expected a saved archive");
+    expect(Sha256DigestSchema.parse(result.artifact.digest)).toBe(
+      result.artifact.digest,
+    );
+    expect(ArtifactDescriptorSchema.parse(result.artifact)).toEqual(
+      result.artifact,
+    );
+  });
+
+  test("describes the key that was actually written, not a recomputed one", async () => {
+    const match = await loadRawMatchFixture();
+    mockSuccessfulPut();
+
+    const result = await archiveMatchToS3(match, []);
+
+    if (result.status !== "saved") throw new Error("expected a saved archive");
+    expect(result.artifact.key).toBe(getValidatedPutCommand().input.Key);
+    expect(result.artifact.kind).toBe("match");
+    expect(result.artifact.contentType).toBe("application/json");
+  });
+
+  test("reports the exact byte count uploaded", async () => {
+    const match = await loadRawMatchFixture();
+    mockSuccessfulPut();
+
+    const result = await archiveMatchToS3(match, []);
+
+    if (result.status !== "saved") throw new Error("expected a saved archive");
+    const body = getValidatedPutCommand().input.Body;
+    const bytes =
+      body instanceof Uint8Array ? body : new TextEncoder().encode(body);
+    expect(result.artifact.bytes).toBe(bytes.length);
+  });
+
+  test("records nothing and archives nothing without a bucket", async () => {
+    const match = await loadRawMatchFixture();
+    setS3TestBucket(undefined);
+    mockSuccessfulPut();
+
+    const result = await archiveMatchToS3(match, []);
+
+    expect(result).toEqual({ status: "skipped_no_bucket" });
+    expect(s3Mock.calls()).toHaveLength(0);
+  });
+
+  test("leaves the legacy status-only signature untouched", async () => {
+    const match = await loadRawMatchFixture();
+    mockSuccessfulPut();
+
+    await expect(saveMatchToS3(match, [])).resolves.toBe("saved");
+  });
+});
+
+describe("timeline partition cutover", () => {
+  test("keys the timeline by the match's game-creation date", async () => {
+    // 2026-03-10T02:30Z is still 2026-03-09 in Pacific time, so this case also
+    // pins WHICH day the shared `generateS3Key` derivation picks — the point is
+    // that the timeline lands on the same one the match does.
+    const gameCreatedAt = new Date("2026-03-10T02:30:00.000Z");
+    const timeline = rawTimelineFixture("NA1_5555555555");
+    mockSuccessfulPut();
+
+    const result = await archiveTimelineToS3(timeline, [], gameCreatedAt);
+
+    if (result.status !== "saved") throw new Error("expected a saved archive");
+    expect(result.artifact.key).toBe(getValidatedPutCommand().input.Key);
+    expect(result.artifact.kind).toBe("timeline");
+  });
+
+  test("puts the timeline under the same prefix as its match", async () => {
+    const match = await loadRawMatchFixture();
+    const gameCreatedAt = new Date(match.info.gameCreation);
+    const timeline = rawTimelineFixture(match.metadata.matchId);
+    mockSuccessfulPut();
+
+    await archiveMatchToS3(match, []);
+    await archiveTimelineToS3(timeline, [], gameCreatedAt);
+
+    const matchKey = getValidatedPutCommand(0).input.Key;
+    const timelineKey = getValidatedPutCommand(1).input.Key;
+    expect(matchKey).toMatch(/\/match\.json$/);
+    expect(timelineKey).toMatch(/\/timeline\.json$/);
+    expect(timelineKey.replace(/timeline\.json$/, "match.json")).toBe(matchKey);
+  });
+
+  test("ignores the upload time, which is what the old layout used", async () => {
+    const gameCreatedAt = new Date("2020-01-02T12:00:00.000Z");
+    const timeline = rawTimelineFixture("NA1_1234567890");
+    mockSuccessfulPut();
+
+    await archiveTimelineToS3(timeline, [], gameCreatedAt);
+
+    expect(getValidatedPutCommand().input.Key).toBe(
+      "games/2020/01/02/NA1_1234567890/timeline.json",
+    );
+  });
+
+  test("stores the timeline digest as object metadata too", async () => {
+    const timeline = rawTimelineFixture("NA1_1234567890");
+    mockSuccessfulPut();
+
+    const result = await archiveTimelineToS3(
+      timeline,
+      [],
+      new Date("2026-01-01T00:00:00.000Z"),
+    );
+
+    if (result.status !== "saved") throw new Error("expected a saved archive");
+    expect(getValidatedPutCommand().input.Metadata?.["sha256"]).toBe(
+      result.artifact.digest,
+    );
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/storage/s3-helpers.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3-helpers.ts
@@ -1,12 +1,14 @@
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { createS3Client } from "#src/storage/s3-client.ts";
-import { z } from "zod";
 import configuration from "#src/configuration.ts";
 import { getErrorMessage } from "#src/utils/errors.ts";
 import type { MatchId } from "@scout-for-lol/data/index.ts";
 import { format } from "date-fns";
 import { createLogger } from "#src/logger.ts";
-import { sendPutWithRetry } from "#src/storage/s3-put-retry.ts";
+import {
+  putContentAddressedObject,
+  type StoredObject,
+} from "#src/storage/object-integrity.ts";
 import { validateS3Metadata } from "#src/storage/s3-metadata.ts";
 
 const logger = createLogger("storage-s3-helpers");
@@ -15,6 +17,15 @@ const logger = createLogger("storage-s3-helpers");
  * Generate S3 key (path) for a file with game-centric hierarchy
  * All assets for a game are grouped under games/{date}/{matchId}/
  * This makes it easy to find all assets related to a single game.
+ *
+ * The layout mirrors `@scout-for-lol/domain`'s `buildMatchArtifactObjectKey`,
+ * and `s3-helpers.contract.test.ts` pins the two together. They differ in one
+ * respect that is deliberately NOT reconciled here: this builder formats the
+ * date in the host's local zone, the domain builder normalizes to UTC, and the
+ * deployment sets `TZ=America/Los_Angeles`. Moving this path to UTC is a
+ * store-wide re-partition that also requires widening the reconstructed
+ * prefixes in `s3-query.ts`, so it is tracked separately rather than folded
+ * into the receipts work.
  */
 export function generateS3Key(
   matchId: MatchId,
@@ -37,97 +48,70 @@ type SaveToS3Config = {
   logEmoji: string;
   logMessage: string;
   errorContext: string;
-  returnUrl?: boolean;
   additionalLogDetails?: Record<string, unknown>;
   keyDate?: Date;
 };
 
 /**
- * Generic function to save content to S3
+ * Generic function to save content to S3.
+ *
+ * Resolves to `undefined` only when no bucket is configured — the dev/test
+ * no-op. Every real upload is content-addressed: the SHA-256 of the body is
+ * computed before the put, stored on the object as user metadata, and returned
+ * so the caller can record it. See `object-integrity.ts` for exactly what the
+ * post-put ETag comparison verifies.
  */
 export async function saveToS3(
   config: SaveToS3Config,
-): Promise<string | undefined> {
-  const {
-    matchId,
-    assetType,
-    extension,
-    body,
-    contentType,
-    metadata,
-    logEmoji,
-    logMessage,
-    errorContext,
-    returnUrl,
-    additionalLogDetails,
-    keyDate,
-  } = config;
+): Promise<StoredObject | undefined> {
   const bucket = configuration.s3BucketName;
-
   if (bucket === undefined) {
     logger.warn(
-      `[S3Storage] ⚠️  S3_BUCKET_NAME not configured, skipping ${errorContext} save for match: ${matchId}`,
+      `[S3Storage] ⚠️  S3_BUCKET_NAME not configured, skipping ${config.errorContext} save for match: ${config.matchId}`,
     );
     return undefined;
   }
 
-  logger.info(`[S3Storage] ${logEmoji} ${logMessage}: ${matchId}`);
+  logger.info(
+    `[S3Storage] ${config.logEmoji} ${config.logMessage}: ${config.matchId}`,
+  );
+
+  const key = generateS3Key(
+    config.matchId,
+    config.assetType,
+    config.extension,
+    config.keyDate ?? new Date(),
+  );
+  const startTime = Date.now();
 
   try {
-    const client = createS3Client();
-    const key = generateS3Key(
-      matchId,
-      assetType,
-      extension,
-      keyDate ?? new Date(),
-    );
-    const StringSchema = z.string();
-    const BytesSchema = z.instanceof(Uint8Array);
-
-    // Try to validate as string first, then bytes
-    const stringResult = StringSchema.safeParse(body);
-    const bodyBuffer: Uint8Array = stringResult.success
-      ? new TextEncoder().encode(stringResult.data)
-      : BytesSchema.parse(body);
-    const sizeBytes = bodyBuffer.length;
-
-    logger.info(`[S3Storage] 📝 Upload details:`, {
+    const stored = await putContentAddressedObject({
+      client: createS3Client(),
       bucket,
       key,
-      sizeBytes,
-      ...additionalLogDetails,
+      body: config.body,
+      contentType: config.contentType,
+      metadata: config.metadata,
+      errorContext: config.errorContext,
+      retryContext: `${config.errorContext} ${config.matchId}`,
+      ...(config.additionalLogDetails === undefined
+        ? {}
+        : { logDetails: config.additionalLogDetails }),
     });
-
-    const startTime = Date.now();
-
-    const command = new PutObjectCommand({
-      Bucket: bucket,
-      Key: key,
-      Body: bodyBuffer,
-      ContentType: contentType,
-      Metadata: validateS3Metadata({
-        ...metadata,
-        uploadedAt: new Date().toISOString(),
-      }),
-    });
-
-    await sendPutWithRetry(client, command, `${errorContext} ${matchId}`);
 
     const uploadTime = Date.now() - startTime;
-    const s3Url = `s3://${bucket}/${key}`;
     logger.info(
-      `[S3Storage] ✅ Successfully saved ${errorContext} ${matchId} to S3 in ${uploadTime.toString()}ms`,
+      `[S3Storage] ✅ Successfully saved ${config.errorContext} ${config.matchId} to S3 in ${uploadTime.toString()}ms`,
     );
-    logger.info(`[S3Storage] 🔗 S3 location: ${s3Url}`);
-
-    return returnUrl === true ? s3Url : undefined;
+    logger.info(`[S3Storage] 🔗 S3 location: ${stored.url}`);
+    return stored;
   } catch (error) {
     logger.error(
-      `[S3Storage] ❌ Failed to save ${errorContext} ${matchId} to S3:`,
+      `[S3Storage] ❌ Failed to save ${config.errorContext} ${config.matchId} to S3:`,
       error,
     );
     throw new Error(
-      `Failed to save ${errorContext} ${matchId} to S3: ${getErrorMessage(error)}`,
+      `Failed to save ${config.errorContext} ${config.matchId} to S3: ${getErrorMessage(error)}`,
       { cause: error },
     );
   }

--- a/packages/scout-for-lol/packages/backend/src/storage/s3-key-contract.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3-key-contract.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "vitest";
+import { MatchIdSchema } from "@scout-for-lol/data";
+import {
+  buildMatchArtifactObjectKey,
+  buildPrematchArtifactObjectKey,
+} from "@scout-for-lol/domain/artifacts/object-key.ts";
+import {
+  IsoInstantSchema,
+  RiotMatchIdSchema,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import { generateS3Key } from "#src/storage/s3-helpers.ts";
+
+/**
+ * The live write path and the domain's object-key builder describe the same
+ * layout, and this pins them together so a change to either has to be a change
+ * to both.
+ *
+ * They are NOT interchangeable today, and the difference is the point of the
+ * last test here: `generateS3Key` formats the date in the host's local zone
+ * while the domain builder normalizes to UTC. The deployment sets
+ * `TZ=America/Los_Angeles`, so the two disagree for any game created in the
+ * Pacific evening. `vitest.config.ts` pins `TZ=UTC`, which is why the whole
+ * suite agreed for so long and why that last test constructs the divergence
+ * arithmetically instead of relying on the runner's zone.
+ */
+
+const MATCH_ID = "NA1_5370969615";
+const CAPTURED_AT = "2026-03-10T02:30:00.000Z";
+
+function domainMatchKey(assetName: string, extension: string): string {
+  return buildMatchArtifactObjectKey({
+    matchId: RiotMatchIdSchema.parse(MATCH_ID),
+    assetName,
+    extension,
+    capturedAt: IsoInstantSchema.parse(CAPTURED_AT),
+  });
+}
+
+describe("write-path and domain key builders agree", () => {
+  test.each([
+    ["match", "json"],
+    ["timeline", "json"],
+    ["report", "png"],
+    ["report", "svg"],
+  ])("agree for %s.%s", (assetName, extension) => {
+    expect(
+      generateS3Key(
+        MatchIdSchema.parse(MATCH_ID),
+        assetName,
+        extension,
+        new Date(CAPTURED_AT),
+      ),
+    ).toBe(domainMatchKey(assetName, extension));
+  });
+
+  test("both pad single-digit months and days", () => {
+    const capturedAt = "2026-01-05T08:15:30.000Z";
+
+    expect(
+      generateS3Key(
+        MatchIdSchema.parse(MATCH_ID),
+        "match",
+        "json",
+        new Date(capturedAt),
+      ),
+    ).toBe(
+      buildMatchArtifactObjectKey({
+        matchId: RiotMatchIdSchema.parse(MATCH_ID),
+        assetName: "match",
+        extension: "json",
+        capturedAt: IsoInstantSchema.parse(capturedAt),
+      }),
+    );
+    expect(
+      generateS3Key(
+        MatchIdSchema.parse(MATCH_ID),
+        "match",
+        "json",
+        new Date(capturedAt),
+      ),
+    ).toContain("/2026/01/05/");
+  });
+
+  test("the prematch namespace is separate from the match namespace", () => {
+    const prematchKey = buildPrematchArtifactObjectKey({
+      resourceId: "5370969615",
+      assetName: "spectator-data",
+      extension: "json",
+      capturedAt: IsoInstantSchema.parse(CAPTURED_AT),
+    });
+
+    expect(prematchKey.startsWith("prematch/")).toBe(true);
+    expect(domainMatchKey("match", "json").startsWith("games/")).toBe(true);
+  });
+});
+
+describe("the local-versus-UTC divergence this layout still carries", () => {
+  test("a Pacific-evening game lands on different days in the two builders", () => {
+    // 18:30 Pacific on 2026-03-09 is 02:30 UTC on 2026-03-10. The domain
+    // builder always says the 10th; the write path says whatever the host's
+    // zone says, which under TZ=America/Los_Angeles is the 9th.
+    const pacificEvening = new Date(CAPTURED_AT);
+    const writePathKey = generateS3Key(
+      MatchIdSchema.parse(MATCH_ID),
+      "match",
+      "json",
+      pacificEvening,
+    );
+    const utcKey = domainMatchKey("match", "json");
+
+    expect(utcKey).toContain("/2026/03/10/");
+
+    // Derive the host's own answer rather than assuming a zone, so this test
+    // states the invariant under every runner: the two builders agree exactly
+    // when the host's local date equals the UTC date.
+    const localDay = pacificEvening.getDate();
+    const utcDay = pacificEvening.getUTCDate();
+    if (localDay === utcDay) {
+      expect(writePathKey).toBe(utcKey);
+    } else {
+      expect(writePathKey).not.toBe(utcKey);
+    }
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/storage/s3-prematch-data.no-bucket.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3-prematch-data.no-bucket.test.ts
@@ -1,35 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { getMetrics } from "#src/metrics/index.ts";
 import { savePrematchDataToS3 } from "#src/storage/s3.ts";
-import { RawCurrentGameInfoSchema } from "@scout-for-lol/data";
+import { rawCurrentGameInfoFixture } from "#src/testing/raw-capture-fixtures.ts";
 import { resetConfigurationForTests } from "#src/configuration.ts";
-
-function makeGameInfo() {
-  return RawCurrentGameInfoSchema.parse({
-    gameId: 5_500_000_002,
-    gameStartTime: Date.now(),
-    gameMode: "CLASSIC",
-    mapId: 11,
-    gameType: "MATCHED_GAME",
-    gameQueueConfigId: 420,
-    gameLength: -15,
-    platformId: "NA1",
-    bannedChampions: [],
-    participants: [
-      {
-        championId: 157,
-        puuid: "test-puuid",
-        teamId: 100,
-        riotId: "Player#NA1",
-        spell1Id: 4,
-        spell2Id: 14,
-        lastSelectedSkinIndex: 0,
-        bot: false,
-        profileIconId: 1,
-      },
-    ],
-  });
-}
 
 function getCounterValue(
   metrics: string,
@@ -66,7 +39,7 @@ describe("savePrematchDataToS3 without S3 bucket", () => {
   });
 
   test("returns skipped_no_bucket and records skip metric", async () => {
-    const gameInfo = makeGameInfo();
+    const gameInfo = rawCurrentGameInfoFixture();
     const metricsBefore = await getMetrics();
     const skippedBefore = getCounterValue(
       metricsBefore,

--- a/packages/scout-for-lol/packages/backend/src/storage/s3-prematch-data.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3-prematch-data.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { mockClient } from "aws-sdk-client-mock";
-import { RawCurrentGameInfoSchema } from "@scout-for-lol/data";
+import { rawCurrentGameInfoFixture } from "#src/testing/raw-capture-fixtures.ts";
 import {
   getMetrics,
   prematchSpectatorPayloadSaveDurationSeconds,
@@ -11,33 +11,6 @@ import { savePrematchDataToS3 } from "#src/storage/s3.ts";
 import { resetConfigurationForTests } from "#src/configuration.ts";
 
 const s3Mock = mockClient(S3Client);
-
-function makeGameInfo() {
-  return RawCurrentGameInfoSchema.parse({
-    gameId: 5_500_000_001,
-    gameStartTime: Date.now(),
-    gameMode: "CLASSIC",
-    mapId: 11,
-    gameType: "MATCHED_GAME",
-    gameQueueConfigId: 420,
-    gameLength: -30,
-    platformId: "NA1",
-    bannedChampions: [],
-    participants: [
-      {
-        championId: 157,
-        puuid: "test-puuid",
-        teamId: 100,
-        riotId: "Player#NA1",
-        spell1Id: 4,
-        spell2Id: 14,
-        lastSelectedSkinIndex: 0,
-        bot: false,
-        profileIconId: 1,
-      },
-    ],
-  });
-}
 
 function getCounterValue(
   metrics: string,
@@ -85,7 +58,7 @@ afterEach(() => {
 
 describe("savePrematchDataToS3", () => {
   test("returns saved and records metrics on successful upload", async () => {
-    const gameInfo = makeGameInfo();
+    const gameInfo = rawCurrentGameInfoFixture();
     const metricsBefore = await getMetrics();
     const savedBefore = getCounterValue(
       metricsBefore,
@@ -137,7 +110,7 @@ describe("savePrematchDataToS3", () => {
   });
 
   test("throws after retries when upload fails", async () => {
-    const gameInfo = makeGameInfo();
+    const gameInfo = rawCurrentGameInfoFixture();
     const metricsBefore = await getMetrics();
     const errorBefore = getCounterValue(
       metricsBefore,

--- a/packages/scout-for-lol/packages/backend/src/storage/s3-prematch.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3-prematch.ts
@@ -1,12 +1,12 @@
-import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { createS3Client } from "#src/storage/s3-client.ts";
-import { z } from "zod";
 import configuration from "#src/configuration.ts";
 import { getErrorMessage } from "#src/utils/errors.ts";
 import { format } from "date-fns";
 import { createLogger } from "#src/logger.ts";
-import { sendPutWithRetry } from "#src/storage/s3-put-retry.ts";
-import { validateS3Metadata } from "#src/storage/s3-metadata.ts";
+import {
+  putContentAddressedObject,
+  type StoredObject,
+} from "#src/storage/object-integrity.ts";
 
 const logger = createLogger("storage-s3-prematch");
 
@@ -34,7 +34,6 @@ type SavePrematchToS3Config = {
   logEmoji: string;
   logMessage: string;
   errorContext: string;
-  returnUrl?: boolean;
   /** Stable source timestamp for idempotent match-keyed assets. */
   keyDate?: Date;
   /** Full natural identity when a numeric game ID is not globally unique. */
@@ -43,10 +42,13 @@ type SavePrematchToS3Config = {
 
 /**
  * Save prematch content to S3 storage.
+ *
+ * Resolves to `undefined` only when no bucket is configured. Real uploads are
+ * content-addressed on the same terms as `saveToS3`; see `object-integrity.ts`.
  */
 export async function savePrematchToS3(
   config: SavePrematchToS3Config,
-): Promise<string | undefined> {
+): Promise<StoredObject | undefined> {
   const {
     gameId,
     assetType,
@@ -57,7 +59,6 @@ export async function savePrematchToS3(
     logEmoji,
     logMessage,
     errorContext,
-    returnUrl,
     keyDate,
     resourceId,
   } = config;
@@ -73,55 +74,31 @@ export async function savePrematchToS3(
 
   logger.info(`[S3Storage] ${logEmoji} ${logMessage}: game ${gameIdStr}`);
 
+  const startTime = Date.now();
+  const key = generatePrematchS3Key(
+    resourceId ?? gameIdStr,
+    assetType,
+    extension,
+    keyDate ?? new Date(),
+  );
+
   try {
-    const client = createS3Client();
-    const key = generatePrematchS3Key(
-      resourceId ?? gameIdStr,
-      assetType,
-      extension,
-      keyDate ?? new Date(),
-    );
-    const StringSchema = z.string();
-    const BytesSchema = z.instanceof(Uint8Array);
-
-    const stringResult = StringSchema.safeParse(body);
-    const bodyBuffer: Uint8Array = stringResult.success
-      ? new TextEncoder().encode(stringResult.data)
-      : BytesSchema.parse(body);
-    const sizeBytes = bodyBuffer.length;
-
-    logger.info(`[S3Storage] 📝 Upload details:`, {
+    const stored = await putContentAddressedObject({
+      client: createS3Client(),
       bucket,
       key,
-      sizeBytes,
+      body,
+      contentType,
+      metadata,
+      errorContext,
+      retryContext: `${errorContext} game ${gameIdStr}`,
     });
-
-    const startTime = Date.now();
-
-    const command = new PutObjectCommand({
-      Bucket: bucket,
-      Key: key,
-      Body: bodyBuffer,
-      ContentType: contentType,
-      Metadata: validateS3Metadata({
-        ...metadata,
-        uploadedAt: new Date().toISOString(),
-      }),
-    });
-
-    await sendPutWithRetry(
-      client,
-      command,
-      `${errorContext} game ${gameIdStr}`,
-    );
 
     const uploadTime = Date.now() - startTime;
-    const s3Url = `s3://${bucket}/${key}`;
     logger.info(
       `[S3Storage] ✅ Saved ${errorContext} game ${gameIdStr} to S3 in ${uploadTime.toString()}ms`,
     );
-
-    return returnUrl === true ? s3Url : undefined;
+    return stored;
   } catch (error) {
     logger.error(
       `[S3Storage] ❌ Failed to save ${errorContext} game ${gameIdStr} to S3:`,

--- a/packages/scout-for-lol/packages/backend/src/storage/s3-put-retry.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3-put-retry.ts
@@ -1,4 +1,8 @@
-import type { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import type {
+  PutObjectCommand,
+  PutObjectCommandOutput,
+  S3Client,
+} from "@aws-sdk/client-s3";
 import { z } from "zod";
 import { createLogger } from "#src/logger.ts";
 import { getErrorMessage } from "#src/utils/errors.ts";
@@ -42,17 +46,20 @@ function isRetryableError(error: unknown): boolean {
 /**
  * Send a PutObjectCommand with a bounded exponential backoff on transient
  * errors. Deterministic (4xx) failures and the final attempt throw.
+ *
+ * The command output is returned so the caller can check the ETag the server
+ * acknowledged against the body it uploaded; see `object-integrity.ts` for what
+ * that comparison does and does not prove.
  */
 export async function sendPutWithRetry(
   client: S3Client,
   command: PutObjectCommand,
   context: string,
-): Promise<void> {
+): Promise<PutObjectCommandOutput> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= MAX_PUT_ATTEMPTS; attempt++) {
     try {
-      await client.send(command);
-      return;
+      return await client.send(command);
     } catch (error) {
       lastError = error;
       if (attempt === MAX_PUT_ATTEMPTS || !isRetryableError(error)) {

--- a/packages/scout-for-lol/packages/backend/src/storage/s3.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3.ts
@@ -6,34 +6,69 @@ import type {
 } from "@scout-for-lol/data/index.ts";
 import { MatchIdSchema } from "@scout-for-lol/data/index.ts";
 import { saveToS3 } from "#src/storage/s3-helpers.ts";
+import type { StoredObject } from "#src/storage/object-integrity.ts";
 import { savePrematchToS3 } from "#src/storage/s3-prematch.ts";
-import configuration from "#src/configuration.ts";
 import {
   prematchSpectatorPayloadSavesTotal,
   prematchSpectatorPayloadSaveDurationSeconds,
 } from "#src/metrics/index.ts";
 import { trackedPlayerCountMetadata } from "#src/storage/s3-metadata.ts";
+import {
+  ArtifactDescriptorSchema,
+  type ArtifactDescriptor,
+  type ArtifactKind,
+} from "@scout-for-lol/domain/artifacts/descriptors.ts";
 
 export type PrematchPayloadSaveResult = {
   status: "saved" | "skipped_no_bucket";
   durationSeconds?: number;
+  /** Present exactly when `status` is `saved`. */
+  artifact?: ArtifactDescriptor;
 };
 
 /**
- * Save a League of Legends match to S3 storage
+ * The outcome of archiving one raw capture: either the descriptor of the object
+ * that now exists, or the dev/test no-op when no bucket is configured.
+ *
+ * The descriptor is built from what the put actually stored — the real key and
+ * the digest of the exact bytes uploaded — so it is usable as durable evidence
+ * rather than a restatement of intent.
+ */
+export type RawArchiveResult =
+  | { status: "saved"; artifact: ArtifactDescriptor }
+  | { status: "skipped_no_bucket" };
+
+function describeArchived(
+  kind: ArtifactKind,
+  stored: StoredObject,
+): ArtifactDescriptor {
+  return ArtifactDescriptorSchema.parse({
+    kind,
+    key: stored.key,
+    digest: stored.digest,
+    bytes: stored.bytes,
+    contentType: stored.contentType,
+    capturedAt: stored.capturedAt,
+  });
+}
+
+function archived(kind: ArtifactKind, stored: StoredObject): RawArchiveResult {
+  return { status: "saved", artifact: describeArchived(kind, stored) };
+}
+
+/**
+ * Archive a League of Legends match to S3 and describe what was stored.
  * @param match The match data to save
  * @param trackedPlayerAliases Array of tracked player aliases in this match (empty array if none)
- * @returns whether the canonical write happened or S3 is unavailable
  */
-export async function saveMatchToS3(
+export async function archiveMatchToS3(
   match: RawMatch,
   trackedPlayerAliases: string[],
-): Promise<"saved" | "skipped_no_bucket"> {
+): Promise<RawArchiveResult> {
   const matchId = MatchIdSchema.parse(match.metadata.matchId);
   const body = JSON.stringify(match, null, 2);
-  const storageAvailable = configuration.s3BucketName !== undefined;
 
-  await saveToS3({
+  const stored = await saveToS3({
     matchId,
     assetType: "match",
     extension: "json",
@@ -59,7 +94,6 @@ export async function saveMatchToS3(
     logEmoji: "💾",
     logMessage: "Saving match to S3",
     errorContext: "match",
-    returnUrl: false,
     keyDate: new Date(match.info.gameCreation),
     additionalLogDetails: {
       participants: match.info.participants.length,
@@ -67,7 +101,21 @@ export async function saveMatchToS3(
       gameDuration: match.info.gameDuration,
     },
   });
-  return storageAvailable ? "saved" : "skipped_no_bucket";
+  return stored === undefined
+    ? { status: "skipped_no_bucket" }
+    : archived("match", stored);
+}
+
+/**
+ * Save a League of Legends match to S3 storage
+ * @returns whether the canonical write happened or S3 is unavailable
+ */
+export async function saveMatchToS3(
+  match: RawMatch,
+  trackedPlayerAliases: string[],
+): Promise<"saved" | "skipped_no_bucket"> {
+  const result = await archiveMatchToS3(match, trackedPlayerAliases);
+  return result.status;
 }
 
 /**
@@ -84,7 +132,7 @@ export async function saveImageToS3(
   queueType: string,
   trackedPlayerAliases: string[],
 ): Promise<string | undefined> {
-  return saveToS3({
+  const stored = await saveToS3({
     matchId,
     assetType: "report",
     extension: "png",
@@ -99,11 +147,11 @@ export async function saveImageToS3(
     logEmoji: "🖼️",
     logMessage: "Saving PNG to S3",
     errorContext: "PNG",
-    returnUrl: true,
     additionalLogDetails: {
       queueType,
     },
   });
+  return stored?.url;
 }
 
 /**
@@ -120,7 +168,7 @@ export async function saveSvgToS3(
   queueType: string,
   trackedPlayerAliases: string[],
 ): Promise<string | undefined> {
-  return saveToS3({
+  const stored = await saveToS3({
     matchId,
     assetType: "report",
     extension: "svg",
@@ -135,11 +183,11 @@ export async function saveSvgToS3(
     logEmoji: "📄",
     logMessage: "Saving SVG to S3",
     errorContext: "SVG",
-    returnUrl: true,
     additionalLogDetails: {
       queueType,
     },
   });
+  return stored?.url;
 }
 
 /**
@@ -154,16 +202,11 @@ export async function savePrematchDataToS3(
   gameInfo: RawCurrentGameInfo,
   trackedPlayerAliases: string[],
 ): Promise<PrematchPayloadSaveResult> {
-  if (configuration.s3BucketName === undefined) {
-    prematchSpectatorPayloadSavesTotal.inc({ status: "skipped_no_bucket" });
-    return { status: "skipped_no_bucket" };
-  }
-
   const body = JSON.stringify(gameInfo, null, 2);
   const startTime = Date.now();
 
   try {
-    await savePrematchToS3({
+    const stored = await savePrematchToS3({
       gameId,
       assetType: "spectator-data",
       extension: "json",
@@ -181,10 +224,19 @@ export async function savePrematchDataToS3(
       errorContext: "prematch-data",
     });
 
+    if (stored === undefined) {
+      prematchSpectatorPayloadSavesTotal.inc({ status: "skipped_no_bucket" });
+      return { status: "skipped_no_bucket" };
+    }
+
     const durationSeconds = (Date.now() - startTime) / 1000;
     prematchSpectatorPayloadSaveDurationSeconds.observe(durationSeconds);
     prematchSpectatorPayloadSavesTotal.inc({ status: "saved" });
-    return { status: "saved", durationSeconds };
+    return {
+      status: "saved",
+      durationSeconds,
+      artifact: describeArchived("prematch", stored),
+    };
   } catch (error) {
     const durationSeconds = (Date.now() - startTime) / 1000;
     prematchSpectatorPayloadSaveDurationSeconds.observe(durationSeconds);
@@ -202,7 +254,7 @@ export async function savePrematchImageToS3(
   queueType: string,
   trackedPlayerAliases: string[],
 ): Promise<string | undefined> {
-  return savePrematchToS3({
+  const stored = await savePrematchToS3({
     gameId,
     assetType: "loading-screen",
     extension: "png",
@@ -217,8 +269,8 @@ export async function savePrematchImageToS3(
     logEmoji: "🖼️",
     logMessage: "Saving loading screen PNG to S3",
     errorContext: "prematch-image",
-    returnUrl: true,
   });
+  return stored?.url;
 }
 
 /**
@@ -230,7 +282,7 @@ export async function savePrematchSvgToS3(
   queueType: string,
   trackedPlayerAliases: string[],
 ): Promise<string | undefined> {
-  return savePrematchToS3({
+  const stored = await savePrematchToS3({
     gameId,
     assetType: "loading-screen",
     extension: "svg",
@@ -245,24 +297,36 @@ export async function savePrematchSvgToS3(
     logEmoji: "📄",
     logMessage: "Saving loading screen SVG to S3",
     errorContext: "prematch-svg",
-    returnUrl: true,
   });
+  return stored?.url;
 }
 
 /**
- * Save a match timeline to S3 storage
+ * Archive a match timeline to S3 and describe what was stored.
+ *
+ * PARTITION CUTOVER (2026-09-12): timelines are keyed by the match's
+ * `gameCreation`, exactly like the match payload, so every asset for a game
+ * shares one `games/yyyy/MM/dd/{matchId}/` prefix. Before this change the
+ * timeline used the upload time instead, which put it under the day it was
+ * fetched — usually, but not always, the day the game was played. Objects
+ * written before the cutover keep their old location; nothing rewrites them.
+ * Readers must therefore tolerate both, which they do by enumerating the whole
+ * `games/` prefix and taking identity from the payload rather than the key
+ * (see `report-lake/rebuild-sources.ts`).
+ *
  * @param timeline The timeline data to save
  * @param trackedPlayerAliases Array of tracked player aliases in this match (empty array if none)
- * @returns Promise that resolves when the timeline is saved
+ * @param gameCreatedAt The match's `info.gameCreation`, which partitions the key
  */
-export async function saveTimelineToS3(
+export async function archiveTimelineToS3(
   timeline: RawTimeline,
   trackedPlayerAliases: string[],
-): Promise<void> {
+  gameCreatedAt: Date,
+): Promise<RawArchiveResult> {
   const matchId = MatchIdSchema.parse(timeline.metadata.matchId);
   const body = JSON.stringify(timeline, null, 2);
 
-  await saveToS3({
+  const stored = await saveToS3({
     matchId,
     assetType: "timeline",
     extension: "json",
@@ -278,10 +342,25 @@ export async function saveTimelineToS3(
     logEmoji: "📊",
     logMessage: "Saving timeline to S3",
     errorContext: "timeline",
-    returnUrl: false,
+    keyDate: gameCreatedAt,
     additionalLogDetails: {
       frameCount: timeline.info.frames.length,
       frameInterval: timeline.info.frameInterval,
     },
   });
+  return stored === undefined
+    ? { status: "skipped_no_bucket" }
+    : archived("timeline", stored);
+}
+
+/**
+ * Save a match timeline to S3 storage
+ * @returns Promise that resolves when the timeline is saved
+ */
+export async function saveTimelineToS3(
+  timeline: RawTimeline,
+  trackedPlayerAliases: string[],
+  gameCreatedAt: Date,
+): Promise<void> {
+  await archiveTimelineToS3(timeline, trackedPlayerAliases, gameCreatedAt);
 }

--- a/packages/scout-for-lol/packages/backend/src/testing/raw-capture-fixtures.ts
+++ b/packages/scout-for-lol/packages/backend/src/testing/raw-capture-fixtures.ts
@@ -1,0 +1,95 @@
+import {
+  RawCurrentGameInfoSchema,
+  RawMatchSchema,
+  RawTimelineSchema,
+  type RawCurrentGameInfo,
+  type RawMatch,
+  type RawTimeline,
+} from "@scout-for-lol/data";
+import {
+  ArtifactDescriptorSchema,
+  type ArtifactDescriptor,
+  type ArtifactKind,
+} from "@scout-for-lol/domain/artifacts/descriptors.ts";
+
+/**
+ * The three raw captures an ingest handles, as test fixtures.
+ *
+ * Every suite that exercises archival, staging or receipts needs the same
+ * three payloads, and hand-rolling them per file produced byte-identical
+ * blocks that duplication detection correctly objected to. Sharing them also
+ * means a schema change breaks one place rather than five.
+ */
+
+const MATCH_FIXTURE_URL = new URL(
+  "../league/model/__tests__/testdata/matches_2025_09_19_NA1_5370969615.json",
+  import.meta.url,
+);
+
+/** The committed MatchV5 payload, parsed through the production schema. */
+export async function loadRawMatchFixture(): Promise<RawMatch> {
+  const json: unknown = await Bun.file(MATCH_FIXTURE_URL).json();
+  return RawMatchSchema.parse(json);
+}
+
+/**
+ * A minimal timeline for `matchId`. Frames are empty by default because most
+ * callers only care about identity and partitioning; pass `frameIntervalMs` to
+ * tell two otherwise identical timelines apart.
+ */
+export function rawTimelineFixture(
+  matchId: string,
+  overrides: { frameIntervalMs?: number } = {},
+): RawTimeline {
+  return RawTimelineSchema.parse({
+    metadata: { dataVersion: "2", matchId, participants: [] },
+    info: {
+      frameInterval: overrides.frameIntervalMs ?? 60_000,
+      frames: [],
+      gameId: Number(matchId.split("_").at(1)),
+      participants: [],
+    },
+  });
+}
+
+/** A spectator snapshot whose platform and game id form `NA1_5500000001`. */
+export function rawCurrentGameInfoFixture(): RawCurrentGameInfo {
+  return RawCurrentGameInfoSchema.parse({
+    gameId: 5_500_000_001,
+    gameStartTime: Date.now(),
+    gameMode: "CLASSIC",
+    mapId: 11,
+    gameType: "MATCHED_GAME",
+    gameQueueConfigId: 420,
+    gameLength: -30,
+    platformId: "NA1",
+    bannedChampions: [],
+    participants: [
+      {
+        championId: 157,
+        puuid: "test-puuid",
+        teamId: 100,
+        riotId: "Player#NA1",
+        spell1Id: 4,
+        spell2Id: 14,
+        lastSelectedSkinIndex: 0,
+        bot: false,
+        profileIconId: 1,
+      },
+    ],
+  });
+}
+
+/** A descriptor standing in for an object some earlier step archived. */
+export function artifactDescriptorFixture(
+  kind: ArtifactKind,
+): ArtifactDescriptor {
+  return ArtifactDescriptorSchema.parse({
+    kind,
+    key: `games/2026/09/12/NA1_5370969615/${kind}.json`,
+    digest: "b".repeat(64),
+    bytes: 2048,
+    contentType: "application/json",
+    capturedAt: "2026-09-12T12:00:00.000Z",
+  });
+}


### PR DESCRIPTION
## Why

Lake staging and S3 archival were unverifiable: staging returned a swallowed boolean, archives carried no integrity evidence, and timelines partitioned by upload date while matches partitioned by game-creation date. The durable pipeline (SJ-186 / SJ-190) needs both receipted and checkable.

## What

- **Content integrity**: every raw archive put computes a sha256 digest (stored as object metadata, returned in a domain `ArtifactDescriptor` whose `key` is the key the put actually used — asserted equal to the mocked PutObjectCommand key, never recomputed); the single-part ETag is independently compared to our own MD5 and a mismatch **fails the put** (no receipt, no cursor advance). SDK request checksums remain the primary write guarantee; read-time, replication, and multipart verification are explicitly out of scope, documented in `object-integrity.ts` and the wiki.
- **Partition co-location**: new timeline writes key by the match's gameCreation through the same `generateS3Key` as match writes — co-located under every timezone; rebuild reader proven layout-independent (fixtures in both layouts, incl. one filed under a deliberately wrong prefix); a contract test pins `generateS3Key` against the domain builder arithmetically. The host-TZ re-partition is scheduled separately (SJ-202).
- **Receipted entry points** (`report-lake/`): `archiveMatchReceipted` / `stage*Receipted` record `raw-archive` and `lake-staging` receipts whose evidence is **content identity** — the full artifact descriptor, and `{objectKind, sourceObjectKey, digest, fileCount}` — never local paths or build ids, so a receipt stays true whichever RWO volume held the staging file (a test asserts serialized evidence contains neither the lake dir nor any staging path). Receipted staging failure throws typed with **no receipt**; every legacy boolean caller is byte-identical (existing tests unchanged).
- **Coordination with #2838** (either merge order works, verified against its live diff): evidence kinds split cleanly (raw-archive/lake-staging here; settlement/deliveries/progression there); `src/metrics/durable.ts` is **deliberately byte-identical on both branches** — an identical both-added file that merges clean; do not 'tidy' it during merge. This PR's descriptors also feed #2838's `MatchArchiveOutcome.artifact` seam, so observations gain real artifact identity once both land.

## Verification

- `bunx turbo run typecheck lint test --filter=@scout-for-lol/backend --filter=@scout-for-lol/domain` — 23 tasks; **408 files / 3860 tests** incl. Postgres integration suites; architecture clean (1246 backend + 34 domain modules); prettier + wiki lint clean.
- Not run: Buildkite exact-head, images, deployment, live behavior. Multipart-upload integrity intentionally degrades to skip (archive path is single-part only today).

Part of SJ-190 (Wave 3 of the Scout durable-architecture program, SJ-186).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qRdG6fzJr3THzYzAJwTZB