### PR TITLE
feat(scout-for-lol): add V2 workflow contracts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1644,6 +1644,7 @@
       "name": "@scout-for-lol/temporal",
       "version": "0.1.0",
       "dependencies": {
+        "@scout-for-lol/domain": "workspace:*",
         "@temporalio/common": "1.22.0",
         "@temporalio/workflow": "1.22.0",
         "zod": "^4.4.3",

--- a/packages/scout-for-lol/packages/temporal/package.json
+++ b/packages/scout-for-lol/packages/temporal/package.json
@@ -9,7 +9,10 @@
   "exports": {
     ".": "./src/index.ts",
     "./activities": "./src/activities.ts",
+    "./activity-contracts-v2": "./src/activity-contracts-v2.ts",
     "./contracts": "./src/contracts.ts",
+    "./contracts-v2": "./src/contracts-v2.ts",
+    "./workflow-contracts-v2": "./src/workflow-contracts-v2.ts",
     "./execution-metadata": "./src/execution-metadata.ts",
     "./identifiers": "./src/identifiers.ts",
     "./signals": "./src/signals.ts",
@@ -33,6 +36,7 @@
     "test:report": "CI_TEST_COVERAGE=1 bun ../../../../scripts/ci/run-ci-test.ts"
   },
   "dependencies": {
+    "@scout-for-lol/domain": "workspace:*",
     "@temporalio/common": "1.22.0",
     "@temporalio/workflow": "1.22.0",
     "zod": "^4.4.3"

--- a/packages/scout-for-lol/packages/temporal/src/activities.ts
+++ b/packages/scout-for-lol/packages/temporal/src/activities.ts
@@ -24,6 +24,43 @@ import type {
   ScoutDuelSeriesInput,
   ScoutDuelSeriesRefreshResult,
 } from "./contracts.ts";
+import type {
+  ScoutGameRefV2,
+  ScoutIntentAttemptRefV2,
+  ScoutIntentRefV2,
+  ScoutMatchRefV2,
+  ScoutRecoveryBatchRefV2,
+} from "./contracts-v2.ts";
+import type {
+  ScoutPipelineReconciliationV2Input,
+  ScoutPostMatchDiscoveryV2Input,
+  ScoutPrematchDiscoveryV2Input,
+} from "./workflow-contracts-v2.ts";
+import type {
+  ScoutArchiveV2Result,
+  ScoutFanOutV2Result,
+  ScoutGuardedEffectV2Result,
+  ScoutLakeStagingV2Result,
+  ScoutMatchCursorV2Result,
+  ScoutMatchObservationV2Result,
+  ScoutMatchPipelineStateV2Result,
+  ScoutMatchReceiptsV2Input,
+  ScoutNotificationDeliveryV2Result,
+  ScoutNotificationIntentV2Result,
+  ScoutNotificationOutcomeV2Input,
+  ScoutNotificationRenderV2Result,
+  ScoutNotificationTransitionV2Result,
+  ScoutPostMatchScanV2Result,
+  ScoutPrematchArchiveV2Result,
+  ScoutPrematchScanV2Result,
+  ScoutReceiptsV2Result,
+  ScoutReconciliationScanV2Result,
+  ScoutRecoveryBatchStateV2Result,
+  ScoutRecoveryCloseV2Input,
+  ScoutRecoveryProcessV2Result,
+  ScoutRecoveryScanV2Result,
+  ScoutRecoveryTransitionV2Result,
+} from "./activity-contracts-v2.ts";
 
 export type ScoutTemporalActivities = {
   probeQueue: (
@@ -69,3 +106,107 @@ export type ScoutTemporalActivities = {
   ) => Promise<ScoutDuelSeriesRefreshResult>;
   markDuelSeriesOverdue: (input: ScoutDuelSeriesInput) => Promise<void>;
 };
+
+/**
+ * Activities the eight V2 Workflow Types call.
+ *
+ * Every signature is identifier-in, summary-out: an input carries references
+ * the backend can resolve, and a result carries domain state unions,
+ * repository outcomes and counts. No Riot payload, rendered report, image or
+ * settlement body crosses this boundary; artifact DESCRIPTORS do, because they
+ * name stored bytes rather than carrying them.
+ *
+ * The queue each Activity runs on is declared once, in
+ * `SCOUT_V2_ACTIVITY_QUEUE_CLASSES` (`identifiers.ts`); the Workflows proxy
+ * them through the matching factory in `workflows/activity-options.ts`.
+ */
+export type ScoutTemporalV2Activities = {
+  // Discovery — Riot reads, realtime.
+  discoverPostMatchIdsV2: (
+    input: ScoutPostMatchDiscoveryV2Input,
+  ) => Promise<ScoutPostMatchScanV2Result>;
+  discoverPrematchGamesV2: (
+    input: ScoutPrematchDiscoveryV2Input,
+  ) => Promise<ScoutPrematchScanV2Result>;
+
+  // Resume points — one aggregate read per machine, realtime except recovery.
+  readMatchPipelineStateV2: (
+    input: ScoutMatchRefV2,
+  ) => Promise<ScoutMatchPipelineStateV2Result>;
+  readNotificationIntentV2: (
+    input: ScoutIntentRefV2,
+  ) => Promise<ScoutNotificationIntentV2Result>;
+  readRecoveryBatchV2: (
+    input: ScoutRecoveryBatchRefV2,
+  ) => Promise<ScoutRecoveryBatchStateV2Result>;
+
+  // Per-match core — Riot fetch, S3 write and short domain commits, realtime.
+  archiveMatchArtifactsV2: (
+    input: ScoutMatchRefV2,
+  ) => Promise<ScoutArchiveV2Result>;
+  commitMatchObservationV2: (
+    input: ScoutMatchRefV2,
+  ) => Promise<ScoutMatchObservationV2Result>;
+  settleMatchMarketsV2: (
+    input: ScoutMatchRefV2,
+  ) => Promise<ScoutGuardedEffectV2Result>;
+  applyMatchProgressionV2: (
+    input: ScoutMatchRefV2,
+  ) => Promise<ScoutGuardedEffectV2Result>;
+  recordMatchReceiptsV2: (
+    input: ScoutMatchReceiptsV2Input,
+  ) => Promise<ScoutReceiptsV2Result>;
+  advanceMatchCursorV2: (
+    input: ScoutMatchRefV2,
+  ) => Promise<ScoutMatchCursorV2Result>;
+  planMatchFanOutV2: (input: ScoutMatchRefV2) => Promise<ScoutFanOutV2Result>;
+
+  // Prematch — spectator fetch and S3 write, realtime.
+  archivePrematchSnapshotV2: (
+    input: ScoutGameRefV2,
+  ) => Promise<ScoutPrematchArchiveV2Result>;
+  planPrematchFanOutV2: (
+    input: ScoutMatchRefV2,
+  ) => Promise<ScoutFanOutV2Result>;
+
+  // Notification — rendering on background, the intent machine on realtime.
+  markNotificationReadyV2: (
+    input: ScoutIntentRefV2,
+  ) => Promise<ScoutNotificationTransitionV2Result>;
+  renderNotificationArtifactV2: (
+    input: ScoutIntentRefV2,
+  ) => Promise<ScoutNotificationRenderV2Result>;
+  beginNotificationSendV2: (
+    input: ScoutIntentAttemptRefV2,
+  ) => Promise<ScoutNotificationTransitionV2Result>;
+  deliverNotificationV2: (
+    input: ScoutIntentAttemptRefV2,
+  ) => Promise<ScoutNotificationDeliveryV2Result>;
+  recordNotificationOutcomeV2: (
+    input: ScoutNotificationOutcomeV2Input,
+  ) => Promise<ScoutNotificationTransitionV2Result>;
+
+  // Lake — receipted staging on the lake queue, heartbeating.
+  stageLakeProjectionV2: (
+    input: ScoutMatchRefV2,
+  ) => Promise<ScoutLakeStagingV2Result>;
+
+  // Recovery and reconciliation — bounded scans, background.
+  scanRecoveryPageV2: (
+    input: ScoutRecoveryBatchRefV2,
+  ) => Promise<ScoutRecoveryScanV2Result>;
+  processRecoveryPageV2: (
+    input: ScoutRecoveryBatchRefV2,
+  ) => Promise<ScoutRecoveryProcessV2Result>;
+  digestRecoveryBatchV2: (
+    input: ScoutRecoveryBatchRefV2,
+  ) => Promise<ScoutRecoveryTransitionV2Result>;
+  closeRecoveryBatchV2: (
+    input: ScoutRecoveryCloseV2Input,
+  ) => Promise<ScoutRecoveryTransitionV2Result>;
+  scanPipelineReconciliationPageV2: (
+    input: ScoutPipelineReconciliationV2Input,
+  ) => Promise<ScoutReconciliationScanV2Result>;
+};
+
+export type ScoutV2ActivityName = keyof ScoutTemporalV2Activities;

--- a/packages/scout-for-lol/packages/temporal/src/activity-contracts-v2.ts
+++ b/packages/scout-for-lol/packages/temporal/src/activity-contracts-v2.ts
@@ -1,0 +1,361 @@
+import { z } from "zod";
+import { ArtifactDescriptorSchema } from "@scout-for-lol/domain/artifacts/descriptors.ts";
+import {
+  DiscordMessageIdSchema,
+  RiotMatchIdSchema,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  MatchProcessingPolicySchema,
+  PipelineOwnerSchema,
+  ReceiptKindSchema,
+} from "@scout-for-lol/domain/match-processing/states.ts";
+import {
+  NotificationFailureSchema,
+  NotificationIntentStateSchema,
+} from "@scout-for-lol/domain/notifications/intent.ts";
+import {
+  RecoveryAbandonReasonSchema,
+  RecoveryBatchStateSchema,
+  RecoveryCountsSchema,
+  RecoveryPolicySchema,
+} from "@scout-for-lol/domain/recovery/batch.ts";
+import {
+  SCOUT_V2_PAGE_MAX,
+  ScoutDurableCommitV2Schema,
+  ScoutIntentAttemptRefV2Schema,
+  ScoutMatchRefV2Schema,
+  ScoutNotificationIntentKeySchema,
+  ScoutPrematchGameRefSchema,
+  ScoutReceiptOutcomeV2Schema,
+  ScoutRecoveryBatchIdSchema,
+  ScoutRecoveryBatchRefV2Schema,
+} from "./contracts-v2.ts";
+
+// ─── V2 Activity contracts ─────────────────────────────────────────────────
+
+/**
+ * Activity payloads are flat and strict. Inputs carry identifiers and small
+ * references; results carry domain state unions, repository outcomes, and
+ * counts. These shapes are append-only: a lane that needs a breaking change
+ * introduces a new Activity name rather than redefining one that in-flight
+ * histories already recorded.
+ */
+
+export const ScoutPostMatchScanV2ResultSchema = z.strictObject({
+  riotMatchIds: z.array(RiotMatchIdSchema).max(SCOUT_V2_PAGE_MAX).readonly(),
+  /** False when the scan hit its page budget before the tail was exhausted. */
+  complete: z.boolean(),
+});
+export type ScoutPostMatchScanV2Result = z.infer<
+  typeof ScoutPostMatchScanV2ResultSchema
+>;
+
+export const ScoutPrematchScanV2ResultSchema = z.strictObject({
+  games: z.array(ScoutPrematchGameRefSchema).max(SCOUT_V2_PAGE_MAX).readonly(),
+  complete: z.boolean(),
+});
+export type ScoutPrematchScanV2Result = z.infer<
+  typeof ScoutPrematchScanV2ResultSchema
+>;
+
+/**
+ * One archived artifact. The descriptor names the stored bytes by key and
+ * digest — a reference, never the payload — and `receipt` reports the durable
+ * attestation separately from the store, because the object write and the
+ * receipt row are two commits that cannot share a transaction.
+ */
+export const ScoutArchivedArtifactV2Schema = z.strictObject({
+  descriptor: ArtifactDescriptorSchema,
+  outcome: z.enum(["stored", "already-stored"]),
+  receipt: ScoutReceiptOutcomeV2Schema,
+});
+export type ScoutArchivedArtifactV2 = z.infer<
+  typeof ScoutArchivedArtifactV2Schema
+>;
+
+export const ScoutArchiveV2ResultSchema = z.strictObject({
+  artifacts: z.array(ScoutArchivedArtifactV2Schema).readonly(),
+});
+export type ScoutArchiveV2Result = z.infer<typeof ScoutArchiveV2ResultSchema>;
+
+export const ScoutPrematchArchiveV2ResultSchema =
+  ScoutArchiveV2ResultSchema.extend({
+    /** Composed from the game reference: Riot builds the same id later. */
+    riotMatchId: RiotMatchIdSchema,
+  });
+export type ScoutPrematchArchiveV2Result = z.infer<
+  typeof ScoutPrematchArchiveV2ResultSchema
+>;
+
+export const ScoutMatchObservationV2ResultSchema = z.strictObject({
+  commit: ScoutDurableCommitV2Schema,
+  owner: PipelineOwnerSchema,
+  policy: MatchProcessingPolicySchema,
+  promoted: z.boolean(),
+});
+export type ScoutMatchObservationV2Result = z.infer<
+  typeof ScoutMatchObservationV2ResultSchema
+>;
+
+/**
+ * A guarded at-most-once effect: settlement, progression, anything whose
+ * second application would be visible.
+ *
+ * `guard` and `fact` are separate fields, not one outcome, because
+ * `ScoutEffectClaim` takes the top-level Prisma client and so cannot enlist in
+ * the transaction that writes the fact. A run that claimed the guard and
+ * crashed before the fact leaves `guard: already-applied` with
+ * `fact: applied` on the next attempt — the reconcile — and that has to be
+ * reportable rather than indistinguishable from a double application.
+ */
+export const ScoutGuardedEffectV2ResultSchema = z.strictObject({
+  guard: ScoutDurableCommitV2Schema,
+  fact: ScoutDurableCommitV2Schema,
+  /** How many domain records this run actually changed. */
+  effects: z.int().nonnegative(),
+});
+export type ScoutGuardedEffectV2Result = z.infer<
+  typeof ScoutGuardedEffectV2ResultSchema
+>;
+
+export const ScoutMatchReceiptsV2InputSchema = ScoutMatchRefV2Schema.extend({
+  kinds: z.array(ReceiptKindSchema).min(1).max(SCOUT_V2_PAGE_MAX).readonly(),
+});
+export type ScoutMatchReceiptsV2Input = z.infer<
+  typeof ScoutMatchReceiptsV2InputSchema
+>;
+
+export const ScoutReceiptsV2ResultSchema = z.strictObject({
+  receipts: z.array(ScoutReceiptOutcomeV2Schema).readonly(),
+});
+export type ScoutReceiptsV2Result = z.infer<typeof ScoutReceiptsV2ResultSchema>;
+
+export const ScoutMatchCursorV2ResultSchema = z.strictObject({
+  advanced: z.int().nonnegative(),
+  alreadyAdvanced: z.int().nonnegative(),
+});
+export type ScoutMatchCursorV2Result = z.infer<
+  typeof ScoutMatchCursorV2ResultSchema
+>;
+
+/**
+ * What to start once the domain commit stands.
+ *
+ * The intent keys are READ from the durable intent rows for this match, never
+ * derived per channel by the caller: a Workflow that guessed a key per channel
+ * would miss intents another producer minted and would re-mint keys for
+ * intents that already exist.
+ */
+export const ScoutFanOutV2ResultSchema = z.strictObject({
+  notificationIntentKeys: z
+    .array(ScoutNotificationIntentKeySchema)
+    .max(SCOUT_V2_PAGE_MAX)
+    .readonly(),
+  lakeProjection: z.boolean(),
+});
+export type ScoutFanOutV2Result = z.infer<typeof ScoutFanOutV2ResultSchema>;
+
+/** One intent, summarised in the domain's own state vocabulary. */
+export const ScoutIntentSummaryV2Schema = z.strictObject({
+  intentKey: ScoutNotificationIntentKeySchema,
+  state: NotificationIntentStateSchema,
+  attemptCount: z.int().nonnegative(),
+  lastFailure: NotificationFailureSchema.optional(),
+});
+export type ScoutIntentSummaryV2 = z.infer<typeof ScoutIntentSummaryV2Schema>;
+
+/**
+ * The resume point for one match: the single aggregate read that tells a
+ * restarted or Continue-As-New'd Workflow which phases already happened.
+ *
+ * It spans observation, receipts, intents and tracked accounts on purpose. A
+ * Workflow that reconstructed this from per-key lookups would need to know the
+ * intent keys before it could read them, which is exactly the thing it is
+ * asking about.
+ */
+export const ScoutMatchPipelineStateV2Schema = z.strictObject({
+  riotMatchId: RiotMatchIdSchema,
+  owner: PipelineOwnerSchema,
+  policy: MatchProcessingPolicySchema,
+  promoted: z.boolean(),
+  receiptKinds: z.array(ReceiptKindSchema).readonly(),
+  intents: z
+    .array(ScoutIntentSummaryV2Schema)
+    .max(SCOUT_V2_PAGE_MAX)
+    .readonly(),
+  trackedAccounts: z.strictObject({
+    total: z.int().nonnegative(),
+    cursorAdvanced: z.int().nonnegative(),
+  }),
+});
+export type ScoutMatchPipelineStateV2 = z.infer<
+  typeof ScoutMatchPipelineStateV2Schema
+>;
+
+export const ScoutMatchPipelineStateV2ResultSchema = z.discriminatedUnion(
+  "kind",
+  [
+    z.strictObject({ kind: z.literal("absent") }),
+    z.strictObject({
+      kind: z.literal("present"),
+      state: ScoutMatchPipelineStateV2Schema,
+    }),
+  ],
+);
+export type ScoutMatchPipelineStateV2Result = z.infer<
+  typeof ScoutMatchPipelineStateV2ResultSchema
+>;
+
+export const ScoutNotificationIntentV2ResultSchema = z.discriminatedUnion(
+  "kind",
+  [
+    z.strictObject({ kind: z.literal("absent") }),
+    z.strictObject({
+      kind: z.literal("present"),
+      intent: ScoutIntentSummaryV2Schema,
+    }),
+  ],
+);
+export type ScoutNotificationIntentV2Result = z.infer<
+  typeof ScoutNotificationIntentV2ResultSchema
+>;
+
+export const ScoutRecoveryBatchStateV2ResultSchema = z.discriminatedUnion(
+  "kind",
+  [
+    z.strictObject({ kind: z.literal("absent") }),
+    z.strictObject({
+      kind: z.literal("present"),
+      policy: RecoveryPolicySchema,
+      state: RecoveryBatchStateSchema,
+    }),
+  ],
+);
+export type ScoutRecoveryBatchStateV2Result = z.infer<
+  typeof ScoutRecoveryBatchStateV2ResultSchema
+>;
+
+export const ScoutNotificationTransitionV2ResultSchema = z.strictObject({
+  commit: ScoutDurableCommitV2Schema,
+  state: NotificationIntentStateSchema,
+  attemptCount: z.int().nonnegative(),
+});
+export type ScoutNotificationTransitionV2Result = z.infer<
+  typeof ScoutNotificationTransitionV2ResultSchema
+>;
+
+/** Rendering reuses committed output; `reused` means nothing was re-rendered. */
+export const ScoutNotificationRenderV2ResultSchema = z.strictObject({
+  outcome: z.enum(["rendered", "reused"]),
+});
+export type ScoutNotificationRenderV2Result = z.infer<
+  typeof ScoutNotificationRenderV2ResultSchema
+>;
+
+/**
+ * What the send attempt observed. `unknown` is not a failure and must never
+ * be turned into one: the request left, the response did not arrive, and only
+ * an operator can decide whether a message exists.
+ */
+export const ScoutNotificationDeliveryV2ResultSchema = z.discriminatedUnion(
+  "outcome",
+  [
+    z.strictObject({
+      outcome: z.literal("delivered"),
+      messageId: DiscordMessageIdSchema.optional(),
+    }),
+    z.strictObject({
+      outcome: z.literal("failed"),
+      failure: NotificationFailureSchema,
+    }),
+    z.strictObject({ outcome: z.literal("unknown") }),
+  ],
+);
+export type ScoutNotificationDeliveryV2Result = z.infer<
+  typeof ScoutNotificationDeliveryV2ResultSchema
+>;
+
+export const ScoutNotificationOutcomeV2InputSchema =
+  ScoutIntentAttemptRefV2Schema.extend({
+    delivery: ScoutNotificationDeliveryV2ResultSchema,
+  });
+export type ScoutNotificationOutcomeV2Input = z.infer<
+  typeof ScoutNotificationOutcomeV2InputSchema
+>;
+
+export const ScoutLakeStagingV2ResultSchema = z.strictObject({
+  receipts: z.array(ScoutReceiptOutcomeV2Schema).readonly(),
+  stagedFileCount: z.int().nonnegative(),
+});
+export type ScoutLakeStagingV2Result = z.infer<
+  typeof ScoutLakeStagingV2ResultSchema
+>;
+
+export const ScoutRecoveryScanV2ResultSchema = z.strictObject({
+  commit: ScoutDurableCommitV2Schema,
+  state: RecoveryBatchStateSchema,
+  discovered: z.int().nonnegative(),
+  /** True once the scan is done, whether exhausted or budget-capped. */
+  complete: z.boolean(),
+});
+export type ScoutRecoveryScanV2Result = z.infer<
+  typeof ScoutRecoveryScanV2ResultSchema
+>;
+
+export const ScoutRecoveryProcessV2ResultSchema = z.strictObject({
+  commit: ScoutDurableCommitV2Schema,
+  state: RecoveryBatchStateSchema,
+  counts: RecoveryCountsSchema,
+  complete: z.boolean(),
+});
+export type ScoutRecoveryProcessV2Result = z.infer<
+  typeof ScoutRecoveryProcessV2ResultSchema
+>;
+
+export const ScoutRecoveryTransitionV2ResultSchema = z.strictObject({
+  commit: ScoutDurableCommitV2Schema,
+  state: RecoveryBatchStateSchema,
+});
+export type ScoutRecoveryTransitionV2Result = z.infer<
+  typeof ScoutRecoveryTransitionV2ResultSchema
+>;
+
+export const ScoutRecoveryCloseV2InputSchema =
+  ScoutRecoveryBatchRefV2Schema.extend({
+    close: z.discriminatedUnion("outcome", [
+      z.strictObject({ outcome: z.literal("complete") }),
+      z.strictObject({
+        outcome: z.literal("abandoned"),
+        reason: RecoveryAbandonReasonSchema,
+      }),
+    ]),
+  });
+export type ScoutRecoveryCloseV2Input = z.infer<
+  typeof ScoutRecoveryCloseV2InputSchema
+>;
+
+/** One bounded reconciliation page: what it found that nothing is driving. */
+export const ScoutReconciliationScanV2ResultSchema = z.strictObject({
+  complete: z.boolean(),
+  pending: z.strictObject({
+    matchProcessing: z
+      .array(RiotMatchIdSchema)
+      .max(SCOUT_V2_PAGE_MAX)
+      .readonly(),
+    notifications: z
+      .array(ScoutNotificationIntentKeySchema)
+      .max(SCOUT_V2_PAGE_MAX)
+      .readonly(),
+    lakeProjections: z
+      .array(RiotMatchIdSchema)
+      .max(SCOUT_V2_PAGE_MAX)
+      .readonly(),
+    recoveryBatches: z
+      .array(ScoutRecoveryBatchIdSchema)
+      .max(SCOUT_V2_PAGE_MAX)
+      .readonly(),
+  }),
+});
+export type ScoutReconciliationScanV2Result = z.infer<
+  typeof ScoutReconciliationScanV2ResultSchema
+>;

--- a/packages/scout-for-lol/packages/temporal/src/activity-contracts-v2.ts
+++ b/packages/scout-for-lol/packages/temporal/src/activity-contracts-v2.ts
@@ -220,6 +220,18 @@ export type ScoutNotificationIntentV2Result = z.infer<
   typeof ScoutNotificationIntentV2ResultSchema
 >;
 
+/**
+ * The resume point for one recovery batch: exactly what the durable row
+ * retains, and nothing reconstructed.
+ *
+ * Counts are deliberately not a field here. The row flattens the state union
+ * and holds count columns only while the batch is `processing`, so `state`
+ * already carries the tally when — and only when — one exists. A separate
+ * counts field would have to be empty for every batch past processing, which
+ * is the same fact stated twice and an invitation to fill it in. A workflow
+ * resumed past processing reports `ScoutRecoveryCountsReportV2`'s
+ * `unobserved` instead.
+ */
 export const ScoutRecoveryBatchStateV2ResultSchema = z.discriminatedUnion(
   "kind",
   [

--- a/packages/scout-for-lol/packages/temporal/src/contracts-v2.test.ts
+++ b/packages/scout-for-lol/packages/temporal/src/contracts-v2.test.ts
@@ -17,6 +17,8 @@ import {
 } from "./contracts-v2.ts";
 import {
   ScoutMatchProcessingV2InputSchema,
+  ScoutRecoveryBatchV2ResultSchema,
+  scoutRecoveryBatchV2ResultCodec,
   scoutLakeProjectionV2InputCodec,
   scoutMatchProcessingV2InputCodec,
   scoutMatchProcessingV2ResultCodec,
@@ -28,7 +30,10 @@ import {
   scoutPrematchGameV2InputCodec,
   scoutRecoveryBatchV2InputCodec,
 } from "./workflow-contracts-v2.ts";
-import { ScoutMatchPipelineStateV2ResultSchema } from "./activity-contracts-v2.ts";
+import {
+  ScoutMatchPipelineStateV2ResultSchema,
+  ScoutRecoveryBatchStateV2ResultSchema,
+} from "./activity-contracts-v2.ts";
 
 const riotMatchId = RiotMatchIdSchema.parse("NA1_5312279829");
 const intentKey = ScoutNotificationIntentKeySchema.parse(
@@ -247,7 +252,97 @@ describe("V2 workflow results", () => {
   });
 });
 
+describe("V2 recovery batch results", () => {
+  test("reports the tally a run that drove processing watched", () => {
+    const result = {
+      status: "completed",
+      recoveryBatchId,
+      state: { kind: "complete" },
+      counts: {
+        kind: "observed",
+        counts: { discovered: 40, succeeded: 38, suppressed: 1, failed: 1 },
+      },
+    } as const;
+    expect(
+      scoutRecoveryBatchV2ResultCodec.parse(
+        scoutRecoveryBatchV2ResultCodec.serialize(result),
+      ),
+    ).toEqual(result);
+  });
+
+  test("lets a run resumed past processing complete without a tally", () => {
+    // A reconciliation sweep or an operator restart can land on a batch whose
+    // row is already `digesting`, `complete` or `abandoned`. Those rows have
+    // NULL count columns — `recoveryBatchStateColumns` writes them that way —
+    // so this run has no tally and never will. Requiring one here would force
+    // an implementation to invent zeros or fail a finished batch.
+    const result = {
+      status: "completed",
+      recoveryBatchId,
+      state: { kind: "complete" },
+      counts: { kind: "unobserved" },
+    } as const;
+    expect(
+      scoutRecoveryBatchV2ResultCodec.parse(
+        scoutRecoveryBatchV2ResultCodec.serialize(result),
+      ),
+    ).toEqual(result);
+  });
+
+  test("lets a run resumed onto an abandoned batch report the reason", () => {
+    const result = {
+      status: "completed",
+      recoveryBatchId,
+      state: { kind: "abandoned", reason: "operator-cancelled" },
+      counts: { kind: "unobserved" },
+    } as const;
+    expect(
+      scoutRecoveryBatchV2ResultCodec.parse(
+        scoutRecoveryBatchV2ResultCodec.serialize(result),
+      ),
+    ).toEqual(result);
+  });
+
+  test("refuses a bare tally that skipped the observation question", () => {
+    // Guards the shape itself: counts must say whether they were observed, so
+    // the old `counts: RecoveryCounts` form cannot quietly come back.
+    expect(() =>
+      ScoutRecoveryBatchV2ResultSchema.parse({
+        status: "completed",
+        recoveryBatchId,
+        state: { kind: "complete" },
+        counts: { discovered: 0, succeeded: 0, suppressed: 0, failed: 0 },
+      }),
+    ).toThrow();
+  });
+});
+
 describe("V2 resume-point read", () => {
+  test("surfaces a processing batch's tally, and has none past it", () => {
+    // The row holds count columns only while the batch is `processing`, so the
+    // state union is the whole truth the read can tell.
+    const processing = ScoutRecoveryBatchStateV2ResultSchema.parse({
+      kind: "present",
+      policy: "normal",
+      state: {
+        kind: "processing",
+        counts: { discovered: 9, succeeded: 4, suppressed: 0, failed: 0 },
+      },
+    });
+    expect(processing).toHaveProperty(["state", "counts", "discovered"], 9);
+
+    const complete = ScoutRecoveryBatchStateV2ResultSchema.parse({
+      kind: "present",
+      policy: "normal",
+      state: { kind: "complete" },
+    });
+    expect(complete).toEqual({
+      kind: "present",
+      policy: "normal",
+      state: { kind: "complete" },
+    });
+  });
+
   test("reports an unstarted match as absent rather than as an empty one", () => {
     // "Nothing recorded" and "recorded with no receipts" are different
     // answers, and a resuming workflow acts differently on each.

--- a/packages/scout-for-lol/packages/temporal/src/contracts-v2.test.ts
+++ b/packages/scout-for-lol/packages/temporal/src/contracts-v2.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, test } from "vitest";
+import type { z } from "zod";
+import type { VersionedCodec } from "@scout-for-lol/domain/codec/versioned.ts";
+import {
+  IsoInstantSchema,
+  RecoveryBatchIdSchema,
+  RiotMatchIdSchema,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import { NotificationAttemptNonceSchema } from "@scout-for-lol/domain/notifications/intent.ts";
+import { ReceiptKindSchema } from "@scout-for-lol/domain/match-processing/states.ts";
+import {
+  SCOUT_V2_CONTRACT_VERSION,
+  ScoutDurableCommitV2Schema,
+  ScoutNotificationIntentKeySchema,
+  ScoutPrematchGameRefSchema,
+  ScoutRecoveryBatchIdSchema,
+} from "./contracts-v2.ts";
+import {
+  ScoutMatchProcessingV2InputSchema,
+  scoutLakeProjectionV2InputCodec,
+  scoutMatchProcessingV2InputCodec,
+  scoutMatchProcessingV2ResultCodec,
+  scoutNotificationV2InputCodec,
+  scoutNotificationV2ResultCodec,
+  scoutPipelineReconciliationV2InputCodec,
+  scoutPostMatchDiscoveryV2InputCodec,
+  scoutPrematchDiscoveryV2InputCodec,
+  scoutPrematchGameV2InputCodec,
+  scoutRecoveryBatchV2InputCodec,
+} from "./workflow-contracts-v2.ts";
+import { ScoutMatchPipelineStateV2ResultSchema } from "./activity-contracts-v2.ts";
+
+const riotMatchId = RiotMatchIdSchema.parse("NA1_5312279829");
+const intentKey = ScoutNotificationIntentKeySchema.parse(
+  "notify:NA1_5312279829:guild:1234567890",
+);
+const recoveryBatchId = ScoutRecoveryBatchIdSchema.parse("recovery_01");
+const gameRef = ScoutPrematchGameRefSchema.parse({
+  puuid: "p".repeat(78),
+  platform: "NA1",
+  gameId: "5312279829",
+});
+
+function expectRoundTrip<Kind extends string, Schema extends z.ZodType>(
+  codec: VersionedCodec<Kind, Schema>,
+  input: z.infer<Schema>,
+): void {
+  const envelope = codec.serialize(input);
+  expect(envelope.kind).toBe(codec.kind);
+  expect(envelope.version).toBe(SCOUT_V2_CONTRACT_VERSION);
+  expect(codec.parse(envelope)).toEqual(input);
+}
+
+describe("V2 workflow input envelopes", () => {
+  test("round-trips every V2 workflow input through its envelope", () => {
+    expectRoundTrip(scoutPostMatchDiscoveryV2InputCodec, {
+      stage: "prod",
+      trigger: "schedule",
+    });
+    expectRoundTrip(scoutMatchProcessingV2InputCodec, {
+      stage: "prod",
+      riotMatchId,
+    });
+    expectRoundTrip(scoutPrematchDiscoveryV2InputCodec, { stage: "beta" });
+    expectRoundTrip(scoutPrematchGameV2InputCodec, { stage: "beta", gameRef });
+    expectRoundTrip(scoutNotificationV2InputCodec, {
+      stage: "prod",
+      intentKey,
+    });
+    expectRoundTrip(scoutLakeProjectionV2InputCodec, {
+      stage: "prod",
+      riotMatchId,
+    });
+    expectRoundTrip(scoutRecoveryBatchV2InputCodec, {
+      stage: "dev",
+      recoveryBatchId,
+    });
+    expectRoundTrip(scoutPipelineReconciliationV2InputCodec, {
+      stage: "prod",
+      trigger: "operator",
+    });
+  });
+
+  test("rejects an envelope from a version it cannot migrate", () => {
+    // A worker meeting a payload written by a future build must fail loudly.
+    // The alternative — reading it as the current shape — is how a field that
+    // changed meaning silently corrupts a match.
+    const envelope = scoutMatchProcessingV2InputCodec.serialize({
+      stage: "prod",
+      riotMatchId,
+    });
+    expect(() =>
+      scoutMatchProcessingV2InputCodec.parse({ ...envelope, version: 2 }),
+    ).toThrow(/unknown scout-match-processing-v2-input envelope version 2/u);
+  });
+
+  test("refuses an envelope carrying another contract's payload", () => {
+    const envelope = scoutLakeProjectionV2InputCodec.serialize({
+      stage: "prod",
+      riotMatchId,
+    });
+    expect(() => scoutMatchProcessingV2InputCodec.parse(envelope)).toThrow();
+  });
+
+  test("refuses a bare payload that skipped the envelope", () => {
+    expect(() =>
+      scoutMatchProcessingV2InputCodec.parse({ stage: "prod", riotMatchId }),
+    ).toThrow();
+  });
+});
+
+describe("V2 workflow inputs carry references, never payloads", () => {
+  test("refuses a match input smuggling a Riot payload alongside the id", () => {
+    expect(() =>
+      ScoutMatchProcessingV2InputSchema.parse({
+        stage: "prod",
+        riotMatchId,
+        // A workflow input is copied into history and kept for the life of the
+        // execution; a MatchV5 body here would be stored forever, per match.
+        info: { participants: [{ puuid: "p".repeat(78) }] },
+      }),
+    ).toThrow();
+  });
+
+  test("refuses a match id Riot could not have issued", () => {
+    expect(() =>
+      ScoutMatchProcessingV2InputSchema.parse({
+        stage: "prod",
+        riotMatchId: "not-a-match-id",
+      }),
+    ).toThrow();
+  });
+
+  test("refuses a game reference holding a spectator snapshot", () => {
+    expect(() =>
+      ScoutPrematchGameRefSchema.parse({
+        puuid: "p".repeat(78),
+        platform: "NA1",
+        gameId: "5312279829",
+        participants: [{ championId: 1 }],
+      }),
+    ).toThrow();
+  });
+
+  test("keeps a game id a digit string so it cannot become a float", () => {
+    expect(() =>
+      ScoutPrematchGameRefSchema.parse({ ...gameRef, gameId: 5_312_279_829 }),
+    ).toThrow();
+  });
+});
+
+describe("V2 identifiers stay usable as workflow ids", () => {
+  test("refuses an intent key outside the replay id character set", () => {
+    // The key is interpolated into a workflow id; a key with a space or slash
+    // produces an execution `replay:candidate-histories` cannot select.
+    expect(() =>
+      ScoutNotificationIntentKeySchema.parse("notify NA1/guild"),
+    ).toThrow();
+    expect(() => ScoutRecoveryBatchIdSchema.parse("recovery batch")).toThrow();
+  });
+
+  test("accepts the separators Scout actually mints keys with", () => {
+    expect(ScoutNotificationIntentKeySchema.parse("notify:NA1_1.guild-2")).toBe(
+      "notify:NA1_1.guild-2",
+    );
+  });
+});
+
+describe("V2 durable commit outcomes", () => {
+  test("speaks the repository vocabulary, including adoption", () => {
+    for (const outcome of ["applied", "already-applied", "adopted"] as const) {
+      expect(ScoutDurableCommitV2Schema.parse({ outcome })).toEqual({
+        outcome,
+      });
+    }
+  });
+
+  test("carries the repository's own drift reason for receipts", () => {
+    // `receipt-evidence-mismatch` is raised by receipt-repository.ts comparing
+    // stored evidence; the pure domain transition compares identity alone and
+    // can no longer answer it. A result limited to the domain's answers would
+    // be unable to report the drift at all.
+    expect(
+      ScoutDurableCommitV2Schema.parse({
+        outcome: "conflict",
+        reason: "receipt-evidence-mismatch",
+      }),
+    ).toEqual({ outcome: "conflict", reason: "receipt-evidence-mismatch" });
+  });
+
+  test("carries persistence reasons no pure transition produces", () => {
+    for (const reason of [
+      "observation-differs",
+      "intent-differs",
+      "batch-differs",
+      "workflow-adopted-by-another-batch",
+    ]) {
+      expect(
+        ScoutDurableCommitV2Schema.parse({ outcome: "conflict", reason }),
+      ).toEqual({ outcome: "conflict", reason });
+    }
+  });
+
+  test("refuses a conflict without a reason", () => {
+    expect(() =>
+      ScoutDurableCommitV2Schema.parse({ outcome: "conflict" }),
+    ).toThrow();
+  });
+});
+
+describe("V2 workflow results", () => {
+  test("round-trips a match result in the domain's own vocabulary", () => {
+    const result = {
+      status: "completed",
+      riotMatchId,
+      owner: { kind: "temporal-v2" },
+      policy: "FULL",
+      receiptKinds: [ReceiptKindSchema.parse("raw-archive-match")],
+      childrenStarted: { notifications: 2, lakeProjections: 1 },
+    } as const;
+    expect(
+      scoutMatchProcessingV2ResultCodec.parse(
+        scoutMatchProcessingV2ResultCodec.serialize(result),
+      ),
+    ).toEqual(result);
+  });
+
+  test("lets a notification finish in unknown-delivery", () => {
+    // Unobserved delivery is a legitimate terminal result, not a failure: the
+    // machine leaves it only through an operator, so the contract has to be
+    // able to report it.
+    const result = {
+      status: "completed",
+      intentKey,
+      state: {
+        kind: "unknown-delivery",
+        attemptNonce: NotificationAttemptNonceSchema.parse("run-abc:1"),
+        observedAt: IsoInstantSchema.parse("2026-09-11T16:00:00.000Z"),
+      },
+      attemptCount: 1,
+    } as const;
+    expect(
+      scoutNotificationV2ResultCodec.parse(
+        scoutNotificationV2ResultCodec.serialize(result),
+      ),
+    ).toEqual(result);
+  });
+});
+
+describe("V2 resume-point read", () => {
+  test("reports an unstarted match as absent rather than as an empty one", () => {
+    // "Nothing recorded" and "recorded with no receipts" are different
+    // answers, and a resuming workflow acts differently on each.
+    expect(
+      ScoutMatchPipelineStateV2ResultSchema.parse({ kind: "absent" }),
+    ).toEqual({ kind: "absent" });
+  });
+
+  test("spans observation, receipts, intents and tracked accounts", () => {
+    const state = {
+      kind: "present",
+      state: {
+        riotMatchId,
+        owner: { kind: "temporal-v2" },
+        policy: "FULL",
+        promoted: false,
+        receiptKinds: [ReceiptKindSchema.parse("lake-staging-match")],
+        intents: [{ intentKey, state: { kind: "ready" }, attemptCount: 0 }],
+        trackedAccounts: { total: 3, cursorAdvanced: 1 },
+      },
+    } as const;
+    expect(ScoutMatchPipelineStateV2ResultSchema.parse(state)).toEqual(state);
+  });
+
+  test("refuses a batch id the workflow id builder could not carry", () => {
+    expect(() => RecoveryBatchIdSchema.parse("")).toThrow();
+  });
+});

--- a/packages/scout-for-lol/packages/temporal/src/contracts-v2.ts
+++ b/packages/scout-for-lol/packages/temporal/src/contracts-v2.ts
@@ -1,0 +1,233 @@
+import { z } from "zod";
+import {
+  NotificationIntentKeySchema,
+  RecoveryBatchIdSchema,
+  RiotMatchIdSchema,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import { LeaguePuuidSchema } from "@scout-for-lol/domain/identity/league-account.ts";
+import { PlatformRouteSchema } from "@scout-for-lol/domain/identity/routes.ts";
+import { ReceiptKindSchema } from "@scout-for-lol/domain/match-processing/states.ts";
+import { MatchProcessingConflictReasonSchema } from "@scout-for-lol/domain/match-processing/transitions.ts";
+import { NotificationAttemptNonceSchema } from "@scout-for-lol/domain/notifications/intent.ts";
+import { NotificationConflictReasonSchema } from "@scout-for-lol/domain/notifications/intent-transitions.ts";
+import { RecoveryConflictReasonSchema } from "@scout-for-lol/domain/recovery/batch-transitions.ts";
+import { ScoutStageSchema } from "./contracts.ts";
+
+// ───────────────────────────────────────────────────────────────────────────
+// V2 durable pipeline
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * The shared vocabulary of the V2 durable pipeline: identifier narrowings,
+ * references, and the outcome shapes every V2 contract is built from. The
+ * Workflow contracts live in `workflow-contracts-v2.ts` and the Activity
+ * contracts in `activity-contracts-v2.ts`.
+ *
+ * The eight V2 Workflow Types are NEW types alongside the v1 ones in
+ * `contracts.ts`. No v1 contract changes: open v1 executions recorded the v1
+ * shapes and replay them forever.
+ *
+ * ## Payload rule
+ *
+ * A V2 Workflow input and result travel in a versioned envelope
+ * (`{ kind, version, data }`) built by the domain's `defineVersionedCodec`.
+ * Activity inputs and results are flat strict objects.
+ *
+ * The split follows who READS a payload. The Scout Workflow Worker runs with
+ * `useWorkerVersioning` and `VersioningBehavior.AUTO_UPGRADE`, so an open
+ * execution moves to the next build: a Workflow input written by build N is
+ * read by build N+1 whenever the run outlives a deploy, and a V2 run routinely
+ * does. `scoutRecoveryBatchV2Workflow` and
+ * `scoutPipelineReconciliationV2Workflow` rewrite their own input through
+ * Continue-As-New; match, notification and lake children follow v1's
+ * `parentClosePolicy: "ABANDON"` and so outlive the parent that wrote their
+ * input; and a parent replays a completed child's result long after both were
+ * written. The envelope gives those payloads an explicit migration hook. The
+ * alternative — widening a flat schema with optional fields and defaults — is
+ * the fallback this repository forbids, and v1's `PostMatchDiscoveryResult` in
+ * `contracts.ts` shows the cost of reaching for it.
+ *
+ * Activity payloads get the other half of the contract instead: their schemas
+ * are strict and CLOSED, and the V2 Activity result shapes are append-only. A
+ * lane that needs a breaking change to an Activity result adds a new Activity
+ * name rather than redefining one that in-flight histories already recorded.
+ *
+ * ## What may cross
+ *
+ * Identifiers, small references, counts, and domain state unions. Never a
+ * Riot payload, a rendered report, an image, or a settlement body. Artifact
+ * DESCRIPTORS (object key, digest, size) do cross: they name bytes rather
+ * than carrying them, and the archival path produces them.
+ */
+
+/** Every V2 contract starts at envelope version 1. */
+export const SCOUT_V2_CONTRACT_VERSION = 1;
+
+/**
+ * The largest identifier list one V2 Activity may return. Discovery, fan-out
+ * and reconciliation scans are paged, and this is what makes a page bounded:
+ * an activity completion adds at most this many identifiers to a history.
+ */
+export const SCOUT_V2_PAGE_MAX = 200;
+
+/**
+ * Values safe to interpolate into a Scout Workflow ID.
+ *
+ * `scripts/replay-*-histories.ts` select candidate histories with
+ * `^scout-(?:beta|prod)-[\w.:-]+$`. An identifier outside that character set
+ * still starts a Workflow, but produces an execution the replay gate cannot
+ * see — so the constraint is enforced here, on the identifiers the V2 ID
+ * builders interpolate, rather than inside the builders. A builder that threw
+ * would throw during a Workflow task and wedge the execution on every retry.
+ */
+const WORKFLOW_ID_SEGMENT = /^[\w.:-]+$/u;
+const workflowIdSegmentIssue = {
+  message:
+    "must match the replay tooling's workflow-id character set ([A-Za-z0-9_.:-])",
+};
+
+/**
+ * A notification intent key, narrowed to what a Workflow ID can carry.
+ * Intent keys are minted by Scout, so a key outside this set is a broken
+ * internal contract rather than bad user input.
+ */
+export const ScoutNotificationIntentKeySchema =
+  NotificationIntentKeySchema.refine(
+    (key) => WORKFLOW_ID_SEGMENT.test(key),
+    workflowIdSegmentIssue,
+  );
+
+/** A recovery batch id, narrowed the same way and for the same reason. */
+export const ScoutRecoveryBatchIdSchema = RecoveryBatchIdSchema.refine(
+  (id) => WORKFLOW_ID_SEGMENT.test(id),
+  workflowIdSegmentIssue,
+);
+
+/**
+ * Why a V2 Workflow run was started. `gateway-ready` is the Discord gateway
+ * reconnect edge; `operator` is a deliberate manual run. The trigger is part
+ * of the Workflow ID so two triggers cannot collapse into one execution.
+ */
+export const ScoutV2TriggerSchema = z.enum([
+  "schedule",
+  "gateway-ready",
+  "operator",
+]);
+export type ScoutV2Trigger = z.infer<typeof ScoutV2TriggerSchema>;
+
+/**
+ * A live game, before Riot's MatchV5 knows about it.
+ *
+ * Deliberately a reference and not a spectator payload: `platform` and
+ * `gameId` are exactly what Riot composes the eventual `RiotMatchId` from, and
+ * `puuid` records which tracked account surfaced the game so the fetch can be
+ * re-issued. `gameId` is a digit string rather than a number because it only
+ * ever gets concatenated into a match id, and a string cannot acquire a
+ * floating-point spelling on the way through a payload converter.
+ */
+export const ScoutPrematchGameRefSchema = z.strictObject({
+  puuid: LeaguePuuidSchema,
+  platform: PlatformRouteSchema,
+  gameId: z.string().min(1).max(32).regex(/^\d+$/u),
+});
+export type ScoutPrematchGameRef = z.infer<typeof ScoutPrematchGameRefSchema>;
+
+/**
+ * Every reason a V2 durable commit can refuse, spanning the three pure domain
+ * machines and the persistence guards layered under them. Assembled from the
+ * domain option tuples so a new domain reason widens this set automatically;
+ * the trailing literals are repository-only, raised by comparing a stored
+ * payload blob that no pure transition ever sees.
+ */
+export const ScoutDurableCommitConflictReasonV2Schema = z.enum([
+  ...MatchProcessingConflictReasonSchema.options,
+  ...NotificationConflictReasonSchema.options,
+  ...RecoveryConflictReasonSchema.options,
+  "observation-differs",
+  "intent-differs",
+  "batch-differs",
+  "workflow-adopted-by-another-batch",
+]);
+export type ScoutDurableCommitConflictReasonV2 = z.infer<
+  typeof ScoutDurableCommitConflictReasonV2Schema
+>;
+
+/**
+ * What a durable write answered.
+ *
+ * This is the REPOSITORY's vocabulary (`DurableWriteOutcomeSchema`), not the
+ * pure domain transition's, and the difference is load-bearing in two places.
+ * `adopted` exists only in the repositories. And drift detection now lives
+ * there too: the domain's `recordReceipt` compares receipt identity alone, so
+ * only `receipt-repository.ts` can answer `receipt-evidence-mismatch` by
+ * comparing the stored evidence blob. An Activity result that reported the
+ * domain answer would be structurally unable to report the drift.
+ *
+ * A V2 Activity that performs an at-most-once effect reports the GUARD and
+ * the FACT as separate fields, never as one outcome. `ScoutEffectClaim` takes
+ * the top-level Prisma client rather than a transaction-scoped handle, so a
+ * claim and the durable fact it guards cannot commit atomically; every
+ * contract here therefore tolerates two commits and names the reconcile.
+ */
+export const ScoutDurableCommitV2Schema = z.discriminatedUnion("outcome", [
+  z.strictObject({ outcome: z.literal("applied") }),
+  z.strictObject({ outcome: z.literal("already-applied") }),
+  z.strictObject({ outcome: z.literal("adopted") }),
+  z.strictObject({
+    outcome: z.literal("conflict"),
+    reason: ScoutDurableCommitConflictReasonV2Schema,
+  }),
+]);
+export type ScoutDurableCommitV2 = z.infer<typeof ScoutDurableCommitV2Schema>;
+
+/** One receipt write, named by kind and answered in repository vocabulary. */
+export const ScoutReceiptOutcomeV2Schema = z.strictObject({
+  kind: ReceiptKindSchema,
+  commit: ScoutDurableCommitV2Schema,
+});
+export type ScoutReceiptOutcomeV2 = z.infer<typeof ScoutReceiptOutcomeV2Schema>;
+
+// ─── V2 references ─────────────────────────────────────────────────────────
+
+/** One match, in one stage. The unit of work the V2 pipeline is keyed by. */
+export const ScoutMatchRefV2Schema = z.strictObject({
+  stage: ScoutStageSchema,
+  riotMatchId: RiotMatchIdSchema,
+});
+export type ScoutMatchRefV2 = z.infer<typeof ScoutMatchRefV2Schema>;
+
+/** One live game, in one stage. */
+export const ScoutGameRefV2Schema = z.strictObject({
+  stage: ScoutStageSchema,
+  gameRef: ScoutPrematchGameRefSchema,
+});
+export type ScoutGameRefV2 = z.infer<typeof ScoutGameRefV2Schema>;
+
+/** One notification intent, in one stage. */
+export const ScoutIntentRefV2Schema = z.strictObject({
+  stage: ScoutStageSchema,
+  intentKey: ScoutNotificationIntentKeySchema,
+});
+export type ScoutIntentRefV2 = z.infer<typeof ScoutIntentRefV2Schema>;
+
+/**
+ * One send attempt of one intent. The nonce is minted by the Workflow, never
+ * by a transition, so a crashed worker's attempt and its replacement stay
+ * distinguishable — which is what lets an unobserved send be recorded as
+ * `unknown-delivery` against the exact attempt that produced it.
+ */
+export const ScoutIntentAttemptRefV2Schema = ScoutIntentRefV2Schema.extend({
+  attemptNonce: NotificationAttemptNonceSchema,
+});
+export type ScoutIntentAttemptRefV2 = z.infer<
+  typeof ScoutIntentAttemptRefV2Schema
+>;
+
+/** One recovery batch, in one stage. */
+export const ScoutRecoveryBatchRefV2Schema = z.strictObject({
+  stage: ScoutStageSchema,
+  recoveryBatchId: ScoutRecoveryBatchIdSchema,
+});
+export type ScoutRecoveryBatchRefV2 = z.infer<
+  typeof ScoutRecoveryBatchRefV2Schema
+>;

--- a/packages/scout-for-lol/packages/temporal/src/identifiers.test.ts
+++ b/packages/scout-for-lol/packages/temporal/src/identifiers.test.ts
@@ -1,12 +1,32 @@
 import { describe, expect, test } from "vitest";
 import {
+  RecoveryBatchIdSchema,
+  RiotMatchIdSchema,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  ScoutNotificationIntentKeySchema,
+  ScoutPrematchGameRefSchema,
+} from "./contracts-v2.ts";
+import {
+  SCOUT_V2_ACTIVITY_QUEUE_CLASSES,
+  SCOUT_V2_WORKFLOW_NAMES,
   scoutChallengeRunRecomputeWorkflowId,
   scoutDuelSeriesWorkflowId,
   scoutHallBaselineWorkflowId,
   scoutIngestionReconciliationGatewayReadyWorkflowId,
   scoutInitialHistoryWorkflowId,
   scoutInteractiveWorkflowId,
+  scoutLakeProjectionV2WorkflowId,
+  scoutMatchProcessingV2WorkflowId,
   scoutMatchWorkflowId,
+  scoutNotificationAttemptNonce,
+  scoutNotificationV2WorkflowId,
+  scoutPipelineReconciliationV2WorkflowId,
+  scoutPostMatchDiscoveryV2WorkflowId,
+  scoutPrematchDiscoveryV2WorkflowId,
+  scoutPrematchGameV2MatchId,
+  scoutPrematchGameV2WorkflowId,
+  scoutRecoveryBatchV2WorkflowId,
   scoutReportScheduleId,
   scoutReportScheduleReconcilerWorkflowId,
   scoutTaskQueues,
@@ -50,6 +70,105 @@ describe("Scout Temporal identifiers", () => {
     );
     expect(scoutDuelSeriesWorkflowId("dev", "series_123")).toBe(
       "scout-dev-duel-series-series_123",
+    );
+  });
+});
+
+const riotMatchId = RiotMatchIdSchema.parse("NA1_5312279829");
+const intentKey = ScoutNotificationIntentKeySchema.parse(
+  "notify:NA1_5312279829:guild:1234567890",
+);
+const recoveryBatchId = RecoveryBatchIdSchema.parse("recovery_2026-09-11_01");
+const gameRef = ScoutPrematchGameRefSchema.parse({
+  puuid: "p".repeat(78),
+  platform: "NA1",
+  gameId: "5312279829",
+});
+
+const v2WorkflowIds = [
+  scoutPostMatchDiscoveryV2WorkflowId("prod", "schedule"),
+  scoutMatchProcessingV2WorkflowId("prod", riotMatchId),
+  scoutPrematchDiscoveryV2WorkflowId("prod"),
+  scoutPrematchGameV2WorkflowId("prod", gameRef),
+  scoutNotificationV2WorkflowId("prod", intentKey),
+  scoutLakeProjectionV2WorkflowId("prod", riotMatchId),
+  scoutRecoveryBatchV2WorkflowId("prod", recoveryBatchId),
+  scoutPipelineReconciliationV2WorkflowId("prod", "gateway-ready"),
+];
+
+describe("Scout V2 workflow identifiers", () => {
+  test("builds a stable id for every V2 workflow type", () => {
+    expect(v2WorkflowIds).toEqual([
+      "scout-prod-post-match-discovery-v2-schedule",
+      "scout-prod-match-v2-NA1_5312279829",
+      "scout-prod-prematch-discovery-v2",
+      "scout-prod-prematch-game-v2-NA1_5312279829",
+      "scout-prod-notification-v2-notify:NA1_5312279829:guild:1234567890",
+      "scout-prod-lake-projection-v2-NA1_5312279829",
+      "scout-prod-recovery-batch-v2-recovery_2026-09-11_01",
+      "scout-prod-pipeline-reconciliation-v2-gateway-ready",
+    ]);
+    expect(v2WorkflowIds).toHaveLength(SCOUT_V2_WORKFLOW_NAMES.length);
+  });
+
+  test("keeps every V2 id selectable by the replay tooling", () => {
+    // `scripts/replay-*-histories.ts` filter candidate histories with exactly
+    // this pattern. An id outside it starts a workflow the replay gate cannot
+    // see, so the whole determinism check silently stops covering it.
+    const replayCandidate = /^scout-(?:beta|prod)-[\w.:-]+$/u;
+    for (const workflowId of v2WorkflowIds) {
+      expect(workflowId).toMatch(replayCandidate);
+    }
+  });
+
+  test("separates a V2 execution from its v1 sibling for the same match", () => {
+    expect(scoutMatchProcessingV2WorkflowId("prod", riotMatchId)).not.toBe(
+      scoutMatchWorkflowId("prod", riotMatchId),
+    );
+  });
+
+  test("gives one prematch execution per game, not per tracked account", () => {
+    const sameGameOtherAccount = ScoutPrematchGameRefSchema.parse({
+      ...gameRef,
+      puuid: "q".repeat(78),
+    });
+    expect(scoutPrematchGameV2WorkflowId("prod", sameGameOtherAccount)).toBe(
+      scoutPrematchGameV2WorkflowId("prod", gameRef),
+    );
+  });
+
+  test("composes the match id Riot will assign a live game", () => {
+    expect(scoutPrematchGameV2MatchId(gameRef)).toBe("NA1_5312279829");
+  });
+
+  test("names each send attempt distinctly and deterministically", () => {
+    expect(scoutNotificationAttemptNonce("run-abc", 2)).toBe("run-abc:2");
+    expect(scoutNotificationAttemptNonce("run-abc", 2)).toBe(
+      scoutNotificationAttemptNonce("run-abc", 2),
+    );
+    expect(scoutNotificationAttemptNonce("run-abc", 3)).not.toBe(
+      scoutNotificationAttemptNonce("run-abc", 2),
+    );
+    expect(scoutNotificationAttemptNonce("run-def", 2)).not.toBe(
+      scoutNotificationAttemptNonce("run-abc", 2),
+    );
+  });
+
+  test("routes each V2 activity to exactly one declared queue class", () => {
+    expect(SCOUT_V2_ACTIVITY_QUEUE_CLASSES.deliverNotificationV2).toBe(
+      "realtime",
+    );
+    expect(SCOUT_V2_ACTIVITY_QUEUE_CLASSES.stageLakeProjectionV2).toBe("lake");
+    expect(SCOUT_V2_ACTIVITY_QUEUE_CLASSES.renderNotificationArtifactV2).toBe(
+      "background",
+    );
+    expect(
+      SCOUT_V2_ACTIVITY_QUEUE_CLASSES.scanPipelineReconciliationPageV2,
+    ).toBe("background");
+    // `interactive` belongs to human-facing runs; nothing in the durable
+    // pipeline may sit in front of one.
+    expect(Object.values(SCOUT_V2_ACTIVITY_QUEUE_CLASSES)).not.toContain(
+      "interactive",
     );
   });
 });

--- a/packages/scout-for-lol/packages/temporal/src/identifiers.ts
+++ b/packages/scout-for-lol/packages/temporal/src/identifiers.ts
@@ -1,4 +1,16 @@
-import type { ScoutStage } from "./contracts.ts";
+import {
+  RiotMatchIdSchema,
+  type NotificationIntentKey,
+  type RecoveryBatchId,
+  type RiotMatchId,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  NotificationAttemptNonceSchema,
+  type NotificationAttemptNonce,
+} from "@scout-for-lol/domain/notifications/intent.ts";
+import type { ScoutQueueClass, ScoutStage } from "./contracts.ts";
+import type { ScoutPrematchGameRef, ScoutV2Trigger } from "./contracts-v2.ts";
+import type { ScoutV2ActivityName } from "./activities.ts";
 
 export const SCOUT_WORKFLOW_NAMES = {
   realtimePoll: "scoutRealtimePollWorkflow",
@@ -16,7 +28,35 @@ export const SCOUT_WORKFLOW_NAMES = {
   hallBaseline: "scoutHallBaselineWorkflow",
   challengeRunRecompute: "scoutChallengeRunRecomputeWorkflow",
   duelSeries: "scoutDuelSeriesWorkflow",
+  postMatchDiscoveryV2: "scoutPostMatchDiscoveryV2Workflow",
+  matchProcessingV2: "scoutMatchProcessingV2Workflow",
+  prematchDiscoveryV2: "scoutPrematchDiscoveryV2Workflow",
+  prematchGameV2: "scoutPrematchGameV2Workflow",
+  notificationV2: "scoutNotificationV2Workflow",
+  lakeProjectionV2: "scoutLakeProjectionV2Workflow",
+  recoveryBatchV2: "scoutRecoveryBatchV2Workflow",
+  pipelineReconciliationV2: "scoutPipelineReconciliationV2Workflow",
 } as const;
+
+/**
+ * The eight V2 Workflow Types, as a closed set.
+ *
+ * They are NEW types: the v1 entries above keep their names and their inputs
+ * because open v1 executions recorded them. The task queue NAMES are likewise
+ * unchanged — `scoutTaskQueues` is shared — since an open execution recorded
+ * the queue it was dispatched on.
+ */
+export const SCOUT_V2_WORKFLOW_NAMES = [
+  SCOUT_WORKFLOW_NAMES.postMatchDiscoveryV2,
+  SCOUT_WORKFLOW_NAMES.matchProcessingV2,
+  SCOUT_WORKFLOW_NAMES.prematchDiscoveryV2,
+  SCOUT_WORKFLOW_NAMES.prematchGameV2,
+  SCOUT_WORKFLOW_NAMES.notificationV2,
+  SCOUT_WORKFLOW_NAMES.lakeProjectionV2,
+  SCOUT_WORKFLOW_NAMES.recoveryBatchV2,
+  SCOUT_WORKFLOW_NAMES.pipelineReconciliationV2,
+] as const;
+export type ScoutV2WorkflowName = (typeof SCOUT_V2_WORKFLOW_NAMES)[number];
 
 export function scoutTaskQueues(stage: ScoutStage) {
   const prefix = `scout-${stage}`;
@@ -115,3 +155,172 @@ export function scoutDuelSeriesWorkflowId(
 export function scoutSchedulePrefix(stage: ScoutStage): string {
   return `scout-${stage}-report-`;
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// V2 durable pipeline identifiers
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Every V2 Workflow ID is `scout-{stage}-{kind}-v2-{identity}` and is derived
+ * only from values already in the Workflow input, so a restart, a retry and a
+ * reconciliation sweep all compute the same ID and collapse onto the same
+ * execution instead of racing duplicates.
+ *
+ * The `-v2-` marker keeps a V2 execution from colliding with its v1 sibling
+ * while both pipelines run: `scout-prod-match-NA1_1` (v1) and
+ * `scout-prod-match-v2-NA1_1` (V2) are the same match under two owners.
+ *
+ * Each interpolated identity must match `[A-Za-z0-9_.:-]+`, which is what
+ * `scripts/replay-*-histories.ts` selects candidate histories with. The
+ * contract schemas enforce that (`ScoutNotificationIntentKeySchema`,
+ * `ScoutRecoveryBatchIdSchema`); these builders only interpolate, because a
+ * builder that threw would throw inside a Workflow task and wedge the
+ * execution on every retry.
+ */
+
+/**
+ * One discovery run per trigger. Two triggers never collapse into one
+ * execution, so an operator sweep cannot be silently absorbed by the
+ * scheduled run that happened to already be in flight.
+ */
+export function scoutPostMatchDiscoveryV2WorkflowId(
+  stage: ScoutStage,
+  trigger: ScoutV2Trigger,
+): string {
+  return `scout-${stage}-post-match-discovery-v2-${trigger}`;
+}
+
+/** The per-match core: one execution per match, forever. */
+export function scoutMatchProcessingV2WorkflowId(
+  stage: ScoutStage,
+  riotMatchId: RiotMatchId,
+): string {
+  return `scout-${stage}-match-v2-${riotMatchId}`;
+}
+
+/** One prematch poller per stage; the poll itself carries no identity. */
+export function scoutPrematchDiscoveryV2WorkflowId(stage: ScoutStage): string {
+  return `scout-${stage}-prematch-discovery-v2`;
+}
+
+/**
+ * One execution per live GAME, not per (account, game).
+ *
+ * The same game surfaces through every tracked account playing in it, and
+ * those are the same snapshot to archive. Keying on the game id deduplicates
+ * them; `gameRef.puuid` stays out of the ID and records only which account
+ * surfaced the game so the spectator fetch can be re-issued.
+ */
+export function scoutPrematchGameV2WorkflowId(
+  stage: ScoutStage,
+  gameRef: ScoutPrematchGameRef,
+): string {
+  return `scout-${stage}-prematch-game-v2-${gameRef.platform}_${gameRef.gameId}`;
+}
+
+export function scoutNotificationV2WorkflowId(
+  stage: ScoutStage,
+  intentKey: NotificationIntentKey,
+): string {
+  return `scout-${stage}-notification-v2-${intentKey}`;
+}
+
+export function scoutLakeProjectionV2WorkflowId(
+  stage: ScoutStage,
+  riotMatchId: RiotMatchId,
+): string {
+  return `scout-${stage}-lake-projection-v2-${riotMatchId}`;
+}
+
+export function scoutRecoveryBatchV2WorkflowId(
+  stage: ScoutStage,
+  recoveryBatchId: RecoveryBatchId,
+): string {
+  return `scout-${stage}-recovery-batch-v2-${recoveryBatchId}`;
+}
+
+/** One reconciliation run per trigger, for the same reason as discovery. */
+export function scoutPipelineReconciliationV2WorkflowId(
+  stage: ScoutStage,
+  trigger: ScoutV2Trigger,
+): string {
+  return `scout-${stage}-pipeline-reconciliation-v2-${trigger}`;
+}
+
+/**
+ * The Riot match id a live game will be assigned.
+ *
+ * The id is not unknown before MatchV5 publishes the game, only unassembled:
+ * Riot composes it from exactly the platform and game id the spectator payload
+ * already carries. That is what lets a prematch snapshot, its match payload
+ * and its timeline share one receipt scope.
+ */
+export function scoutPrematchGameV2MatchId(
+  gameRef: ScoutPrematchGameRef,
+): RiotMatchId {
+  return RiotMatchIdSchema.parse(`${gameRef.platform}_${gameRef.gameId}`);
+}
+
+/**
+ * Name one send attempt of one notification intent.
+ *
+ * Derived from the Workflow run and the attempt number so it is deterministic
+ * under replay, and distinct across runs so a crashed worker's attempt and the
+ * attempt that replaces it can never be confused — which is what makes an
+ * unobserved send resolvable against the exact attempt that produced it.
+ */
+export function scoutNotificationAttemptNonce(
+  workflowRunId: string,
+  attempt: number,
+): NotificationAttemptNonce {
+  return NotificationAttemptNonceSchema.parse(
+    `${workflowRunId}:${attempt.toString()}`,
+  );
+}
+
+/**
+ * Where each V2 Activity runs. Declared once so a Workflow, the Activity
+ * Worker registration, and the queue canary all read the same assignment
+ * instead of three implicit agreements; `satisfies` makes an Activity added
+ * without a queue a type error.
+ *
+ * Riot reads, S3 writes, short transactional domain commits and Discord
+ * delivery go to `realtime`, where latency is the product. Rendering, AI, and
+ * the bounded recovery and reconciliation scans go to `background`, where a
+ * slow run must never sit in front of a live match. Lake staging goes to
+ * `lake`, which owns the report lake's volume and heartbeats through long
+ * projections. Nothing goes to `interactive`: that queue serves a human
+ * waiting on an Explore or report-AI turn, and durable pipeline work must
+ * never queue ahead of one.
+ *
+ * This lives here rather than beside the proxy factories in
+ * `workflows/activity-options.ts` because the Activity Worker needs it too,
+ * and that module imports `@temporalio/workflow`.
+ */
+export const SCOUT_V2_ACTIVITY_QUEUE_CLASSES = {
+  discoverPostMatchIdsV2: "realtime",
+  discoverPrematchGamesV2: "realtime",
+  readMatchPipelineStateV2: "realtime",
+  readNotificationIntentV2: "realtime",
+  readRecoveryBatchV2: "background",
+  archiveMatchArtifactsV2: "realtime",
+  commitMatchObservationV2: "realtime",
+  settleMatchMarketsV2: "realtime",
+  applyMatchProgressionV2: "realtime",
+  recordMatchReceiptsV2: "realtime",
+  advanceMatchCursorV2: "realtime",
+  planMatchFanOutV2: "realtime",
+  archivePrematchSnapshotV2: "realtime",
+  planPrematchFanOutV2: "realtime",
+  markNotificationReadyV2: "realtime",
+  renderNotificationArtifactV2: "background",
+  beginNotificationSendV2: "realtime",
+  deliverNotificationV2: "realtime",
+  recordNotificationOutcomeV2: "realtime",
+  stageLakeProjectionV2: "lake",
+  scanRecoveryPageV2: "background",
+  processRecoveryPageV2: "background",
+  digestRecoveryBatchV2: "background",
+  closeRecoveryBatchV2: "background",
+  scanPipelineReconciliationPageV2: "background",
+} as const satisfies Record<ScoutV2ActivityName, ScoutQueueClass>;

--- a/packages/scout-for-lol/packages/temporal/src/index.ts
+++ b/packages/scout-for-lol/packages/temporal/src/index.ts
@@ -79,4 +79,17 @@ export {
   scoutHallBaselineWorkflowId,
   scoutChallengeRunRecomputeWorkflowId,
   scoutDuelSeriesWorkflowId,
+  SCOUT_V2_ACTIVITY_QUEUE_CLASSES,
+  SCOUT_V2_WORKFLOW_NAMES,
+  scoutLakeProjectionV2WorkflowId,
+  scoutMatchProcessingV2WorkflowId,
+  scoutNotificationAttemptNonce,
+  scoutNotificationV2WorkflowId,
+  scoutPipelineReconciliationV2WorkflowId,
+  scoutPostMatchDiscoveryV2WorkflowId,
+  scoutPrematchDiscoveryV2WorkflowId,
+  scoutPrematchGameV2MatchId,
+  scoutPrematchGameV2WorkflowId,
+  scoutRecoveryBatchV2WorkflowId,
 } from "./identifiers.ts";
+export type { ScoutV2WorkflowName } from "./identifiers.ts";

--- a/packages/scout-for-lol/packages/temporal/src/workflow-contracts-v2.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflow-contracts-v2.ts
@@ -1,0 +1,344 @@
+import { z } from "zod";
+import { defineVersionedCodec } from "@scout-for-lol/domain/codec/versioned.ts";
+import { RiotMatchIdSchema } from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  MatchProcessingPolicySchema,
+  PipelineOwnerSchema,
+  ReceiptKindSchema,
+} from "@scout-for-lol/domain/match-processing/states.ts";
+import { NotificationIntentStateSchema } from "@scout-for-lol/domain/notifications/intent.ts";
+import {
+  RecoveryBatchStateSchema,
+  RecoveryCountsSchema,
+} from "@scout-for-lol/domain/recovery/batch.ts";
+import { ScoutStageSchema, ScoutWorkflowStatusSchema } from "./contracts.ts";
+import {
+  SCOUT_V2_CONTRACT_VERSION,
+  ScoutNotificationIntentKeySchema,
+  ScoutPrematchGameRefSchema,
+  ScoutRecoveryBatchIdSchema,
+  ScoutV2TriggerSchema,
+} from "./contracts-v2.ts";
+
+/** The envelope type a codec produces, without restating its kind literal. */
+type EnvelopeOf<
+  Codec extends { readonly serialize: (value: never) => unknown },
+> = ReturnType<Codec["serialize"]>;
+
+// ─── V2 Workflow inputs ────────────────────────────────────────────────────
+
+export const ScoutPostMatchDiscoveryV2InputSchema = z.strictObject({
+  stage: ScoutStageSchema,
+  trigger: ScoutV2TriggerSchema,
+});
+export type ScoutPostMatchDiscoveryV2Input = z.infer<
+  typeof ScoutPostMatchDiscoveryV2InputSchema
+>;
+
+/**
+ * The per-match core is keyed by nothing but the match it processes.
+ *
+ * Spelled out rather than aliased to `ScoutMatchRefV2Schema`: the Workflow
+ * input and the Activity reference happen to agree today, and a frozen
+ * Workflow contract must not change because an Activity reference did.
+ */
+export const ScoutMatchProcessingV2InputSchema = z.strictObject({
+  stage: ScoutStageSchema,
+  riotMatchId: RiotMatchIdSchema,
+});
+export type ScoutMatchProcessingV2Input = z.infer<
+  typeof ScoutMatchProcessingV2InputSchema
+>;
+
+export const ScoutPrematchDiscoveryV2InputSchema = z.strictObject({
+  stage: ScoutStageSchema,
+});
+export type ScoutPrematchDiscoveryV2Input = z.infer<
+  typeof ScoutPrematchDiscoveryV2InputSchema
+>;
+
+export const ScoutPrematchGameV2InputSchema = z.strictObject({
+  stage: ScoutStageSchema,
+  gameRef: ScoutPrematchGameRefSchema,
+});
+export type ScoutPrematchGameV2Input = z.infer<
+  typeof ScoutPrematchGameV2InputSchema
+>;
+
+export const ScoutNotificationV2InputSchema = z.strictObject({
+  stage: ScoutStageSchema,
+  intentKey: ScoutNotificationIntentKeySchema,
+});
+export type ScoutNotificationV2Input = z.infer<
+  typeof ScoutNotificationV2InputSchema
+>;
+
+export const ScoutLakeProjectionV2InputSchema = z.strictObject({
+  stage: ScoutStageSchema,
+  riotMatchId: RiotMatchIdSchema,
+});
+export type ScoutLakeProjectionV2Input = z.infer<
+  typeof ScoutLakeProjectionV2InputSchema
+>;
+
+/**
+ * A recovery batch carries no cursor in its input, and that is deliberate.
+ * The scan position, page budget and counts live in the durable batch row,
+ * which is the whole reason the row exists: a Continue-As-New that re-serialized
+ * them would give the batch two sources of truth that a crash between the
+ * cursor write and the Continue-As-New could disagree about.
+ */
+export const ScoutRecoveryBatchV2InputSchema = z.strictObject({
+  stage: ScoutStageSchema,
+  recoveryBatchId: ScoutRecoveryBatchIdSchema,
+});
+export type ScoutRecoveryBatchV2Input = z.infer<
+  typeof ScoutRecoveryBatchV2InputSchema
+>;
+
+/**
+ * Reconciliation likewise carries no cursor. Its scan is idempotent and
+ * resumes from the durable watermark each run, so a Continue-As-New repeats
+ * the input unchanged.
+ */
+export const ScoutPipelineReconciliationV2InputSchema = z.strictObject({
+  stage: ScoutStageSchema,
+  trigger: ScoutV2TriggerSchema,
+});
+export type ScoutPipelineReconciliationV2Input = z.infer<
+  typeof ScoutPipelineReconciliationV2InputSchema
+>;
+
+export const scoutPostMatchDiscoveryV2InputCodec = defineVersionedCodec({
+  kind: "scout-post-match-discovery-v2-input",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutPostMatchDiscoveryV2InputSchema,
+});
+export const scoutMatchProcessingV2InputCodec = defineVersionedCodec({
+  kind: "scout-match-processing-v2-input",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutMatchProcessingV2InputSchema,
+});
+export const scoutPrematchDiscoveryV2InputCodec = defineVersionedCodec({
+  kind: "scout-prematch-discovery-v2-input",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutPrematchDiscoveryV2InputSchema,
+});
+export const scoutPrematchGameV2InputCodec = defineVersionedCodec({
+  kind: "scout-prematch-game-v2-input",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutPrematchGameV2InputSchema,
+});
+export const scoutNotificationV2InputCodec = defineVersionedCodec({
+  kind: "scout-notification-v2-input",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutNotificationV2InputSchema,
+});
+export const scoutLakeProjectionV2InputCodec = defineVersionedCodec({
+  kind: "scout-lake-projection-v2-input",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutLakeProjectionV2InputSchema,
+});
+export const scoutRecoveryBatchV2InputCodec = defineVersionedCodec({
+  kind: "scout-recovery-batch-v2-input",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutRecoveryBatchV2InputSchema,
+});
+export const scoutPipelineReconciliationV2InputCodec = defineVersionedCodec({
+  kind: "scout-pipeline-reconciliation-v2-input",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutPipelineReconciliationV2InputSchema,
+});
+
+export type ScoutPostMatchDiscoveryV2InputEnvelope = EnvelopeOf<
+  typeof scoutPostMatchDiscoveryV2InputCodec
+>;
+export type ScoutMatchProcessingV2InputEnvelope = EnvelopeOf<
+  typeof scoutMatchProcessingV2InputCodec
+>;
+export type ScoutPrematchDiscoveryV2InputEnvelope = EnvelopeOf<
+  typeof scoutPrematchDiscoveryV2InputCodec
+>;
+export type ScoutPrematchGameV2InputEnvelope = EnvelopeOf<
+  typeof scoutPrematchGameV2InputCodec
+>;
+export type ScoutNotificationV2InputEnvelope = EnvelopeOf<
+  typeof scoutNotificationV2InputCodec
+>;
+export type ScoutLakeProjectionV2InputEnvelope = EnvelopeOf<
+  typeof scoutLakeProjectionV2InputCodec
+>;
+export type ScoutRecoveryBatchV2InputEnvelope = EnvelopeOf<
+  typeof scoutRecoveryBatchV2InputCodec
+>;
+export type ScoutPipelineReconciliationV2InputEnvelope = EnvelopeOf<
+  typeof scoutPipelineReconciliationV2InputCodec
+>;
+
+// ─── V2 Workflow results ───────────────────────────────────────────────────
+
+export const ScoutPostMatchDiscoveryV2ResultSchema = z.strictObject({
+  status: ScoutWorkflowStatusSchema,
+  discovered: z.int().nonnegative(),
+  childrenStarted: z.int().nonnegative(),
+  /** False when discovery could not see the whole tail of completed matches. */
+  complete: z.boolean(),
+});
+export type ScoutPostMatchDiscoveryV2Result = z.infer<
+  typeof ScoutPostMatchDiscoveryV2ResultSchema
+>;
+
+export const ScoutMatchProcessingV2ResultSchema = z.strictObject({
+  status: ScoutWorkflowStatusSchema,
+  riotMatchId: RiotMatchIdSchema,
+  owner: PipelineOwnerSchema,
+  policy: MatchProcessingPolicySchema,
+  /** Which facts this run attested to, in the order it recorded them. */
+  receiptKinds: z.array(ReceiptKindSchema).readonly(),
+  childrenStarted: z.strictObject({
+    notifications: z.int().nonnegative(),
+    lakeProjections: z.int().nonnegative(),
+  }),
+});
+export type ScoutMatchProcessingV2Result = z.infer<
+  typeof ScoutMatchProcessingV2ResultSchema
+>;
+
+export const ScoutPrematchDiscoveryV2ResultSchema = z.strictObject({
+  status: ScoutWorkflowStatusSchema,
+  discovered: z.int().nonnegative(),
+  childrenStarted: z.int().nonnegative(),
+  complete: z.boolean(),
+});
+export type ScoutPrematchDiscoveryV2Result = z.infer<
+  typeof ScoutPrematchDiscoveryV2ResultSchema
+>;
+
+export const ScoutPrematchGameV2ResultSchema = z.strictObject({
+  status: ScoutWorkflowStatusSchema,
+  /** The match id the snapshot belongs to, composed from the game reference. */
+  riotMatchId: RiotMatchIdSchema,
+  receiptKinds: z.array(ReceiptKindSchema).readonly(),
+  childrenStarted: z.strictObject({
+    notifications: z.int().nonnegative(),
+  }),
+});
+export type ScoutPrematchGameV2Result = z.infer<
+  typeof ScoutPrematchGameV2ResultSchema
+>;
+
+/**
+ * The intent's state when the Workflow stopped driving it. `unknown-delivery`
+ * is a legitimate stopping point and NOT a failure: the machine leaves it only
+ * through an operator resolution, because a retry could double-deliver.
+ */
+export const ScoutNotificationV2ResultSchema = z.strictObject({
+  status: ScoutWorkflowStatusSchema,
+  intentKey: ScoutNotificationIntentKeySchema,
+  state: NotificationIntentStateSchema,
+  attemptCount: z.int().nonnegative(),
+});
+export type ScoutNotificationV2Result = z.infer<
+  typeof ScoutNotificationV2ResultSchema
+>;
+
+export const ScoutLakeProjectionV2ResultSchema = z.strictObject({
+  status: ScoutWorkflowStatusSchema,
+  riotMatchId: RiotMatchIdSchema,
+  receiptKinds: z.array(ReceiptKindSchema).readonly(),
+  stagedFileCount: z.int().nonnegative(),
+});
+export type ScoutLakeProjectionV2Result = z.infer<
+  typeof ScoutLakeProjectionV2ResultSchema
+>;
+
+export const ScoutRecoveryBatchV2ResultSchema = z.strictObject({
+  status: ScoutWorkflowStatusSchema,
+  recoveryBatchId: ScoutRecoveryBatchIdSchema,
+  state: RecoveryBatchStateSchema,
+  counts: RecoveryCountsSchema,
+});
+export type ScoutRecoveryBatchV2Result = z.infer<
+  typeof ScoutRecoveryBatchV2ResultSchema
+>;
+
+export const ScoutPipelineReconciliationV2ResultSchema = z.strictObject({
+  status: ScoutWorkflowStatusSchema,
+  trigger: ScoutV2TriggerSchema,
+  pagesScanned: z.int().nonnegative(),
+  childrenStarted: z.strictObject({
+    matchProcessing: z.int().nonnegative(),
+    notifications: z.int().nonnegative(),
+    lakeProjections: z.int().nonnegative(),
+    recoveryBatches: z.int().nonnegative(),
+  }),
+});
+export type ScoutPipelineReconciliationV2Result = z.infer<
+  typeof ScoutPipelineReconciliationV2ResultSchema
+>;
+
+export const scoutPostMatchDiscoveryV2ResultCodec = defineVersionedCodec({
+  kind: "scout-post-match-discovery-v2-result",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutPostMatchDiscoveryV2ResultSchema,
+});
+export const scoutMatchProcessingV2ResultCodec = defineVersionedCodec({
+  kind: "scout-match-processing-v2-result",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutMatchProcessingV2ResultSchema,
+});
+export const scoutPrematchDiscoveryV2ResultCodec = defineVersionedCodec({
+  kind: "scout-prematch-discovery-v2-result",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutPrematchDiscoveryV2ResultSchema,
+});
+export const scoutPrematchGameV2ResultCodec = defineVersionedCodec({
+  kind: "scout-prematch-game-v2-result",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutPrematchGameV2ResultSchema,
+});
+export const scoutNotificationV2ResultCodec = defineVersionedCodec({
+  kind: "scout-notification-v2-result",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutNotificationV2ResultSchema,
+});
+export const scoutLakeProjectionV2ResultCodec = defineVersionedCodec({
+  kind: "scout-lake-projection-v2-result",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutLakeProjectionV2ResultSchema,
+});
+export const scoutRecoveryBatchV2ResultCodec = defineVersionedCodec({
+  kind: "scout-recovery-batch-v2-result",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutRecoveryBatchV2ResultSchema,
+});
+export const scoutPipelineReconciliationV2ResultCodec = defineVersionedCodec({
+  kind: "scout-pipeline-reconciliation-v2-result",
+  version: SCOUT_V2_CONTRACT_VERSION,
+  schema: ScoutPipelineReconciliationV2ResultSchema,
+});
+
+export type ScoutPostMatchDiscoveryV2ResultEnvelope = EnvelopeOf<
+  typeof scoutPostMatchDiscoveryV2ResultCodec
+>;
+export type ScoutMatchProcessingV2ResultEnvelope = EnvelopeOf<
+  typeof scoutMatchProcessingV2ResultCodec
+>;
+export type ScoutPrematchDiscoveryV2ResultEnvelope = EnvelopeOf<
+  typeof scoutPrematchDiscoveryV2ResultCodec
+>;
+export type ScoutPrematchGameV2ResultEnvelope = EnvelopeOf<
+  typeof scoutPrematchGameV2ResultCodec
+>;
+export type ScoutNotificationV2ResultEnvelope = EnvelopeOf<
+  typeof scoutNotificationV2ResultCodec
+>;
+export type ScoutLakeProjectionV2ResultEnvelope = EnvelopeOf<
+  typeof scoutLakeProjectionV2ResultCodec
+>;
+export type ScoutRecoveryBatchV2ResultEnvelope = EnvelopeOf<
+  typeof scoutRecoveryBatchV2ResultCodec
+>;
+export type ScoutPipelineReconciliationV2ResultEnvelope = EnvelopeOf<
+  typeof scoutPipelineReconciliationV2ResultCodec
+>;

--- a/packages/scout-for-lol/packages/temporal/src/workflow-contracts-v2.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflow-contracts-v2.ts
@@ -252,11 +252,43 @@ export type ScoutLakeProjectionV2Result = z.infer<
   typeof ScoutLakeProjectionV2ResultSchema
 >;
 
+/**
+ * What THIS run can say about a recovery batch's tally.
+ *
+ * A batch carries counts only while it is `processing`. The durable row
+ * flattens the state union, and `recoveryBatchStateColumns` builds every row
+ * from a base whose count columns are null, filling them for `processing`
+ * alone — so the transition into `digesting`, `complete` or `abandoned` writes
+ * NULL over the tally, and the migration CHECKs make any other combination
+ * unrepresentable. The counts are gone, not merely absent from the state
+ * union, and no read can recover them.
+ *
+ * A run that drove the batch through processing watched the tally and reports
+ * it. A run that a reconciliation sweep or an operator started onto a batch
+ * already past processing never saw one, and `unobserved` is that answer said
+ * out loud. Without it, such a run has two dishonest options: report zeros it
+ * invented, or fail a batch that actually finished.
+ *
+ * The two axes are independent — a run that drove processing to completion
+ * reports `observed` counts with a `complete` state — so this is a field on
+ * the result rather than a split of it.
+ */
+export const ScoutRecoveryCountsReportV2Schema = z.discriminatedUnion("kind", [
+  z.strictObject({
+    kind: z.literal("observed"),
+    counts: RecoveryCountsSchema,
+  }),
+  z.strictObject({ kind: z.literal("unobserved") }),
+]);
+export type ScoutRecoveryCountsReportV2 = z.infer<
+  typeof ScoutRecoveryCountsReportV2Schema
+>;
+
 export const ScoutRecoveryBatchV2ResultSchema = z.strictObject({
   status: ScoutWorkflowStatusSchema,
   recoveryBatchId: ScoutRecoveryBatchIdSchema,
   state: RecoveryBatchStateSchema,
-  counts: RecoveryCountsSchema,
+  counts: ScoutRecoveryCountsReportV2Schema,
 });
 export type ScoutRecoveryBatchV2Result = z.infer<
   typeof ScoutRecoveryBatchV2ResultSchema

--- a/packages/scout-for-lol/packages/temporal/src/workflows/activity-options.test.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflows/activity-options.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, test } from "vitest";
-
-import { BACKGROUND_ACTIVITY_RETRY_POLICY } from "./activity-options.ts";
+import { ActivityCancellationType } from "@temporalio/workflow";
+import type { ScoutStage } from "#src/contracts.ts";
+import { SCOUT_V2_ACTIVITY_QUEUE_CLASSES } from "#src/identifiers.ts";
+import {
+  BACKGROUND_ACTIVITY_OPTIONS,
+  BACKGROUND_ACTIVITY_RETRY_POLICY,
+  LAKE_ACTIVITY_OPTIONS,
+  NOTIFICATION_DELIVERY_ACTIVITY_OPTIONS,
+  REALTIME_ACTIVITY_OPTIONS,
+  backgroundV2Activities,
+  lakeV2Activities,
+  notificationDeliveryV2Activities,
+  realtimeV2Activities,
+} from "./activity-options.ts";
 
 describe("background activity retry ownership", () => {
   test("keeps four attempts for transient failures and stops quota retries", () => {
@@ -8,5 +20,103 @@ describe("background activity retry ownership", () => {
     expect(BACKGROUND_ACTIVITY_RETRY_POLICY.nonRetryableErrorTypes).toContain(
       "ProviderQuotaExhausted",
     );
+  });
+});
+
+const STAGES: readonly ScoutStage[] = ["dev", "beta", "prod"];
+
+describe("V2 proxy factories", () => {
+  test("build options the SDK accepts, for every stage", () => {
+    // `proxyActivities` validates eagerly: an options set with neither a
+    // start-to-close nor a schedule-to-close timeout throws here rather than
+    // at the first Activity a live Workflow tries to schedule.
+    for (const stage of STAGES) {
+      expect(() => realtimeV2Activities(stage)).not.toThrow();
+      expect(() => backgroundV2Activities(stage)).not.toThrow();
+      expect(() => lakeV2Activities(stage)).not.toThrow();
+      expect(() => notificationDeliveryV2Activities(stage)).not.toThrow();
+    }
+  });
+
+  test("expose the V2 activity surface, not v1's", () => {
+    expect(typeof realtimeV2Activities("prod").commitMatchObservationV2).toBe(
+      "function",
+    );
+    expect(
+      typeof backgroundV2Activities("prod").scanPipelineReconciliationPageV2,
+    ).toBe("function");
+    expect(typeof lakeV2Activities("prod").stageLakeProjectionV2).toBe(
+      "function",
+    );
+    expect(
+      typeof notificationDeliveryV2Activities("prod").deliverNotificationV2,
+    ).toBe("function");
+  });
+
+  test("cover every queue class a V2 activity declares", () => {
+    // A V2 Activity assigned to a class with no factory would have nothing to
+    // dispatch it, and `interactive` in particular must stay uncovered: that
+    // queue serves a human waiting on a turn.
+    const factoriesByQueueClass = {
+      realtime: realtimeV2Activities,
+      background: backgroundV2Activities,
+      lake: lakeV2Activities,
+    };
+    for (const queueClass of new Set(
+      Object.values(SCOUT_V2_ACTIVITY_QUEUE_CLASSES),
+    )) {
+      expect(factoriesByQueueClass).toHaveProperty(queueClass);
+    }
+  });
+});
+
+describe("frozen V2 activity budgets", () => {
+  test("never retries a notification send", () => {
+    // The request may have posted to Discord before the response was lost, so
+    // a second attempt can double-deliver to a user. One attempt makes an
+    // ambiguous send terminate, which the Workflow records as
+    // `unknown-delivery` against that attempt's nonce.
+    expect(NOTIFICATION_DELIVERY_ACTIVITY_OPTIONS.retry.maximumAttempts).toBe(
+      1,
+    );
+  });
+
+  test("waits out a cancelled send rather than abandoning its outcome", () => {
+    expect(NOTIFICATION_DELIVERY_ACTIVITY_OPTIONS.cancellationType).toBe(
+      ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+    );
+  });
+
+  test("gives delivery Discord's budget, not the shared realtime one", () => {
+    // A send that has not answered in 30 seconds is already ambiguous;
+    // waiting out the realtime window only widens the window in which the
+    // Workflow cannot say what happened.
+    expect(NOTIFICATION_DELIVERY_ACTIVITY_OPTIONS.startToCloseTimeout).toBe(
+      "30 seconds",
+    );
+    expect(NOTIFICATION_DELIVERY_ACTIVITY_OPTIONS.scheduleToCloseTimeout).toBe(
+      "2 minutes",
+    );
+    expect(
+      NOTIFICATION_DELIVERY_ACTIVITY_OPTIONS.scheduleToCloseTimeout,
+    ).not.toBe(REALTIME_ACTIVITY_OPTIONS.scheduleToCloseTimeout);
+  });
+
+  test("heartbeats lake staging through long projections", () => {
+    expect(LAKE_ACTIVITY_OPTIONS.heartbeatTimeout).toBe("30 seconds");
+    expect(LAKE_ACTIVITY_OPTIONS.startToCloseTimeout).toBe("2 hours");
+    expect(LAKE_ACTIVITY_OPTIONS.scheduleToCloseTimeout).toBe("6 hours");
+  });
+
+  test("spends the same budget on V2 background work as on detached v1 work", () => {
+    // Identity, not equality: one object, so the two cannot drift apart.
+    expect(BACKGROUND_ACTIVITY_OPTIONS.retry).toBe(
+      BACKGROUND_ACTIVITY_RETRY_POLICY,
+    );
+  });
+
+  test("keeps realtime latency-shaped for both pipelines", () => {
+    expect(REALTIME_ACTIVITY_OPTIONS.startToCloseTimeout).toBe("90 seconds");
+    expect(REALTIME_ACTIVITY_OPTIONS.retry.maximumAttempts).toBe(5);
   });
 });

--- a/packages/scout-for-lol/packages/temporal/src/workflows/activity-options.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflows/activity-options.ts
@@ -1,6 +1,7 @@
 import {
   ActivityCancellationType,
   proxyActivities,
+  type ActivityOptions,
 } from "@temporalio/workflow";
 import type { RetryPolicy } from "@temporalio/common";
 import type {
@@ -28,29 +29,61 @@ export const BACKGROUND_ACTIVITY_RETRY_POLICY = {
   nonRetryableErrorTypes: [...NON_RETRYABLE_FAILURES],
 } satisfies RetryPolicy;
 
+/**
+ * One queue class's budget, minus the queue it is spent on.
+ *
+ * A queue class gets a named object exactly when two proxies share it: v1 and
+ * V2 both dispatch to `scout-{stage}-realtime`, and workers there serve both,
+ * so "V2 mirrors its v1 sibling" has to be one object rather than two copies
+ * that agree today. `interactiveActivities` keeps its options inline because
+ * nothing else spends that budget.
+ */
+type QueueActivityOptions = Omit<ActivityOptions, "taskQueue">;
+
+export const REALTIME_ACTIVITY_OPTIONS = {
+  startToCloseTimeout: "90 seconds",
+  scheduleToCloseTimeout: "5 minutes",
+  heartbeatTimeout: "30 seconds",
+  retry: {
+    maximumAttempts: 5,
+    initialInterval: "2 seconds",
+    backoffCoefficient: 2,
+    maximumInterval: "30 seconds",
+    nonRetryableErrorTypes: [...NON_RETRYABLE_FAILURES],
+  },
+} satisfies QueueActivityOptions;
+
+export const BACKGROUND_ACTIVITY_OPTIONS = {
+  startToCloseTimeout: "30 minutes",
+  scheduleToCloseTimeout: "2 hours",
+  heartbeatTimeout: "30 seconds",
+  retry: BACKGROUND_ACTIVITY_RETRY_POLICY,
+} satisfies QueueActivityOptions;
+
+export const LAKE_ACTIVITY_OPTIONS = {
+  startToCloseTimeout: "2 hours",
+  scheduleToCloseTimeout: "6 hours",
+  heartbeatTimeout: "30 seconds",
+  retry: {
+    maximumAttempts: 3,
+    initialInterval: "30 seconds",
+    backoffCoefficient: 2,
+    maximumInterval: "10 minutes",
+    nonRetryableErrorTypes: [...NON_RETRYABLE_FAILURES],
+  },
+} satisfies QueueActivityOptions;
+
 export function realtimeActivities(stage: ScoutStage) {
   return proxyActivities<ScoutTemporalActivities>({
     taskQueue: scoutTaskQueues(stage).realtime,
-    startToCloseTimeout: "90 seconds",
-    scheduleToCloseTimeout: "5 minutes",
-    heartbeatTimeout: "30 seconds",
-    retry: {
-      maximumAttempts: 5,
-      initialInterval: "2 seconds",
-      backoffCoefficient: 2,
-      maximumInterval: "30 seconds",
-      nonRetryableErrorTypes: [...NON_RETRYABLE_FAILURES],
-    },
+    ...REALTIME_ACTIVITY_OPTIONS,
   });
 }
 
 export function backgroundActivities(stage: ScoutStage) {
   return proxyActivities<ScoutTemporalActivities>({
     taskQueue: scoutTaskQueues(stage).background,
-    startToCloseTimeout: "30 minutes",
-    scheduleToCloseTimeout: "2 hours",
-    heartbeatTimeout: "30 seconds",
-    retry: BACKGROUND_ACTIVITY_RETRY_POLICY,
+    ...BACKGROUND_ACTIVITY_OPTIONS,
   });
 }
 
@@ -77,16 +110,7 @@ export function interactiveActivities(stage: ScoutStage) {
 export function lakeActivities(stage: ScoutStage) {
   return proxyActivities<ScoutTemporalActivities>({
     taskQueue: scoutTaskQueues(stage).lake,
-    startToCloseTimeout: "2 hours",
-    scheduleToCloseTimeout: "6 hours",
-    heartbeatTimeout: "30 seconds",
-    retry: {
-      maximumAttempts: 3,
-      initialInterval: "30 seconds",
-      backoffCoefficient: 2,
-      maximumInterval: "10 minutes",
-      nonRetryableErrorTypes: [...NON_RETRYABLE_FAILURES],
-    },
+    ...LAKE_ACTIVITY_OPTIONS,
   });
 }
 
@@ -97,42 +121,21 @@ export function lakeActivities(stage: ScoutStage) {
 export function realtimeV2Activities(stage: ScoutStage) {
   return proxyActivities<ScoutTemporalV2Activities>({
     taskQueue: scoutTaskQueues(stage).realtime,
-    startToCloseTimeout: "90 seconds",
-    scheduleToCloseTimeout: "5 minutes",
-    heartbeatTimeout: "30 seconds",
-    retry: {
-      maximumAttempts: 5,
-      initialInterval: "2 seconds",
-      backoffCoefficient: 2,
-      maximumInterval: "30 seconds",
-      nonRetryableErrorTypes: [...NON_RETRYABLE_FAILURES],
-    },
+    ...REALTIME_ACTIVITY_OPTIONS,
   });
 }
 
 export function backgroundV2Activities(stage: ScoutStage) {
   return proxyActivities<ScoutTemporalV2Activities>({
     taskQueue: scoutTaskQueues(stage).background,
-    startToCloseTimeout: "30 minutes",
-    scheduleToCloseTimeout: "2 hours",
-    heartbeatTimeout: "30 seconds",
-    retry: BACKGROUND_ACTIVITY_RETRY_POLICY,
+    ...BACKGROUND_ACTIVITY_OPTIONS,
   });
 }
 
 export function lakeV2Activities(stage: ScoutStage) {
   return proxyActivities<ScoutTemporalV2Activities>({
     taskQueue: scoutTaskQueues(stage).lake,
-    startToCloseTimeout: "2 hours",
-    scheduleToCloseTimeout: "6 hours",
-    heartbeatTimeout: "30 seconds",
-    retry: {
-      maximumAttempts: 3,
-      initialInterval: "30 seconds",
-      backoffCoefficient: 2,
-      maximumInterval: "10 minutes",
-      nonRetryableErrorTypes: [...NON_RETRYABLE_FAILURES],
-    },
+    ...LAKE_ACTIVITY_OPTIONS,
   });
 }
 
@@ -155,18 +158,22 @@ export function lakeV2Activities(stage: ScoutStage) {
  * out the 5-minute realtime window only widens the window in which the
  * Workflow cannot say what happened.
  */
+export const NOTIFICATION_DELIVERY_ACTIVITY_OPTIONS = {
+  startToCloseTimeout: "30 seconds",
+  scheduleToCloseTimeout: "2 minutes",
+  heartbeatTimeout: "10 seconds",
+  cancellationType: ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+  retry: {
+    maximumAttempts: 1,
+    nonRetryableErrorTypes: [...NON_RETRYABLE_FAILURES],
+  },
+} satisfies QueueActivityOptions;
+
 export function notificationDeliveryV2Activities(stage: ScoutStage) {
   return proxyActivities<
     Pick<ScoutTemporalV2Activities, "deliverNotificationV2">
   >({
     taskQueue: scoutTaskQueues(stage).realtime,
-    startToCloseTimeout: "30 seconds",
-    scheduleToCloseTimeout: "2 minutes",
-    heartbeatTimeout: "10 seconds",
-    cancellationType: ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
-    retry: {
-      maximumAttempts: 1,
-      nonRetryableErrorTypes: [...NON_RETRYABLE_FAILURES],
-    },
+    ...NOTIFICATION_DELIVERY_ACTIVITY_OPTIONS,
   });
 }

--- a/packages/scout-for-lol/packages/temporal/src/workflows/activity-options.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflows/activity-options.ts
@@ -3,7 +3,10 @@ import {
   proxyActivities,
 } from "@temporalio/workflow";
 import type { RetryPolicy } from "@temporalio/common";
-import type { ScoutTemporalActivities } from "#src/activities.ts";
+import type {
+  ScoutTemporalActivities,
+  ScoutTemporalV2Activities,
+} from "#src/activities.ts";
 import type { ScoutStage } from "#src/contracts.ts";
 import { DETACHED_WORK_MAX_ATTEMPTS } from "#src/contracts.ts";
 import { scoutTaskQueues } from "#src/identifiers.ts";
@@ -82,6 +85,87 @@ export function lakeActivities(stage: ScoutStage) {
       initialInterval: "30 seconds",
       backoffCoefficient: 2,
       maximumInterval: "10 minutes",
+      nonRetryableErrorTypes: [...NON_RETRYABLE_FAILURES],
+    },
+  });
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// V2 durable pipeline
+// ───────────────────────────────────────────────────────────────────────────
+
+export function realtimeV2Activities(stage: ScoutStage) {
+  return proxyActivities<ScoutTemporalV2Activities>({
+    taskQueue: scoutTaskQueues(stage).realtime,
+    startToCloseTimeout: "90 seconds",
+    scheduleToCloseTimeout: "5 minutes",
+    heartbeatTimeout: "30 seconds",
+    retry: {
+      maximumAttempts: 5,
+      initialInterval: "2 seconds",
+      backoffCoefficient: 2,
+      maximumInterval: "30 seconds",
+      nonRetryableErrorTypes: [...NON_RETRYABLE_FAILURES],
+    },
+  });
+}
+
+export function backgroundV2Activities(stage: ScoutStage) {
+  return proxyActivities<ScoutTemporalV2Activities>({
+    taskQueue: scoutTaskQueues(stage).background,
+    startToCloseTimeout: "30 minutes",
+    scheduleToCloseTimeout: "2 hours",
+    heartbeatTimeout: "30 seconds",
+    retry: BACKGROUND_ACTIVITY_RETRY_POLICY,
+  });
+}
+
+export function lakeV2Activities(stage: ScoutStage) {
+  return proxyActivities<ScoutTemporalV2Activities>({
+    taskQueue: scoutTaskQueues(stage).lake,
+    startToCloseTimeout: "2 hours",
+    scheduleToCloseTimeout: "6 hours",
+    heartbeatTimeout: "30 seconds",
+    retry: {
+      maximumAttempts: 3,
+      initialInterval: "30 seconds",
+      backoffCoefficient: 2,
+      maximumInterval: "10 minutes",
+      nonRetryableErrorTypes: [...NON_RETRYABLE_FAILURES],
+    },
+  });
+}
+
+/**
+ * The one V2 deviation from the sibling options, and the reason it exists.
+ *
+ * `deliverNotificationV2` is the single Activity whose retry is itself the
+ * hazard: the request may have reached Discord and posted a message before
+ * the response was lost, so a second attempt can double-deliver to a user.
+ * `maximumAttempts: 1` makes an ambiguous send terminate as one attempt, which
+ * the Workflow then records as `unknown-delivery` against that attempt's
+ * nonce — the domain's deliberate dead end, left only by an operator who
+ * looked. Retrying here would trade a visible stall for an invisible
+ * duplicate.
+ *
+ * `WAIT_CANCELLATION_COMPLETED` closes the same hole from the other side: a
+ * cancelled Workflow must not walk away from a send whose outcome is still
+ * unobserved. The timeouts are Discord's, not the shared realtime budget — a
+ * send that has not answered in 30 seconds is already ambiguous, and waiting
+ * out the 5-minute realtime window only widens the window in which the
+ * Workflow cannot say what happened.
+ */
+export function notificationDeliveryV2Activities(stage: ScoutStage) {
+  return proxyActivities<
+    Pick<ScoutTemporalV2Activities, "deliverNotificationV2">
+  >({
+    taskQueue: scoutTaskQueues(stage).realtime,
+    startToCloseTimeout: "30 seconds",
+    scheduleToCloseTimeout: "2 minutes",
+    heartbeatTimeout: "10 seconds",
+    cancellationType: ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+    retry: {
+      maximumAttempts: 1,
       nonRetryableErrorTypes: [...NON_RETRYABLE_FAILURES],
     },
   });

--- a/packages/scout-for-lol/packages/temporal/src/workflows/durable-v2.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflows/durable-v2.ts
@@ -1,0 +1,95 @@
+import type {
+  ScoutLakeProjectionV2InputEnvelope,
+  ScoutLakeProjectionV2ResultEnvelope,
+  ScoutNotificationV2InputEnvelope,
+  ScoutNotificationV2ResultEnvelope,
+  ScoutPipelineReconciliationV2InputEnvelope,
+  ScoutPipelineReconciliationV2ResultEnvelope,
+  ScoutRecoveryBatchV2InputEnvelope,
+  ScoutRecoveryBatchV2ResultEnvelope,
+} from "#src/workflow-contracts-v2.ts";
+import { SCOUT_WORKFLOW_NAMES } from "#src/identifiers.ts";
+import { unimplementedV2Workflow } from "./unimplemented-v2.ts";
+
+/**
+ * One notification intent, V2.
+ *
+ * Drives the domain intent machine: ready, render, begin the send under a
+ * freshly minted attempt nonce, deliver, and record the outcome.
+ *
+ * The send is deliberately three Activities rather than one. The nonce is
+ * committed BEFORE the Discord call and the outcome AFTER it, so a worker that
+ * dies mid-send leaves an attempt that is identifiable rather than a gap.
+ * `deliverNotificationV2` runs with `maximumAttempts: 1`; an ambiguous send
+ * becomes `unknown-delivery` against that nonce and stops there. That state is
+ * terminal for the Workflow by design — only an operator who looked can say
+ * whether a message exists, and an automatic retry would risk telling a user
+ * the same thing twice.
+ */
+export function scoutNotificationV2Workflow(
+  input: ScoutNotificationV2InputEnvelope,
+): Promise<ScoutNotificationV2ResultEnvelope> {
+  return unimplementedV2Workflow(
+    SCOUT_WORKFLOW_NAMES.notificationV2,
+    input.kind,
+  );
+}
+
+/**
+ * Lake projection for one match, V2.
+ *
+ * Receipted staging on the lake queue. The projection is derived and
+ * rebuildable — S3 holds the canonical bytes — so its receipt attests to the
+ * source object and digest the rows came from rather than to the staging files
+ * themselves, which live on one role's own volume and mean nothing elsewhere.
+ */
+export function scoutLakeProjectionV2Workflow(
+  input: ScoutLakeProjectionV2InputEnvelope,
+): Promise<ScoutLakeProjectionV2ResultEnvelope> {
+  return unimplementedV2Workflow(
+    SCOUT_WORKFLOW_NAMES.lakeProjectionV2,
+    input.kind,
+  );
+}
+
+/**
+ * One recovery batch, V2.
+ *
+ * Scans a bounded number of pages, processes what it found, digests the
+ * outcome for an operator, and closes — continuing as new before the history
+ * grows, guided by `continueAsNewSuggested` and the batch's own page budget.
+ *
+ * The input carries no cursor. The scan position, budget and counts live in
+ * the durable batch row, so a Continue-As-New that re-serialized them would
+ * create a second source of truth that a crash between the cursor write and
+ * the Continue-As-New could disagree with.
+ */
+export function scoutRecoveryBatchV2Workflow(
+  input: ScoutRecoveryBatchV2InputEnvelope,
+): Promise<ScoutRecoveryBatchV2ResultEnvelope> {
+  return unimplementedV2Workflow(
+    SCOUT_WORKFLOW_NAMES.recoveryBatchV2,
+    input.kind,
+  );
+}
+
+/**
+ * Pipeline reconciliation, V2.
+ *
+ * Bounded scans for work nothing is currently driving — unprocessed matches,
+ * stalled intents, unstaged projections, orphaned recovery batches — starting
+ * the owning Workflow for each. Every child ID is derived from the work
+ * itself, so restarting one that is already running is a no-op rather than a
+ * duplicate.
+ *
+ * Like recovery, it carries no cursor across Continue-As-New: the scan is
+ * idempotent and resumes from the durable watermark each run.
+ */
+export function scoutPipelineReconciliationV2Workflow(
+  input: ScoutPipelineReconciliationV2InputEnvelope,
+): Promise<ScoutPipelineReconciliationV2ResultEnvelope> {
+  return unimplementedV2Workflow(
+    SCOUT_WORKFLOW_NAMES.pipelineReconciliationV2,
+    input.kind,
+  );
+}

--- a/packages/scout-for-lol/packages/temporal/src/workflows/index.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflows/index.ts
@@ -18,6 +18,24 @@ import type {
   ScoutChallengeRunRecomputeInput,
   ScoutDuelSeriesInput,
 } from "#src/contracts.ts";
+import type {
+  ScoutLakeProjectionV2InputEnvelope,
+  ScoutLakeProjectionV2ResultEnvelope,
+  ScoutMatchProcessingV2InputEnvelope,
+  ScoutMatchProcessingV2ResultEnvelope,
+  ScoutNotificationV2InputEnvelope,
+  ScoutNotificationV2ResultEnvelope,
+  ScoutPipelineReconciliationV2InputEnvelope,
+  ScoutPipelineReconciliationV2ResultEnvelope,
+  ScoutPostMatchDiscoveryV2InputEnvelope,
+  ScoutPostMatchDiscoveryV2ResultEnvelope,
+  ScoutPrematchDiscoveryV2InputEnvelope,
+  ScoutPrematchDiscoveryV2ResultEnvelope,
+  ScoutPrematchGameV2InputEnvelope,
+  ScoutPrematchGameV2ResultEnvelope,
+  ScoutRecoveryBatchV2InputEnvelope,
+  ScoutRecoveryBatchV2ResultEnvelope,
+} from "#src/workflow-contracts-v2.ts";
 import { scoutRealtimePollWorkflow as realtimePoll } from "./realtime.ts";
 import { scoutMatchIngestionWorkflow as matchIngestion } from "./realtime.ts";
 import { scoutPostMatchDiscoveryWorkflow as postMatchDiscovery } from "./realtime.ts";
@@ -35,6 +53,20 @@ import {
   scoutDuelSeriesWorkflow as duelSeries,
   scoutHallBaselineWorkflow as hallBaseline,
 } from "./progression.ts";
+import {
+  scoutMatchProcessingV2Workflow as matchProcessingV2,
+  scoutPostMatchDiscoveryV2Workflow as postMatchDiscoveryV2,
+} from "./match-v2.ts";
+import {
+  scoutPrematchDiscoveryV2Workflow as prematchDiscoveryV2,
+  scoutPrematchGameV2Workflow as prematchGameV2,
+} from "./prematch-v2.ts";
+import {
+  scoutLakeProjectionV2Workflow as lakeProjectionV2,
+  scoutNotificationV2Workflow as notificationV2,
+  scoutPipelineReconciliationV2Workflow as pipelineReconciliationV2,
+  scoutRecoveryBatchV2Workflow as recoveryBatchV2,
+} from "./durable-v2.ts";
 
 export async function scoutRealtimePollWorkflow(
   input: ScoutRealtimePollInput,
@@ -124,4 +156,52 @@ export async function scoutDuelSeriesWorkflow(
   input: ScoutDuelSeriesInput,
 ): Promise<ScoutWorkflowStatus> {
   return await duelSeries(input);
+}
+
+export async function scoutPostMatchDiscoveryV2Workflow(
+  input: ScoutPostMatchDiscoveryV2InputEnvelope,
+): Promise<ScoutPostMatchDiscoveryV2ResultEnvelope> {
+  return await postMatchDiscoveryV2(input);
+}
+
+export async function scoutMatchProcessingV2Workflow(
+  input: ScoutMatchProcessingV2InputEnvelope,
+): Promise<ScoutMatchProcessingV2ResultEnvelope> {
+  return await matchProcessingV2(input);
+}
+
+export async function scoutPrematchDiscoveryV2Workflow(
+  input: ScoutPrematchDiscoveryV2InputEnvelope,
+): Promise<ScoutPrematchDiscoveryV2ResultEnvelope> {
+  return await prematchDiscoveryV2(input);
+}
+
+export async function scoutPrematchGameV2Workflow(
+  input: ScoutPrematchGameV2InputEnvelope,
+): Promise<ScoutPrematchGameV2ResultEnvelope> {
+  return await prematchGameV2(input);
+}
+
+export async function scoutNotificationV2Workflow(
+  input: ScoutNotificationV2InputEnvelope,
+): Promise<ScoutNotificationV2ResultEnvelope> {
+  return await notificationV2(input);
+}
+
+export async function scoutLakeProjectionV2Workflow(
+  input: ScoutLakeProjectionV2InputEnvelope,
+): Promise<ScoutLakeProjectionV2ResultEnvelope> {
+  return await lakeProjectionV2(input);
+}
+
+export async function scoutRecoveryBatchV2Workflow(
+  input: ScoutRecoveryBatchV2InputEnvelope,
+): Promise<ScoutRecoveryBatchV2ResultEnvelope> {
+  return await recoveryBatchV2(input);
+}
+
+export async function scoutPipelineReconciliationV2Workflow(
+  input: ScoutPipelineReconciliationV2InputEnvelope,
+): Promise<ScoutPipelineReconciliationV2ResultEnvelope> {
+  return await pipelineReconciliationV2(input);
 }

--- a/packages/scout-for-lol/packages/temporal/src/workflows/match-v2.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflows/match-v2.ts
@@ -1,0 +1,53 @@
+import type {
+  ScoutMatchProcessingV2InputEnvelope,
+  ScoutMatchProcessingV2ResultEnvelope,
+  ScoutPostMatchDiscoveryV2InputEnvelope,
+  ScoutPostMatchDiscoveryV2ResultEnvelope,
+} from "#src/workflow-contracts-v2.ts";
+import { SCOUT_WORKFLOW_NAMES } from "#src/identifiers.ts";
+import { unimplementedV2Workflow } from "./unimplemented-v2.ts";
+
+/**
+ * Post-match discovery, V2.
+ *
+ * Discovers completed matches for tracked accounts, then starts one
+ * `scoutMatchProcessingV2Workflow` child per match, serialized in discovery
+ * order. Serialization is not incidental: bounded Dare plans are ordered by
+ * match end time, so a later match must not settle while an earlier one is
+ * still being processed.
+ *
+ * Child IDs come from `scoutMatchProcessingV2WorkflowId`, so a rediscovered
+ * match collapses onto the execution already processing it rather than
+ * starting a second one.
+ */
+export function scoutPostMatchDiscoveryV2Workflow(
+  input: ScoutPostMatchDiscoveryV2InputEnvelope,
+): Promise<ScoutPostMatchDiscoveryV2ResultEnvelope> {
+  return unimplementedV2Workflow(
+    SCOUT_WORKFLOW_NAMES.postMatchDiscoveryV2,
+    input.kind,
+  );
+}
+
+/**
+ * The per-match core, V2.
+ *
+ * Phases, in order: archive the raw artifacts, commit the observation, settle
+ * markets, apply progression, record receipts, advance tracked-account
+ * cursors, and only then fan out notification and lake-projection children.
+ *
+ * Fan-out happens after the domain commit because a notification is a promise
+ * about a fact: a child started before the commit could deliver a claim the
+ * pipeline then fails to make durable. `readMatchPipelineStateV2` is the
+ * resume point — one aggregate read spanning observation, receipts, intents
+ * and tracked accounts — so a restarted execution skips the phases that
+ * already happened instead of re-applying them.
+ */
+export function scoutMatchProcessingV2Workflow(
+  input: ScoutMatchProcessingV2InputEnvelope,
+): Promise<ScoutMatchProcessingV2ResultEnvelope> {
+  return unimplementedV2Workflow(
+    SCOUT_WORKFLOW_NAMES.matchProcessingV2,
+    input.kind,
+  );
+}

--- a/packages/scout-for-lol/packages/temporal/src/workflows/prematch-v2.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflows/prematch-v2.ts
@@ -1,0 +1,48 @@
+import type {
+  ScoutPrematchDiscoveryV2InputEnvelope,
+  ScoutPrematchDiscoveryV2ResultEnvelope,
+  ScoutPrematchGameV2InputEnvelope,
+  ScoutPrematchGameV2ResultEnvelope,
+} from "#src/workflow-contracts-v2.ts";
+import { SCOUT_WORKFLOW_NAMES } from "#src/identifiers.ts";
+import { unimplementedV2Workflow } from "./unimplemented-v2.ts";
+
+/**
+ * Prematch discovery, V2.
+ *
+ * Polls spectator state for tracked accounts and starts one
+ * `scoutPrematchGameV2Workflow` per live game. The child carries a game
+ * REFERENCE, never the spectator payload: the payload is large, is already
+ * destined for the object store, and would otherwise be copied into a
+ * Workflow history that keeps it forever.
+ */
+export function scoutPrematchDiscoveryV2Workflow(
+  input: ScoutPrematchDiscoveryV2InputEnvelope,
+): Promise<ScoutPrematchDiscoveryV2ResultEnvelope> {
+  return unimplementedV2Workflow(
+    SCOUT_WORKFLOW_NAMES.prematchDiscoveryV2,
+    input.kind,
+  );
+}
+
+/**
+ * One live game, V2.
+ *
+ * Archives the spectator snapshot, receipts it, then fans out the
+ * game-starting notifications. The snapshot is keyed by the match id Riot will
+ * later assign — `scoutPrematchGameV2MatchId` composes it from the platform
+ * and game id the reference already carries — so the prematch snapshot, the
+ * eventual match payload and its timeline all land in one receipt scope.
+ *
+ * Several tracked accounts can be in the same game, and they are the same
+ * snapshot. The Workflow ID drops the puuid for exactly that reason, so the
+ * duplicates collapse instead of racing.
+ */
+export function scoutPrematchGameV2Workflow(
+  input: ScoutPrematchGameV2InputEnvelope,
+): Promise<ScoutPrematchGameV2ResultEnvelope> {
+  return unimplementedV2Workflow(
+    SCOUT_WORKFLOW_NAMES.prematchGameV2,
+    input.kind,
+  );
+}

--- a/packages/scout-for-lol/packages/temporal/src/workflows/registration-v2.test.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflows/registration-v2.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { WorkflowFailedError } from "@temporalio/client";
+import { ApplicationFailure } from "@temporalio/common";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+import {
+  RecoveryBatchIdSchema,
+  RiotMatchIdSchema,
+} from "@scout-for-lol/domain/identity/brands.ts";
+import {
+  ScoutNotificationIntentKeySchema,
+  ScoutPrematchGameRefSchema,
+} from "#src/contracts-v2.ts";
+import {
+  scoutLakeProjectionV2InputCodec,
+  scoutMatchProcessingV2InputCodec,
+  scoutNotificationV2InputCodec,
+  scoutPipelineReconciliationV2InputCodec,
+  scoutPostMatchDiscoveryV2InputCodec,
+  scoutPrematchDiscoveryV2InputCodec,
+  scoutPrematchGameV2InputCodec,
+  scoutRecoveryBatchV2InputCodec,
+} from "#src/workflow-contracts-v2.ts";
+import {
+  SCOUT_WORKFLOW_NAMES,
+  SCOUT_V2_WORKFLOW_NAMES,
+  scoutLakeProjectionV2WorkflowId,
+  scoutMatchProcessingV2WorkflowId,
+  scoutNotificationV2WorkflowId,
+  scoutPipelineReconciliationV2WorkflowId,
+  scoutPostMatchDiscoveryV2WorkflowId,
+  scoutPrematchDiscoveryV2WorkflowId,
+  scoutPrematchGameV2WorkflowId,
+  scoutRecoveryBatchV2WorkflowId,
+} from "#src/identifiers.ts";
+
+let environment: TestWorkflowEnvironment;
+
+beforeEach(async () => {
+  environment = await TestWorkflowEnvironment.createTimeSkipping();
+}, 60_000);
+
+afterEach(async () => {
+  await environment.teardown();
+});
+
+const stage = "dev" as const;
+const riotMatchId = RiotMatchIdSchema.parse("NA1_5312279829");
+const intentKey = ScoutNotificationIntentKeySchema.parse(
+  "notify:NA1_5312279829:guild:1234567890",
+);
+const recoveryBatchId = RecoveryBatchIdSchema.parse("recovery_01");
+const gameRef = ScoutPrematchGameRefSchema.parse({
+  puuid: "p".repeat(78),
+  platform: "NA1",
+  gameId: "5312279829",
+});
+
+/**
+ * Each V2 type, started the way production will start it: by NAME, with the
+ * ID its builder computes and an input its codec serialized. Naming the type
+ * as a string rather than importing the function is the point — that is what
+ * a Schedule, an operator and a reconciliation sweep all do, and it is the
+ * only way the test can tell registration from a local import.
+ */
+const registrations = [
+  {
+    name: SCOUT_WORKFLOW_NAMES.postMatchDiscoveryV2,
+    workflowId: scoutPostMatchDiscoveryV2WorkflowId(stage, "schedule"),
+    input: scoutPostMatchDiscoveryV2InputCodec.serialize({
+      stage,
+      trigger: "schedule",
+    }),
+  },
+  {
+    name: SCOUT_WORKFLOW_NAMES.matchProcessingV2,
+    workflowId: scoutMatchProcessingV2WorkflowId(stage, riotMatchId),
+    input: scoutMatchProcessingV2InputCodec.serialize({ stage, riotMatchId }),
+  },
+  {
+    name: SCOUT_WORKFLOW_NAMES.prematchDiscoveryV2,
+    workflowId: scoutPrematchDiscoveryV2WorkflowId(stage),
+    input: scoutPrematchDiscoveryV2InputCodec.serialize({ stage }),
+  },
+  {
+    name: SCOUT_WORKFLOW_NAMES.prematchGameV2,
+    workflowId: scoutPrematchGameV2WorkflowId(stage, gameRef),
+    input: scoutPrematchGameV2InputCodec.serialize({ stage, gameRef }),
+  },
+  {
+    name: SCOUT_WORKFLOW_NAMES.notificationV2,
+    workflowId: scoutNotificationV2WorkflowId(stage, intentKey),
+    input: scoutNotificationV2InputCodec.serialize({ stage, intentKey }),
+  },
+  {
+    name: SCOUT_WORKFLOW_NAMES.lakeProjectionV2,
+    workflowId: scoutLakeProjectionV2WorkflowId(stage, riotMatchId),
+    input: scoutLakeProjectionV2InputCodec.serialize({ stage, riotMatchId }),
+  },
+  {
+    name: SCOUT_WORKFLOW_NAMES.recoveryBatchV2,
+    workflowId: scoutRecoveryBatchV2WorkflowId(stage, recoveryBatchId),
+    input: scoutRecoveryBatchV2InputCodec.serialize({
+      stage,
+      recoveryBatchId,
+    }),
+  },
+  {
+    name: SCOUT_WORKFLOW_NAMES.pipelineReconciliationV2,
+    workflowId: scoutPipelineReconciliationV2WorkflowId(stage, "operator"),
+    input: scoutPipelineReconciliationV2InputCodec.serialize({
+      stage,
+      trigger: "operator",
+    }),
+  },
+] as const;
+
+test("registers all eight V2 types, and each refuses to run unimplemented", async () => {
+  expect(registrations.map((entry) => entry.name)).toEqual([
+    ...SCOUT_V2_WORKFLOW_NAMES,
+  ]);
+
+  const worker = await Worker.create({
+    connection: environment.nativeConnection,
+    taskQueue: "scout-dev",
+    workflowsPath: new URL("index.ts", import.meta.url).pathname,
+    maxConcurrentWorkflowTaskExecutions: 4,
+  });
+
+  await worker.runUntil(async () => {
+    for (const entry of registrations) {
+      // A type missing from the bundle fails its workflow task and retries
+      // forever, so this settling at all is the registration proof; the
+      // assertions are that it stopped, terminally, and said why.
+      const settled: unknown = await environment.client.workflow
+        .execute(entry.name, {
+          taskQueue: "scout-dev",
+          workflowId: entry.workflowId,
+          args: [entry.input],
+        })
+        .then(
+          (value: unknown) => value,
+          (error: unknown) => error,
+        );
+
+      expect(settled).toBeInstanceOf(WorkflowFailedError);
+      if (!(settled instanceof WorkflowFailedError)) return;
+      expect(settled.cause).toBeInstanceOf(ApplicationFailure);
+      if (!(settled.cause instanceof ApplicationFailure)) return;
+      expect(settled.cause.type).toBe("UnimplementedWorkflow");
+      expect(settled.cause.nonRetryable).toBe(true);
+      expect(settled.cause.message).toContain(entry.name);
+    }
+  });
+}, 120_000);

--- a/packages/scout-for-lol/packages/temporal/src/workflows/unimplemented-v2.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflows/unimplemented-v2.ts
@@ -1,0 +1,27 @@
+import { ApplicationFailure } from "@temporalio/common";
+
+/**
+ * The body of every V2 Workflow until its implementation lane lands.
+ *
+ * The eight V2 types are registered now so the ID builders, contracts and
+ * queue assignments are one frozen surface that three lanes can build against
+ * in parallel. Registration without a body is a hazard, though: a Schedule
+ * pointed at a V2 type, or an operator starting one by name, would otherwise
+ * get an execution that completes having done nothing — the most expensive
+ * kind of silence in a pipeline whose whole job is to be able to say what
+ * happened.
+ *
+ * So a stub fails, terminally. `nonRetryable` because no amount of retrying
+ * adds an implementation, and a Workflow failure rather than a Workflow task
+ * failure because a task failure would retry forever and leave the execution
+ * open and quiet instead of visibly failed.
+ */
+export function unimplementedV2Workflow(
+  workflowType: string,
+  contract: string,
+): never {
+  throw ApplicationFailure.nonRetryable(
+    `Scout Workflow ${workflowType} is a registered V2 contract with no implementation yet (${contract})`,
+    "UnimplementedWorkflow",
+  );
+}


### PR DESCRIPTION
## Why

Wave 4 of the Scout durable-architecture program needs a frozen Temporal V2 surface before the post-match, prematch, and recovery/notification/lake implementation lanes can build on it. Contracts land alone so consumer branches restack on a reviewed, immutable vocabulary — and so review focuses on the contract decisions, not implementation noise.

## What

- **Eight V2 Workflow Types** registered with deterministic IDs on the existing `scout-{stage}` workflow queue (no task-queue names changed; v1 `contracts.ts` is byte-identical): post-match discovery, match processing, prematch discovery, prematch game, notification, lake projection, recovery batch, pipeline reconciliation.
- **Versioned codec envelopes** (`defineVersionedCodec` from `@scout-for-lol/domain`) for every workflow input/result — these payloads are read across builds (Continue-As-New, ABANDON children, parent replay of child results). Activity payloads stay flat strict zod; a breaking Activity result change gets a NEW activity name, written into `activities.ts` as binding.
- **25 V2 Activity signatures** with a compile-checked queue map (`SCOUT_V2_ACTIVITY_QUEUE_CLASSES`, `satisfies Record<ScoutV2ActivityName, ScoutQueueClass>`): 17 realtime, 7 background, 1 lake, 0 interactive (asserted by test — interactive serves humans waiting on a turn).
- **Guarded-effect results** carry guard and fact as separate repository-vocabulary outcomes (`applied | already-applied | adopted | conflict{reason}`), so at-most-once claims and durable facts never need to share a transaction and a crash between them reports as reconcile, not double-application.
- **No-retry delivery proxy**: `deliverNotificationV2` runs with `maximumAttempts: 1`; an ambiguous Discord send terminates as one attempt and records `unknown-delivery` against a pre-committed nonce.
- **Stub bodies fail terminally** (non-retryable `ApplicationFailure`, type `UnimplementedWorkflow`); the registration test starts every type by name string with codec-serialized inputs and asserts terminal failure — an unregistered type would retry its workflow task forever.
- ID details: prematch-game IDs exclude the puuid (one game via several tracked accounts collapses to one execution); discovery/reconciliation IDs embed the trigger (operator sweeps are never absorbed by an in-flight scheduled run); recovery/reconciliation inputs carry no cursor (position lives in durable rows so Continue-As-New has one source of truth).
- Reviewers: the V2 contracts live in three sibling modules (`contracts-v2`, `workflow-contracts-v2`, `activity-contracts-v2`) rather than inside `contracts.ts` — the combined surface would breach the 500-line cap, and a per-file override would weaken a gate.

## Verification

- `bunx turbo run typecheck test lint --filter=@scout-for-lol/temporal --filter=@scout-for-lol/backend` green (backend 414 test files / 3939 tests; temporal independently re-run with `--force`: bun suite, Node time-skipping `test:workflows`, registration-by-name test, bundle test proving no backend/Prisma/Discord/AWS/DuckDB dependency reaches the workflow bundle — it pulls only bundle-safe domain identity modules).
- `bunx lefthook run pre-commit` green.
- **Not run**: Buildkite (this PR's build), any deployment layer, live workflow execution — the stubs are designed to fail if started; nothing becomes startable until the Wave-4 implementation lanes land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qRdG6fzJr3THzYzAJwTZB