### PR TITLE
chore: refresh Brewfile, add streambot guild targeting, EU5 docs, and an Effect sandbox

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/eu5-on-macos.md
+++ b/packages/docs/wiki/src/content/docs/explanation/eu5-on-macos.md
@@ -1,0 +1,132 @@
+---
+title: Running Europa Universalis V on macOS
+description: Why EU5 needs a hand-built Wine 11.16 + DXMT stack on Apple silicon, and how the deadlock, the black Steam client, and the notch were each solved.
+sidebar:
+  order: 9
+---
+
+Europa Universalis V is a Windows-only Paradox title. It runs on a notched
+Apple-silicon MacBook through a self-built Wine 11.16 engine rather than
+CrossOver, because three separate problems each had to be solved and only a
+patched, from-source engine solves all of them at once. This page explains why
+the obvious approaches fail and what the working architecture actually is. The
+commands to operate it live in [Play EU5 on macOS](/how-to/play-eu5-on-macos/);
+the exact versions, paths, and flags live in
+[the EU5 Wine stack reference](/reference/eu5-wine-stack/).
+
+## Why not CrossOver
+
+CrossOver is the usual way to run a Windows game on macOS, and its Steam client
+renders perfectly. But EU5 1.3 ("Pavia") deadlocks under it: every game thread
+parks forever with no window. The cause is a lost-wakeup race in Wine's
+`NtWaitForAlertByThreadId` — a waiter and its waker can index different
+alert-table slots, so the wakeup is dropped and the thread sleeps permanently.
+EU5 1.3 leans on that path heavily during startup.
+
+The race was fixed upstream in Wine 11.8. CrossOver 26's engine is built on a
+Wine 11.0 base and has not been rebased since, so no CrossOver setting can avoid
+the hang. That single fact forces the whole approach: the game needs a Wine
+newer than 11.8, which means going outside CrossOver.
+
+## Three problems, one engine
+
+Moving to a stock newer Wine fixes the deadlock but surfaces two more problems
+that CrossOver had quietly handled. The working setup is the smallest stack that
+solves all three.
+
+```mermaid
+flowchart TD
+  accTitle: The EU5 macOS stack
+  accDescr: A patched Wine 11.16 engine runs both EU5 on Vulkan and the Steam client on DXMT, inside a prefix cloned from CrossOver.
+
+  subgraph engine[Patched Wine 11.16 engine]
+    WM[winemac.drv<br/>cross-process patch]
+    DX[DXMT winemetal<br/>remote-layer patch]
+  end
+  P[Prefix cloned from the<br/>old CrossOver bottle] --> engine
+  engine --> G[eu5.exe<br/>native Vulkan via MoltenVK]
+  engine --> S[Steam client<br/>CEF on DXMT/Metal]
+  S --> G
+  D[Display-mode switch<br/>notch-excluded 16:10] -.wraps.-> G
+```
+
+### The game itself
+
+EU5 renders through Vulkan, which Wine maps to Metal via MoltenVK. This was the
+easy part once the engine was new enough: the game reaches its menu and runs a
+campaign without any graphics translation layer of its own. It never touches
+Direct3D, which matters for keeping it isolated from the Steam-client fix below.
+
+### The Steam client rendered black
+
+Under stock Wine the Steam client window is entirely black. Steam's UI is
+Chromium (CEF), and Chromium's GPU process asks the driver for a Metal view
+belonging to a window owned by _another_ process. Stock `winemac.drv` keeps its
+window records per-process, so the lookup fails, the GPU process crashes six
+times, and Chromium gives up — a black window. CrossOver carries a private fix
+for exactly this; stock Wine does not.
+
+The open-source cure is a two-sided patch — one half in `winemac.drv`, one half
+in DXMT's Metal layer — that lets the driver hand a remote layer across the
+process boundary. It comes from the
+[macgameport Cities: Skylines II project](https://github.com/macgameport/cities-skylines-2-macos),
+which traced the same bug (WineHQ bug 60263). Applying it requires building both
+Wine and DXMT from source.
+
+That fix alone was still not enough. Even with the crash gone, Chromium refused
+to use the GPU: its driver blocklist saw no usable Direct3D or Vulkan device and
+fell back to software rendering, which cannot present the cross-process window —
+still black. The breakthrough was routing Chromium's ANGLE layer through its
+**Vulkan** backend, which reaches Metal via MoltenVK. ANGLE's Direct3D path fails
+on the adapter query and its GL path caps below what Chromium needs; only the
+Vulkan backend gives a working GPU context. Once ANGLE is on Vulkan and the GPU
+blocklist is overridden, compositing turns on and the client renders fully, with
+text.
+
+Those switches cannot be passed normally, because Steam strips them from its own
+web-helper's command line. They are injected by a tiny shim that stands in for
+the web-helper. EU5 keeps rendering through plain Vulkan and never loads the DXMT
+Direct3D layer, so the client fix and the game path stay independent.
+
+### The camera notch
+
+In fullscreen the game covered the whole display, so its top bar sat under the
+camera notch. macOS has a per-app "scale below built-in camera" mode for this,
+but it does not attach to Wine — the driver reads the raw display bounds and
+covers the notch regardless of the setting.
+
+The fix works one level down, at the display itself. A notched MacBook exposes
+two families of resolution: notch-inclusive modes that use the full panel height,
+and 16:10 notch-excluded modes that render everything below the notch with the
+notch row left black. Switching the built-in display to its notch-excluded twin
+for the duration of a play session — same sharpness, a few points shorter — puts
+the game, and everything else, below the notch. The launcher makes the switch on
+start and restores the normal mode on exit. On an external monitor there is no
+notch, so the switch is skipped.
+
+## The prefix and the Steam session
+
+The Wine prefix is a clone of the working CrossOver bottle, which mattered for
+one non-obvious reason: Steam's saved login. The refresh token lives in a file
+encrypted with Wine's implementation of Windows DPAPI, and under Wine that
+encryption is keyed only to the Windows user name, not the machine. Cloning the
+bottle and running the engine as the same Windows user (`crossover`) lets the
+existing token decrypt, so Steam logs in without a fresh sign-in. Copying
+individual config files did not work, because the token is not in them.
+
+One rule follows from sharing an account across two installs: the old CrossOver
+Steam must never be launched again. Each login rotates the refresh token and
+invalidates the other install's copy, so the two clients would knock each other
+out. The clone is now the only Steam that should run.
+
+## What this buys
+
+The game runs at full speed on Vulkan; the Steam client renders completely, so
+the store, library, Workshop, and cloud saves all work; and fullscreen clears the
+notch. Everything is one Wine 11.16 engine and one prefix, with CrossOver no
+longer in the path.
+
+## Related
+
+- [Play EU5 on macOS](/how-to/play-eu5-on-macos/) — launch, recover, rebuild
+- [EU5 Wine stack reference](/reference/eu5-wine-stack/) — versions, paths, flags

--- a/packages/docs/wiki/src/content/docs/how-to/play-eu5-on-macos.md
+++ b/packages/docs/wiki/src/content/docs/how-to/play-eu5-on-macos.md
@@ -1,0 +1,105 @@
+---
+title: Play EU5 on macOS
+description: Launch Europa Universalis V and the Steam client on the hand-built Wine stack, recover the display after a crash, and rebuild the patched engine.
+sidebar:
+  order: 17
+---
+
+Europa Universalis V runs on macOS through a self-built Wine 11.16 engine under
+`~/Applications/Wine-EU5`. This page is the operating manual. For why the stack
+is shaped this way see [Running EU5 on macOS](/explanation/eu5-on-macos/); for
+exact versions, paths, and flags see
+[the EU5 Wine stack reference](/reference/eu5-wine-stack/).
+
+## Play the game
+
+Double-click `EU5.app` in `~/Applications/Wine-EU5`, or run the launcher:
+
+```sh
+~/Applications/Wine-EU5/play-eu5.command
+```
+
+The launcher starts Steam headless (it auto-logs-in from the saved token),
+switches the built-in display to its notch-excluded mode, launches EU5 on Vulkan,
+and restores the display when the game exits. Steam, cloud saves, and Workshop
+are all live through the running client while you play.
+
+The first launch after a reboot spends up to a minute bringing Steam up before
+the game window appears; that is normal.
+
+## Open just the Steam client
+
+To browse the store, manage Workshop subscriptions, or check downloads without
+starting the game:
+
+```sh
+~/Applications/Wine-EU5/steam.command
+```
+
+The client window renders fully (store, library, friends). One known cosmetic
+limit: the store tab's article thumbnails stay dark. The library — which is what
+matters for launching and Workshop — is clean.
+
+## The one rule
+
+Never launch Steam from the old CrossOver install. It shares your account, and
+each CrossOver login rotates the refresh token and locks the Wine install out
+(the symptom is an `Access Denied` on next launch). Use only `play-eu5.command`
+and `steam.command`. If the token ever does get invalidated, sign in once through
+`steam.command`'s window to refresh it.
+
+## Recover the display after a crash
+
+The launcher restores your normal resolution when EU5 quits. If the game or the
+launcher is force-killed, the built-in display can be left in the shorter
+notch-excluded mode. Restore it with:
+
+```sh
+~/Applications/Wine-EU5/notch-restore.command
+```
+
+This is a no-op if the display is already normal or if you are on an external
+monitor.
+
+## Subscribe to Workshop mods
+
+Workshop content downloads through the running Steam client. Subscribe either
+from the client's Workshop pages (via `steam.command`) or from
+`steamcommunity.com` in any browser — the running client picks up the
+subscription and downloads it. Mods then appear in EU5's launcher.
+
+## Rebuild the patched engine
+
+The engine is prebuilt and committed to `~/Applications/Wine-EU5/runtime-1116`.
+Rebuild it only after a macOS or toolchain change breaks it. The build needs the
+toolchain (`brew install bison flex meson ninja mingw-w64 pkgconf`) and an
+x86_64 LLVM 15 for DXMT's shader compiler.
+
+1. Fetch and verify the Wine 11.16 source, apply the winemac patches from
+   `~/Applications/Wine-EU5/build/scripts`, and build `ntdll.so` plus the patched
+   `winemac.so` (unix side, x86_64).
+2. Build the patched DXMT `winemetal.so` and its Direct3D DLLs from the DXMT
+   v0.80 source with the remote-layer patch.
+3. Swap the patched `winemac.so` and `winemetal.so` into a fresh Gcenx Wine 11.16
+   runtime, install the DXMT DLLs into the prefix scoped to the web-helper, and
+   confirm the font-backend rpath is present on `win32u`, `dwrite`, `crypt32`,
+   and `secur32`.
+
+The exact commands, patch names, and verification checks are recorded in the
+build notes under `~/Applications/Wine-EU5/build`; the
+[reference page](/reference/eu5-wine-stack/) lists the version pins.
+
+## Verify a change
+
+After any change to the engine or launchers, confirm the whole path still works:
+
+- EU5 reaches its main menu and a campaign loads.
+- The Steam client library renders with text.
+- A save syncs (Steam's cloud log shows `PerformSyncCloud - all sync'd up`).
+- Fullscreen on the built-in display clears the notch, and the resolution
+  restores after quitting.
+
+## Related
+
+- [Running EU5 on macOS](/explanation/eu5-on-macos/) — why the stack looks like this
+- [EU5 Wine stack reference](/reference/eu5-wine-stack/) — versions, paths, flags

--- a/packages/docs/wiki/src/content/docs/reference/eu5-wine-stack.md
+++ b/packages/docs/wiki/src/content/docs/reference/eu5-wine-stack.md
@@ -1,0 +1,103 @@
+---
+title: EU5 Wine stack
+description: Versions, file layout, launch flags, and registry keys for the Europa Universalis V macOS setup under ~/Applications/Wine-EU5.
+sidebar:
+  order: 8
+---
+
+Lookup for the Europa Universalis V macOS setup. Rationale is in
+[Running EU5 on macOS](/explanation/eu5-on-macos/); procedures are in
+[Play EU5 on macOS](/how-to/play-eu5-on-macos/). Everything lives under
+`~/Applications/Wine-EU5`.
+
+## Versions
+
+| Component       | Version / build                                              |
+| --------------- | ------------------------------------------------------------ |
+| Wine engine     | 11.16 (Gcenx base, self-built patched `winemac.so`)          |
+| DXMT            | v0.80 + remote-layer patch (patched `winemetal.so`)          |
+| MoltenVK        | 1.4.1 (bundled in the Gcenx runtime)                         |
+| Game            | EU5, Steam app id `3450310` (1.3 "Pavia")                    |
+| Fallback engine | Wine 11.13 (Gcenx, unused; kept as `Wine Devel.app` at root) |
+| Patch source    | github.com/macgameport/cities-skylines-2-macos               |
+
+## File layout
+
+| Path (under `~/Applications/Wine-EU5`) | What it is                                             |
+| -------------------------------------- | ------------------------------------------------------ |
+| `runtime-1116/Wine Devel.app`          | The patched Wine 11.16 engine (the one in use)         |
+| `clone/`                               | The Wine prefix (cloned from the CrossOver bottle)     |
+| `clone/.../steamapps/`                 | The game files (~15 GB), moved out of the bottle       |
+| `build/`                               | Clone of the macgameport repo (patches, shim src)      |
+| `bin/notchmode`                        | Display-mode helper (source in `diag/notchmode.swift`) |
+| `play-eu5.command`                     | Launch Steam + game, with notch switch/restore         |
+| `steam.command`                        | Launch the Steam client only                           |
+| `notch-restore.command`                | Manual display recovery                                |
+| `EU5.app`                              | Double-click wrapper that runs `play-eu5.command`      |
+| `Wine Devel.app`                       | Unused 11.13 fallback engine (removable)               |
+
+## Run environment
+
+The engine must run as the Windows user `crossover` so Steam's DPAPI-encrypted
+refresh token decrypts:
+
+- `WINEPREFIX=~/Applications/Wine-EU5/clone`
+- `USER=crossover`
+- Wine binaries: `runtime-1116/Wine Devel.app/Contents/Resources/wine/bin`
+- Steam token: `clone/drive_c/users/crossover/AppData/Local/Steam/local.vdf`
+  (`ConnectCache`)
+- Game launch argument: `-vulkan`
+
+## Steam client render flags
+
+Injected into `steamwebhelper.exe` by the shim via the `SHIM_ARGS` environment
+variable (Steam strips them from its own command line otherwise):
+
+| Flag                         | Purpose                                             |
+| ---------------------------- | --------------------------------------------------- |
+| `--use-angle=vulkan`         | Route ANGLE to MoltenVK/Metal (D3D11 + GL fail)     |
+| `--in-process-gpu`           | Keep the GPU swapchain in the browser process       |
+| `--ignore-gpu-blocklist`     | Chromium blocklists the Wine GPU → software → black |
+| `--enable-gpu-rasterization` | Complete the GPU path                               |
+
+Steam is started with `-no-cef-sandbox -noverifyfiles`. `-noverifyfiles` is
+required: the client CRC-checks its executables and would otherwise restore the
+original web-helper over the shim. `steam.cfg` also carries
+`BootStrapperInhibitAll=Enable`.
+
+The shim replaces `steamwebhelper.exe` (original kept as
+`steamwebhelper_real.exe`), size-padded to the original's byte count. Source:
+`build/scripts/steamwebhelper-shim.c`.
+
+## Registry keys (in the prefix)
+
+DXMT's Direct3D DLLs are set to `native` **scoped to the web-helper only**, so
+EU5's own Vulkan path is unaffected:
+
+```
+HKCU\Software\Wine\AppDefaults\steamwebhelper.exe\DllOverrides
+  d3d11, d3d10core, dxgi, winemetal = native
+```
+
+The global `DllOverrides` must **not** carry these — a global `winemetal=native`
+breaks EU5's launch.
+
+## Display modes (built-in panel)
+
+`bin/notchmode` targets the built-in display only; it is a no-op in clamshell or
+on an external monitor.
+
+| Mode                | Resolution                  | Use                        |
+| ------------------- | --------------------------- | -------------------------- |
+| Normal              | 1512×982 pt (3024×1964 @2×) | Everyday (notch-inclusive) |
+| Notch-excluded twin | 1512×945 pt (3024×1890 @2×) | While playing (16:10)      |
+
+Helper subcommands: `print` (emit current mode token), `notch-off` (switch to the
+notch-excluded twin), `notch-on` (switch back to the notch-inclusive mode),
+`restore <ptW ptH pixW pixH refresh>` (restore an exact saved mode). The launcher
+saves the mode with `print`, calls `notch-off`, and restores via a shell `trap`.
+
+## Related
+
+- [Running EU5 on macOS](/explanation/eu5-on-macos/) — why the stack looks like this
+- [Play EU5 on macOS](/how-to/play-eu5-on-macos/) — how to operate it

--- a/packages/dotfiles/.Brewfile_darwin
+++ b/packages/dotfiles/.Brewfile_darwin
@@ -1,4 +1,4 @@
-tap "artginzburg/tap", trusted: { formulae: ["sudo-touchid"] }
+tap "artginzburg/tap"
 tap "buildkite/buildkite"
 tap "catppuccin/tap"
 tap "cormacrelf/tap"
@@ -76,6 +76,8 @@ brew "herdr"
 brew "hyperfine"
 # Tool to unpack installers created by Inno Setup
 brew "innoextract", args: ["HEAD"]
+# Enhanced version of john, a UNIX password cracker
+brew "john-jumbo"
 # Lightweight and flexible command-line JSON processor
 brew "jq"
 # Static analysis tool for Kubernetes YAML files and Helm charts
@@ -144,6 +146,8 @@ brew "watch"
 brew "watchman"
 # Internet file retriever
 brew "wget"
+# Network analyzer and capture tool - without graphical user interface
+brew "wireshark"
 # Generate your Xcode project from a spec file and your folder structure
 brew "xcodegen"
 # Process YAML, JSON, XML, CSV and properties documents from the CLI
@@ -152,6 +156,8 @@ brew "yq"
 brew "yt-dlp"
 # Pluggable terminal workspace, with terminal multiplexer as the base feature
 brew "zellij"
+# Permanent TouchID support for sudo
+brew "artginzburg/tap/sudo-touchid", trusted: true
 # Work with Buildkite from the command-line
 brew "buildkite/buildkite/bk@3", trusted: true
 # Watcher for macOS 10.14+ light/dark mode changes
@@ -212,6 +218,8 @@ cask "ghostty"
 cask "google-chrome"
 # Web browser
 cask "google-chrome@canary"
+# Extensible coding agent for the terminal
+cask "grok-build"
 # Free and open-source media player
 cask "iina"
 # File archiver
@@ -236,6 +244,8 @@ cask "paseo"
 cask "qlmarkdown"
 # Window snapping tool
 cask "rectangle-pro"
+# Video game digital distribution service
+cask "steam"
 # Text editor for code, markup and prose
 cask "sublime-text"
 # Control windows and applications right from your trackpad
@@ -246,8 +256,12 @@ cask "syncthing-app"
 cask "syntax-highlight"
 # Mesh VPN based on WireGuard
 cask "tailscale-app"
+# Virtual machines UI using QEMU
+cask "utm"
 # Open-source code editor
 cask "visual-studio-code"
+# Network protocol analyzer
+cask "wireshark-app"
 # Multiplayer code editor
 cask "zed"
 vscode "catppuccin.catppuccin-vsc"
@@ -256,7 +270,6 @@ vscode "vscodevim.vim"
 go "cmd/go"
 go "cmd/gofmt"
 uv "docling[asr,easyocr,htmlrender,ocrmac,onnxruntime,rapidocr,remote-serving,tesserocr,vlm,xbrl]"
-npm "@google/gemini-cli"
 npm "@posthog/cli"
 npm "corepack"
 npm "eslint"

--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -1047,6 +1047,20 @@
           "result": true
         },
         {
+          "segmentKey": "streambot-guild-208425771172102144",
+          "segmentOperator": "OR_SEGMENT_OPERATOR",
+          "matchType": "ALL_SEGMENT_MATCH_TYPE",
+          "constraints": [
+            {
+              "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+              "property": "server",
+              "operator": "eq",
+              "value": "208425771172102144"
+            }
+          ],
+          "result": true
+        },
+        {
           "segmentKey": "streambot-user-160509172704739328",
           "segmentOperator": "OR_SEGMENT_OPERATOR",
           "matchType": "ALL_SEGMENT_MATCH_TYPE",
@@ -1124,6 +1138,20 @@
               "property": "server",
               "operator": "eq",
               "value": "1337623164146155593"
+            }
+          ],
+          "result": true
+        },
+        {
+          "segmentKey": "streambot-guild-208425771172102144",
+          "segmentOperator": "OR_SEGMENT_OPERATOR",
+          "matchType": "ALL_SEGMENT_MATCH_TYPE",
+          "constraints": [
+            {
+              "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+              "property": "server",
+              "operator": "eq",
+              "value": "208425771172102144"
             }
           ],
           "result": true

--- a/sandbox/practice/effect/.gitignore
+++ b/sandbox/practice/effect/.gitignore
@@ -1,0 +1,34 @@
+# dependencies (bun install)
+node_modules
+
+# output
+out
+dist
+*.tgz
+
+# code coverage
+coverage
+*.lcov
+
+# logs
+logs
+_.log
+report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# caches
+.eslintcache
+.cache
+*.tsbuildinfo
+
+# IntelliJ based IDEs
+.idea
+
+# Finder (MacOS) folder config
+.DS_Store

--- a/sandbox/practice/effect/AGENTS.md
+++ b/sandbox/practice/effect/AGENTS.md
@@ -1,0 +1,105 @@
+Default to using Bun instead of Node.js.
+
+- Use `bun <file>` instead of `node <file>` or `ts-node <file>`
+- Use `bun test` instead of `jest` or `vitest`
+- Use `bun build <file.html|file.ts|file.css>` instead of `webpack` or `esbuild`
+- Use `bun install` instead of `npm install` or `yarn install` or `pnpm install`
+- Use `bun run <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
+- Use `bunx <package> <command>` instead of `npx <package> <command>`
+- Bun automatically loads .env, so don't use dotenv.
+
+## APIs
+
+- `Bun.serve()` supports WebSockets, HTTPS, and routes. Don't use `express`.
+- `bun:sqlite` for SQLite. Don't use `better-sqlite3`.
+- `Bun.redis` for Redis. Don't use `ioredis`.
+- `Bun.sql` for Postgres. Don't use `pg` or `postgres.js`.
+- `WebSocket` is built-in. Don't use `ws`.
+- Prefer `Bun.file` over `node:fs`'s readFile/writeFile
+- Bun.$`ls` instead of execa.
+
+## Testing
+
+Use `bun test` to run tests.
+
+```ts#index.test.ts
+import { test, expect } from "bun:test";
+
+test("hello world", () => {
+  expect(1).toBe(1);
+});
+```
+
+## Frontend
+
+Use HTML imports with `Bun.serve()`. Don't use `vite`. HTML imports fully support React, CSS, Tailwind.
+
+Server:
+
+```ts#index.ts
+import index from "./index.html"
+
+Bun.serve({
+  routes: {
+    "/": index,
+    "/api/users/:id": {
+      GET: (req) => {
+        return new Response(JSON.stringify({ id: req.params.id }));
+      },
+    },
+  },
+  // optional websocket support
+  websocket: {
+    open: (ws) => {
+      ws.send("Hello, world!");
+    },
+    message: (ws, message) => {
+      ws.send(message);
+    },
+    close: (ws) => {
+      // handle close
+    }
+  },
+  development: {
+    hmr: true,
+    console: true,
+  }
+})
+```
+
+HTML files can import .tsx, .jsx or .js files directly and Bun's bundler will transpile & bundle automatically. `<link>` tags can point to stylesheets and Bun's CSS bundler will bundle.
+
+```html#index.html
+<html>
+  <body>
+    <h1>Hello, world!</h1>
+    <script type="module" src="./frontend.tsx"></script>
+  </body>
+</html>
+```
+
+With the following `frontend.tsx`:
+
+```tsx#frontend.tsx
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+// import .css files directly and it works
+import './index.css';
+
+const root = createRoot(document.body);
+
+export default function Frontend() {
+  return <h1>Hello, world!</h1>;
+}
+
+root.render(<Frontend />);
+```
+
+Then, run index.ts
+
+```sh
+bun --hot ./index.ts
+```
+
+For more information, read the Bun API docs in `node_modules/bun-types/docs/**.mdx`.

--- a/sandbox/practice/effect/CLAUDE.md
+++ b/sandbox/practice/effect/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/sandbox/practice/effect/README.md
+++ b/sandbox/practice/effect/README.md
@@ -1,0 +1,15 @@
+# effect
+
+To install dependencies:
+
+```bash
+bun install
+```
+
+To run:
+
+```bash
+bun run index.ts
+```
+
+This project was created using `bun init` in bun v1.4.0. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.

--- a/sandbox/practice/effect/bun.lock
+++ b/sandbox/practice/effect/bun.lock
@@ -1,0 +1,97 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "effect",
+      "dependencies": {
+        "effect": "^4.0.0-rc.111",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^7",
+      },
+    },
+  },
+  "packages": {
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "effect": ["effect@4.0.0-rc.111", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA=="],
+
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
+    "msgpackr": ["msgpackr@2.0.5", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
+
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
+
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/sandbox/practice/effect/index.ts
+++ b/sandbox/practice/effect/index.ts
@@ -1,0 +1,31 @@
+import { Effect } from "effect";
+import * as fs from "fs";
+
+const divide = (a: number, b: number): Effect.Effect<number, Error, never> =>
+  b === 0
+    ? Effect.fail(new Error("Cannot divide by zero"))
+    : Effect.succeed(a / b);
+
+function grabFromFile(path: string): Effect.Effect<string, Error, never> {
+  return Effect.try({
+    try: () => fs.readFileSync(path, "utf-8"),
+    catch: (error) => {
+      return new Error(`Error reading file: ${error}`);
+    },
+  });
+}
+
+function doingTwoThings(): Effect.Effect<unknown, Error, never> {
+  const result = divide(4, 2);
+  const fileContent = grabFromFile("example.txt");
+
+  // OK, but what if fileContent or divide fail?
+
+  // at this point we essentially just have
+  // an effect with iirc will be a Monad
+  // so we are doing computation in a wrapper
+  // we would need to perform the console log also in an effect
+  console.log(`${result}, ${fileContent}`);
+}
+
+Effect.runSync(divide(4, 2)); // => 2

--- a/sandbox/practice/effect/package.json
+++ b/sandbox/practice/effect/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "effect",
+  "module": "index.ts",
+  "type": "module",
+  "private": true,
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^7"
+  },
+  "dependencies": {
+    "effect": "^4.0.0-rc.111"
+  }
+}

--- a/sandbox/practice/effect/tsconfig.json
+++ b/sandbox/practice/effect/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "types": ["bun"],
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}


### PR DESCRIPTION
## Why

Four unrelated local changes had accumulated in the worktree: the committed
macOS Brewfile had drifted from what is actually installed, a Discord guild
still needed opting into two streambot rollouts, the EU5-on-macOS Wine setup
existed only as undocumented knowledge, and an Effect scratch project was
sitting untracked.

## What

One focused commit per area:

- `chore(dotfiles)` — refresh `.Brewfile_darwin` from the live machine: add
  `john-jumbo`, `wireshark`, `sudo-touchid`, `grok-build`, `steam`, `utm`,
  `wireshark-app`; drop the `@google/gemini-cli` npm entry; move
  `sudo-touchid`'s trusted marker from the tap to the formula entry.
- `feat(feature-flags)` — add a `streambot-guild-208425771172102144` segment
  (matching on `server`) to `streambot-assistant-v2-enabled` and
  `streambot-history-enabled`. No defaults or existing targeting touched.
- `docs(docs)` — three cross-linked Diataxis wiki pages for running Europa
  Universalis V on Apple silicon: explanation (why CrossOver and stock Wine each
  fail), how-to (launch, display recovery, engine rebuild), reference (versions,
  paths, flags, registry keys).
- `chore(practice)` — `sandbox/practice/effect`, a self-contained `bun init`
  project on effect 4.0.0-rc. Its bun-init boilerplate guidance was normalized
  to the repo convention (AGENTS.md plus a CLAUDE.md symlink, no duplicate
  `.cursor/rules` copy) so the agent-guidance guard passes.

A leftover `packages/homelab/homelab-release-result.json` — a per-run Buildkite
receipt, not source — was deleted rather than committed.

## Verification

- `bunx turbo run build typecheck test lint --continue` for
  `@shepherdjerred/feature-flags`, `@shepherdjerred/docs-wiki`, and
  `@shepherdjerred/dotfiles-scripts`: 14/14 tasks green, including the managed
  flag drift and inventory tests and a full 76-page wiki build covering the
  three new routes.
- `bunx lefthook run pre-commit` on the staged paths of every commit
  (prettier, gitleaks, lockfile-check, agent-guidance, suppressions).
- The one new external URL in the docs returns HTTP 200.

Not verified: Buildkite CI on this head (this PR is the first build); a
clean-machine `install_macos.sh` bootstrap; live Flipt evaluation for guild
`208425771172102144`, which needs the Flipt UI since the API has no update verb
for existing flags. No deployment or runtime behavior is affected by this
branch.