### PR TITLE
fix(scout-for-lol): correct analytics data quality

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout-temporal-rules.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout-temporal-rules.ts
@@ -41,11 +41,11 @@ export function getScoutTemporalRuleGroup(): PrometheusRuleSpecGroups {
         annotations: {
           summary: "Scout Temporal Activities are failing",
           message: escapePrometheusTemplate(
-            "Scout queue {{ $labels.task_queue }} has failed Activities in the last 30 minutes. Inspect the Workflow history and effect claims before retrying manually.",
+            "Scout {{ $labels.exported_namespace }} queue {{ $labels.taskqueue }} Activity {{ $labels.activityType }} has failed in the last 30 minutes. Inspect the Workflow history and effect claims before retrying manually.",
           ),
         },
         expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          'sum by (task_queue) (increase(activity_task_fail{task_queue=~"scout-(beta|prod).*"}[30m])) > 0',
+          'sum by (exported_namespace, taskqueue, activityType) (increase(activity_task_fail{exported_namespace=~"beta|prod", taskqueue=~"scout(_.*)?"}[30m])) > 0',
         ),
         for: "10m",
         labels: { severity: "warning" },
@@ -54,11 +54,12 @@ export function getScoutTemporalRuleGroup(): PrometheusRuleSpecGroups {
         alert: "ScoutTemporalTaskScheduleToStartHigh",
         annotations: {
           summary: "Scout Temporal tasks are waiting for a Worker",
-          message:
-            "Scout task p95 schedule-to-start latency has exceeded ten seconds. Inspect the affected task queue and embedded Worker resources before tuning concurrency.",
+          message: escapePrometheusTemplate(
+            "Scout {{ $labels.exported_namespace }} queue {{ $labels.taskqueue }} task p95 schedule-to-start latency has exceeded ten seconds. Inspect the affected Worker before tuning concurrency.",
+          ),
         },
         expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          'histogram_quantile(0.95, sum by (task_queue, le) (rate(task_schedule_to_start_latency_bucket{task_queue=~"scout-(beta|prod).*"}[5m]))) > 10000',
+          'histogram_quantile(0.95, sum by (exported_namespace, taskqueue, le) (rate(task_schedule_to_start_latency_bucket{exported_namespace=~"beta|prod", taskqueue=~"scout(_.*)?"}[5m]))) > 10',
         ),
         for: "5m",
         labels: { severity: "warning" },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.test.ts
@@ -46,6 +46,44 @@ describe("Scout Temporal alert rules", () => {
       expect(expression).toContain(String.raw`environment=\"prod\"`);
     }
   });
+
+  test("uses live Temporal server labels and second-valued queue latency", () => {
+    if (temporal?.rules === undefined) {
+      throw new Error("Missing scout-temporal rule group");
+    }
+    const activityFailure = temporal.rules.find(
+      (rule) => rule.alert === "ScoutTemporalActivityFailing",
+    );
+    const scheduleToStart = temporal.rules.find(
+      (rule) => rule.alert === "ScoutTemporalTaskScheduleToStartHigh",
+    );
+    if (activityFailure === undefined || scheduleToStart === undefined) {
+      throw new Error("Missing Scout Temporal server-metric alert rules");
+    }
+
+    const activityExpression = JSON.stringify(activityFailure.expr);
+    expect(activityExpression).toContain(
+      "sum by (exported_namespace, taskqueue, activityType)",
+    );
+    expect(activityExpression).toContain(
+      String.raw`exported_namespace=~\"beta|prod\"`,
+    );
+    expect(activityExpression).toContain(
+      String.raw`taskqueue=~\"scout(_.*)?\"`,
+    );
+    expect(activityExpression).not.toContain("task_queue");
+
+    const latencyExpression = JSON.stringify(scheduleToStart.expr);
+    expect(latencyExpression).toContain(
+      "sum by (exported_namespace, taskqueue, le)",
+    );
+    expect(latencyExpression).toContain(
+      "task_schedule_to_start_latency_bucket",
+    );
+    expect(latencyExpression).toContain("> 10");
+    expect(latencyExpression).not.toContain("10000");
+    expect(latencyExpression).not.toContain("task_queue");
+  });
 });
 
 describe("Scout Riot API alert rules", () => {

--- a/packages/homelab/src/tofu/posthog/generated.tf
+++ b/packages/homelab/src/tofu/posthog/generated.tf
@@ -1407,55 +1407,15 @@ resource "posthog_insight" "insight_11297204" {
   dashboard_ids    = [2027696]
   deleted          = false
   derived_name     = null
-  description      = "Deduplicated market lifecycle counts by transition."
-  name             = "Bryan Bucks markets opened settled and voided"
+  description      = "Deduplicated count of every valid Bryan Bucks lifecycle transition; the table preserves every value instead of collapsing low-volume transitions into Other."
+  name             = "Bryan Bucks lifecycle transitions"
   project_id       = "549883"
   query_json = jsonencode({
-    kind = "InsightVizNode"
+    display = "ActionsTable"
+    kind    = "DataVisualizationNode"
     source = {
-      breakdownFilter = {
-        breakdown_type = "event"
-        breakdowns = [{
-          property = "transition"
-          type     = "event"
-        }]
-      }
-      dateRange = {
-        date_from                = "-90d"
-        excludeIncompletePeriods = false
-        explicitDate             = false
-      }
-      filterTestAccounts = false
-      interval           = "day"
-      kind               = "TrendsQuery"
-      properties         = []
-      series = [{
-        event      = "bryan_bucks_lifecycle"
-        kind       = "EventsNode"
-        math       = "hogql"
-        math_hogql = "count(distinct uuid)"
-      }]
-      trendsFilter = {
-        aggregationAxisFormat   = "numeric"
-        display                 = "ActionsStackedBar"
-        excludeBoxPlotOutliers  = true
-        hideWeekends            = false
-        legendPosition          = "bottom"
-        metricColorByDirection  = false
-        metricShowChange        = true
-        metricSummary           = "total"
-        resultCustomizationBy   = "value"
-        showAlertThresholdLines = false
-        showAnnotations         = true
-        showLegend              = false
-        showMultipleYAxes       = false
-        showPercentStackView    = false
-        showValuesOnSeries      = false
-        smoothingIntervals      = 1
-        stackBreakdownValues    = false
-        yAxisScaleType          = "linear"
-        yAxisStartAtZero        = true
-      }
+      kind  = "HogQLQuery"
+      query = "SELECT properties.transition AS transition, count(DISTINCT uuid) AS transition_count FROM events WHERE event = 'bryan_bucks_lifecycle' AND {filters} GROUP BY transition ORDER BY transition_count DESC"
     }
   })
   query_sql = null
@@ -1476,7 +1436,7 @@ resource "posthog_insight" "insight_11297203" {
     kind    = "DataVisualizationNode"
     source = {
       kind  = "HogQLQuery"
-      query = "SELECT day, sum(-delta) AS stake_volume FROM (SELECT uuid, toStartOfDay(timestamp) AS day, argMax(toFloat(properties.delta_bucks), timestamp) AS delta FROM events WHERE event = 'bryan_bucks_economy' AND properties.movement IN ('bet_stake', 'parlay_stake') AND {filters} GROUP BY uuid, day) GROUP BY day ORDER BY day"
+      query = "SELECT day, sum(-delta) AS stake_volume FROM (SELECT uuid, toStartOfDay(timestamp) AS day, argMax(toFloat(properties.delta_bucks), timestamp) AS delta FROM events WHERE event = 'bryan_bucks_economy' AND endsWith(properties.movement, '_stake') AND {filters} GROUP BY uuid, day) GROUP BY day ORDER BY day"
     }
   })
   query_sql = null
@@ -2821,7 +2781,7 @@ resource "posthog_insight" "insight_11297206" {
     kind    = "DataVisualizationNode"
     source = {
       kind  = "HogQLQuery"
-      query = "SELECT day, sumIf(delta, movement IN ('earn_game', 'earn_win', 'earn_mvp', 'earn_ranked_5s_bonus')) AS earnings, sumIf(delta, movement IN ('bet_payout', 'parlay_payout')) AS payouts FROM (SELECT uuid, toStartOfDay(timestamp) AS day, properties.movement AS movement, argMax(toFloat(properties.delta_bucks), timestamp) AS delta FROM events WHERE event = 'bryan_bucks_economy' AND {filters} GROUP BY uuid, day, movement) GROUP BY day ORDER BY day"
+      query = "SELECT day, sumIf(delta, startsWith(movement, 'earn_')) AS earnings, sumIf(delta, endsWith(movement, '_payout')) AS payouts FROM (SELECT uuid, toStartOfDay(timestamp) AS day, properties.movement AS movement, argMax(toFloat(properties.delta_bucks), timestamp) AS delta FROM events WHERE event = 'bryan_bucks_economy' AND {filters} GROUP BY uuid, day, movement) GROUP BY day ORDER BY day"
     }
   })
   query_sql = null
@@ -3534,16 +3494,16 @@ resource "posthog_insight" "insight_11297198" {
   dashboard_ids    = [2027696]
   deleted          = false
   derived_name     = null
-  description      = "Weekly retention after a member first uses Bryan Bucks."
+  description      = "Weekly retention after a member first uses Bryan Bucks, beginning with analytics instrumentation on 2026-08-16."
   name             = "Bryan Bucks first-use retention cohorts"
   project_id       = "549883"
   query_json = jsonencode({
     kind = "InsightVizNode"
     source = {
       dateRange = {
-        date_from                = "-90d"
+        date_from                = "2026-08-16"
         excludeIncompletePeriods = false
-        explicitDate             = false
+        explicitDate             = true
       }
       filterTestAccounts = false
       kind               = "RetentionQuery"
@@ -3946,8 +3906,8 @@ resource "posthog_insight" "insight_11251185" {
   dashboard_ids    = [2022116]
   deleted          = false
   derived_name     = null
-  description      = "Interim channel attribution until guild_install_attributed / bot_install_completed land (PR #2338): CTA clicks broken down by the person's first-touch utm_source."
-  name             = "Get Started clicks by first-touch source"
+  description      = "CTA clicks broken down by first-touch utm_source. This is an install-intent proxy, not completed installs; a null source means no first-touch source was captured. Replace it after production emits guild_install_attributed and bot_install_completed."
+  name             = "Get Started CTA clicks by first-touch source (install proxy)"
   project_id       = "549883"
   query_json = jsonencode({
     kind = "InsightVizNode"
@@ -4049,8 +4009,8 @@ resource "posthog_insight" "insight_11297201" {
   dashboard_ids    = [2027696]
   deleted          = false
   derived_name     = null
-  description      = "Deduplicated member activity split by command versus button surface."
-  name             = "Bryan Bucks activity by betting surface"
+  description      = "Deduplicated interaction volume split by command, button, and web surface. UUID deduplication prevents duplicate delivery; it does not count unique members."
+  name             = "Bryan Bucks interactions by betting surface"
   project_id       = "549883"
   query_json = jsonencode({
     kind = "InsightVizNode"

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -587,7 +587,7 @@ describe("Scout Bryan Bucks analytics schedule config", () => {
       },
       taskQueue: TASK_QUEUES.WORKFLOWS,
       overlap: ScheduleOverlapPolicy.SKIP,
-      workflowExecutionTimeout: "5 minutes",
+      workflowExecutionTimeout: "15 minutes",
     });
   });
 });

--- a/packages/temporal/src/schedules/schedule-definitions.ts
+++ b/packages/temporal/src/schedules/schedule-definitions.ts
@@ -229,7 +229,10 @@ export const SCHEDULES: ScheduleDefinition[] = schedulesInNamespace("prod", [
     },
     taskQueue: TASK_QUEUES.WORKFLOWS,
     overlap: ScheduleOverlapPolicy.SKIP,
-    workflowExecutionTimeout: "5 minutes",
+    // Five 2m Activity attempts plus 2m10s of retry backoff need more than the
+    // old five-minute Workflow deadline. The 15m cap fits that envelope while
+    // SKIP still prevents concurrent snapshot publication.
+    workflowExecutionTimeout: "15 minutes",
     memo: "Every-15-minute committed Bryan Bucks ledger and economy analytics sync",
   },
   {

--- a/packages/temporal/src/workflows/replay-fixtures/scout-bryan-bucks-pre-v1.ts
+++ b/packages/temporal/src/workflows/replay-fixtures/scout-bryan-bucks-pre-v1.ts
@@ -1,0 +1,18 @@
+import { proxyActivities } from "@temporalio/workflow";
+
+const { syncScoutBryanBucksAnalytics } = proxyActivities<{
+  syncScoutBryanBucksAnalytics: () => Promise<{
+    status: "reconciled";
+    detail: string;
+  }>;
+}>({
+  taskQueue: "scout",
+  startToCloseTimeout: "2 minutes",
+});
+
+export async function runScoutBryanBucksAnalyticsWorkflow(): Promise<{
+  status: "reconciled";
+  detail: string;
+}> {
+  return await syncScoutBryanBucksAnalytics();
+}

--- a/packages/temporal/src/workflows/replay-fixtures/scout-bryan-bucks-v1.ts
+++ b/packages/temporal/src/workflows/replay-fixtures/scout-bryan-bucks-v1.ts
@@ -1,0 +1,25 @@
+import { patched, proxyActivities } from "@temporalio/workflow";
+
+type Result = { status: "reconciled"; detail: string };
+type Activities = {
+  syncScoutBryanBucksAnalytics: () => Promise<Result>;
+};
+
+const { syncScoutBryanBucksAnalytics } = proxyActivities<Activities>({
+  taskQueue: "scout",
+  startToCloseTimeout: "2 minutes",
+});
+
+const { syncScoutBryanBucksAnalytics: syncEmbeddedScoutBryanBucksAnalytics } =
+  proxyActivities<Activities>({
+    taskQueue: "scout-beta-background",
+    startToCloseTimeout: "2 minutes",
+    heartbeatTimeout: "30 seconds",
+  });
+
+export async function runScoutBryanBucksAnalyticsWorkflow(): Promise<Result> {
+  if (patched("scout-bryan-bucks-embedded-activity-v1")) {
+    return await syncEmbeddedScoutBryanBucksAnalytics();
+  }
+  return await syncScoutBryanBucksAnalytics();
+}

--- a/packages/temporal/src/workflows/scout/scout-bryan-bucks.test.ts
+++ b/packages/temporal/src/workflows/scout/scout-bryan-bucks.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, expect, test } from "vitest";
 import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { runScoutBryanBucksAnalyticsWorkflow as runPreV1Workflow } from "#workflows/replay-fixtures/scout-bryan-bucks-pre-v1.ts";
+import { runScoutBryanBucksAnalyticsWorkflow as runV1Workflow } from "#workflows/replay-fixtures/scout-bryan-bucks-v1.ts";
 import { runScoutBryanBucksAnalyticsWorkflow } from "./scout-bryan-bucks.ts";
+
+const WORKFLOW_TASK_QUEUE = "central-temporal-worker";
+const RESULT = { status: "reconciled", detail: "published" } as const;
 
 let environment: TestWorkflowEnvironment;
 
@@ -13,36 +19,127 @@ afterEach(async () => {
   await environment.teardown();
 });
 
-test("routes new Bryan Bucks histories to Scout's embedded background queue", async () => {
-  let calls = 0;
+async function runWorkersUntil<T>(
+  workers: readonly Worker[],
+  operation: () => Promise<T>,
+): Promise<T> {
+  const runs = workers.map((worker) => worker.run());
+  try {
+    return await operation();
+  } finally {
+    for (const worker of workers) worker.shutdown();
+    await Promise.all(runs);
+  }
+}
+
+async function captureHistory(
+  fixture: {
+    workflow: typeof runScoutBryanBucksAnalyticsWorkflow;
+    workflowsPath: string;
+  },
+  activityTaskQueue: string,
+  workflowId: string,
+) {
   const workflowWorker = await Worker.create({
     connection: environment.nativeConnection,
-    taskQueue: "central-temporal-worker",
-    workflowsPath: new URL("../index.ts", import.meta.url).pathname,
+    taskQueue: WORKFLOW_TASK_QUEUE,
+    workflowsPath: fixture.workflowsPath,
   });
   const activityWorker = await Worker.create({
+    connection: environment.nativeConnection,
+    taskQueue: activityTaskQueue,
+    activities: { syncScoutBryanBucksAnalytics: () => RESULT },
+  });
+
+  return await runWorkersUntil([workflowWorker, activityWorker], async () => {
+    const handle = await environment.client.workflow.start(fixture.workflow, {
+      taskQueue: WORKFLOW_TASK_QUEUE,
+      workflowId,
+    });
+    await expect(handle.result()).resolves.toEqual(RESULT);
+    return await handle.fetchHistory();
+  });
+}
+
+test("routes new Bryan Bucks histories to the central Scout queue", async () => {
+  let centralCalls = 0;
+  let embeddedCalls = 0;
+  const workflowWorker = await Worker.create({
+    connection: environment.nativeConnection,
+    taskQueue: WORKFLOW_TASK_QUEUE,
+    workflowsPath: new URL("../index.ts", import.meta.url).pathname,
+  });
+  const centralActivityWorker = await Worker.create({
+    connection: environment.nativeConnection,
+    taskQueue: TASK_QUEUES.SCOUT,
+    activities: {
+      syncScoutBryanBucksAnalytics: () => {
+        centralCalls += 1;
+        return RESULT;
+      },
+    },
+  });
+  const embeddedActivityWorker = await Worker.create({
     connection: environment.nativeConnection,
     taskQueue: "scout-beta-background",
     activities: {
       syncScoutBryanBucksAnalytics: () => {
-        calls += 1;
-        return { status: "reconciled", detail: "published" };
+        embeddedCalls += 1;
+        return RESULT;
       },
     },
   });
-  const workflowRun = workflowWorker.run();
-  const activityRun = activityWorker.run();
-  try {
-    await expect(
-      environment.client.workflow.execute(runScoutBryanBucksAnalyticsWorkflow, {
-        taskQueue: "central-temporal-worker",
-        workflowId: "scout-bryan-bucks-embedded-queue",
-      }),
-    ).resolves.toEqual({ status: "reconciled", detail: "published" });
-    expect(calls).toBe(1);
-  } finally {
-    workflowWorker.shutdown();
-    activityWorker.shutdown();
-    await Promise.all([workflowRun, activityRun]);
-  }
+
+  await runWorkersUntil(
+    [workflowWorker, centralActivityWorker, embeddedActivityWorker],
+    async () => {
+      await expect(
+        environment.client.workflow.execute(
+          runScoutBryanBucksAnalyticsWorkflow,
+          {
+            taskQueue: WORKFLOW_TASK_QUEUE,
+            workflowId: "scout-bryan-bucks-central-queue",
+          },
+        ),
+      ).resolves.toEqual(RESULT);
+    },
+  );
+  expect(centralCalls).toBe(1);
+  expect(embeddedCalls).toBe(0);
+});
+
+test.each([
+  {
+    name: "pre-v1 central",
+    fixture: {
+      workflow: runPreV1Workflow,
+      workflowsPath: new URL(
+        "../replay-fixtures/scout-bryan-bucks-pre-v1.ts",
+        import.meta.url,
+      ).pathname,
+    },
+    activityTaskQueue: TASK_QUEUES.SCOUT,
+  },
+  {
+    name: "v1 embedded",
+    fixture: {
+      workflow: runV1Workflow,
+      workflowsPath: new URL(
+        "../replay-fixtures/scout-bryan-bucks-v1.ts",
+        import.meta.url,
+      ).pathname,
+    },
+    activityTaskQueue: "scout-beta-background",
+  },
+] as const)("replays $name histories after the v2 route", async (testCase) => {
+  const history = await captureHistory(
+    testCase.fixture,
+    testCase.activityTaskQueue,
+    `scout-bryan-bucks-replay-${testCase.name.replaceAll(" ", "-")}`,
+  );
+
+  await Worker.runReplayHistory(
+    { workflowsPath: new URL("../index.ts", import.meta.url).pathname },
+    history,
+  );
 });

--- a/packages/temporal/src/workflows/scout/scout-bryan-bucks.ts
+++ b/packages/temporal/src/workflows/scout/scout-bryan-bucks.ts
@@ -31,6 +31,9 @@ const { syncScoutBryanBucksAnalytics: syncEmbeddedScoutBryanBucksAnalytics } =
   });
 
 export async function runScoutBryanBucksAnalyticsWorkflow(): Promise<ScoutBryanBucksAnalyticsResult> {
+  if (patched("scout-bryan-bucks-central-activity-v2")) {
+    return await syncScoutBryanBucksAnalytics();
+  }
   if (patched("scout-bryan-bucks-embedded-activity-v1")) {
     return await syncEmbeddedScoutBryanBucksAnalytics();
   }


### PR DESCRIPTION
## Why

Scout custom dashboards contained misleading labels and brittle movement filters. The Bryan Bucks analytics Workflow could also exhaust its deadline before configured retries completed, while its Temporal alerts queried stale label names and millisecond-scale thresholds against second-valued metrics.

## What

- Make dashboard labels, lifecycle coverage, economy taxonomy, retention window, and attribution caveats match emitted data.
- Route new analytics Activities to the shared Scout queue behind a Temporal patch while preserving replay for both historical routes.
- Fit the schedule timeout to the retry envelope and correct Temporal server alert selectors, grouping, and latency units.

## Verification

- Affected Turbo build, typecheck, lint: 22/22 tasks passed.
- Temporal workflow routing and replay: 3/3 tests passed.
- Temporal schedule contracts: 161/161 tests passed.
- Scout alert rules: 24/24 tests passed.
- Full cdk8s suite: 710 tests passed, 13 skipped.
- OpenTofu format and posthog validate passed.
- Pre-commit safety and package-quality hooks passed.
- Read-only PostHog queries confirmed all 39 observed lifecycle transitions remain visible, movement-family totals reconcile, first member activity began 2026-08-16, CTA clicks exist, and attributed install events do not yet exist.

## Not yet verified

- Buildkite exact-head CI is pending.
- OpenTofu apply, Temporal and alert rollout, live dashboard rendering, and post-deployment runtime health have not occurred.
- No Scout production feature promotion is included.