### PR TITLE
fix(scout-for-lol): close the wave-two review's production gaps

### DIFF
--- a/packages/scout-for-lol/packages/backend/README.md
+++ b/packages/scout-for-lol/packages/backend/README.md
@@ -209,7 +209,7 @@ unrecognised value throws at startup rather than falling back.
 | ------------------------------------------------ | ------------------------------------------------------------------------------ | --------------------------- | ------------------ | -------------------- |
 | Champion asset verification                      | yes                                                                            | yes                         | yes                | yes                  |
 | Voice assistant (Hey Scout)                      | yes                                                                            | —                           | yes                | —                    |
-| Report lake mounted (reads + staging writes)     | yes                                                                            | yes                         | —                  | yes                  |
+| Report lake mounted (reads + staging writes)     | yes                                                                            | yes                         | yes                | yes                  |
 | Report-lake fold / publish at boot               | yes                                                                            | yes                         | —                  | —                    |
 | Temporal workers                                 | workflow, interactive, lake (+ realtime, background once the gateway is ready) | workflow, interactive, lake | none (client only) | realtime, background |
 | Discord gateway login, commands, guild lifecycle | yes                                                                            | —                           | yes                | —                    |
@@ -227,6 +227,19 @@ Notes that are easy to get wrong:
 - **Voice is gateway-coupled by design.** It reads an active voice connection's
   audio, so it cannot be moved off the shard. That makes `gateway` an explicitly
   stateful role.
+- **`gateway` needs the lake even though it runs no Temporal worker.** `/scout
+ask` and the Dare commands execute the Explore agent in the process that
+  received the interaction, which is a synchronous DuckDB read. It declared no
+  lake access while doing exactly that, and because the boot gate only runs for
+  roles that declare access, the pod that needed the check was the one that
+  skipped it — DuckDB scans zero parquet files rather than failing, so every
+  question came back "no games found", successfully. Wave 6 settles this either
+  by routing Discord-surface Explore turns through the `interactive` queue (the
+  same mechanism this role already owes customs voice) or by giving the gateway
+  Deployment the lake volume. Independently of the table, every in-process lake
+  read now asserts the capability at the read site in
+  `reports/duckdb/lake.ts`: a capability whose `false` skips a safety check
+  cannot protect the role that sets it false.
 - **`application` publishes the report lake**, and owns the collectors that
   sweep the database on every `/metrics` scrape. Every role serves `/metrics`,
   but running those four collectors on all of them would turn one Prometheus
@@ -273,6 +286,13 @@ are used automatically. For a full local backend + web app, use
 `--no-background-jobs` now sets only `SCOUT_DEV_SKIP_REPORT_LAKE_FOLD`, a
 dev-only switch for the one boot step a laptop with no published lake build and
 no S3 bucket cannot complete; it is rejected outside `ENVIRONMENT=dev`.
+
+That flag skips the fold and nothing else. The separate check that the lake
+holds a published build still runs while it is set, downgraded from a refusal
+to a warning: a lake-reading pod pointed at an empty directory does not fail —
+DuckDB scans zero files and the run is recorded as a success — so the one thing
+this check must never be is silent. Outside dev it always refuses. See
+`src/runtime/report-lake-gate.ts`.
 
 See the [report-lake explanation](../../../docs/wiki/src/content/docs/explanation/scout-report-lake.md)
 and the parent [README](../../README.md) for architecture. The parent

--- a/packages/scout-for-lol/packages/backend/scripts/repair/repair-dare-domain-contracts.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/repair/repair-dare-domain-contracts.ts
@@ -27,6 +27,7 @@ import {
   BucksLedgerContextSchema,
   BucksLedgerKindSchema,
   RawMatchSchema,
+  StoredBucksLedgerContextSchema,
 } from "@scout-for-lol/data";
 import { prisma } from "#src/database/index.ts";
 import { settleDaresV2ForMatch } from "#src/betting/dares/settlement/dare-settle-v2.ts";
@@ -225,7 +226,13 @@ async function settlementEntriesForDare(dareId: number, since: Date | null) {
     orderBy: { id: "asc" },
   });
   return candidates.filter((entry) => {
-    const context = BucksLedgerContextSchema.parse(JSON.parse(entry.context));
+    // The STORED union: this scans every settlement-kind row in the window,
+    // most of which belong to other dares and to ordinary pool settlements.
+    // Parsing those through the write schema made an old-domain settlement row
+    // abort the whole repair before it could even be skipped.
+    const context = StoredBucksLedgerContextSchema.parse(
+      JSON.parse(entry.context),
+    );
     return context.type === "dare" && context.dareId === dareId;
   });
 }
@@ -376,7 +383,10 @@ async function reverseSettlement(target: PendingResettlement): Promise<void> {
         // joins to the settlement it is correcting.
         matchId: entry.matchId ?? undefined,
         // Reuse the original entry's context verbatim so the reversal is
-        // traceable to exactly the movement it undoes.
+        // traceable to exactly the movement it undoes. The WRITE schema here,
+        // unlike the scan above: this parse guards a new row, and every entry
+        // that reaches it is already a `dare` context, whose domain the money
+        // brands never widened.
         context: BucksLedgerContextSchema.parse(JSON.parse(entry.context)),
       });
     }

--- a/packages/scout-for-lol/packages/backend/src/betting/navigation.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/navigation.ts
@@ -1,6 +1,6 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from "discord.js";
 import {
-  BucksLedgerContextSchema,
+  StoredBucksLedgerContextSchema,
   BucksPoolRosterSchema,
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
@@ -97,7 +97,12 @@ function formatGameLabel(aliases: readonly string[]): string | undefined {
 
 function parsedContext(entry: LedgerPageEntry) {
   try {
-    return BucksLedgerContextSchema.safeParse(JSON.parse(entry.context)).data;
+    // The STORED union, not the write one: a settlement row written before the
+    // money brands narrowed its domain is history, not corruption, and losing
+    // its explanation to a bare match ID is exactly the silent degradation
+    // this page is here to avoid.
+    return StoredBucksLedgerContextSchema.safeParse(JSON.parse(entry.context))
+      .data;
   } catch {
     // Historical rows predate some context shapes; an unreadable one simply
     // falls back to the match ID.

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement/reconcile-pools.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement/reconcile-pools.ts
@@ -204,7 +204,10 @@ function auditHouseExposure(
       houseBet.predictedTeamId !== summary.houseTeamId ||
       houseBet.stake !== summary.houseFill ||
       houseBet.matchedStake !== summary.houseFill ||
-      houseDebit !== -summary.houseFill);
+      // The debit is the negative side of the same movement, so its magnitude
+      // is what must equal the fill. Negating the ledger figure rather than
+      // the summary's leaves the branded pool total unmodified.
+      -houseDebit !== summary.houseFill);
   if (
     emptyHouseInvalid ||
     fundedHouseInvalid ||

--- a/packages/scout-for-lol/packages/backend/src/configuration/runtime-capability-error.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/runtime-capability-error.ts
@@ -1,0 +1,24 @@
+/**
+ * The refusal a process raises when asked to do something its runtime role
+ * does not declare.
+ *
+ * Deliberately transport-neutral and deliberately here rather than in
+ * `runtime/`. The capability *vocabulary* lives in `configuration/` — a leaf
+ * every layer may import — precisely so that a guard can be written at the
+ * place the work actually happens without that module gaining a dependency on
+ * the composition root. `customs/voice-capability.ts` raises an HTTP-shaped
+ * refusal because its only caller is an HTTP endpoint; a guard on a shared
+ * read path has callers on every transport, so its error must name a
+ * capability and nothing else. Each transport maps it to its own status.
+ */
+
+export class RuntimeCapabilityError extends Error {
+  constructor(
+    /** The {@link ScoutRuntimeCapabilities} field this process does not hold. */
+    readonly capability: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "RuntimeCapabilityError";
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/configuration/runtime-role.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/runtime-role.test.ts
@@ -52,7 +52,10 @@ const EXPECTED: Readonly<Record<ScoutRuntimeRole, ScoutRuntimeCapabilities>> = {
     championAssets: true,
     voiceAssistant: true,
     voiceStateAccess: true,
-    reportLakeAccess: false,
+    // True with no Temporal queue of its own: `/scout ask` and the Dare
+    // commands run the Explore agent in the process that received the
+    // interaction, and that is this one.
+    reportLakeAccess: true,
     reportLakeFold: false,
     temporalWorkers: [],
     deferredTemporalWorkers: [],
@@ -177,6 +180,21 @@ describe("scout runtime roles", () => {
     for (const role of SCOUT_RUNTIME_ROLES) {
       const capabilities = scoutRuntimeCapabilities(role);
       if (!capabilities.reportLakeFold) continue;
+      expect(capabilities.reportLakeAccess).toBe(true);
+    }
+  });
+
+  test("a role that receives Discord interactions declares lake access", () => {
+    // Running a Temporal queue is NOT the test for needing the lake. `/scout
+    // ask` and the Dare commands execute the Explore agent in whichever
+    // process received the interaction — a synchronous DuckDB read on the
+    // gateway role, with no queue anywhere in it. The gateway declared `false`
+    // while doing exactly that, and since the boot gate runs only for roles
+    // declaring `true`, the one pod that needed the check was the one that
+    // skipped it.
+    for (const role of SCOUT_RUNTIME_ROLES) {
+      const capabilities = scoutRuntimeCapabilities(role);
+      if (!capabilities.discordGateway) continue;
       expect(capabilities.reportLakeAccess).toBe(true);
     }
   });

--- a/packages/scout-for-lol/packages/backend/src/configuration/runtime-role.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/runtime-role.ts
@@ -26,7 +26,9 @@
  *   the Hey Scout voice assistant. Voice is gateway-coupled by design (it reads
  *   an active voice connection's audio), which makes this role explicitly
  *   stateful and unsplittable from the shard. It runs no Temporal workers, only
- *   a Temporal client, because commands start Workflows they do not execute.
+ *   a Temporal client, because commands start Workflows they do not execute —
+ *   but it still needs the report lake, because `/scout ask` and the Dare
+ *   commands answer from it synchronously, in this process.
  * - `activity-worker` — the `realtime` and `background` Temporal activity
  *   workers plus the competition activity worker: Riot polling, ingestion,
  *   report rendering and Discord delivery over REST. No gateway connection.
@@ -111,6 +113,14 @@ export type ScoutRuntimeCapabilities = {
    * empty directory does not fail — DuckDB happily scans zero parquet files —
    * so it records empty query results as successful runs. That is why this is a
    * declared capability with a boot gate rather than an assumption.
+   *
+   * The queues are not the only readers, so "runs a worker" is not the test.
+   * `/scout ask` and the Dare commands run the Explore agent in the process
+   * that received the interaction, which puts a lake read on the gateway role
+   * with no queue involved. Every in-process reader is funnelled through
+   * `reports/duckdb/lake.ts`, which asserts this capability at the read site —
+   * the boot gate alone cannot protect a role that declares `false`, because
+   * declaring `false` is what skips the gate.
    */
   readonly reportLakeAccess: boolean;
   /**
@@ -204,9 +214,22 @@ const SCOUT_RUNTIME_CAPABILITIES: Readonly<
     championAssets: true,
     voiceAssistant: true,
     voiceStateAccess: true,
-    // The only role that runs no activity queue, and therefore the only one
-    // that needs no lake volume at all.
-    reportLakeAccess: false,
+    // True despite running no Temporal activity queue, because the queues are
+    // not the only lake readers. `/scout ask` and the Dare commands execute
+    // the Explore agent IN PROCESS on whichever pod received the interaction
+    // (`discord/commands/scout.ts` → `explore/agent.ts` → the DuckDB engine),
+    // and this is the role that receives every interaction. It previously
+    // declared `false` while doing exactly this, which made the boot gate skip
+    // the pod that needed it most: DuckDB scans zero parquet files rather than
+    // failing, so every question came back "no games found", successfully.
+    //
+    // Wave 6 must settle this properly, and has two ways to: route
+    // Discord-surface Explore turns through the `interactive` queue — the same
+    // mechanism this role already owes customs voice — or keep executing them
+    // here and give the gateway Deployment the lake volume. Until then the
+    // table says what the process actually does, so the boot gate protects it
+    // honestly.
+    reportLakeAccess: true,
     reportLakeFold: false,
     temporalWorkers: NO_WORKERS,
     deferredTemporalWorkers: NO_WORKERS,

--- a/packages/scout-for-lol/packages/backend/src/consumer/access.ts
+++ b/packages/scout-for-lol/packages/backend/src/consumer/access.ts
@@ -85,9 +85,25 @@ export type InstalledGuildLookup = (
  * shared across callers, so a busy server costs one REST read a minute rather
  * than one per request.
  *
+ * ## Concurrently, and with a boundary per guild
+ *
+ * The confirmations are independent, so they run together rather than in
+ * sequence. Every one of them needs an answer — the result is also the scope
+ * Explore resolves aliases in, so there is nothing to short-circuit on — and
+ * serially they were N cold reads each bounded by the REST client's 5-second
+ * timeout, which put a signed-in member's first page load behind a stall
+ * growing with the number of Scout servers they are in. The port's own
+ * `MAX_CONCURRENT_READS` bounds the fan-out, so this does not trade latency
+ * for a saturated REST pool.
+ *
  * Every candidate here has a live row by construction, so an unreachable
  * Discord takes the port's documented asymmetry: the row is trusted and a
  * warning is logged, rather than locking a real member out during an outage.
+ * A candidate that throws anyway is therefore something unexpected rather than
+ * an outage, and it is contained to that guild — one broken server must not
+ * turn the caller's entire consumer surface into `unavailable`, which is what
+ * a single rejection escaping this function does. Only an all-candidates
+ * failure propagates, because only then is there no partial truth to serve.
  */
 export async function confirmedInstalledAmong(
   guildIds: string[],
@@ -95,14 +111,40 @@ export async function confirmedInstalledAmong(
 ): Promise<Iterable<string>> {
   const { installedGuildIdsAmong, isScoutInstalledInGuild } =
     await import("#src/lib/discord/installed-guilds.ts");
-  const candidates = await installedGuildIdsAmong(guildIds, dependencies);
-  const confirmed: string[] = [];
-  for (const guildId of candidates) {
-    if (await isScoutInstalledInGuild(guildId, dependencies)) {
-      confirmed.push(guildId);
-    }
+  const candidates = [
+    ...(await installedGuildIdsAmong(guildIds, dependencies)),
+  ];
+  const confirmations = await Promise.all(
+    candidates.map(async (guildId) => {
+      try {
+        const installed = await isScoutInstalledInGuild(guildId, dependencies);
+        return { guildId, installed, error: undefined };
+      } catch (error: unknown) {
+        return { guildId, installed: undefined, error };
+      }
+    }),
+  );
+
+  const failures = confirmations.filter(
+    (confirmation) => confirmation.installed === undefined,
+  );
+  const total = confirmations.length;
+  if (failures.length > 0 && failures.length === total) {
+    // Nothing answered, so there is no partial truth to serve. Rethrowing the
+    // first failure keeps its type: `installedGuildIdsOrUnavailable` logs it
+    // and turns it into `unavailable`, never into a denial.
+    throw failures[0]?.error;
   }
-  return confirmed;
+  for (const failure of failures) {
+    logger.warn("Skipping a guild whose installation could not be confirmed", {
+      guildId: failure.guildId,
+      error: failure.error,
+    });
+  }
+
+  return confirmations.flatMap((confirmation) =>
+    confirmation.installed === true ? [confirmation.guildId] : [],
+  );
 }
 
 /**

--- a/packages/scout-for-lol/packages/backend/src/consumer/confirmed-access.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/consumer/confirmed-access.test.ts
@@ -153,4 +153,76 @@ describe("confirmed consumer access", () => {
     expect([...granted].toSorted()).toEqual([LIVE, second].toSorted());
     expect(asked.toSorted()).toEqual([LIVE, second].toSorted());
   });
+
+  test("confirmations run together, not one after another", async () => {
+    // Serially these were N cold reads each bounded by the REST client's
+    // 5-second timeout, so a member in several Scout servers waited out the
+    // sum of them before their first page rendered.
+    const second = testGuildId("714");
+    await seedInstall(LIVE);
+    await seedInstall(second);
+    let inFlight = 0;
+    let peakInFlight = 0;
+    const arrived = Promise.withResolvers<undefined>();
+
+    const granted = await confirmedInstalledAmong(
+      [LIVE, second],
+      dependencies(async () => {
+        inFlight += 1;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        // Every read parks until both have arrived, which only completes if
+        // they were started without waiting for each other.
+        if (inFlight === 2) arrived.resolve(undefined);
+        await arrived.promise;
+        inFlight -= 1;
+        return true;
+      }),
+    );
+
+    expect(peakInFlight).toBe(2);
+    expect([...granted].toSorted()).toEqual([LIVE, second].toSorted());
+  });
+
+  test("one broken guild is skipped, not fatal to the rest", async () => {
+    // Every candidate has a live row, so the port already absorbs a Discord
+    // outage by trusting the row. A throw is therefore something unexpected —
+    // and a single rejection escaping here would make the caller's WHOLE
+    // consumer surface `unavailable`, taking away every other server they have.
+    const second = testGuildId("714");
+    await seedInstall(LIVE);
+    await seedInstall(second);
+
+    const granted = await confirmedInstalledAmong(
+      [LIVE, second],
+      dependencies((guildId) =>
+        guildId === second
+          ? Promise.reject(new Error("something unexpected"))
+          : Promise.resolve(true),
+      ),
+    );
+
+    expect([...granted]).toEqual([LIVE]);
+  });
+
+  test("every candidate failing DOES propagate", async () => {
+    // With nothing confirmed there is no partial truth to serve, so the
+    // failure has to surface as `unavailable` rather than as an empty list —
+    // an empty list is a denial telling a real member they have no servers.
+    await seedInstall(LIVE);
+
+    await expect(
+      confirmedInstalledAmong(
+        [LIVE],
+        dependencies(() => Promise.reject(new Error("something unexpected"))),
+      ),
+    ).rejects.toThrow("something unexpected");
+  });
+
+  test("no candidates at all is an empty answer, not a failure", async () => {
+    // Nothing failed here — the caller simply shares no Scout server. That is
+    // a legitimate `forbidden`, and must not be dressed up as unavailable.
+    await expect(
+      confirmedInstalledAmong([UNRELATED], dependencies(unused)),
+    ).resolves.toEqual([]);
+  });
 });

--- a/packages/scout-for-lol/packages/backend/src/database/durable/observation-repository.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/observation-repository.integration.test.ts
@@ -272,7 +272,7 @@ describe("receipts and state assembly", () => {
 
     const differingEvidence = matchProcessingReceiptRowToRecord({
       ...receiptRow(120, "global"),
-      recordedAt: new Date("2026-09-07T13:00:00.000Z"),
+      evidence: JSON.stringify({ messageId: "a-different-claim" }),
     });
     expect(await recordReceipt(prisma, differingEvidence)).toEqual({
       outcome: "conflict",
@@ -284,9 +284,32 @@ describe("receipts and state assembly", () => {
       matchId: globalReceipt.matchId,
     });
     expect(listed).toHaveLength(1);
-    expect(listed[0]?.receipt.recordedAt).toBe(
-      globalReceipt.receipt.recordedAt,
-    );
+    expect(listed[0]?.evidence).toBeNull();
+  });
+
+  test("a benign retry with a later wall clock is already-applied", async () => {
+    // `recordedAt` is wall-clock at write time and receipt writers are
+    // Temporal Activities, so an ordinary retry of an already-committed write
+    // differs in that column and in nothing else. Counting those as conflicts
+    // inflated the very counter the dual-write alerting watches, with events
+    // that are the system working correctly.
+    await observeMatch(prisma, observation(122));
+    const first = receipt(122, "global");
+    expect(await recordReceipt(prisma, first)).toEqual({ outcome: "applied" });
+
+    const retriedLater = matchProcessingReceiptRowToRecord({
+      ...receiptRow(122, "global"),
+      recordedAt: new Date("2026-09-07T13:00:00.000Z"),
+    });
+    expect(retriedLater.receipt.recordedAt).not.toBe(first.receipt.recordedAt);
+    expect(await recordReceipt(prisma, retriedLater)).toEqual({
+      outcome: "already-applied",
+    });
+
+    // ...and the first attestation's timestamp is what the table retains.
+    const listed = await listReceipts(prisma, { matchId: first.matchId });
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.receipt.recordedAt).toBe(first.receipt.recordedAt);
   });
 
   test("exactly one of two concurrent identical receipt writers applies", async () => {

--- a/packages/scout-for-lol/packages/backend/src/database/durable/receipt-repository.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/receipt-repository.ts
@@ -10,11 +10,20 @@ import {
  * Repository for MatchProcessingReceipt.
  *
  * Mirrors the domain's recordReceipt: identity is `(kind, version, scope)`
- * within one match, an exact replay — same identity, same evidence — is
- * `already-applied`, and a replay whose evidence disagrees is a conflict
- * (something recorded the same fact twice with different observations; the
- * table keeps the first). The unique constraint is what makes the answer
- * authoritative under concurrency.
+ * within one match, a replay carrying the same evidence is `already-applied`,
+ * and a replay whose evidence disagrees is a conflict — something recorded the
+ * same fact twice with different claims about it, and the table keeps the
+ * first. The unique constraint is what makes the answer authoritative under
+ * concurrency.
+ *
+ * `recordedAt` is NOT part of that comparison, and this is the layer where
+ * including it did visible damage. It is wall-clock at write time and receipt
+ * writers are Temporal Activities, so an ordinary retry of an already-
+ * committed write differs in exactly that column and in nothing else — every
+ * one of them was answered `conflict`, inflating the counter the dual-write
+ * alerting watches with events that are the system working correctly. The
+ * evidence blob is the claim about the fact; the timestamp only records when
+ * the first writer happened to look.
  */
 
 export type RecordReceiptResult =
@@ -49,9 +58,7 @@ export async function recordReceipt(
       `MatchProcessingReceipt ${row.scopeKey} for ${row.riotMatchId} vanished between a duplicate insert and its read-back`,
     );
   }
-  const sameEvidence =
-    existing.recordedAt.getTime() === row.recordedAt.getTime() &&
-    existing.evidence === row.evidence;
+  const sameEvidence = existing.evidence === row.evidence;
   return sameEvidence
     ? { outcome: "already-applied" }
     : { outcome: "conflict", reason: "receipt-evidence-mismatch" };

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/validate-data.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/validate-data.integration.test.ts
@@ -1,0 +1,258 @@
+/**
+ * The hourly data-validation job's DELETION layer, against a real schema.
+ *
+ * `validate-data.test.ts` covers the decision — which guilds are orphaned —
+ * with pure functions. Nothing covered what happens after that decision, which
+ * is where the rows actually disappear: the blast radius of one guild's
+ * cleanup, and what a partial failure leaves behind.
+ *
+ * The two properties pinned here both used to be violable. The three deletes
+ * ran independently, so a fault after the first left a guild with no
+ * subscriptions and an intact permission table; and the cleanup caught its own
+ * errors, so the caller's per-guild handler could never run and a database
+ * fault was recorded as a successful cleanup.
+ */
+
+import { Client, GatewayIntentBits } from "discord.js";
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import type { DiscordGuildId } from "@scout-for-lol/data";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import { DiscordUpstreamError } from "#src/lib/discord-rest.ts";
+import type { DiscordChannel } from "#src/lib/discord/bot-rest-schemas.ts";
+import {
+  runDataValidation,
+  type GuildValidationDependencies,
+} from "#src/league/tasks/cleanup/validate-data.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+} from "#src/testing/test-ids.ts";
+
+const { prisma } = createTestDatabase("validate-data-deletion");
+
+// Ascending, because the cleanup walks stored guilds in `serverId` order: the
+// first id is the one a test can put a fault on and still prove the run
+// reached the second.
+const FIRST = testGuildId("11");
+const SECOND = testGuildId("12");
+
+const ACTOR = testAccountId("900");
+const CHANNEL = testChannelId("100");
+
+/** A live channel, so the channel half of the job deletes nothing. */
+const liveChannel: DiscordChannel = {
+  id: CHANNEL,
+  name: "general",
+  type: 0,
+  guild_id: FIRST,
+  permission_overwrites: [],
+};
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+async function seedGuild(serverId: DiscordGuildId): Promise<void> {
+  const now = new Date();
+  const player = await prisma.player.create({
+    data: {
+      alias: `player-${serverId}`,
+      discordId: ACTOR,
+      serverId,
+      creatorDiscordId: ACTOR,
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+  await prisma.subscription.create({
+    data: {
+      playerId: player.id,
+      channelId: CHANNEL,
+      serverId,
+      creatorDiscordId: ACTOR,
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+  await prisma.serverPermission.create({
+    data: {
+      serverId,
+      discordUserId: ACTOR,
+      permission: "CREATE_COMPETITION",
+      grantedBy: ACTOR,
+      grantedAt: now,
+    },
+  });
+  await prisma.guildPermissionError.create({
+    data: {
+      serverId,
+      channelId: CHANNEL,
+      errorType: "channel_missing",
+      firstOccurrence: now,
+      lastOccurrence: now,
+    },
+  });
+}
+
+type GuildRowCounts = {
+  subscriptions: number;
+  permissions: number;
+  permissionErrors: number;
+};
+
+async function countsFor(serverId: DiscordGuildId): Promise<GuildRowCounts> {
+  const [subscriptions, permissions, permissionErrors] = await Promise.all([
+    prisma.subscription.count({ where: { serverId } }),
+    prisma.serverPermission.count({ where: { serverId } }),
+    prisma.guildPermissionError.count({ where: { serverId } }),
+  ]);
+  return { subscriptions, permissions, permissionErrors };
+}
+
+const SEEDED: GuildRowCounts = {
+  subscriptions: 1,
+  permissions: 1,
+  permissionErrors: 1,
+};
+const EMPTY: GuildRowCounts = {
+  subscriptions: 0,
+  permissions: 0,
+  permissionErrors: 0,
+};
+
+function dependencies(input: {
+  db?: ExtendedPrismaClient;
+  /** Guilds Discord confirms Scout is still in. Everything else is orphaned. */
+  present?: readonly string[];
+  /** Guilds whose confirmation fails outright. */
+  unreachable?: readonly string[];
+}): GuildValidationDependencies {
+  return {
+    db: input.db ?? prisma,
+    // No live install rows: every stored guild is a deletion candidate that
+    // has to be confirmed against Discord one at a time.
+    installedAmong: () => Promise.resolve(new Set()),
+    isInstalled: (guildId) => {
+      if (input.unreachable?.includes(guildId) === true) {
+        return Promise.reject(
+          new DiscordUpstreamError("http_error", "Discord is down", 503),
+        );
+      }
+      return Promise.resolve(input.present?.includes(guildId) === true);
+    },
+    readChannel: () => Promise.resolve(liveChannel),
+  };
+}
+
+/**
+ * A client that fails one guild's permission-error delete.
+ *
+ * A Prisma query extension rather than a hand-rolled double: it runs inside
+ * the real transaction, so the rollback under test is Postgres's own and not
+ * something this file simulates.
+ */
+function faultOnPermissionErrorDelete(
+  serverId: DiscordGuildId,
+): ExtendedPrismaClient {
+  return prisma.$extends({
+    query: {
+      guildPermissionError: {
+        deleteMany({ args, query }) {
+          if (args.where?.serverId === serverId) {
+            throw new Error("simulated database fault");
+          }
+          return query(args);
+        },
+      },
+    },
+  });
+}
+
+beforeEach(async () => {
+  await prisma.guildPermissionError.deleteMany();
+  await prisma.serverPermission.deleteMany();
+  await prisma.subscription.deleteMany();
+  await prisma.player.deleteMany();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("runDataValidation deletion blast radius", () => {
+  test("a confirmed-gone guild loses its rows and only its rows", async () => {
+    await seedGuild(FIRST);
+    await seedGuild(SECOND);
+
+    await runDataValidation(client, dependencies({ present: [SECOND] }));
+
+    expect(await countsFor(FIRST)).toEqual(EMPTY);
+    expect(await countsFor(SECOND)).toEqual(SEEDED);
+  });
+
+  test("a guild Discord still has keeps everything", async () => {
+    await seedGuild(FIRST);
+
+    await runDataValidation(client, dependencies({ present: [FIRST] }));
+
+    expect(await countsFor(FIRST)).toEqual(SEEDED);
+  });
+
+  test("an unreachable Discord mid-batch deletes nothing at all", async () => {
+    // The orphan list is resolved in full before the first delete, so an
+    // outage on the second guild must not cost the first guild its rows —
+    // "Scout could not ask" is never "Scout was removed".
+    await seedGuild(FIRST);
+    await seedGuild(SECOND);
+
+    await expect(
+      runDataValidation(client, dependencies({ unreachable: [SECOND] })),
+    ).rejects.toBeInstanceOf(DiscordUpstreamError);
+
+    expect(await countsFor(FIRST)).toEqual(SEEDED);
+    expect(await countsFor(SECOND)).toEqual(SEEDED);
+  });
+});
+
+describe("runDataValidation partial-failure isolation", () => {
+  test("a database fault leaves that guild whole and still clears the next", async () => {
+    // FIRST is walked first and faults on the LAST of its three deletes, so
+    // the two that already succeeded have to be rolled back — a guild with no
+    // subscriptions but an intact permission table is exactly the half-state
+    // the transaction exists to prevent.
+    await seedGuild(FIRST);
+    await seedGuild(SECOND);
+
+    await runDataValidation(
+      client,
+      dependencies({ db: faultOnPermissionErrorDelete(FIRST) }),
+    );
+
+    expect(await countsFor(FIRST)).toEqual(SEEDED);
+    // ...and the run kept going rather than dying on the first guild.
+    expect(await countsFor(SECOND)).toEqual(EMPTY);
+  });
+
+  test("the whole batch failing still leaves every guild whole", async () => {
+    await seedGuild(FIRST);
+    await seedGuild(SECOND);
+
+    await runDataValidation(
+      client,
+      dependencies({
+        db: prisma.$extends({
+          query: {
+            guildPermissionError: {
+              deleteMany() {
+                throw new Error("simulated database fault");
+              },
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(await countsFor(FIRST)).toEqual(SEEDED);
+    expect(await countsFor(SECOND)).toEqual(SEEDED);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/validate-data.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/validate-data.ts
@@ -11,7 +11,7 @@ import {
   DiscordChannelIdSchema,
   DiscordGuildIdSchema,
 } from "@scout-for-lol/data/index.ts";
-import { prisma } from "#src/database/index.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { getCompetitionsByChannelId } from "#src/database/competition/queries.ts";
 import { botRest } from "#src/lib/discord/bot-rest.ts";
 import type { DiscordChannel } from "#src/lib/discord/bot-rest-schemas.ts";
@@ -31,10 +31,14 @@ import { createLogger } from "#src/logger.ts";
 const logger = createLogger("cleanup-validate-data");
 
 /**
- * The two guild-presence questions this cleanup asks, injectable so the
- * destructive path can be exercised without Discord.
+ * The database and the two guild-presence questions this cleanup asks,
+ * injectable so the destructive path can be exercised without Discord — and,
+ * because deleting is the whole point of this job, against a real schema
+ * rather than against a mock that cannot roll a transaction back.
  */
 export type GuildValidationDependencies = {
+  /** The database every read and every delete in this job goes through. */
+  readonly db: ExtendedPrismaClient;
   /** Which of these guilds have a live install row. One query, no Discord. */
   readonly installedAmong: (guildIds: string[]) => Promise<Set<string>>;
   /**
@@ -56,6 +60,7 @@ export type GuildValidationDependencies = {
 
 export function defaultGuildValidationDependencies(): GuildValidationDependencies {
   return {
+    db: prisma,
     installedAmong: async (guildIds) => await installedGuildIdsAmong(guildIds),
     isInstalled: async (guildId) => await isScoutInstalledInGuild(guildId),
     readChannel: async (channelId) => await botRest().channel(channelId),
@@ -143,10 +148,13 @@ async function validateGuilds(
   logger.info("[DataValidation] Validating guilds...");
 
   try {
-    // Get all unique guild IDs from subscriptions
-    const storedGuilds = await prisma.subscription.findMany({
+    // Get all unique guild IDs from subscriptions. Ordered so a run that dies
+    // partway through is resumable in the same order rather than in whatever
+    // order the planner happened to produce.
+    const storedGuilds = await dependencies.db.subscription.findMany({
       select: { serverId: true },
       distinct: ["serverId"],
+      orderBy: { serverId: "asc" },
     });
 
     const storedGuildIds = storedGuilds.map((s) => s.serverId);
@@ -168,10 +176,13 @@ async function validateGuilds(
       `[DataValidation] ⚠️  Found ${orphanedGuildIds.length.toString()} orphaned guild(s)`,
     );
 
-    // Clean up each orphaned guild
+    // Clean up each orphaned guild. One guild's failure is isolated here and
+    // nowhere below: the cleanup itself no longer catches, so this is the only
+    // place that decides to keep going, and it decides that having seen the
+    // error rather than in place of seeing it.
     for (const guildId of orphanedGuildIds) {
       try {
-        await cleanupOrphanedGuild(guildId);
+        await cleanupOrphanedGuild(dependencies.db, guildId);
       } catch (error) {
         logger.error(
           `[DataValidation] Error cleaning up guild ${guildId}:`,
@@ -180,6 +191,7 @@ async function validateGuilds(
         Sentry.captureException(error, {
           tags: { source: "guild-cleanup", guildId },
         });
+        guildDataCleanupTotal.inc({ data_type: "all", status: "failed" });
         // Continue with other guilds
       }
     }
@@ -194,70 +206,79 @@ async function validateGuilds(
 }
 
 /**
- * Clean up data for a guild the bot is no longer in
+ * Delete one confirmed-gone guild's operational data, all or nothing.
+ *
+ * The three deletes are one transaction, for the same reason
+ * `cleanup/remove-guild.ts` uses one: they are a single decision ("Scout is no
+ * longer in this server"), and half of it is a worse state than either whole.
+ * Run independently, a fault after the first delete left the guild with no
+ * subscriptions and an intact permission table — Scout stops reporting, the
+ * dashboard still lists collaborators, and the next hourly pass would have to
+ * rediscover a half-deleted guild to finish the job.
+ *
+ * It also no longer catches its own errors. Swallowing them here made the
+ * caller's per-guild handler unreachable, so a database fault was recorded as
+ * a successful cleanup and the counts silently came back zero; the caller is
+ * the one that knows there are other guilds to get to.
  */
-async function cleanupOrphanedGuild(serverId: string): Promise<void> {
+async function cleanupOrphanedGuild(
+  db: ExtendedPrismaClient,
+  serverId: string,
+): Promise<void> {
   logger.info(`[DataValidation] Cleaning up orphaned guild ${serverId}`);
 
-  try {
-    const guildId = DiscordGuildIdSchema.parse(serverId);
+  const guildId = DiscordGuildIdSchema.parse(serverId);
 
-    // Delete subscriptions
-    const deletedSubs = await prisma.subscription.deleteMany({
+  const deleted = await db.$transaction(async (tx) => {
+    const subscriptions = await tx.subscription.deleteMany({
       where: { serverId: guildId },
     });
-
-    if (deletedSubs.count > 0) {
-      logger.info(
-        `[DataValidation]   Deleted ${deletedSubs.count.toString()} subscription(s)`,
-      );
-      discordSubscriptionsCleanedTotal.inc(
-        { reason: "periodic_validation_guild" },
-        deletedSubs.count,
-      );
-      guildDataCleanupTotal.inc({
-        data_type: "subscriptions",
-        status: "success",
-      });
-    }
-
-    // Delete server permissions
-    const deletedPerms = await prisma.serverPermission.deleteMany({
+    const permissions = await tx.serverPermission.deleteMany({
       where: { serverId: guildId },
     });
-
-    if (deletedPerms.count > 0) {
-      logger.info(
-        `[DataValidation]   Deleted ${deletedPerms.count.toString()} permission(s)`,
-      );
-      guildDataCleanupTotal.inc({
-        data_type: "permissions",
-        status: "success",
-      });
-    }
-
-    // Delete permission error records
-    const deletedErrors = await prisma.guildPermissionError.deleteMany({
+    const permissionErrors = await tx.guildPermissionError.deleteMany({
       where: { serverId: guildId },
     });
+    return {
+      subscriptions: subscriptions.count,
+      permissions: permissions.count,
+      permissionErrors: permissionErrors.count,
+    };
+  });
 
-    if (deletedErrors.count > 0) {
-      logger.info(
-        `[DataValidation]   Deleted ${deletedErrors.count.toString()} error record(s)`,
-      );
-    }
-
-    logger.info(`[DataValidation] ✅ Cleaned up guild ${serverId}`);
-  } catch (error) {
-    logger.error(
-      `[DataValidation] Error cleaning up guild ${serverId}:`,
-      getErrorMessage(error),
+  // Counted only once the transaction committed: a rolled-back delete removed
+  // nothing, and a metric that says otherwise is worse than no metric.
+  if (deleted.subscriptions > 0) {
+    logger.info(
+      `[DataValidation]   Deleted ${deleted.subscriptions.toString()} subscription(s)`,
     );
-    Sentry.captureException(error, {
-      tags: { source: "cleanup-orphaned-guild", serverId },
+    discordSubscriptionsCleanedTotal.inc(
+      { reason: "periodic_validation_guild" },
+      deleted.subscriptions,
+    );
+    guildDataCleanupTotal.inc({
+      data_type: "subscriptions",
+      status: "success",
     });
-    guildDataCleanupTotal.inc({ data_type: "all", status: "failed" });
   }
+
+  if (deleted.permissions > 0) {
+    logger.info(
+      `[DataValidation]   Deleted ${deleted.permissions.toString()} permission(s)`,
+    );
+    guildDataCleanupTotal.inc({
+      data_type: "permissions",
+      status: "success",
+    });
+  }
+
+  if (deleted.permissionErrors > 0) {
+    logger.info(
+      `[DataValidation]   Deleted ${deleted.permissionErrors.toString()} error record(s)`,
+    );
+  }
+
+  logger.info(`[DataValidation] ✅ Cleaned up guild ${serverId}`);
 }
 
 /**
@@ -302,13 +323,13 @@ export async function resolveOrphanedChannelIds(
  */
 async function validateChannels(
   client: Client,
-  dependencies: Pick<GuildValidationDependencies, "readChannel">,
+  dependencies: Pick<GuildValidationDependencies, "db" | "readChannel">,
 ): Promise<void> {
   logger.info("[DataValidation] Validating channels...");
 
   try {
     // Get all unique channel IDs from subscriptions
-    const storedChannels = await prisma.subscription.findMany({
+    const storedChannels = await dependencies.db.subscription.findMany({
       select: { channelId: true },
       distinct: ["channelId"],
     });
@@ -332,7 +353,7 @@ async function validateChannels(
     );
 
     // Clean up orphaned channels and notify owners (grouped by owner)
-    await cleanupOrphanedChannels(client, orphanedChannels);
+    await cleanupOrphanedChannels(dependencies.db, client, orphanedChannels);
 
     logger.info(
       `[DataValidation] ✅ Cleaned up ${orphanedChannels.length.toString()} orphaned channel(s)`,
@@ -352,6 +373,7 @@ async function validateChannels(
  * Groups notifications by owner to prevent spam
  */
 async function cleanupOrphanedChannels(
+  db: ExtendedPrismaClient,
   client: Client,
   channelIds: string[],
 ): Promise<void> {
@@ -366,7 +388,7 @@ async function cleanupOrphanedChannels(
       const parsedChannelId = DiscordChannelIdSchema.parse(channelId);
 
       // Delete subscriptions for this channel
-      const deletedSubs = await prisma.subscription.deleteMany({
+      const deletedSubs = await db.subscription.deleteMany({
         where: { channelId: parsedChannelId },
       });
 
@@ -382,7 +404,7 @@ async function cleanupOrphanedChannels(
 
       // Get competitions using this channel
       const competitions = await getCompetitionsByChannelId(
-        prisma,
+        db,
         parsedChannelId,
       );
 

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest.test.ts
@@ -136,6 +136,48 @@ describe("createBotRestReader caching", () => {
     await expect(harness.rest.guildMember(GUILD, USER)).resolves.not.toBeNull();
   });
 
+  test("an absent guild is never retained, while a present one is", async () => {
+    // The install check is the one read whose negative a user action
+    // invalidates on the spot: adding Scout to a server cannot evict a cache
+    // it does not touch, so holding "not installed" for the TTL blanks a
+    // dashboard the user just earned.
+    let present = false;
+    const clock = { value: 0 };
+    const harness = reader(
+      () =>
+        present
+          ? Promise.resolve({ id: GUILD, name: "guild", owner_id: USER })
+          : Promise.reject(new ApiError(10_004, 404)),
+      clock,
+    );
+
+    await expect(harness.rest.guildExists(GUILD)).resolves.toBe(false);
+    await expect(harness.rest.guildExists(GUILD)).resolves.toBe(false);
+    expect(harness.routes).toHaveLength(2);
+
+    present = true;
+    await expect(harness.rest.guildExists(GUILD)).resolves.toBe(true);
+    await expect(harness.rest.guildExists(GUILD)).resolves.toBe(true);
+    expect(harness.routes).toHaveLength(3);
+  });
+
+  test("concurrent install checks still collapse into one request", async () => {
+    // Declining to cache the negative must not cost the request collapsing the
+    // cache also provides.
+    const arrived = Promise.withResolvers<undefined>();
+    const harness = reader(async () => {
+      await arrived.promise;
+      throw new ApiError(10_004, 404);
+    });
+
+    const first = harness.rest.guildExists(GUILD);
+    const second = harness.rest.guildExists(GUILD);
+    arrived.resolve(undefined);
+    await expect(first).resolves.toBe(false);
+    await expect(second).resolves.toBe(false);
+    expect(harness.routes).toHaveLength(1);
+  });
+
   test("caches per guild, not globally", async () => {
     const harness = reader(() => Promise.resolve(ROLES));
     await harness.rest.guildRoles(GUILD);

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/bot-rest.ts
@@ -36,10 +36,14 @@
  * - a single member lookup — {@link MEMBERSHIP_TTL_MS} (30s). Shorter, because
  *   this one gates access decisions (the last-role-manager check, Activity
  *   membership): losing access should not lag by a whole minute.
- * - guild existence — {@link INSTALL_TTL_MS} (60s). Only ever consulted after
- *   the `GuildInstall` port has already said "no row" (see
- *   `installed-guilds.ts`), and a fresh install writes that row immediately, so
- *   this TTL delays nothing a user waits on.
+ * - guild existence — {@link INSTALL_TTL_MS} (60s), and **positive answers
+ *   only**. `installed-guilds.ts` confirms every install check against this
+ *   read, in both directions, so a retained "Scout is not in that guild" would
+ *   be served for a whole minute after the user installed Scout — the one
+ *   window where a stale answer is both wrong and immediately visible. See
+ *   {@link cachePositiveOnly}. A retained *positive* is harmless in the same
+ *   way the other TTLs are: removal is a rare, deliberate act, and the previous
+ *   gateway-cache answer was staler still.
  * - user profiles — {@link USER_TTL_MS} (5m), matching the display-name cache
  *   this replaced. Names and avatars are cosmetic.
  *
@@ -68,7 +72,10 @@ import {
   type DiscordUser,
 } from "#src/lib/discord/bot-rest-schemas.ts";
 import { createLogger } from "#src/logger.ts";
-import { createBoundedAsyncCache } from "#src/utils/bounded-async-cache.ts";
+import {
+  createBoundedAsyncCache,
+  type BoundedAsyncCache,
+} from "#src/utils/bounded-async-cache.ts";
 
 const logger = createLogger("discord-bot-rest");
 
@@ -199,6 +206,54 @@ async function read<Parsed>(
 }
 
 /**
+ * Private signal that a load found nothing, so nothing should be retained.
+ *
+ * Never escapes {@link cachePositiveOnly}.
+ */
+class AbsentAnswer extends Error {
+  constructor() {
+    super("Discord answered absent; deliberately not cached");
+    this.name = "AbsentAnswer";
+  }
+}
+
+/**
+ * Memoize a read's positive answers and none of its negatives.
+ *
+ * For the one read whose negative a user action invalidates immediately.
+ * Someone who opens the dashboard a second before adding Scout to their server
+ * would otherwise be told "Scout is not installed in that guild" for the rest
+ * of {@link INSTALL_TTL_MS} — the install itself cannot clear a cache it never
+ * touches, so the only recourse is to wait out a minute of a screen saying the
+ * thing they just did did not happen.
+ *
+ * The mechanism is the shared primitive's existing contract rather than a
+ * change to it: {@link createBoundedAsyncCache} caches what a load *resolves*
+ * to and retains nothing when it rejects, while still collapsing concurrent
+ * callers onto one in-flight promise. So an absent answer leaves the cache as a
+ * private {@link AbsentAnswer} rejection and becomes `null` again out here.
+ * Adding a "don't cache this value" option to the primitive instead would push
+ * a decision that belongs to one call site into every other cache built from
+ * it.
+ */
+async function cachePositiveOnly<Result>(
+  cache: BoundedAsyncCache<Result>,
+  key: string,
+  load: () => Promise<Result | null>,
+): Promise<Result | null> {
+  try {
+    return await cache(key, async () => {
+      const result = await load();
+      if (result === null) throw new AbsentAnswer();
+      return result;
+    });
+  } catch (error) {
+    if (error instanceof AbsentAnswer) return null;
+    throw error;
+  }
+}
+
+/**
  * The authoritative Discord reads a web request may need.
  *
  * A `null` result always means Discord said the resource does not exist —
@@ -284,7 +339,9 @@ export function createBotRestReader(
     now,
   });
 
-  const guildCache = createBoundedAsyncCache<DiscordGuildSummary | null>(
+  // Non-nullable on purpose: absence is never a cached value here. See
+  // {@link cachePositiveOnly}.
+  const guildCache = createBoundedAsyncCache<DiscordGuildSummary>(
     cacheOptions(INSTALL_TTL_MS),
   );
   const channelCache = createBoundedAsyncCache<DiscordGuildChannel[] | null>(
@@ -323,7 +380,8 @@ export function createBotRestReader(
     });
 
   const readGuild = async (guildId: string) =>
-    await guildCache(
+    await cachePositiveOnly(
+      guildCache,
       guildId,
       async () =>
         await read(get, {

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/installed-guilds.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/installed-guilds.test.ts
@@ -12,7 +12,12 @@ import {
   isScoutInstalledInGuild,
   type InstalledGuildsDependencies,
 } from "#src/lib/discord/installed-guilds.ts";
-import type { BotRestReader } from "#src/lib/discord/bot-rest.ts";
+import {
+  INSTALL_TTL_MS,
+  createBotRestReader,
+  type BotRestGet,
+  type BotRestReader,
+} from "#src/lib/discord/bot-rest.ts";
 import { createTestDatabase } from "#src/testing/test-database.ts";
 import { testAccountId, testGuildId } from "#src/testing/test-ids.ts";
 
@@ -22,6 +27,7 @@ const INSTALLED = testGuildId("701");
 const REMOVED = testGuildId("702");
 const ABSENT = testGuildId("703");
 const DEV_ONLY = testGuildId("704");
+const JUST_INSTALLED = testGuildId("705");
 
 type RestStub = {
   reader: BotRestReader;
@@ -193,6 +199,109 @@ describe("isScoutInstalledInGuild", () => {
       isScoutInstalledInGuild(DEV_ONLY, dependencies(rest.reader, [DEV_ONLY])),
     ).resolves.toBe(true);
     expect(rest.calls).toEqual([]);
+  });
+});
+
+/** Shaped like discord.js `DiscordAPIError` for Unknown Guild. */
+class UnknownGuildError extends Error {
+  readonly code = 10_004;
+  readonly status = 404;
+  constructor() {
+    super("Unknown Guild");
+  }
+}
+
+describe("a freshly installed guild is visible immediately", () => {
+  beforeEach(async () => {
+    await prisma.guildInstall.deleteMany();
+  });
+
+  /**
+   * The REAL reader, because the defect this pins lives in its cache rather
+   * than in the port above it.
+   *
+   * Confirming a live row against Discord (which this port now does in both
+   * directions) made a cached negative user-visible for the first time: a
+   * person who opened the dashboard seconds before adding Scout, then
+   * installed it, would keep being told "Scout is not installed in that
+   * guild" until the entry aged out. Nothing the install does can evict it,
+   * so the only remedy was to wait. Negative answers are therefore never
+   * retained.
+   */
+  test("a negative answer from before the install is not held against it", async () => {
+    const clock = { value: 0 };
+    const routes: string[] = [];
+    let scoutIsInTheGuild = false;
+    const get: BotRestGet = async (route) => {
+      routes.push(route);
+      await Promise.resolve();
+      if (!scoutIsInTheGuild) throw new UnknownGuildError();
+      return {
+        id: JUST_INSTALLED,
+        name: "Server",
+        owner_id: testAccountId("81"),
+      };
+    };
+    const rest = createBotRestReader({
+      get,
+      now: () => clock.value,
+      botUserId: testAccountId("99"),
+    });
+
+    // Someone opens the dashboard for a server Scout is not in yet.
+    await expect(
+      isScoutInstalledInGuild(JUST_INSTALLED, dependencies(rest)),
+    ).resolves.toBe(false);
+
+    // They install Scout: `guildCreate` writes the live row, and Discord now
+    // answers for the guild.
+    await seed(JUST_INSTALLED, null);
+    scoutIsInTheGuild = true;
+    clock.value += 1000;
+    expect(clock.value).toBeLessThan(INSTALL_TTL_MS);
+
+    await expect(
+      isScoutInstalledInGuild(JUST_INSTALLED, dependencies(rest)),
+    ).resolves.toBe(true);
+    // The second check really did ask Discord again rather than replay the
+    // 404 — that is the whole property.
+    expect(routes).toHaveLength(2);
+  });
+
+  test("the positive answer IS cached, so the window costs no extra requests", async () => {
+    const clock = { value: 0 };
+    const routes: string[] = [];
+    const get: BotRestGet = async (route) => {
+      routes.push(route);
+      await Promise.resolve();
+      return {
+        id: INSTALLED,
+        name: "Server",
+        owner_id: testAccountId("81"),
+      };
+    };
+    const rest = createBotRestReader({
+      get,
+      now: () => clock.value,
+      botUserId: testAccountId("99"),
+    });
+    await seed(INSTALLED, null);
+
+    await expect(
+      isScoutInstalledInGuild(INSTALLED, dependencies(rest)),
+    ).resolves.toBe(true);
+    clock.value += INSTALL_TTL_MS - 1;
+    await expect(
+      isScoutInstalledInGuild(INSTALLED, dependencies(rest)),
+    ).resolves.toBe(true);
+    expect(routes).toHaveLength(1);
+
+    // ...and it still expires on schedule, so a removal is not cached forever.
+    clock.value += 2;
+    await expect(
+      isScoutInstalledInGuild(INSTALLED, dependencies(rest)),
+    ).resolves.toBe(true);
+    expect(routes).toHaveLength(2);
   });
 });
 

--- a/packages/scout-for-lol/packages/backend/src/lib/discord/postable-channels.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord/postable-channels.ts
@@ -16,6 +16,7 @@
 import { ChannelType, PermissionFlagsBits } from "discord.js";
 import type { DiscordGuildId } from "@scout-for-lol/data";
 import { botRest, type BotRestReader } from "#src/lib/discord/bot-rest.ts";
+import type { DiscordGuildChannel } from "#src/lib/discord/bot-rest-schemas.ts";
 import {
   computeChannelPermissions,
   hasPermission,
@@ -49,17 +50,38 @@ const POSTABLE_CHANNEL_TYPES = new Set<number>([
 ]);
 
 /**
- * Text channels in `guildId` that the bot can post to, sorted by name.
+ * One guild's channels plus the verdict that decides which are offerable.
  *
- * Returns `[]` when Discord says Scout is not in the guild — callers have
- * already proved installation, so that is a narrowing, not a decision. A
- * failure to reach Discord throws {@link DiscordUpstreamError} instead, so an
+ * `null` when Discord says Scout is not in the guild.
+ */
+export type GuildChannelPostability = {
+  readonly channels: readonly DiscordGuildChannel[];
+  /** Whether Scout can actually post in this channel, right now. */
+  readonly isPostable: (channel: DiscordGuildChannel) => boolean;
+};
+
+/**
+ * Read a guild's channels and build the postability predicate over them.
+ *
+ * Exported because the picker is not the only surface that must apply it: the
+ * tRPC channel guard has to accept exactly the channels the picker offers, and
+ * a second implementation of "can Scout post here" drifts. When it did, the
+ * guard checked only the channel's *type* — so every mutation accepted a
+ * channel the picker had refused on permissions, and the subscription was
+ * created against a channel Scout can never post in, failing silently at
+ * delivery time instead of visibly at creation time.
+ *
+ * The permission answer needs Scout's *effective* permissions, which the
+ * gateway used to compute: over REST that is three TTL-cached reads combined
+ * by `channel-permissions.ts`.
+ *
+ * Throws {@link DiscordUpstreamError} when Discord cannot be reached, so an
  * outage is never presented as "this server has no channels".
  */
-export async function listPostableChannels(
+export async function readGuildChannelPostability(
   guildId: DiscordGuildId,
   dependencies: PostableChannelDependencies = defaultDependencies(),
-): Promise<PostableChannel[]> {
+): Promise<GuildChannelPostability | null> {
   const { rest } = dependencies;
   const [channels, roles, me] = await Promise.all([
     rest.guildChannels(guildId),
@@ -68,14 +90,15 @@ export async function listPostableChannels(
   ]);
   if (channels === null || roles === null || me === null) {
     logger.warn("Discord reports Scout is not in the guild", { guildId });
-    return [];
+    return null;
   }
 
   const rolePermissions = new Map(
     roles.map((role) => [role.id, role.permissions]),
   );
-  const postable = channels
-    .filter((channel) => {
+  return {
+    channels,
+    isPostable: (channel) => {
       if (!POSTABLE_CHANNEL_TYPES.has(channel.type)) return false;
       // Only offer channels the bot can actually post in. Without this we'd
       // show channels Scout could read but never message.
@@ -92,7 +115,27 @@ export async function listPostableChannels(
         hasPermission(permissions, PermissionFlagsBits.ViewChannel) &&
         hasPermission(permissions, PermissionFlagsBits.SendMessages)
       );
-    })
+    },
+  };
+}
+
+/**
+ * Text channels in `guildId` that the bot can post to, sorted by name.
+ *
+ * Returns `[]` when Discord says Scout is not in the guild — callers have
+ * already proved installation, so that is a narrowing, not a decision. A
+ * failure to reach Discord throws {@link DiscordUpstreamError} instead, so an
+ * outage is never presented as "this server has no channels".
+ */
+export async function listPostableChannels(
+  guildId: DiscordGuildId,
+  dependencies: PostableChannelDependencies = defaultDependencies(),
+): Promise<PostableChannel[]> {
+  const guild = await readGuildChannelPostability(guildId, dependencies);
+  if (guild === null) return [];
+
+  const postable = guild.channels
+    .filter((channel) => guild.isPostable(channel))
     .map((channel) => ({
       id: channel.id,
       name: channel.name,

--- a/packages/scout-for-lol/packages/backend/src/reports/duckdb/lake-capability.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/duckdb/lake-capability.test.ts
@@ -1,0 +1,122 @@
+/**
+ * A role that does not declare lake access cannot read the lake anyway.
+ *
+ * The defect this closes was a composition defect, not a query bug. The boot
+ * gate in `runtime/subsystems.ts` verifies a published build only for roles
+ * whose `reportLakeAccess` is true, so a role that declares `false` and then
+ * reads the lake regardless is invisible to it — declaring `false` is what
+ * skips the check. The gateway role did exactly that: `/scout ask` and the
+ * Dare commands execute the Explore agent in the process that received the
+ * interaction, which is a synchronous DuckDB read with no Temporal queue in
+ * it, and a lake-less pod answered every question "no games found" and called
+ * it a success.
+ *
+ * The table now says what the gateway does (`runtime-role.test.ts` pins it),
+ * so no role sets this false today. That is the intended end state, not a
+ * reason to drop the guard — it is what makes the next role's claim true, or
+ * makes it fail loudly on the first read instead of answering nothing.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, test } from "vitest";
+import configuration from "#src/configuration.ts";
+import { RuntimeCapabilityError } from "#src/configuration/runtime-capability-error.ts";
+import {
+  SCOUT_RUNTIME_ROLES,
+  scoutRuntimeCapabilities,
+} from "#src/configuration/runtime-role.ts";
+import { ensureLakeScaffold } from "#src/report-lake/paths.ts";
+import {
+  assertReportLakeAccess,
+  resolveLakeFiles,
+} from "#src/reports/duckdb/lake.ts";
+
+const roots: string[] = [];
+
+async function emptyLake(): Promise<string> {
+  const lakeDir = await mkdtemp(path.join(tmpdir(), "scout-lake-capability-"));
+  roots.push(lakeDir);
+  await ensureLakeScaffold(lakeDir);
+  return lakeDir;
+}
+
+afterAll(async () => {
+  for (const root of roots) {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+describe("the lake read site", () => {
+  test("refuses a role without reportLakeAccess", async () => {
+    // Driven through the real `resolveLakeFiles`, because the assertion is
+    // only worth anything if it sits on the path every reader takes.
+    const lakeDir = await emptyLake();
+    await expect(
+      resolveLakeFiles(lakeDir, { reportLakeAccess: false }),
+    ).rejects.toBeInstanceOf(RuntimeCapabilityError);
+  });
+
+  test("names the capability it refused on", async () => {
+    const lakeDir = await emptyLake();
+    await expect(
+      resolveLakeFiles(lakeDir, { reportLakeAccess: false }),
+    ).rejects.toMatchObject({ capability: "reportLakeAccess" });
+  });
+
+  test("refuses BEFORE touching the directory, so an absent lake is not the signal", async () => {
+    // A missing directory must not be what makes this fail: the whole problem
+    // is that a missing directory does NOT fail, it returns zero rows.
+    await expect(
+      resolveLakeFiles("/nonexistent/lake/for/a/roleless/pod", {
+        reportLakeAccess: false,
+      }),
+    ).rejects.toBeInstanceOf(RuntimeCapabilityError);
+  });
+
+  test("allows a role that declares it, even with nothing published yet", async () => {
+    // Absence stays the boot gate's business; this guard is about the claim.
+    const lakeDir = await emptyLake();
+    const files = await resolveLakeFiles(lakeDir, { reportLakeAccess: true });
+    expect(files.matchesParquet).toEqual([]);
+  });
+
+  test("defaults to this process's own declared capabilities", async () => {
+    const lakeDir = await emptyLake();
+    // Tests run as the default `combined` role, which declares access.
+    expect(configuration.runtimeCapabilities.reportLakeAccess).toBe(true);
+    await expect(resolveLakeFiles(lakeDir)).resolves.toMatchObject({
+      matchesParquet: [],
+    });
+  });
+});
+
+describe("assertReportLakeAccess", () => {
+  test("passes for every role in the table", () => {
+    // No role declares false today — the gateway was the last one, and it read
+    // the lake anyway. Pinned so that adding a role without lake access is a
+    // deliberate act that also has to answer for this guard.
+    for (const role of SCOUT_RUNTIME_ROLES) {
+      expect(() =>
+        assertReportLakeAccess(scoutRuntimeCapabilities(role)),
+      ).not.toThrow();
+    }
+  });
+
+  test("throws a neutral capability error, not a transport-shaped one", () => {
+    // Deliberately NOT customs' HTTP-shaped refusal: this guard sits on a path
+    // reached from Discord interactions, Temporal activities and tRPC alike,
+    // so it names a capability and lets each transport map it.
+    const thrown = (() => {
+      try {
+        assertReportLakeAccess({ reportLakeAccess: false });
+      } catch (error) {
+        return error;
+      }
+      throw new Error("expected the read to be refused");
+    })();
+    expect(thrown).toBeInstanceOf(RuntimeCapabilityError);
+    expect(thrown).toBeInstanceOf(Error);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/reports/duckdb/lake.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/duckdb/lake.ts
@@ -1,4 +1,7 @@
 import path from "node:path";
+import configuration from "#src/configuration.ts";
+import { RuntimeCapabilityError } from "#src/configuration/runtime-capability-error.ts";
+import type { ScoutRuntimeCapabilities } from "#src/configuration/runtime-role.ts";
 import { readCurrentBuildDir } from "#src/report-lake/paths.ts";
 import {
   COMPETITION_RANK_HISTORY_LAKE_COLUMNS,
@@ -81,7 +84,47 @@ async function globParquet(root: string, table: string): Promise<string[]> {
   return files.toSorted();
 }
 
-export async function resolveLakeFiles(lakeDir: string): Promise<LakeFiles> {
+/**
+ * Refuse to resolve lake files on a role that does not declare lake access.
+ *
+ * This is a *structural* rule, and it is here rather than in `runtime/`
+ * because of how the boot gate failed. `subsystems.ts` verifies a published
+ * build only for roles whose `reportLakeAccess` is true — so the check a role
+ * skips by declaring `false` is the very check that would have caught the
+ * role reading the lake anyway. A capability whose `false` skips a safety
+ * check cannot protect the role that sets it false; only an assertion at the
+ * read site can.
+ *
+ * And the read site is where the damage is silent. An unmounted or
+ * unpublished lake is not an error for DuckDB — it scans zero parquet files
+ * and returns zero rows — so the caller does not fail, it reports "no games
+ * found" and records a successful run. Every in-process lake reader funnels
+ * through {@link resolveLakeFiles}, which is what makes one assertion here
+ * cover Explore turns, report runs, dare settlement, parlay generation and
+ * the consumer profile alike.
+ *
+ * No role in the table sets this false today, and that is the intended end
+ * state rather than the reason to drop the guard: the table is the claim, and
+ * this is what makes a future role's claim true or make it fail loudly.
+ */
+export function assertReportLakeAccess(
+  capabilities: Pick<ScoutRuntimeCapabilities, "reportLakeAccess">,
+): void {
+  if (capabilities.reportLakeAccess) return;
+  throw new RuntimeCapabilityError(
+    "reportLakeAccess",
+    "This process's runtime role does not declare reportLakeAccess, so it must not query the report lake. An unmounted or unpublished lake answers every query with zero rows instead of failing, which a caller records as a successful run that found nothing.",
+  );
+}
+
+export async function resolveLakeFiles(
+  lakeDir: string,
+  capabilities: Pick<
+    ScoutRuntimeCapabilities,
+    "reportLakeAccess"
+  > = configuration.runtimeCapabilities,
+): Promise<LakeFiles> {
+  assertReportLakeAccess(capabilities);
   const buildDir = await readCurrentBuildDir(lakeDir);
   const [
     matchesStaging,

--- a/packages/scout-for-lol/packages/backend/src/runtime/boot.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/runtime/boot.test.ts
@@ -127,11 +127,14 @@ describe("scout runtime boot", () => {
     expect(log.boot).not.toContain("discord-gateway");
   });
 
-  test("gateway boots without the product HTTP surface or the lake", async () => {
+  test("gateway boots without the product HTTP surface, but with the lake", async () => {
     const log = await boot("gateway");
     expect(log.boot).toEqual([
       "champion-assets",
       "voice-assistant",
+      // Present because this role answers `/scout ask` and the Dare commands
+      // from the lake in process, not because it runs a Temporal queue.
+      "report-lake",
       "temporal-core",
       "discord-gateway",
       "gateway-ready-reconciliation",
@@ -139,7 +142,6 @@ describe("scout runtime boot", () => {
     ]);
     // It logs in, so it must not pre-mark its own gateway as disabled.
     expect(log.discord).toEqual(["rest-token"]);
-    expect(log.boot).not.toContain("report-lake");
     expect(log.boot).not.toContain("database-seeding");
   });
 

--- a/packages/scout-for-lol/packages/backend/src/runtime/plan.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/runtime/plan.test.ts
@@ -55,6 +55,7 @@ describe("runtime boot order", () => {
     expect(steps).toEqual([
       "champion-assets",
       "voice-assistant",
+      "report-lake",
       "temporal-core",
       "discord-gateway",
       "gateway-ready-reconciliation",
@@ -65,7 +66,12 @@ describe("runtime boot order", () => {
     expect(steps.indexOf("voice-assistant")).toBeLessThan(
       steps.indexOf("discord-gateway"),
     );
-    expect(steps).not.toContain("report-lake");
+    // The lake is settled before the shard connects too: this role answers
+    // `/scout ask` and the Dare commands from the lake, in process, as soon as
+    // the first interaction arrives.
+    expect(steps.indexOf("report-lake")).toBeLessThan(
+      steps.indexOf("discord-gateway"),
+    );
     expect(steps).not.toContain("database-seeding");
   });
 

--- a/packages/scout-for-lol/packages/backend/src/runtime/report-lake-gate.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/runtime/report-lake-gate.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The lake boot gate, in both directions, against real directories.
+ *
+ * The gate had no test at all, which matters more than usual here: it is the
+ * only thing standing between a worker pod with an unmounted volume and an
+ * hour of report runs, parlay generations and dare settlements that each
+ * "succeed" while finding nothing. Nothing below stubs `readCurrentBuildDir` —
+ * the publish protocol it reads (a `CURRENT` pointer naming a non-empty build
+ * directory) is exactly what a mounted volume does or does not have.
+ */
+
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, test } from "vitest";
+import {
+  buildDirPath,
+  ensureLakeScaffold,
+  newBuildId,
+  publishBuild,
+} from "#src/report-lake/paths.ts";
+import { assertPublishedReportLake } from "#src/runtime/report-lake-gate.ts";
+
+const roots: string[] = [];
+
+async function tempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix));
+  roots.push(dir);
+  return dir;
+}
+
+async function emptyLake(): Promise<string> {
+  const lakeDir = await tempDir("scout-lake-gate-");
+  await ensureLakeScaffold(lakeDir);
+  return lakeDir;
+}
+
+/** A lake with one published build, written through the real publish path. */
+async function publishedLake(): Promise<string> {
+  const lakeDir = await emptyLake();
+  const buildId = newBuildId();
+  const dir = buildDirPath(lakeDir, buildId);
+  await mkdir(dir, { recursive: true });
+  await Bun.write(path.join(dir, "manifest.json"), "{}");
+  await publishBuild(lakeDir, buildId);
+  return lakeDir;
+}
+
+afterAll(async () => {
+  for (const root of roots) {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+describe("assertPublishedReportLake", () => {
+  test("refuses to continue when the lake holds no published build", async () => {
+    const lakeDir = await emptyLake();
+    await expect(assertPublishedReportLake({ lakeDir })).rejects.toThrow(
+      "no published build",
+    );
+  });
+
+  test("refuses a directory that was never a lake at all", async () => {
+    // The unmounted-volume case: the path exists because the container created
+    // it, and holds nothing.
+    const lakeDir = await tempDir("scout-lake-gate-bare-");
+    await expect(assertPublishedReportLake({ lakeDir })).rejects.toThrow(
+      "no published build",
+    );
+  });
+
+  test("the refusal names the directory, so the fix is the mount", async () => {
+    const lakeDir = await emptyLake();
+    await expect(assertPublishedReportLake({ lakeDir })).rejects.toThrow(
+      lakeDir,
+    );
+  });
+
+  test("passes once a build has been published", async () => {
+    const lakeDir = await publishedLake();
+    await expect(
+      assertPublishedReportLake({ lakeDir }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("the dev fold-skip policy", () => {
+  test("warns instead of refusing when the fold was skipped", async () => {
+    // `SCOUT_DEV_SKIP_REPORT_LAKE_FOLD` is dev-only (configuration.ts refuses
+    // it anywhere else) and exists so a laptop with no S3 bucket can boot. It
+    // used to skip this check entirely and in silence; the absence is now
+    // still said out loud.
+    const lakeDir = await emptyLake();
+    await expect(
+      assertPublishedReportLake({ lakeDir, onUnpublished: "warn" }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("a published build is verified under the dev policy as well", async () => {
+    const lakeDir = await publishedLake();
+    await expect(
+      assertPublishedReportLake({ lakeDir, onUnpublished: "warn" }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("a CORRUPT lake still fails loudly under the dev policy", async () => {
+    // Absence is negotiable in dev; corruption is not. A CURRENT pointer
+    // naming a build that is gone is a broken internal contract, and the dev
+    // flag is not a licence to serve from one.
+    const lakeDir = await emptyLake();
+    await publishBuild(lakeDir, "a-build-that-was-never-written");
+    await expect(
+      assertPublishedReportLake({ lakeDir, onUnpublished: "warn" }),
+    ).rejects.toThrow();
+  });
+
+  test("an empty CURRENT pointer fails under the dev policy too", async () => {
+    const lakeDir = await emptyLake();
+    await Bun.write(path.join(lakeDir, "CURRENT"), "   \n");
+    await expect(
+      assertPublishedReportLake({ lakeDir, onUnpublished: "warn" }),
+    ).rejects.toThrow("CURRENT pointer");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/runtime/report-lake-gate.ts
+++ b/packages/scout-for-lol/packages/backend/src/runtime/report-lake-gate.ts
@@ -1,0 +1,60 @@
+/**
+ * The boot gate for a role that reads the report lake.
+ *
+ * An empty or unmounted lake directory is not an error condition for DuckDB —
+ * it scans zero parquet files and returns zero rows — so a pod pointed at one
+ * records every report run, parlay generation and dare settlement as a
+ * *successful* run that happened to find nothing. That is the failure this
+ * gate exists to convert into a refusal to start: a pod that cannot answer
+ * correctly must not answer at all.
+ *
+ * Lives in its own module, rather than inline in `subsystems.ts`, for two
+ * reasons. It stays dynamically imported, so a role that never touches the
+ * lake does not load the report-lake paths module; and it can be called
+ * directly against a temp directory, so the gate is provable in both
+ * directions instead of only being reachable through a booting process.
+ */
+
+import { readCurrentBuildDir, resolveLakeDir } from "#src/report-lake/paths.ts";
+import { createLogger } from "#src/logger.ts";
+
+const logger = createLogger("report-lake-gate");
+
+/**
+ * What an unpublished lake means for this process.
+ *
+ * `refuse` is production and every non-dev path. `warn` exists only for
+ * `SCOUT_DEV_SKIP_REPORT_LAKE_FOLD`, which `configuration.ts` refuses outside
+ * `environment=dev` — see {@link assertPublishedReportLake}.
+ */
+export type UnpublishedLakePolicy = "refuse" | "warn";
+
+function unpublishedLakeMessage(lakeDir: string): string {
+  return `The report lake at ${lakeDir} has no published build. A role that reads the lake but does not publish it would answer every query with an empty result and record it as success. Mount the lake volume, or run a role that folds it.`;
+}
+
+/**
+ * Refuse to continue when the lake this process reads has no published build.
+ *
+ * A corrupt lake — an empty `CURRENT` pointer, or one naming a build directory
+ * that is gone — is a different condition and is never softened: that throw
+ * comes out of {@link readCurrentBuildDir} and propagates under either policy.
+ * Only *absence* is negotiable, and only in dev.
+ */
+export async function assertPublishedReportLake(
+  options: {
+    readonly onUnpublished?: UnpublishedLakePolicy;
+    readonly lakeDir?: string;
+  } = {},
+): Promise<void> {
+  const lakeDir = options.lakeDir ?? resolveLakeDir();
+  const current = await readCurrentBuildDir(lakeDir);
+  if (current === undefined) {
+    if (options.onUnpublished === "warn") {
+      logger.warn(`⚠️  ${unpublishedLakeMessage(lakeDir)}`, { lakeDir });
+      return;
+    }
+    throw new Error(unpublishedLakeMessage(lakeDir));
+  }
+  logger.info("🗂️  Report lake build verified", { lakeDir, build: current });
+}

--- a/packages/scout-for-lol/packages/backend/src/runtime/subsystems.ts
+++ b/packages/scout-for-lol/packages/backend/src/runtime/subsystems.ts
@@ -32,29 +32,6 @@ type CompetitionActivityWorker = {
 };
 
 /**
- * Refuse to start a lake-reading role whose lake has no published build.
- *
- * This is the gate for roles that read the lake but do not own its fold. An
- * empty or unmounted lake directory is not an error condition for DuckDB — it
- * scans zero parquet files and returns zero rows — so without this a worker
- * would record every report run, parlay generation and dare settlement as a
- * *successful* run that found nothing. A pod that cannot answer correctly must
- * not answer at all.
- */
-async function assertPublishedReportLake(): Promise<void> {
-  const { readCurrentBuildDir, resolveLakeDir } =
-    await import("#src/report-lake/paths.ts");
-  const lakeDir = resolveLakeDir();
-  const current = await readCurrentBuildDir(lakeDir);
-  if (current === undefined) {
-    throw new Error(
-      `The report lake at ${lakeDir} has no published build. This role reads the lake but does not publish it, so it would answer every query with an empty result and record it as success. Mount the lake volume, or run a role that folds it.`,
-    );
-  }
-  logger.info("🗂️  Report lake build verified", { lakeDir, build: current });
-}
-
-/**
  * Build the production dependency set for one role.
  *
  * The mutable handles are closed over rather than returned, because the boot
@@ -92,11 +69,34 @@ export function scoutRuntimeSubsystems(
         await bootstrapVoiceAssistant();
       },
 
+      /**
+       * Settle the report lake for this role: fold it, or verify someone else
+       * did.
+       *
+       * `SCOUT_DEV_SKIP_REPORT_LAKE_FOLD` skips the *fold* — the step a laptop
+       * with no S3 bucket cannot complete — and deliberately no longer skips
+       * the check that a build exists. Skipping both is what let a dev-skip
+       * process serve an unpublished lake in total silence, which is the exact
+       * failure the gate was written to make loud.
+       *
+       * The gate is downgraded rather than given a second environment
+       * variable, because a second variable would be one nobody sets: dev-web
+       * only ever runs `combined` or `application`, both of which fold, so the
+       * refusing branch is not on its path at all. The only way a developer
+       * reaches the gate is by explicitly asking for a reader role locally,
+       * where refusing to boot would defeat the fold flag's whole purpose. In
+       * dev-skip mode an unpublished lake therefore logs a warning naming the
+       * consequence; outside dev the flag cannot be set (`configuration.ts`
+       * throws), so every deployed pod keeps the refusal unconditionally.
+       */
       "report-lake": async () => {
+        const { assertPublishedReportLake } =
+          await import("#src/runtime/report-lake-gate.ts");
         if (configuration.skipReportLakeFold) {
           logger.warn(
-            "⏭️  Skipping the boot report-lake check (SCOUT_DEV_SKIP_REPORT_LAKE_FOLD)",
+            "⏭️  Skipping the boot report-lake fold (SCOUT_DEV_SKIP_REPORT_LAKE_FOLD)",
           );
+          await assertPublishedReportLake({ onUnpublished: "warn" });
           return;
         }
         if (capabilities.reportLakeFold) {
@@ -105,7 +105,7 @@ export function scoutRuntimeSubsystems(
           await runReportLakeFold();
           return;
         }
-        await assertPublishedReportLake();
+        await assertPublishedReportLake({ onUnpublished: "refuse" });
       },
 
       "temporal-core": async () => {

--- a/packages/scout-for-lol/packages/backend/src/trpc/guild-guard.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/guild-guard.ts
@@ -5,26 +5,21 @@
  * are enforced by the web UI's guild procedures.
  *
  * Both checks read application ports (`installed-guilds.ts` for installation,
- * `bot-rest.ts` for channels) rather than the gateway guild cache, so they
- * answer the same way whether or not this pod holds a gateway connection.
+ * `postable-channels.ts` — over `bot-rest.ts` — for channels) rather than the
+ * gateway guild cache, so they answer the same way whether or not this pod
+ * holds a gateway connection.
  */
 
 import { TRPCError } from "@trpc/server";
-import { ChannelType } from "discord.js";
 import type { User } from "#generated/prisma/client/index.js";
+import type { DiscordGuildId } from "@scout-for-lol/data";
 import { hasAdministrator } from "#src/lib/discord-rest.ts";
-import { botRest } from "#src/lib/discord/bot-rest.ts";
 import { isScoutInstalledInGuild } from "#src/lib/discord/installed-guilds.ts";
+import { readGuildChannelPostability } from "#src/lib/discord/postable-channels.ts";
 import {
   callDiscordForRequest,
   fetchUserGuildsForRequest,
 } from "#src/trpc/discord-upstream.ts";
-
-/** Same open-integer reasoning as the picker's filter in `postable-channels.ts`. */
-const POSTABLE_CHANNEL_TYPES = new Set<number>([
-  ChannelType.GuildText,
-  ChannelType.GuildAnnouncement,
-]);
 
 export async function assertGuildAdmin(params: {
   user: User;
@@ -58,29 +53,34 @@ export async function assertGuildAdmin(params: {
 }
 
 /**
- * Verifies that `channelId` is a postable text/announcement channel inside
- * `guildId`. Without this, an admin of guild A could pass any channel ID
+ * Verifies that `channelId` is a channel inside `guildId` that Scout can
+ * actually post in. Without this, an admin of guild A could pass any channel ID
  * (even one belonging to guild B) into a subscription mutation and have
  * Scout's poll cycle later post into that foreign channel — `assertGuildAdmin`
  * alone is not enough because it only proves admin on the *requested* guild.
  *
- * Mirrors the filter in `guildRouter.listChannels` so mutations only accept
- * channels the picker would have offered.
+ * The postability question goes through the SAME code the picker's filter does
+ * ({@link readGuildChannelPostability}), rather than a second implementation of
+ * it. Claiming to mirror the picker while checking only the channel *type* is
+ * how this drifted: every mutation accepted channels the picker had refused on
+ * permissions, and the resulting subscription was created successfully and then
+ * never posted — a failure the user learns about by noticing nothing happens,
+ * at a point where nothing connects it to the channel they picked.
  */
 export async function assertChannelInGuild(params: {
-  guildId: string;
+  guildId: DiscordGuildId;
   channelId: string;
 }): Promise<void> {
-  const channels = await callDiscordForRequest(() =>
-    botRest().guildChannels(params.guildId),
+  const guild = await callDiscordForRequest(() =>
+    readGuildChannelPostability(params.guildId),
   );
-  if (channels === null) {
+  if (guild === null) {
     throw new TRPCError({
       code: "NOT_FOUND",
       message: "Scout is not installed in that guild",
     });
   }
-  const channel = channels.find(
+  const channel = guild.channels.find(
     (candidate) => candidate.id === params.channelId,
   );
   if (channel === undefined) {
@@ -89,10 +89,11 @@ export async function assertChannelInGuild(params: {
       message: "Channel does not belong to that guild",
     });
   }
-  if (!POSTABLE_CHANNEL_TYPES.has(channel.type)) {
+  if (!guild.isPostable(channel)) {
     throw new TRPCError({
       code: "BAD_REQUEST",
-      message: "Channel must be a text or announcement channel",
+      message:
+        "Scout cannot post in that channel. Pick a text or announcement channel where Scout has View Channel and Send Messages.",
     });
   }
 }

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/gatewayless-web.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/gatewayless-web.test.ts
@@ -13,6 +13,7 @@ import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { ChannelType, PermissionFlagsBits } from "discord.js";
 import {
   DiscordAccountIdSchema,
+  DiscordChannelIdSchema,
   DiscordGuildIdSchema,
   permissionKey,
   type Permission,
@@ -37,6 +38,36 @@ const ACTOR = DiscordAccountIdSchema.parse("900000000000009001");
 const PEER = DiscordAccountIdSchema.parse("900000000000009002");
 const BOT = "900000000000000000";
 const BOT_ROLE = "100000000000009901";
+const TRACKED_ALIAS = "virmel";
+const POSTABLE_CHANNEL = DiscordChannelIdSchema.parse("100000000000009201");
+const MUTED_CHANNEL = DiscordChannelIdSchema.parse("100000000000009202");
+const FOREIGN_CHANNEL = DiscordChannelIdSchema.parse("100000000000009203");
+
+function postableChannel(id: string, name: string): DiscordGuildChannel {
+  return { id, name, type: ChannelType.GuildText, permission_overwrites: [] };
+}
+
+/**
+ * A text channel Scout can see but not speak in.
+ *
+ * The picker has always filtered these out; the shape of the failure is that
+ * the mutation guard did not, so the two disagreed about the same channel.
+ */
+function mutedChannel(): DiscordGuildChannel {
+  return {
+    id: MUTED_CHANNEL,
+    name: "announcements-only",
+    type: ChannelType.GuildText,
+    permission_overwrites: [
+      {
+        id: BOT_ROLE,
+        type: 0,
+        allow: "0",
+        deny: PermissionFlagsBits.SendMessages.toString(),
+      },
+    ],
+  };
+}
 
 type RestState = {
   guildsOnDiscord: Set<string>;
@@ -248,6 +279,20 @@ async function seedInstall(
   });
 }
 
+async function seedTrackedPlayer(): Promise<void> {
+  const now = new Date();
+  await prisma.player.create({
+    data: {
+      alias: TRACKED_ALIAS,
+      discordId: ACTOR,
+      serverId: INSTALLED,
+      creatorDiscordId: ACTOR,
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+}
+
 async function seedGrants(
   discordUserId: string,
   permissions: readonly Permission[],
@@ -270,6 +315,8 @@ const MANAGER: Permission[] = [
 
 beforeEach(async () => {
   await prisma.auditLog.deleteMany({});
+  await prisma.subscription.deleteMany({});
+  await prisma.player.deleteMany({});
   await prisma.serverPermission.deleteMany({});
   await prisma.guildInstall.deleteMany({});
   state.guildsOnDiscord = new Set([INSTALLED, UNROWED]);
@@ -406,6 +453,76 @@ describe("channel picker without a gateway", () => {
     await expect(
       caller().guild.listChannels({ guildId: INSTALLED }),
     ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+  });
+
+  test("does not offer a channel whose overwrite denies Send Messages", async () => {
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED]);
+    state.channels = [postableChannel("1", "general"), mutedChannel()];
+
+    await expect(
+      caller().guild.listChannels({ guildId: INSTALLED }),
+    ).resolves.toEqual([{ id: "1", name: "general", parentId: null }]);
+  });
+});
+
+/**
+ * The mutation guard must refuse exactly what the picker refuses.
+ *
+ * It claimed to mirror `listChannels` but checked only the channel's *type*,
+ * so a channel the picker had filtered out on permissions was still accepted
+ * by every subscription mutation. The subscription was then created
+ * successfully and simply never posted — a failure the user discovers by
+ * noticing that nothing happens, long after anything points back at the
+ * channel they chose.
+ */
+describe("the channel guard mirrors the picker", () => {
+  test("a mutation into a Send-Messages-denied channel is rejected", async () => {
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED]);
+    await seedTrackedPlayer();
+    state.channels = [mutedChannel()];
+
+    await expect(
+      caller().subscription.addChannel({
+        guildId: INSTALLED,
+        alias: TRACKED_ALIAS,
+        channelId: MUTED_CHANNEL,
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    // Nothing was written on the way to the refusal.
+    expect(await prisma.subscription.count()).toBe(0);
+  });
+
+  test("the same mutation into a postable channel still succeeds", async () => {
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED]);
+    await seedTrackedPlayer();
+    state.channels = [postableChannel(POSTABLE_CHANNEL, "general")];
+
+    await expect(
+      caller().subscription.addChannel({
+        guildId: INSTALLED,
+        alias: TRACKED_ALIAS,
+        channelId: POSTABLE_CHANNEL,
+      }),
+    ).resolves.toMatchObject({ kind: "added" });
+    expect(await prisma.subscription.count()).toBe(1);
+  });
+
+  test("a channel from another guild is still rejected", async () => {
+    await seedInstall(INSTALLED);
+    asMemberOf([INSTALLED]);
+    await seedTrackedPlayer();
+    state.channels = [postableChannel(POSTABLE_CHANNEL, "general")];
+
+    await expect(
+      caller().subscription.addChannel({
+        guildId: INSTALLED,
+        alias: TRACKED_ALIAS,
+        channelId: FOREIGN_CHANNEL,
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 });
 

--- a/packages/scout-for-lol/packages/data/README.md
+++ b/packages/scout-for-lol/packages/data/README.md
@@ -55,6 +55,32 @@ placement turns it into a "storage limit" reply. So
 rather than declaring its own — a second class would typecheck fine and silently
 stop matching every one of those catches.
 
+### Reading a ledger row is not writing one
+
+`src/model/bucks/bryan-bucks.ts` exports two ledger-context unions, and which
+one you reach for depends on the direction:
+
+- `BucksLedgerContextSchema` validates what Scout is about to **write**. Every
+  producer — `betting/ledger.ts`, the transfer path, the dare repair script's
+  reversal — parses through it, so today's narrowed money domains are enforced
+  going forward.
+- `StoredBucksLedgerContextSchema` parses a `BucksLedgerEntry.context` **read
+  back** out of the database. Everything that loads history uses it.
+
+They differ in exactly one variant. A settlement row's `winnersPool`,
+`losersPool`, `stakeReturned`, and `winnings` were persisted as plain signed
+integers from the first Bryan Bucks release until the money brands narrowed all
+four to non-negative; a stored row means what the schema in force when it was
+written said it meant, and existing records keep their original interpretation.
+So the stored union restates the historical domain for those four fields and the
+write union does not. Narrowing the read side instead is not harmless
+strictness — it makes the ledger page drop an old row's whole explanation and
+the repair script abort while merely scanning candidates.
+
+Add a new variant to `SHARED_LEDGER_CONTEXT_VARIANTS` so both unions get it. Give
+a variant its own read and write forms only when a persisted domain genuinely
+changed, and say in the schema which release changed it.
+
 ## Data Dragon assets
 
 `src/data-dragon/assets/` is a committed snapshot of Riot's Data Dragon (plus

--- a/packages/scout-for-lol/packages/data/src/model/bucks/bryan-bucks.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/bucks/bryan-bucks.test.ts
@@ -4,11 +4,20 @@ import {
   BucksDareStateSchema,
   BucksLedgerContextSchema,
   BucksLedgerKindSchema,
+  BucksMatchingSummarySchema,
+  StoredBucksLedgerContextSchema,
   type BucksLedgerContext,
 } from "./bryan-bucks.ts";
-import { BucksStakeSchema } from "./bryan-bucks-money.ts";
+import {
+  BucksAmountSchema,
+  BucksPoolTotalSchema,
+  BucksStakeSchema,
+  type BucksPoolTotal,
+} from "./bryan-bucks-money.ts";
 
 const stake = (value: number) => BucksStakeSchema.parse(value);
+const amount = (value: number) => BucksAmountSchema.parse(value);
+const pool = (value: number) => BucksPoolTotalSchema.parse(value);
 
 describe("BucksLedgerKindSchema dare kinds", () => {
   test.each(["dare_stake", "dare_payout", "dare_refund", "dare_fee"] as const)(
@@ -50,6 +59,171 @@ describe("BucksDareHorizonKindSchema", () => {
 
   test("rejects an unknown horizon", () => {
     expect(BucksDareHorizonKindSchema.safeParse("season").success).toBe(false);
+  });
+});
+
+describe("BucksMatchingSummarySchema pool aggregates", () => {
+  const summary = {
+    version: 1,
+    humanMatchedPerSide: 120,
+    houseFill: 0,
+    houseTeamId: null,
+    houseBetId: null,
+    totalMatchedPerSide: 120,
+    allocations: [],
+  };
+
+  test("round-trips a stored summary through JSON", () => {
+    const stored = JSON.stringify(summary);
+    expect(BucksMatchingSummarySchema.parse(JSON.parse(stored))).toEqual(
+      summary,
+    );
+  });
+
+  test("the side totals carry the pool-total brand", () => {
+    // They are sums across every position on a side — the shape
+    // `BucksPoolTotal` exists to name — and were bare nonnegative ints: the
+    // same domain spelled out by hand, which no call site could be held to.
+    const parsed = BucksMatchingSummarySchema.parse(summary);
+    const asPoolTotals: BucksPoolTotal[] = [
+      parsed.humanMatchedPerSide,
+      parsed.houseFill,
+      parsed.totalMatchedPerSide,
+    ];
+    expect(asPoolTotals).toEqual([120, 0, 120]);
+  });
+
+  test("the validated domain did not move, so stored blobs still parse", () => {
+    // Unlike the settlement context below, branding these was safe on the read
+    // side too: the brand IS `.int().nonnegative()`, so nothing that parsed
+    // before can fail now, and a negative was never representable anyway.
+    expect(
+      BucksMatchingSummarySchema.safeParse({
+        ...summary,
+        humanMatchedPerSide: -1,
+      }).success,
+    ).toBe(false);
+    expect(
+      BucksMatchingSummarySchema.safeParse({ ...summary, houseFill: 0 })
+        .success,
+    ).toBe(true);
+  });
+});
+
+describe("the settlement variant, written and stored", () => {
+  const paidWinner: BucksLedgerContext = {
+    type: "settlement",
+    subjectAlias: "virmel",
+    backedAliases: ["virmel"],
+    opposingAliases: ["bryan"],
+    winnersPool: pool(120),
+    losersPool: pool(80),
+    stakeReturned: amount(40),
+    winnings: amount(36),
+    grossPayout: amount(80),
+    houseCut: amount(4),
+    netPayout: amount(76),
+    submittedStake: amount(40),
+    matchedStake: amount(40),
+    unmatchedStake: amount(0),
+    payoutComponent: "gross",
+  };
+
+  const voidedRefund: BucksLedgerContext = {
+    type: "settlement",
+    subjectAlias: "virmel",
+    backedAliases: ["virmel"],
+    opposingAliases: ["bryan"],
+    winnersPool: pool(0),
+    losersPool: pool(0),
+    stakeReturned: amount(40),
+    winnings: amount(0),
+    payoutComponent: "refund",
+    voidReason: "no_counterparty",
+  };
+
+  test.each([
+    ["a paid winner", paidWinner],
+    ["a voided refund", voidedRefund],
+  ])("round-trips %s row through JSON", (_label, context) => {
+    const stored = JSON.stringify(context);
+    expect(BucksLedgerContextSchema.parse(JSON.parse(stored))).toEqual(context);
+    expect(StoredBucksLedgerContextSchema.parse(JSON.parse(stored))).toEqual(
+      context,
+    );
+  });
+
+  /**
+   * Rows written before the money brands landed.
+   *
+   * `winnersPool`, `losersPool`, `stakeReturned` and `winnings` were persisted
+   * as plain signed integers for the whole life of the feature until the
+   * brands narrowed all four at once. Reading history back through the
+   * narrowed schema would retroactively declare those rows invalid — the
+   * ledger page loses the row's explanation and the dare repair script aborts
+   * mid-scan — so the stored schema keeps the domain they were written in.
+   */
+  const historicalNegativeWinnings = {
+    type: "settlement",
+    subjectAlias: "virmel",
+    backedAliases: ["virmel"],
+    opposingAliases: ["bryan"],
+    winnersPool: 120,
+    losersPool: 80,
+    stakeReturned: 40,
+    winnings: -40,
+  };
+
+  test("a historical row with negative winnings still reads back", () => {
+    const stored = JSON.stringify(historicalNegativeWinnings);
+    expect(StoredBucksLedgerContextSchema.parse(JSON.parse(stored))).toEqual(
+      historicalNegativeWinnings,
+    );
+  });
+
+  test.each([
+    ["winnings", { ...historicalNegativeWinnings, winnings: -40 }],
+    [
+      "stakeReturned",
+      { ...historicalNegativeWinnings, winnings: 0, stakeReturned: -1 },
+    ],
+    [
+      "winnersPool",
+      { ...historicalNegativeWinnings, winnings: 0, winnersPool: -1 },
+    ],
+    [
+      "losersPool",
+      { ...historicalNegativeWinnings, winnings: 0, losersPool: -1 },
+    ],
+  ])("a negative %s is readable but no longer writable", (_field, row) => {
+    expect(StoredBucksLedgerContextSchema.safeParse(row).success).toBe(true);
+    // The tightening still holds going forward: nothing may WRITE one.
+    expect(BucksLedgerContextSchema.safeParse(row).success).toBe(false);
+  });
+
+  test("the two unions differ in the settlement variant and nowhere else", () => {
+    // A dare row is the same shape either way, so widening the read side did
+    // not quietly relax every other variant with it.
+    const dareRow = {
+      type: "dare",
+      dareId: 7,
+      role: "contributor",
+      targetAliases: ["virmel"],
+      conditionSummary: "win 7 games on Warwick",
+      potTotal: 12,
+      amount: -5,
+    };
+    expect(StoredBucksLedgerContextSchema.safeParse(dareRow).success).toBe(
+      false,
+    );
+    expect(BucksLedgerContextSchema.safeParse(dareRow).success).toBe(false);
+  });
+
+  test("neither union accepts a fractional settlement amount", () => {
+    const fractional = { ...historicalNegativeWinnings, winnings: -0.5 };
+    expect(StoredBucksLedgerContextSchema.safeParse(fractional).success).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/scout-for-lol/packages/data/src/model/bucks/bryan-bucks.ts
+++ b/packages/scout-for-lol/packages/data/src/model/bucks/bryan-bucks.ts
@@ -254,15 +254,30 @@ export const BucksMatchingAllocationSchema = z.strictObject({
   ...MatchingAmountFields,
 });
 
-/** Complete, versioned close-time allocation for one guild's match pool. */
+/**
+ * Complete, versioned close-time allocation for one guild's match pool.
+ *
+ * The three money fields are sums across every position on a side, which is
+ * exactly what `BucksPoolTotal` names: an aggregate that may legally exceed
+ * what any single `Int` column holds, unlike the per-bet values inside
+ * `allocations`. They were bare `z.number().int().nonnegative()` — the brand's
+ * own shape, written out by hand — which is the gap that motivated splitting
+ * the semantic brand from Int32 storability in the first place.
+ *
+ * Branding is safe here on the read side as well as the write side, unlike the
+ * settlement context's historical money fields: `BucksPoolTotalSchema` *is*
+ * `.int().nonnegative()`, so the validated domain does not move and no stored
+ * blob that parsed before can fail now. These are recomputed at close time
+ * from sums of stakes, which cannot be negative, so no version bump is owed.
+ */
 export type BucksMatchingSummary = z.infer<typeof BucksMatchingSummarySchema>;
 export const BucksMatchingSummarySchema = z.strictObject({
   version: z.literal(BUCKS_MATCHING_VERSION),
-  humanMatchedPerSide: z.number().int().nonnegative(),
-  houseFill: z.number().int().nonnegative(),
+  humanMatchedPerSide: BucksPoolTotalSchema,
+  houseFill: BucksPoolTotalSchema,
   houseTeamId: RiotTeamIdSchema.nullable(),
   houseBetId: z.number().int().positive().nullable(),
-  totalMatchedPerSide: z.number().int().nonnegative(),
+  totalMatchedPerSide: BucksPoolTotalSchema,
   allocations: z.array(BucksMatchingAllocationSchema),
 });
 
@@ -279,8 +294,17 @@ const MvpContextSchema = z.strictObject({
  * Discriminated on `type` so a row is self-describing without consulting its
  * `kind` column, and so adding a future entry shape cannot silently widen the
  * meaning of an existing one.
+ *
+ * This is the WRITE contract: what Scout is allowed to record today. Reading
+ * `BucksLedgerEntry.context` back out of the database uses
+ * {@link StoredBucksLedgerContextSchema}, which differs in exactly one
+ * variant — see {@link StoredSettlementContextSchema}.
  */
 export type BucksLedgerContext = z.infer<typeof BucksLedgerContextSchema>;
+/** One persisted row's context, in the domain it was written in. */
+export type StoredBucksLedgerContext = z.infer<
+  typeof StoredBucksLedgerContextSchema
+>;
 // Weekly v2 pricing uses a challenging 20–30% YES range. Keep the original
 // 40–60% range readable for v1 ledger entries because ledger history is
 // append-only and the context does not carry the weekly schema version.
@@ -288,7 +312,76 @@ export const BucksWeeklyParlayYesProbabilityBpsSchema = z.union([
   z.number().int().min(2000).max(3000),
   z.number().int().min(4000).max(6000),
 ]);
-export const BucksLedgerContextSchema = z.discriminatedUnion("type", [
+
+/** Everything a settlement row records that both domains agree on. */
+const SettlementContextCommonFields = {
+  type: z.literal("settlement"),
+  subjectAlias: z.string(),
+  backedAliases: z.array(z.string()),
+  opposingAliases: z.array(z.string()),
+  /** Added with house cuts. Optional so historical ledger JSON remains
+   * parseable under the current schema. Per-bet Int-column values, so the
+   * branded Int32 schemas restate the stored domain — and unlike the four
+   * money fields below, these were introduced already branded, so no row
+   * exists that was written under a wider domain. */
+  grossPayout: BucksAmountSchema.optional(),
+  houseCut: BucksAmountSchema.optional(),
+  netPayout: BucksAmountSchema.optional(),
+  submittedStake: BucksAmountSchema.optional(),
+  matchedStake: BucksAmountSchema.optional(),
+  unmatchedStake: BucksAmountSchema.optional(),
+  /** Gross payouts may be split around the fee transfer so every
+   * intermediate wallet balance remains representable. */
+  payoutComponent: z
+    .enum(["gross", "principal", "profit", "refund"])
+    .optional(),
+  voidReason: BucksVoidReasonSchema.optional(),
+};
+
+/**
+ * The settlement context Scout writes today.
+ *
+ * Pool-level aggregates sum many bettors' Int32 positions, so unlike the
+ * per-bet fields they carry no storage bound — `BucksPoolTotal` is the brand
+ * for exactly that shape. `stakeReturned` and `winnings` are per-bet despite
+ * sitting beside the aggregates: settlement writes this bettor's own matched
+ * stake and own winnings, both already branded where they are computed.
+ */
+const WrittenSettlementContextSchema = z.strictObject({
+  ...SettlementContextCommonFields,
+  winnersPool: BucksPoolTotalSchema,
+  losersPool: BucksPoolTotalSchema,
+  stakeReturned: BucksAmountSchema,
+  winnings: BucksAmountSchema,
+});
+
+/**
+ * The same context as it may actually exist in the database.
+ *
+ * These four fields were persisted as plain signed `z.number().int()` from the
+ * first Bryan Bucks release until the money brands landed, which narrowed all
+ * four to non-negative in one step. Today's writer provably cannot emit a
+ * negative — that is what the brands are for — but a stored row's meaning is
+ * fixed by the schema that was in force when it was written, and that schema
+ * bounded none of these below. Existing records keep their original
+ * interpretation, so the read side restates the domain history was written in
+ * and only the write path narrows.
+ *
+ * Reading through the narrowed schema instead is not a harmless strictness:
+ * the ledger page silently drops a row's whole explanation and falls back to a
+ * bare match ID, and the dare repair script hard-throws while merely scanning
+ * candidate rows — both on rows that are not corrupt, just old.
+ */
+const StoredSettlementContextSchema = z.strictObject({
+  ...SettlementContextCommonFields,
+  winnersPool: z.number().int(),
+  losersPool: z.number().int(),
+  stakeReturned: z.number().int(),
+  winnings: z.number().int(),
+});
+
+/** Every variant whose domain is the same read or written. */
+const SHARED_LEDGER_CONTEXT_VARIANTS = [
   z.strictObject({
     type: z.literal("seed"),
     note: z.string(),
@@ -322,37 +415,6 @@ export const BucksLedgerContextSchema = z.discriminatedUnion("type", [
     /** Aliases on the side the bettor backed, and on the other side. */
     backedAliases: z.array(z.string()),
     opposingAliases: z.array(z.string()),
-  }),
-  z.strictObject({
-    type: z.literal("settlement"),
-    subjectAlias: z.string(),
-    backedAliases: z.array(z.string()),
-    opposingAliases: z.array(z.string()),
-    // Pool-level aggregates sum many bettors' Int32 positions, so unlike the
-    // per-bet fields below they carry no storage bound. `BucksPoolTotal` is
-    // the brand for exactly that shape.
-    winnersPool: BucksPoolTotalSchema,
-    losersPool: BucksPoolTotalSchema,
-    // Per-bet values, despite sitting beside the aggregates: settlement writes
-    // this bettor's own matched stake and own winnings, both already branded
-    // where they are computed.
-    stakeReturned: BucksAmountSchema,
-    winnings: BucksAmountSchema,
-    /** Added with house cuts. Optional so historical ledger JSON remains
-     * parseable under the current schema. Per-bet Int-column values, so the
-     * branded Int32 schemas restate the stored domain. */
-    grossPayout: BucksAmountSchema.optional(),
-    houseCut: BucksAmountSchema.optional(),
-    netPayout: BucksAmountSchema.optional(),
-    submittedStake: BucksAmountSchema.optional(),
-    matchedStake: BucksAmountSchema.optional(),
-    unmatchedStake: BucksAmountSchema.optional(),
-    /** Gross payouts may be split around the fee transfer so every
-     * intermediate wallet balance remains representable. */
-    payoutComponent: z
-      .enum(["gross", "principal", "profit", "refund"])
-      .optional(),
-    voidReason: BucksVoidReasonSchema.optional(),
   }),
   z.strictObject({
     type: z.literal("matching"),
@@ -513,6 +575,24 @@ export const BucksLedgerContextSchema = z.discriminatedUnion("type", [
     note: z.string(),
     actorDiscordId: z.string(),
   }),
+] as const;
+
+export const BucksLedgerContextSchema = z.discriminatedUnion("type", [
+  ...SHARED_LEDGER_CONTEXT_VARIANTS,
+  WrittenSettlementContextSchema,
+]);
+
+/**
+ * The union to parse `BucksLedgerEntry.context` with.
+ *
+ * Identical to {@link BucksLedgerContextSchema} except for the settlement
+ * variant, whose money fields keep the wider domain they were written in.
+ * Everything that reads a persisted row uses this; everything that writes one
+ * uses the narrowed write schema, so the tightening still holds going forward.
+ */
+export const StoredBucksLedgerContextSchema = z.discriminatedUnion("type", [
+  ...SHARED_LEDGER_CONTEXT_VARIANTS,
+  StoredSettlementContextSchema,
 ]);
 
 /** A `{ channelId, messageId }` pair for one guild's prematch message, so the

--- a/packages/scout-for-lol/packages/domain/src/match-processing/states.ts
+++ b/packages/scout-for-lol/packages/domain/src/match-processing/states.ts
@@ -94,9 +94,17 @@ export const MatchProcessingReceiptSchema = z.strictObject({
 /**
  * Full identity of a receipt: `(kind, version, scope)`. Two receipts sharing
  * this key are the same receipt — a state holds at most one, and
- * `recordReceipt` is idempotent over it. `recordedAt` is evidence, not
- * identity. The encoding is injective: kinds cannot contain `:`, the version
- * is an integer, and the scope key is itself injective.
+ * `recordReceipt` is idempotent over it.
+ *
+ * `recordedAt` is neither identity nor evidence: it is observational metadata
+ * of the first attestation, recording when the fact was noticed rather than
+ * what the fact is. Receipt writers are Temporal Activities, so a retry of an
+ * already-committed write carries the same identity and a fresh wall clock by
+ * construction; `recordReceipt` therefore ignores it and keeps the first
+ * value.
+ *
+ * The encoding is injective: kinds cannot contain `:`, the version is an
+ * integer, and the scope key is itself injective.
  */
 export function matchProcessingReceiptIdentityKey(args: {
   kind: ReceiptKind;

--- a/packages/scout-for-lol/packages/domain/src/match-processing/transitions.test.ts
+++ b/packages/scout-for-lol/packages/domain/src/match-processing/transitions.test.ts
@@ -202,18 +202,25 @@ describe("recordReceipt", () => {
     },
   );
 
-  test("conflicts when the same identity arrives with different evidence", () => {
-    const state = makeState({
-      receipts: [makeReceipt({ scope: { kind: "global" } })],
-    });
-    const divergent = makeReceipt({
+  test("a replay with a later recordedAt is still already applied", () => {
+    // `recordedAt` is observational metadata of the first attestation, not
+    // evidence. Receipt writers are Temporal Activities, so a retry of an
+    // already-committed write arrives with the same identity and a fresh wall
+    // clock by construction — comparing clocks turned every benign retry into
+    // a conflict, which is the metric dual-write alerting watches.
+    const first = makeReceipt({ scope: { kind: "global" } });
+    const state = makeState({ receipts: [first] });
+    const later = makeReceipt({
       scope: { kind: "global" },
       recordedAt: "2025-10-16T18:00:00Z",
     });
-    expect(recordReceipt({ state, receipt: divergent })).toEqual({
-      outcome: "conflict",
-      reason: "receipt-evidence-mismatch",
+    expect(later.recordedAt).not.toBe(first.recordedAt);
+    expect(recordReceipt({ state, receipt: later })).toEqual({
+      outcome: "already-applied",
     });
+    // `already-applied` carries no next state, so the state keeps the first
+    // receipt and with it the first `recordedAt`.
+    expect(state.receipts).toEqual([first]);
   });
 
   test("applies a second kind for the same scope", () => {

--- a/packages/scout-for-lol/packages/domain/src/match-processing/transitions.ts
+++ b/packages/scout-for-lol/packages/domain/src/match-processing/transitions.ts
@@ -81,11 +81,25 @@ export function promoteArchiveOnlyToFull(args: {
 
 /**
  * Record a processing receipt. Idempotent by the full receipt identity
- * `(kind, version, scope)`: an exact replay — same identity, same evidence —
- * is `already-applied`, while a receipt that shares an identity but carries
- * different evidence (`recordedAt`) is a conflict: something recorded the
- * same fact twice with disagreeing observations, and the state keeps the
- * first.
+ * `(kind, version, scope)`: a receipt whose identity the state already holds
+ * is `already-applied`, and the state keeps the one it has — including that
+ * first receipt's `recordedAt`.
+ *
+ * `recordedAt` is deliberately outside the comparison, though it used to BE
+ * the comparison. It is observational metadata about the first attestation —
+ * when the fact was noticed, not what the fact is — and treating it as
+ * evidence predates the operational reality that receipt writers are Temporal
+ * Activities: a retry of an already-committed write arrives with the same
+ * identity and a fresh wall clock by construction, so comparing clocks turned
+ * every benign retry into a conflict.
+ *
+ * That leaves this transition nothing left to disagree about, because a domain
+ * receipt carries its identity and `recordedAt` and nothing else: an identity
+ * match here is always a replay. `receipt-evidence-mismatch` stays in the
+ * vocabulary for the layer that does hold evidence — the persistence
+ * repository compares the stored evidence blob, which is a claim about the
+ * fact rather than about when it was seen. Both layers discriminate on
+ * evidence alone, so they cannot answer the same replay differently.
  */
 export function recordReceipt(args: {
   state: MatchProcessingState;
@@ -93,13 +107,11 @@ export function recordReceipt(args: {
 }): TransitionResult<MatchProcessingState> {
   const { state, receipt } = args;
   const identityKey = matchProcessingReceiptIdentityKey(receipt);
-  const existing = state.receipts.find(
+  const alreadyHeld = state.receipts.some(
     (candidate) => matchProcessingReceiptIdentityKey(candidate) === identityKey,
   );
-  if (existing !== undefined) {
-    return existing.recordedAt === receipt.recordedAt
-      ? { outcome: "already-applied" }
-      : { outcome: "conflict", reason: "receipt-evidence-mismatch" };
+  if (alreadyHeld) {
+    return { outcome: "already-applied" };
   }
   return {
     outcome: "applied",


### PR DESCRIPTION
## Why

Wave 2's closing architectural and test-gap reviews found nine production-grade gaps across the merged Wave 1-2 surface — including one composition P0 (the gateway role reads the DuckDB lake in-process via `/scout ask` while declaring no lake access, so a lake-less pod would answer every question 'no games found' successfully) and three defects introduced by Wave 2's own review fixes.

## What (each guard mutation-verified: revert → fail → restore)

- **Fresh-install blanking**: the guild-existence read caches positives only — a cached negative no longer overrules a live install row for 60s after installing.
- **Published-lake boot gate**: tested in both directions; the dev fold-skip flag now downgrades the read gate to a loud warning instead of silently disabling it; corruption always throws.
- **Historical ledger rows**: read/write settlement-schema split over one shared variant tuple (new variants must land in both); four fields verified against the actual tightening commit; negative-winnings history parses on read, writes stay branded.
- **Cleanup deletion layer**: per-guild `$transaction` with real failure surfacing; five integration tests pin exact blast radius, unreachable-Discord zero-deletion, and per-guild rollback with the next guild still processed.
- **Guard/picker mirror**: `assertChannelInGuild` shares `listPostableChannels`' actual postability predicate — a deny-overwrite channel is rejected at the mutation with nothing written.
- **Gateway lake P0**: `resolveLakeFiles` asserts `reportLakeAccess` before touching the directory (neutral `RuntimeCapabilityError` in `configuration/` — transport-agnostic by design), and the capability table now tells the truth: gateway declares lake access and settles the lake before the shard connects. The read-site assertion is deliberately dormant while every role declares access — it is what makes the next role's claim fail loudly instead of silently.
- **Consumer confirmations**: concurrent with per-guild error boundaries; only all-candidates failure propagates as unavailable.
- **Persisted pool aggregates**: `BucksPoolTotal` both directions (validated domain provably unmoved — no version bump owed).
- **Receipt replay equality**: evidence-only in BOTH the domain transition and the repository — `recordedAt` is observational metadata of the first attestation, so benign Temporal retries no longer count as conflicts on the counter dual-write alerting watches; both pin tests updated; the domain receipt carries no evidence, making the repository `receipt-evidence-mismatch`'s one producer (documented).

## Verification

- `bunx turbo run typecheck test lint` across backend/data/domain — **27/27 tasks** (backend 3845, data 1515, domain 605 tests), re-run green after restacking onto main including the merged dual-write bridge; architecture clean incl. the new `reports → configuration` edge.
- `bun run knip` clean; `bun run jscpd` 407/407; directory gate + markdownlint clean.
- Four guards mutation-tested. Not run: Buildkite exact-head, images, deployment, live behavior.

Part of SJ-186 (wave-closing hardening; findings from the Wave 2 architectural + test-gap reviews).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qRdG6fzJr3THzYzAJwTZB