### PR TITLE
fix(homelab): outlast registry rate limits when generating Helm types

### DIFF
--- a/packages/homelab/src/cdk8s/scripts/generate-helm-types.test.ts
+++ b/packages/homelab/src/cdk8s/scripts/generate-helm-types.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { helmFetchRetryDelayMs } from "./generate-helm-types.ts";
+
+describe("helmFetchRetryDelayMs", () => {
+  test("backs off exponentially from the base delay", () => {
+    expect(helmFetchRetryDelayMs(1, 0)).toBe(5000);
+    expect(helmFetchRetryDelayMs(2, 0)).toBe(10_000);
+    expect(helmFetchRetryDelayMs(3, 0)).toBe(20_000);
+    expect(helmFetchRetryDelayMs(4, 0)).toBe(40_000);
+  });
+
+  test("outlasts a per-minute registry quota window before giving up", () => {
+    // The generator makes 5 attempts, so it waits 4 times. Even with zero
+    // jitter those waits must exceed the 60s window a 429 quota resets on,
+    // otherwise a single quota blip fails the deploy-paths gate.
+    const totalMs = [1, 2, 3, 4].reduce(
+      (sum, attempt) => sum + helmFetchRetryDelayMs(attempt, 0),
+      0,
+    );
+    expect(totalMs).toBeGreaterThan(60_000);
+  });
+
+  test("caps the exponential growth", () => {
+    expect(helmFetchRetryDelayMs(10, 0)).toBe(60_000);
+  });
+
+  test("jitter only ever lengthens a wait, by at most 25%", () => {
+    const nominal = helmFetchRetryDelayMs(2, 0);
+    expect(helmFetchRetryDelayMs(2, 0.5)).toBe(11_250);
+    expect(helmFetchRetryDelayMs(2, 0.999)).toBeGreaterThan(nominal);
+    expect(helmFetchRetryDelayMs(2, 0.999)).toBeLessThanOrEqual(nominal * 1.25);
+  });
+
+  test("rejects out-of-range inputs instead of silently retrying wrong", () => {
+    expect(() => helmFetchRetryDelayMs(0, 0)).toThrow();
+    expect(() => helmFetchRetryDelayMs(1.5, 0)).toThrow();
+    expect(() => helmFetchRetryDelayMs(1, 1)).toThrow();
+    expect(() => helmFetchRetryDelayMs(1, -0.1)).toThrow();
+  });
+});

--- a/packages/homelab/src/cdk8s/scripts/generate-helm-types.ts
+++ b/packages/homelab/src/cdk8s/scripts/generate-helm-types.ts
@@ -56,8 +56,49 @@ async function main() {
   }
 }
 
-const MAX_FETCH_ATTEMPTS = 3;
-const RETRY_BACKOFF_MS = 3000;
+// Chart registries (registry.k8s.io in particular) enforce *per-minute* request
+// quotas: a 429 clears only when the quota window rolls over. A flat 3s x 3
+// backoff gave up ~21s in — still inside that window — so a single quota blip
+// failed the whole deploy-paths gate on an otherwise-correct tree. Back off
+// exponentially so the retries outlast a full minute (5s + 10s + 20s + 40s =
+// 75s of waiting at minimum, before jitter).
+const MAX_FETCH_ATTEMPTS = 5;
+const RETRY_BASE_BACKOFF_MS = 5000;
+const RETRY_MAX_BACKOFF_MS = 60_000;
+// Charts are fetched sequentially, so a genuine registry outage would otherwise
+// spend the full per-chart backoff on every chart and blow the step's 30 minute
+// timeout — turning a precise "registry unreachable" error into an opaque
+// timeout. Cap the waiting across the whole run: blips (one or two charts) get
+// the full backoff, an outage fails fast and loudly.
+const RETRY_TOTAL_BUDGET_MS = 5 * 60_000;
+
+/**
+ * Delay before retry `attempt` (1-based: the wait *after* the attempt-th
+ * failure). Exponential from {@link RETRY_BASE_BACKOFF_MS}, capped at
+ * {@link RETRY_MAX_BACKOFF_MS}, with up to +25% jitter so concurrent builds
+ * pulling the same charts do not retry in lockstep and re-collide on the same
+ * quota window. `jitterFraction` is supplied by the caller (in [0, 1)) to keep
+ * this pure and testable; jitter only ever lengthens a wait, so the minimum
+ * total backoff is guaranteed.
+ */
+export function helmFetchRetryDelayMs(
+  attempt: number,
+  jitterFraction: number,
+): number {
+  if (!Number.isInteger(attempt) || attempt < 1) {
+    throw new Error(
+      `retry attempt must be a positive integer, got ${attempt.toString()}`,
+    );
+  }
+  if (!(jitterFraction >= 0 && jitterFraction < 1)) {
+    throw new Error(
+      `jitterFraction must be in [0, 1), got ${jitterFraction.toString()}`,
+    );
+  }
+  const exponential = RETRY_BASE_BACKOFF_MS * 2 ** (attempt - 1);
+  const capped = Math.min(exponential, RETRY_MAX_BACKOFF_MS);
+  return Math.round(capped * (1 + 0.25 * jitterFraction));
+}
 
 async function generateHelmTypes(outputDir: string) {
   // Do NOT wipe the output directory: chart fetches hit the network and can
@@ -89,6 +130,7 @@ async function generateHelmTypes(outputDir: string) {
 
   // Generate types for each chart, retrying transient (network) fetch failures.
   const failures: string[] = [];
+  let retryWaitSpentMs = 0;
 
   for (const chart of charts) {
     console.log(`\n🔍 Processing ${chart.name}...`);
@@ -100,17 +142,26 @@ async function generateHelmTypes(outputDir: string) {
         console.log(`✅ Generated types for ${chart.name}`);
         break;
       } catch (error) {
-        if (attempt < MAX_FETCH_ATTEMPTS) {
-          console.warn(
-            `⚠️  Attempt ${attempt.toString()}/${MAX_FETCH_ATTEMPTS.toString()} for ${chart.name} failed; retrying...`,
-          );
-          await Bun.sleep(RETRY_BACKOFF_MS);
-        } else {
+        if (attempt >= MAX_FETCH_ATTEMPTS) {
           console.error(
             `❌ Failed to process ${chart.name} after ${MAX_FETCH_ATTEMPTS.toString()} attempts:`,
             error,
           );
+          break;
         }
+        const delayMs = helmFetchRetryDelayMs(attempt, Math.random());
+        if (retryWaitSpentMs + delayMs > RETRY_TOTAL_BUDGET_MS) {
+          console.error(
+            `❌ Giving up on ${chart.name} at attempt ${attempt.toString()}: this run has spent its ${Math.round(RETRY_TOTAL_BUDGET_MS / 1000).toString()}s retry budget, so the chart registries are down rather than rate limiting:`,
+            error,
+          );
+          break;
+        }
+        retryWaitSpentMs += delayMs;
+        console.warn(
+          `⚠️  Attempt ${attempt.toString()}/${MAX_FETCH_ATTEMPTS.toString()} for ${chart.name} failed; retrying in ${Math.round(delayMs / 1000).toString()}s...`,
+        );
+        await Bun.sleep(delayMs);
       }
     }
     if (!generated) {


### PR DESCRIPTION
## Why

The chart registries behind `generate-helm-types` enforce **per-minute** request quotas. `registry.k8s.io` returned HTTP 429 (`Quota exceeded for quota metric 'Requests per project per region' ... per minute per region`) for the `kueue` chart on [build 15363](https://buildkite.com/sjerred/monorepo/builds/15363), failing the `pr-dryrun` gate on a tree that was otherwise correct — which in turn held up the pin-bump PR that main's `argocd-sync` was waiting on.

The generator already had retry logic written explicitly for transient network failures, but it was a flat 3s backoff over 3 attempts: it gave up ~21s in, still well inside the one-minute window it was waiting for. The retries could not, by construction, clear the failure class they existed for.

## What

- Exponential backoff — 5s, 10s, 20s, 40s over 5 attempts, capped at 60s — so a chart fetch waits at least 75s before being declared failed, past a full quota window.
- Up to +25% jitter, so concurrent builds pulling the same charts do not retry in lockstep and re-collide on the same window. Jitter only ever lengthens a wait, so the minimum total backoff is guaranteed.
- A 5-minute **total** retry budget for the run. Charts are fetched sequentially, so a genuine registry outage would otherwise spend the full per-chart backoff on all 24 charts and blow the step's 30-minute timeout — turning a precise "registry unreachable" error into an opaque timeout. Blips get the full backoff; an outage now fails fast and says why.
- The delay schedule is a pure exported function with unit tests pinning the exponential steps, the cap, the jitter bound, the input validation, and the property that the waits exceed 60s.

Failure semantics are unchanged: a chart that cannot be fetched still fails the whole run loudly and leaves the committed type files untouched. This does not weaken the drift gate — it only stops a transient upstream quota blip from being reported as drift.

## Verification

- `bunx turbo run build typecheck lint test --filter=@homelab/cdk8s` — 9 tasks green, including the 5 new tests.
- `bunx lefthook run pre-commit` — clean.
- **Not run:** Buildkite (this PR's build is the check); the live 429 path, which reproduces only under an actual upstream quota breach; images; deployment.