### PR TITLE
fix(scout-for-lol): fix Explore local dev flags and composer gradient fade

### DIFF
--- a/packages/scout-for-lol/packages/app/src/routes/explore.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/explore.tsx
@@ -341,7 +341,7 @@ export function Explore() {
 
       {/* Pinned to the bottom of the viewport with a translucent gradient fade:
           allows chat text to remain visible below the composer through the fade effect. */}
-      <div className="sticky bottom-0 w-full pointer-events-none pt-8 pb-4 bg-gradient-to-t from-scout-canvas/80 via-scout-canvas/30 via-40% to-transparent dark:from-black/75 dark:via-black/30 dark:via-40% dark:to-transparent">
+      <div className="sticky bottom-0 w-full pointer-events-none pt-8 pb-4 bg-gradient-to-t from-scout-canvas/80 via-scout-canvas/30 via-40% to-scout-canvas/0 dark:from-black/75 dark:via-black/30 dark:via-40% dark:to-black/0">
         <ExploreJumpToLatest pinned={pinned} onClick={scrollToBottom} />
         <div className="pointer-events-auto">
           <ExploreComposer

--- a/packages/scout-for-lol/scripts/dev/dev-web-args.test.ts
+++ b/packages/scout-for-lol/scripts/dev/dev-web-args.test.ts
@@ -4,7 +4,10 @@ import {
   resolveBackendEntrypoint,
   shouldPrepareReportLake,
 } from "./dev-web.ts";
-import { buildDevEnvironment } from "./dev-web-environment.ts";
+import {
+  buildDevEnvironment,
+  DEFAULT_STATIC_FLAG_OVERRIDES,
+} from "./dev-web-environment.ts";
 
 test("parses isolated ports and database URL", () => {
   expect(
@@ -185,8 +188,9 @@ test("defaults a local boot to the consumer preview and dev login", () => {
     DEV_USER_GUILDS: "1337623164146155593",
     EXPLORE_GUILD_ALLOWLIST: "1337623164146155593",
     FEATURE_FLAGS_MODE: "static",
-    FEATURE_FLAGS_STATIC_OVERRIDES:
-      '{"scout-consumer-player-profiles-enabled":true}',
+    FEATURE_FLAGS_STATIC_OVERRIDES: JSON.stringify(
+      DEFAULT_STATIC_FLAG_OVERRIDES,
+    ),
     WEB_APP_ORIGIN: "http://localhost:5180",
     SCOUT_RUNTIME_ROLE: "application",
     SCOUT_DEV_SKIP_REPORT_LAKE_FOLD: "true",

--- a/packages/scout-for-lol/scripts/dev/dev-web-environment.ts
+++ b/packages/scout-for-lol/scripts/dev/dev-web-environment.ts
@@ -12,45 +12,47 @@ export type DevAuthMode = "dev-login" | "oauth";
  * is the one exception, flipped on to exercise the consumer preview this
  * script boots by default.
  */
-const DEFAULT_STATIC_FLAG_OVERRIDES: Record<string, boolean | string | number> =
-  {
-    ai_reports_enabled: false,
-    ai_reports_unlimited: false,
-    ai_reviews_enabled: false,
-    betting_enabled: false,
-    betting_player_bet_outcome_dm_enabled: false,
-    betting_settlement_dm_enabled: false,
-    bucks_dares_enabled: false,
-    bucks_transfers_enabled: false,
-    challenge_runs_enabled: false,
-    competition_builder_v2_enabled: false,
-    custom_nights_enabled: false,
-    dare_extended_contracts_enabled: false,
-    dare_notifications_enabled: false,
-    dare_v2: false,
-    debug: false,
-    duels_enabled: false,
-    explore_creation_enabled: false,
-    hall_of_fame_enabled: false,
-    initial_match_history_import_enabled: false,
-    scoutql_relational_enabled: false,
-    "scout-consumer-player-profiles-enabled": true,
-    "scout-temporal-call-graph-tracing": false,
-    tournament_lobbies_enabled: false,
-    voice_assistant_enabled: false,
-    weekly_parlays_enabled: false,
-    // Variant flags: same defaults as the `DEFINITION` snapshot in
-    // packages/backend/src/config/dynamic.ts, which already falls back to them
-    // gracefully on a refresh failure — listing them here just stops the noisy
-    // "no static override" warning on every poll.
-    "scout-betting-parlay-ai-model": "gpt-5.6-sol",
-    "scout-explore-model": "gpt-5.6-luna",
-    "scout-report-ai-model": "gpt-5.6-sol",
-    "scout-tournament-api-mode": "stub",
-    "scout-tournament-max-open-lobbies": 10,
-    "llm-hourly-token-budget": 2_000_000,
-    "llm-daily-token-budget": 20_000_000,
-  };
+export const DEFAULT_STATIC_FLAG_OVERRIDES: Record<
+  string,
+  boolean | string | number
+> = {
+  ai_reports_enabled: false,
+  ai_reports_unlimited: false,
+  ai_reviews_enabled: false,
+  betting_enabled: false,
+  betting_player_bet_outcome_dm_enabled: false,
+  betting_settlement_dm_enabled: false,
+  bucks_dares_enabled: false,
+  bucks_transfers_enabled: false,
+  challenge_runs_enabled: false,
+  competition_builder_v2_enabled: false,
+  custom_nights_enabled: false,
+  dare_extended_contracts_enabled: false,
+  dare_notifications_enabled: false,
+  dare_v2: false,
+  debug: false,
+  duels_enabled: false,
+  explore_creation_enabled: false,
+  hall_of_fame_enabled: false,
+  initial_match_history_import_enabled: false,
+  scoutql_relational_enabled: false,
+  "scout-consumer-player-profiles-enabled": true,
+  "scout-temporal-call-graph-tracing": false,
+  tournament_lobbies_enabled: false,
+  voice_assistant_enabled: false,
+  weekly_parlays_enabled: false,
+  // Variant flags: same defaults as the `DEFINITION` snapshot in
+  // packages/backend/src/config/dynamic.ts, which already falls back to them
+  // gracefully on a refresh failure — listing them here just stops the noisy
+  // "no static override" warning on every poll.
+  "scout-betting-parlay-ai-model": "gpt-5.6-sol",
+  "scout-explore-model": "gpt-5.6-luna",
+  "scout-report-ai-model": "gpt-5.6-sol",
+  "scout-tournament-api-mode": "stub",
+  "scout-tournament-max-open-lobbies": 10,
+  "llm-hourly-token-budget": 2_000_000,
+  "llm-daily-token-budget": 20_000_000,
+};
 
 export type DevWebOptions = {
   readonly backendPort: number;

--- a/packages/scout-for-lol/scripts/dev/dev-web-environment.ts
+++ b/packages/scout-for-lol/scripts/dev/dev-web-environment.ts
@@ -1,5 +1,57 @@
 export type DevAuthMode = "dev-login" | "oauth";
 
+/**
+ * `FEATURE_FLAGS_MODE=static` fails loudly (`FlagNotFoundError`) on any flag
+ * key missing from `FEATURE_FLAGS_STATIC_OVERRIDES` — that is by design (see
+ * `packages/feature-flags/CLAUDE.md`), so every key the backend can read
+ * locally must be listed here or the read site throws. Values mirror each
+ * flag's own registered default in
+ * `packages/backend/src/configuration/flags.ts` (`FLAG_REGISTRY`), so a local
+ * static-mode run behaves like a production Flipt outage rather than
+ * inventing new local-only behavior. `scout-consumer-player-profiles-enabled`
+ * is the one exception, flipped on to exercise the consumer preview this
+ * script boots by default.
+ */
+const DEFAULT_STATIC_FLAG_OVERRIDES: Record<string, boolean | string | number> =
+  {
+    ai_reports_enabled: false,
+    ai_reports_unlimited: false,
+    ai_reviews_enabled: false,
+    betting_enabled: false,
+    betting_player_bet_outcome_dm_enabled: false,
+    betting_settlement_dm_enabled: false,
+    bucks_dares_enabled: false,
+    bucks_transfers_enabled: false,
+    challenge_runs_enabled: false,
+    competition_builder_v2_enabled: false,
+    custom_nights_enabled: false,
+    dare_extended_contracts_enabled: false,
+    dare_notifications_enabled: false,
+    dare_v2: false,
+    debug: false,
+    duels_enabled: false,
+    explore_creation_enabled: false,
+    hall_of_fame_enabled: false,
+    initial_match_history_import_enabled: false,
+    scoutql_relational_enabled: false,
+    "scout-consumer-player-profiles-enabled": true,
+    "scout-temporal-call-graph-tracing": false,
+    tournament_lobbies_enabled: false,
+    voice_assistant_enabled: false,
+    weekly_parlays_enabled: false,
+    // Variant flags: same defaults as the `DEFINITION` snapshot in
+    // packages/backend/src/config/dynamic.ts, which already falls back to them
+    // gracefully on a refresh failure — listing them here just stops the noisy
+    // "no static override" warning on every poll.
+    "scout-betting-parlay-ai-model": "gpt-5.6-sol",
+    "scout-explore-model": "gpt-5.6-luna",
+    "scout-report-ai-model": "gpt-5.6-sol",
+    "scout-tournament-api-mode": "stub",
+    "scout-tournament-max-open-lobbies": 10,
+    "llm-hourly-token-budget": 2_000_000,
+    "llm-daily-token-budget": 20_000_000,
+  };
+
 export type DevWebOptions = {
   readonly backendPort: number;
   readonly webPort: number;
@@ -91,7 +143,7 @@ export function buildDevEnvironment(
   const featureFlagsOverrides =
     baseEnvironment["FEATURE_FLAGS_STATIC_OVERRIDES"] ??
     (options.consumerPreview
-      ? '{"scout-consumer-player-profiles-enabled":true}'
+      ? JSON.stringify(DEFAULT_STATIC_FLAG_OVERRIDES)
       : "{}");
 
   return {


### PR DESCRIPTION
## Summary

- Fixes every Scout Explore turn failing locally with a generic "This answer could not be completed." error: `dev:web`'s default static feature-flag overrides only stubbed one flag, so every other flag read anywhere in the backend (`betting_enabled`, `debug`, `challenge_runs_enabled`, ...) threw `FlagNotFoundError` by design (see `packages/feature-flags/CLAUDE.md`) instead of falling back. `explore/tools/bucks-tools.ts` checks `betting_enabled` while assembling turn context, so this broke Explore outright, plus `challenge.status`, `bucks.status`, and `guild.listManageable` (500s).
- Fixes the Explore composer's bottom scrim fading through a visible gray/muddy band instead of a clean fade — it faded to the literal `transparent` keyword (black at zero alpha) instead of its own hue at zero alpha, which showed up worse on Windows Chrome than Safari/macOS.

## What

- `packages/scout-for-lol/scripts/dev/dev-web-environment.ts`: adds a `DEFAULT_STATIC_FLAG_OVERRIDES` map covering every key in `packages/feature-flags/src/managed-flag-keys.generated.ts`'s `SCOUT_FLAG_KEYS`, each set to that flag's own registered default from `FLAG_REGISTRY` (`configuration/flags.ts`) — so local static-mode behaves like a production Flipt outage rather than crashing. `scout-consumer-player-profiles-enabled` stays the one flag flipped on for the consumer preview this script already boots.
- `packages/scout-for-lol/packages/app/src/routes/explore.tsx`: changes the composer scrim's fade endpoint from `to-transparent` / `dark:to-transparent` to `to-scout-canvas/0` / `dark:to-black/0`.

## Verification

- `bunx turbo run typecheck lint --filter='./packages/scout-for-lol'` and `--filter=@scout-for-lol/app`: passing.
- Restarted the full `dev:web` stack (Temporal, Postgres, backend, web) against a real beta snapshot database — startup log shows zero flag errors (down from a dozen+ `FlagNotFoundError`/500s).
- Replayed a real Explore turn via curl against the running backend: returns a genuine generated answer instead of failing.
- Confirmed `challenge.status`/`bucks.status`/`guild.listManageable` no longer 500.
- Rendered the Explore composer via Playwright against the running local dev backend in both light and dark mode — smooth fade, no banding, in both. Could not reproduce the original Windows Chrome rendering directly (no Windows machine available); the fix addresses the color-math mechanism that produces this class of artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)