### PR TITLE
fix(scout-for-lol): wire the receipted projection into live ingest

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/scout-report-lake.md
+++ b/packages/docs/wiki/src/content/docs/explanation/scout-report-lake.md
@@ -69,8 +69,10 @@ raw JSON, so the new column simply appears the next morning.
 Ingest makes two writes with deliberately different contracts, spelled out in
 [store.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/report-store/store.ts).
 The S3 put throws on failure, because raw data is unrecoverable. Match and
-timeline lake staging writes never throw, because a lost staging row is
-re-derived from S3 that night anyway.
+timeline lake staging writes never throw at the ingest caller, because a lost
+staging row is re-derived from S3 that night anyway. Both steps run through the
+receipted doors described below, and `store.ts` is where the receipted contract
+is translated back into the boolean one ingest has always had.
 
 The quiet first-run import tightens that contract. It snapshots exactly 20
 Match-V5 IDs once, imports newest first, and checkpoints a match only when the
@@ -126,9 +128,9 @@ rebuild is reproducible.
 
 ### Receipted ingest is a second door, not a replacement
 
-The durable architecture adds a receipted entry point alongside the boolean one:
-the same staging and archival primitives underneath, the opposite failure
-contract on top. A caller that asks for a receipted write is asking for a
+The durable architecture adds a receipted entry point over the same staging and
+archival primitives, with the opposite failure contract on top. A caller that
+asks for a receipted write is asking for a
 durable claim that the projection happened, so a staging failure throws and
 records nothing rather than returning `false`
 ([receipted-staging.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/report-lake/receipted-staging.ts),
@@ -136,6 +138,28 @@ records nothing rather than returning `false`
 correspond to a real staging file would be worse than no receipt, because the
 value of the table is that a row in it can be trusted without re-deriving the
 fact it attests to.
+
+Live ingest goes through this door, which is how a raw archive and a lake
+projection become facts anyone can check rather than events only the logs
+remember.
+
+On the archival side there is no longer a second door at all. Two status-only
+wrappers used to sit over the archive functions and returned `"saved"` instead
+of the descriptor; every caller that went through them threw the artifact's
+identity away, which is precisely why the observation's artifact columns were
+NULL for every live match. They are gone, and a caller that wants only the
+status reads it off the result.
+
+The boolean STAGING door does remain, with two callers: competition rank-history
+staging, which has no receipted counterpart, and the dev/test path where no
+bucket is configured — there nothing was archived, so there is no source object
+a staging receipt could name and no archive to attest to.
+
+The translation between the two contracts lives in one place, `store.ts`, and
+only one failure crosses it: a staging failure becomes the `false` that has
+always blocked cursor advancement. A source descriptor that does not describe
+what was staged is a broken internal contract rather than a failed projection,
+and stays fatal.
 
 The receipt write itself is the one fail-open step. Refusing an archive because
 its bookkeeping row could not be inserted would trade a bookkeeping problem for a
@@ -157,6 +181,16 @@ write, so they arrive from the ingest worker roles rather than from
 `application`; neither is one of the database-sweeping collectors only
 `application` serves ([sweep-policy.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/metrics/sweep-policy.ts)), so a
 dashboard over the pair joins across roles.
+
+Both producers count through the same place, and that is what keeps the pair
+readable. The `write_kind` label comes from one closed set shared with the
+per-match durable services
+([durable-facts.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/durable/match/durable-facts.ts)),
+so neither producer can grow the label on its own, and the repository's answer is
+parsed before it becomes an `outcome`, so a repository that learns a new answer
+surfaces as a loud failure rather than a quietly widened axis. The two fail-open
+wrappers also refuse to nest: both count a completed write, so recording a
+receipt from inside a durable write would report one fact as two.
 
 ### A receipt identifies content, never a location
 

--- a/packages/scout-for-lol/packages/backend/README.md
+++ b/packages/scout-for-lol/packages/backend/README.md
@@ -80,7 +80,16 @@ a reader can go find what the receipt attests to. No evidence carries a money
 amount; the identities locate the ledger rows and the amounts live there under
 the storable Bucks brands. The `raw-archive` and `lake-staging` receipt kinds
 belong to the receipted lake projection in `report-lake/`, which records them
-from the writer that knows the artifact's key and digest.
+from the writer that knows the artifact's key and digest; the two vocabularies
+are disjoint, so no receipt identity carries two evidence shapes.
+
+`MatchObservation`'s artifact columns are stamped from that same archive.
+`report-store/store.ts` runs live ingest through the receipted doors and passes
+the descriptor back up through `recordMatchForReportStore` to
+`requestMatchArchive`, so the stored key and digest are what the put actually
+wrote rather than a key rebuilt from the layout convention. They stay NULL when
+no object was written (no bucket configured) or when an earlier run had already
+archived the match, which is exactly what NULL means there.
 
 Two metrics carry the parity signal, both defined once in
 `src/metrics/durable.ts` — prom-client throws at import time on a duplicate
@@ -100,6 +109,15 @@ Both are per-write counters incremented by whichever runtime role executed the
 write, so a parity dashboard joins across roles rather than reading one
 process. Neither is derived from a database sweep, so neither belongs in
 `getMetrics()`'s `databaseMetricSweepsEnabled()` block.
+
+`write_kind` comes from the single closed set in
+`src/durable/match/durable-facts.ts`, which covers the receipted lake
+projection's kinds as well as the per-match services'; a new dual-write site
+adds a member there rather than passing a free-form string. `outcome` is parsed
+from the repository's own answer before it becomes a label. The two fail-open
+wrappers — `recordDurableWrite` and `recordReceiptFailOpen` — refuse to nest,
+because both count a completed write and nesting them would report one fact
+twice.
 
 ## Beta Customs operations
 

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -2673,6 +2673,10 @@ model DuelStatusOutbox {
 /// riotMatchId is the claim key, `pipelineOwner` NULL is the domain's
 /// `unowned` variant, and promotion mirrors promoteArchiveOnlyToFull — a FULL
 /// row with NULL promotedAt was born FULL and can never have been promoted.
+/// observeMatch is idempotent over what an observation ASSERTS, which is not
+/// the whole row: `observedAt` is excluded from the replay comparison exactly
+/// as `recordedAt` is excluded from a receipt's identity, so an ordinary
+/// replay is `already-applied` and not a conflict.
 model MatchObservation {
   riotMatchId      String    @id
   platformRoute    String
@@ -2680,10 +2684,13 @@ model MatchObservation {
   pipelineOwner    String? // LEGACY_V1 | TEMPORAL_V2; NULL = unowned
   promotedAt       DateTime?
   gameCreatedAt    DateTime
-  observedAt       DateTime
+  observedAt       DateTime // when someone first looked; never replay identity
 
   // Raw capture artifact references (S3 object key + SHA-256 digest, always
-  // paired). NULL means the artifact has not been stored yet.
+  // paired). NULL means no writer has reported one yet — silence, not a claim
+  // that none exists, so an observation carrying none leaves a stored identity
+  // standing. A first identity fills the pair in; a DIFFERENT one is two
+  // producers disagreeing about the canonical bytes, and conflicts.
   matchObjectKey    String?
   matchDigest       String?
   timelineObjectKey String?

--- a/packages/scout-for-lol/packages/backend/src/database/durable/observation-repository.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/observation-repository.integration.test.ts
@@ -30,12 +30,26 @@ const AT = new Date("2026-09-07T10:00:00.000Z");
 const LATER = new Date("2026-09-07T11:00:00.000Z");
 const PROMOTED_AT = IsoInstantSchema.parse("2026-09-07T12:00:00.000Z");
 
+/** One archived match payload's identity, in the shape the row stores it. */
+function matchArtifact(
+  gameId: number,
+  digestChar: string,
+): { matchObjectKey: string; matchDigest: string } {
+  return {
+    matchObjectKey: `games/2026/09/07/NA1_${String(gameId)}/match.json`,
+    matchDigest: digestChar.repeat(64),
+  };
+}
+
 function observation(
   gameId: number,
   overrides: Partial<{
     processingPolicy: string;
     pipelineOwner: string | null;
     promotedAt: Date | null;
+    observedAt: Date;
+    matchObjectKey: string | null;
+    matchDigest: string | null;
   }> = {},
 ): MatchObservationRecord {
   return matchObservationRowToRecord({
@@ -145,6 +159,85 @@ describe("observeMatch", () => {
   });
 });
 
+describe("what an observation asserts, and what it merely records", () => {
+  test("a replay differing only in its wall clock is already-applied", async () => {
+    // `observedAt` is wall-clock at write time, so an ordinary reprocess of a
+    // match differs in exactly that column and in nothing else. Counting those
+    // as conflicts inflated the very dual-write signal the parity alerting
+    // watches, with events that are the system working correctly — the same
+    // reasoning that keeps `recordedAt` out of a receipt's identity.
+    const first = observation(130);
+    expect(await observeMatch(prisma, first)).toEqual({ outcome: "applied" });
+
+    const lookedAgainLater = observation(130, {
+      observedAt: new Date("2026-09-07T18:00:00.000Z"),
+    });
+    expect(lookedAgainLater.observedAt).not.toBe(first.observedAt);
+    expect(await observeMatch(prisma, lookedAgainLater)).toEqual({
+      outcome: "already-applied",
+    });
+
+    // The first observer's instant stands; a later look does not restamp it.
+    const stored = await getObservation(prisma, { matchId: first.matchId });
+    expect(stored?.observedAt).toBe(first.observedAt);
+  });
+
+  test("an observation carrying no artifact leaves a stored one standing", async () => {
+    const artifact = matchArtifact(131, "a");
+    const archived = observation(131, artifact);
+    expect(await observeMatch(prisma, archived)).toEqual({
+      outcome: "applied",
+    });
+
+    // A pass whose archive an earlier run already completed has no descriptor
+    // to offer. Its silence is not a claim that there is no artifact, so it
+    // must not read as disagreement — nor erase what is recorded.
+    expect(await observeMatch(prisma, observation(131))).toEqual({
+      outcome: "already-applied",
+    });
+    const stored = await getObservation(prisma, { matchId: archived.matchId });
+    expect(stored?.artifacts.match).toEqual({
+      key: artifact.matchObjectKey,
+      digest: artifact.matchDigest,
+    });
+  });
+
+  test("a first artifact identity fills the columns in and applies", async () => {
+    const silent = observation(132);
+    expect(await observeMatch(prisma, silent)).toEqual({ outcome: "applied" });
+    const beforeArchive = await getObservation(prisma, {
+      matchId: silent.matchId,
+    });
+    expect(beforeArchive?.artifacts.match).toBeNull();
+
+    // The archive-less observation becoming archived. This happens at most
+    // once, because the columns are never cleared.
+    const artifact = matchArtifact(132, "a");
+    expect(await observeMatch(prisma, observation(132, artifact))).toEqual({
+      outcome: "applied",
+    });
+    const stored = await getObservation(prisma, { matchId: silent.matchId });
+    expect(stored?.artifacts.match).toEqual({
+      key: artifact.matchObjectKey,
+      digest: artifact.matchDigest,
+    });
+  });
+
+  test("two producers naming different bytes for one match conflict", async () => {
+    const first = observation(133, matchArtifact(133, "a"));
+    expect(await observeMatch(prisma, first)).toEqual({ outcome: "applied" });
+
+    // Never softened: this is genuine disagreement about which object is the
+    // canonical capture of this match, and the first writer's identity keeps
+    // the columns.
+    expect(
+      await observeMatch(prisma, observation(133, matchArtifact(133, "b"))),
+    ).toEqual({ outcome: "conflict", reason: "observation-differs" });
+    const stored = await getObservation(prisma, { matchId: first.matchId });
+    expect(stored?.artifacts.match?.digest).toBe("a".repeat(64));
+  });
+});
+
 describe("promoteObservation", () => {
   test("promotes at most once and conflicts on a born-FULL match", async () => {
     const record = observation(110);
@@ -232,14 +325,17 @@ describe("promoteObservation", () => {
       promotedAt: PROMOTED_AT,
     });
 
+    // A different game-creation instant is genuine divergence: two producers
+    // disagree about when this match was played. A different `observedAt`
+    // would NOT be — that records when someone looked, not what they claim.
     const divergent = matchObservationRowToRecord({
       riotMatchId: "NA1_115",
       platformRoute: "NA1",
       processingPolicy: "ARCHIVE_ONLY",
       pipelineOwner: null,
       promotedAt: null,
-      gameCreatedAt: AT,
-      observedAt: new Date("2026-09-07T14:00:00.000Z"),
+      gameCreatedAt: new Date("2026-09-07T09:00:00.000Z"),
+      observedAt: LATER,
       matchObjectKey: null,
       matchDigest: null,
       timelineObjectKey: null,

--- a/packages/scout-for-lol/packages/backend/src/database/durable/observation-repository.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/durable/observation-repository.ts
@@ -24,6 +24,13 @@ import { dateFromIsoInstant } from "#src/database/durable/row-values.ts";
  * the pure domain transitions (claimOwnership, promoteArchiveOnlyToFull) as
  * single guarded statements so racing writers get an expected `conflict`
  * result instead of an exception or a silent overwrite.
+ *
+ * Three groups of columns reconcile differently on a replay, and separating
+ * them is what keeps `observation-differs` meaning "two producers disagree".
+ * {@link observationClaim} is the claim itself and must match. The artifact
+ * columns follow {@link reconcileArtifact}: silence is not disagreement, and a
+ * first identity fills the columns in. `pipelineOwner` follows claimOwnership.
+ * `observedAt` is in none of them — see {@link observationClaim}.
  */
 
 const OBSERVE_ATTEMPTS = 3;
@@ -36,8 +43,46 @@ export type ObserveMatchResult =
       reason: "ownership-held-by-another-owner" | "observation-differs";
     };
 
-function ownerNeutral(row: MatchObservationRow): MatchObservationRow {
-  return { ...row, pipelineOwner: null };
+/**
+ * What an observation ASSERTS, as opposed to how it was recorded.
+ *
+ * `observedAt` is deliberately not part of it, for the same reason
+ * `recordedAt` is not part of a receipt's identity (see
+ * `receipt-repository.ts`): it is wall-clock at write time, so an ordinary
+ * replay of an already-committed observation differed in exactly that column
+ * and in nothing else, and every one of those was answered
+ * `observation-differs` — inflating the very dual-write signal the parity
+ * alerting watches with events that are the system working correctly. The
+ * first observer's instant stands; it records when someone first looked, never
+ * what they claim.
+ *
+ * The owner and artifact columns are excluded too, because each has its own
+ * reconciliation rule. Everything else is the claim, and it is spelled as a
+ * REST omission rather than an allowlist on purpose: a column added to the row
+ * joins the claim automatically, so a new fact conflicts when producers
+ * disagree instead of being silently ignored until someone notices.
+ */
+type ObservationClaim = Omit<
+  MatchObservationRow,
+  | "pipelineOwner"
+  | "observedAt"
+  | "matchObjectKey"
+  | "matchDigest"
+  | "timelineObjectKey"
+  | "timelineDigest"
+>;
+
+function observationClaim(row: MatchObservationRow): ObservationClaim {
+  const {
+    pipelineOwner: _pipelineOwner,
+    observedAt: _observedAt,
+    matchObjectKey: _matchObjectKey,
+    matchDigest: _matchDigest,
+    timelineObjectKey: _timelineObjectKey,
+    timelineDigest: _timelineDigest,
+    ...claim
+  } = row;
+  return claim;
 }
 
 /**
@@ -66,10 +111,41 @@ function isRetryOfPrePromotionObservation(
     promotedAt: null,
   };
   return Bun.deepEquals(
-    ownerNeutral(prePromotionForm),
-    ownerNeutral(incoming),
+    observationClaim(prePromotionForm),
+    observationClaim(incoming),
     true,
   );
+}
+
+/** One artifact's columns. The row codec keeps the pair written and read together. */
+type ArtifactColumns = { key: string | null; digest: string | null };
+
+/**
+ * How an incoming artifact identity relates to the stored one.
+ *
+ * An observation that carries no artifact makes NO ASSERTION about it. The v1
+ * path genuinely does not always know: a pass whose archive was already
+ * completed by an earlier run skips the archive entirely and has no descriptor
+ * to offer, so treating its silence as "there is no artifact" would turn every
+ * ordinary reprocess into a conflict.
+ *
+ * A first identity arriving over stored NULLs FILLS THEM IN — the archive-less
+ * observation becoming archived, which happens at most once because the
+ * columns are never cleared. Two DIFFERENT identities stay a conflict: that is
+ * two producers disagreeing about which bytes are canonical for this match,
+ * and nothing about it should be softened.
+ */
+type ArtifactAgreement = "silent" | "backfills" | "agrees" | "disagrees";
+
+function reconcileArtifact(
+  stored: ArtifactColumns,
+  incoming: ArtifactColumns,
+): ArtifactAgreement {
+  if (incoming.key === null) return "silent";
+  if (stored.key === null) return "backfills";
+  return stored.key === incoming.key && stored.digest === incoming.digest
+    ? "agrees"
+    : "disagrees";
 }
 
 async function resolveObservedConflict(
@@ -87,44 +163,82 @@ async function resolveObservedConflict(
   const existingRow = matchObservationRecordToRow(
     matchObservationRowToRecord(existing),
   );
-  if (Bun.deepEquals(existingRow, row, true)) {
-    return { outcome: "already-applied" };
-  }
   const sameObservation =
-    Bun.deepEquals(ownerNeutral(existingRow), ownerNeutral(row), true) ||
-    isRetryOfPrePromotionObservation(existingRow, row);
+    Bun.deepEquals(
+      observationClaim(existingRow),
+      observationClaim(row),
+      true,
+    ) || isRetryOfPrePromotionObservation(existingRow, row);
   if (!sameObservation) {
     return { outcome: "conflict", reason: "observation-differs" };
   }
-  // Same observation, different owner columns. NULL is the domain's
-  // `unowned`: an observation that arrives with an assigned owner claims an
-  // unowned row with a guarded update, exactly like claimOwnership.
-  if (existingRow.pipelineOwner === null && row.pipelineOwner !== null) {
-    const claimed = await db.matchObservation.updateMany({
-      where: { riotMatchId: row.riotMatchId, pipelineOwner: null },
-      data: { pipelineOwner: row.pipelineOwner },
-    });
-    return claimed.count === 1 ? { outcome: "applied" } : "retry";
+
+  const matchArtifact = reconcileArtifact(
+    { key: existingRow.matchObjectKey, digest: existingRow.matchDigest },
+    { key: row.matchObjectKey, digest: row.matchDigest },
+  );
+  const timelineArtifact = reconcileArtifact(
+    { key: existingRow.timelineObjectKey, digest: existingRow.timelineDigest },
+    { key: row.timelineObjectKey, digest: row.timelineDigest },
+  );
+  if (matchArtifact === "disagrees" || timelineArtifact === "disagrees") {
+    return { outcome: "conflict", reason: "observation-differs" };
   }
+
+  // NULL is the domain's `unowned`: an observation that arrives with an
+  // assigned owner claims an unowned row, exactly like claimOwnership.
+  const claimsOwner =
+    existingRow.pipelineOwner === null && row.pipelineOwner !== null;
   if (
-    row.pipelineOwner === null ||
-    row.pipelineOwner === existingRow.pipelineOwner
+    !claimsOwner &&
+    row.pipelineOwner !== null &&
+    row.pipelineOwner !== existingRow.pipelineOwner
   ) {
-    // The observation itself is already recorded, and either the retry does
-    // not claim at all or the claim it repeats is the one already held.
+    return { outcome: "conflict", reason: "ownership-held-by-another-owner" };
+  }
+
+  // One guarded update carries everything this replay adds. The guard names
+  // the NULLs it observed, so a racing writer that filled them first sends
+  // this attempt back around to reconcile against what they wrote.
+  const patch = {
+    ...(claimsOwner ? { pipelineOwner: row.pipelineOwner } : {}),
+    ...(matchArtifact === "backfills"
+      ? { matchObjectKey: row.matchObjectKey, matchDigest: row.matchDigest }
+      : {}),
+    ...(timelineArtifact === "backfills"
+      ? {
+          timelineObjectKey: row.timelineObjectKey,
+          timelineDigest: row.timelineDigest,
+        }
+      : {}),
+  };
+  if (Object.keys(patch).length === 0) {
+    // Everything this observation asserts is already recorded.
     return { outcome: "already-applied" };
   }
-  return { outcome: "conflict", reason: "ownership-held-by-another-owner" };
+  const updated = await db.matchObservation.updateMany({
+    where: {
+      riotMatchId: row.riotMatchId,
+      ...(claimsOwner ? { pipelineOwner: null } : {}),
+      ...(matchArtifact === "backfills" ? { matchObjectKey: null } : {}),
+      ...(timelineArtifact === "backfills" ? { timelineObjectKey: null } : {}),
+    },
+    data: patch,
+  });
+  return updated.count === 1 ? { outcome: "applied" } : "retry";
 }
 
 /**
  * Record one observed match, claiming ownership when the record carries an
- * assigned owner. Exactly one of two racing writers applies; the loser gets
- * `already-applied` for an identical retry — including a delayed retry of the
- * original ARCHIVE_ONLY observation after a promotion raced past it — an
- * ownership conflict for a different claimant, and `observation-differs` only
- * when the facts themselves genuinely disagree (which is a bug upstream,
- * surfaced as a conflict so the caller decides how loudly to fail).
+ * assigned owner and stamping the raw artifact's identity the first time one
+ * arrives. Exactly one of two racing writers applies; the loser gets
+ * `already-applied` for a retry that adds nothing — including one differing
+ * only in its wall clock, and a delayed retry of the original ARCHIVE_ONLY
+ * observation after a promotion raced past it — `applied` for a retry that
+ * genuinely adds an owner or an artifact identity, an ownership conflict for a
+ * different claimant, and `observation-differs` only when the facts themselves
+ * disagree (which is a bug upstream, surfaced as a conflict so the caller
+ * decides how loudly to fail).
  */
 export async function observeMatch(
   db: Db,

--- a/packages/scout-for-lol/packages/backend/src/durable/match/archive-facts.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/archive-facts.ts
@@ -50,10 +50,13 @@ import {
  * What the v1 archive step reports back about one match.
  *
  * `artifact` is the raw payload's durable identity — object key plus content
- * digest. Today's v1 writer returns neither, so it is absent and the
- * observation's artifact columns stay NULL, which is exactly what NULL means
- * there. A writer that does return a descriptor passes it through and the
- * observation carries the identity instead.
+ * digest — as v1's archive writer reported it. It is absent when no object was
+ * written at all (the dev/test no-bucket path), and then the observation's
+ * artifact columns stay NULL, which is exactly what NULL means there.
+ *
+ * The shape is structural rather than the object store's own descriptor
+ * because this service must stay importable without `report-lake/`, which is
+ * where the archive, the staging files and the receipts are composed.
  */
 export type MatchArchiveOutcome = {
   readonly staged: boolean;

--- a/packages/scout-for-lol/packages/backend/src/durable/match/delivery-intents.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/delivery-intents.ts
@@ -24,11 +24,13 @@ import {
 } from "@scout-for-lol/domain/notifications/intent-transitions.ts";
 import { recordReceipt } from "#src/database/durable/receipt-repository.ts";
 import {
+  getIntent,
   transitionIntent,
   upsertIntent,
 } from "#src/database/durable/intent-repository.ts";
 import {
   recordDurableWrite,
+  reportDurableWriteFailure,
   resolveDurableIdentity,
   type DurableFacts,
 } from "#src/durable/match/durable-facts.ts";
@@ -78,6 +80,12 @@ export type ChannelDeliveryEvent =
   | { kind: "prepared"; channelId: string }
   | { kind: "send-started"; channelId: string }
   | { kind: "delivered"; channelId: string; messageId: string }
+  /**
+   * A send an EARLIER pass performed, proven by a completed effect claim. The
+   * lifecycle above never runs for it, so its intent has to be adopted from
+   * wherever that pass left it. See {@link adoptCompletedDelivery}.
+   */
+  | { kind: "already-delivered"; channelId: string; messageId: string }
   | { kind: "failed"; channelId: string; permissionError: boolean };
 
 export type ChannelDeliveryRecorder = (
@@ -163,7 +171,7 @@ function confirmDelivery(args: {
   };
 }
 
-async function createIntent(
+async function upsertPendingIntent(
   config: RecorderConfig,
   channelId: string,
 ): Promise<void> {
@@ -190,8 +198,59 @@ async function createIntent(
       },
     }),
   );
+}
+
+async function markIntentReady(
+  config: RecorderConfig,
+  channelId: string,
+): Promise<void> {
+  const key = NotificationIntentKeySchema.parse(
+    intentKeyFor(config, channelId),
+  );
   await recordDurableWrite(config.facts, "intent-ready", async (db) =>
     transitionIntent(db, { intentKey: key, transition: markReady }),
+  );
+}
+
+async function createIntent(
+  config: RecorderConfig,
+  channelId: string,
+): Promise<void> {
+  await upsertPendingIntent(config, channelId);
+  await markIntentReady(config, channelId);
+}
+
+async function beginIntentSend(
+  config: RecorderConfig,
+  channelId: string,
+): Promise<void> {
+  const nonce = attemptNonceFor(config, channelId);
+  await applyIntentTransition(
+    config,
+    channelId,
+    "intent-send-started",
+    (intent) =>
+      beginSend(intent, {
+        attemptNonce: nonce,
+        startedAt: toIsoInstant(config.facts.now()),
+      }),
+  );
+}
+
+async function confirmIntentDelivered(
+  config: RecorderConfig,
+  channelId: string,
+  messageId: string,
+): Promise<void> {
+  await applyIntentTransition(
+    config,
+    channelId,
+    "intent-delivered",
+    confirmDelivery({
+      attemptNonce: attemptNonceFor(config, channelId),
+      messageId,
+      deliveredAt: () => toIsoInstant(config.facts.now()),
+    }),
   );
 }
 
@@ -210,6 +269,109 @@ async function applyIntentTransition(
 }
 
 /**
+ * The lifecycle steps still owed to an intent whose send already happened.
+ *
+ * The domain machine does not allow skipping states, and this does not invent
+ * a way around it: it reads where the intent actually stopped and replays the
+ * ordinary transitions from exactly there.
+ */
+type AdoptionStep = "created" | "ready" | "send-started" | "delivered";
+
+function stepsOwedTo(stored: NotificationIntent | null): AdoptionStep[] {
+  if (stored === null) {
+    return ["created", "ready", "send-started", "delivered"];
+  }
+  switch (stored.state.kind) {
+    case "pending":
+      return ["ready", "send-started", "delivered"];
+    case "ready":
+      return ["send-started", "delivered"];
+    case "sending":
+      return ["delivered"];
+    // These owe only the confirmation, and the domain's answer to it is the
+    // point: `delivered` under the same message id is `already-applied`, a
+    // different one conflicts, `unknown-delivery` stays the operator's to
+    // resolve, and a terminal state that disagrees with a proven send is a
+    // conflict worth seeing. Adoption completes a record; it never overwrites
+    // evidence that contradicts it.
+    case "delivered":
+    case "unknown-delivery":
+    case "suppressed":
+    case "expired":
+    case "permission-denied":
+      return ["delivered"];
+  }
+}
+
+/**
+ * Adopt a delivery an EARLIER pass performed, from wherever its intent stopped.
+ *
+ * The `ScoutEffectClaim` is the at-most-once guard, so a `completed` claim is
+ * proof the message went out, and it names the message. The intent recording
+ * that send is fail-open, though, so the run that sent it may have ended before
+ * any of its writes landed: the row can be missing, `pending`, `ready`, or
+ * `sending`. Every later pass takes the completed-claim branch and never runs
+ * the lifecycle, so this is the only place those rows can still be finished —
+ * and finishing them is the whole point of keeping the record.
+ *
+ * `beginSend` enforces the freshness deadline, which cannot fail on this path:
+ * the delivery gate and the deadline both come from
+ * `postmatchReportFreshnessDeadline`, so a pass that was allowed to deliver is
+ * by construction inside the deadline its intent carries. The prematch path
+ * does not use `deliverToChannels` at all.
+ *
+ * Every step is separately guarded and separately fail-open, so a step that
+ * cannot be applied is counted and the rest still run.
+ */
+async function adoptCompletedDelivery(
+  config: RecorderConfig,
+  channelId: string,
+  messageId: string,
+): Promise<void> {
+  const stored = await readIntent(config, channelId);
+  if (stored === "unreadable") return;
+  for (const step of stepsOwedTo(stored)) {
+    switch (step) {
+      case "created":
+        await upsertPendingIntent(config, channelId);
+        break;
+      case "ready":
+        await markIntentReady(config, channelId);
+        break;
+      case "send-started":
+        await beginIntentSend(config, channelId);
+        break;
+      case "delivered":
+        await confirmIntentDelivered(config, channelId, messageId);
+        break;
+    }
+  }
+}
+
+/**
+ * Read the stored intent behind the same fail-open boundary as the writes: a
+ * recorder that cannot reach its tables must not throw at a send that already
+ * succeeded. `unreadable` is distinct from `null` — absent means "create it",
+ * broken means "record nothing this pass".
+ */
+async function readIntent(
+  config: RecorderConfig,
+  channelId: string,
+): Promise<NotificationIntent | null | "unreadable"> {
+  try {
+    const stored = await getIntent(config.facts.db, {
+      intentKey: NotificationIntentKeySchema.parse(
+        intentKeyFor(config, channelId),
+      ),
+    });
+    return stored === null ? null : stored.intent;
+  } catch (error) {
+    reportDurableWriteFailure("intent-delivered", error);
+    return "unreadable";
+  }
+}
+
+/**
  * Build a recorder for one delivery pass.
  *
  * The recorder remembers which channels actually began a send, so a failure
@@ -225,34 +387,16 @@ export function createChannelDeliveryRecorder(
       case "prepared":
         await createIntent(config, event.channelId);
         return;
-      case "send-started": {
+      case "send-started":
         started.add(event.channelId);
-        const nonce = attemptNonceFor(config, event.channelId);
-        await applyIntentTransition(
-          config,
-          event.channelId,
-          "intent-send-started",
-          (intent) =>
-            beginSend(intent, {
-              attemptNonce: nonce,
-              startedAt: toIsoInstant(config.facts.now()),
-            }),
-        );
+        await beginIntentSend(config, event.channelId);
         return;
-      }
-      case "delivered": {
-        await applyIntentTransition(
-          config,
-          event.channelId,
-          "intent-delivered",
-          confirmDelivery({
-            attemptNonce: attemptNonceFor(config, event.channelId),
-            messageId: event.messageId,
-            deliveredAt: () => toIsoInstant(config.facts.now()),
-          }),
-        );
+      case "delivered":
+        await confirmIntentDelivered(config, event.channelId, event.messageId);
         return;
-      }
+      case "already-delivered":
+        await adoptCompletedDelivery(config, event.channelId, event.messageId);
+        return;
       case "failed": {
         if (!started.has(event.channelId)) return;
         const nonce = attemptNonceFor(config, event.channelId);

--- a/packages/scout-for-lol/packages/backend/src/durable/match/delivery-intents.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/delivery-intents.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import {
   DiscordMessageIdSchema,
   NotificationIntentKeySchema,
+  type IsoInstant,
   type RiotMatchId,
 } from "@scout-for-lol/domain/identity/brands.ts";
 import {
@@ -12,12 +13,14 @@ import {
   NotificationAttemptNonceSchema,
   type NotificationAttemptNonce,
   type NotificationFailure,
+  type NotificationIntent,
 } from "@scout-for-lol/domain/notifications/intent.ts";
 import {
   beginSend,
   confirmDelivered,
   markReady,
   recordFailure,
+  type NotificationTransitionResult,
 } from "@scout-for-lol/domain/notifications/intent-transitions.ts";
 import { recordReceipt } from "#src/database/durable/receipt-repository.ts";
 import {
@@ -119,6 +122,47 @@ function attemptNonceFor(
   );
 }
 
+/**
+ * Confirm a delivery, tolerating one that is already recorded under the same
+ * message id.
+ *
+ * The domain compares the delivery instant as well as the id, which is right
+ * for the transition itself: two confirmations naming different moments are
+ * genuinely different claims. But a pass that finds the send already completed
+ * knows the message id and NOT the instant the earlier pass stamped, and an
+ * intent already delivered under that same id is exactly the fact being
+ * recorded — so it is `already-applied` rather than drift. Without this, every
+ * ordinary reprocess of a delivered match would report a conflict on the
+ * counter the parity alerting watches. Every other state still goes through
+ * the domain unchanged.
+ *
+ * The message id is parsed INSIDE the returned transition, which is what runs
+ * inside {@link recordDurableWrite}. v1 hands over whatever Discord (or a test
+ * double) answered with, and a value that cannot be a durable identity must be
+ * counted as this recorder's failure rather than thrown at a send that already
+ * succeeded.
+ */
+function confirmDelivery(args: {
+  attemptNonce: NotificationAttemptNonce;
+  messageId: string;
+  deliveredAt: () => IsoInstant;
+}): (intent: NotificationIntent) => NotificationTransitionResult {
+  return (intent) => {
+    const messageId = DiscordMessageIdSchema.parse(args.messageId);
+    if (
+      intent.state.kind === "delivered" &&
+      intent.state.messageId === messageId
+    ) {
+      return { outcome: "already-applied" };
+    }
+    return confirmDelivered(intent, {
+      attemptNonce: args.attemptNonce,
+      messageId,
+      deliveredAt: args.deliveredAt(),
+    });
+  };
+}
+
 async function createIntent(
   config: RecorderConfig,
   channelId: string,
@@ -197,17 +241,15 @@ export function createChannelDeliveryRecorder(
         return;
       }
       case "delivered": {
-        const nonce = attemptNonceFor(config, event.channelId);
         await applyIntentTransition(
           config,
           event.channelId,
           "intent-delivered",
-          (intent) =>
-            confirmDelivered(intent, {
-              attemptNonce: nonce,
-              messageId: DiscordMessageIdSchema.parse(event.messageId),
-              deliveredAt: toIsoInstant(config.facts.now()),
-            }),
+          confirmDelivery({
+            attemptNonce: attemptNonceFor(config, event.channelId),
+            messageId: event.messageId,
+            deliveredAt: () => toIsoInstant(config.facts.now()),
+          }),
         );
         return;
       }

--- a/packages/scout-for-lol/packages/backend/src/durable/match/delivery-intents.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/delivery-intents.ts
@@ -76,6 +76,14 @@ export function deliveryAttemptNonce(effectKey: string): string {
     .slice(0, 25);
 }
 
+/**
+ * When a send that already happened began, and when it was observed to have
+ * happened. Both are historical: a pass recovering the send can be running
+ * hours later, and the intent's freshness guard would rightly reject a send
+ * claiming to have started then.
+ */
+export type ProvenSend = { startedAt: Date; deliveredAt: Date };
+
 export type ChannelDeliveryEvent =
   | { kind: "prepared"; channelId: string }
   | { kind: "send-started"; channelId: string }
@@ -85,7 +93,12 @@ export type ChannelDeliveryEvent =
    * lifecycle above never runs for it, so its intent has to be adopted from
    * wherever that pass left it. See {@link adoptCompletedDelivery}.
    */
-  | { kind: "already-delivered"; channelId: string; messageId: string }
+  | {
+      kind: "already-delivered";
+      channelId: string;
+      messageId: string;
+      send: ProvenSend;
+    }
   | { kind: "failed"; channelId: string; permissionError: boolean };
 
 export type ChannelDeliveryRecorder = (
@@ -220,9 +233,16 @@ async function createIntent(
   await markIntentReady(config, channelId);
 }
 
+/**
+ * `startedAt` is passed rather than read from the clock because a recovery
+ * adopts a send that began earlier, and `beginSend`'s freshness guard compares
+ * against it. The guard stays exactly as the domain wrote it; what changes is
+ * that it is given the true instant instead of the recovering pass's own.
+ */
 async function beginIntentSend(
   config: RecorderConfig,
   channelId: string,
+  startedAt: Date,
 ): Promise<void> {
   const nonce = attemptNonceFor(config, channelId);
   await applyIntentTransition(
@@ -232,7 +252,7 @@ async function beginIntentSend(
     (intent) =>
       beginSend(intent, {
         attemptNonce: nonce,
-        startedAt: toIsoInstant(config.facts.now()),
+        startedAt: toIsoInstant(startedAt),
       }),
   );
 }
@@ -241,6 +261,7 @@ async function confirmIntentDelivered(
   config: RecorderConfig,
   channelId: string,
   messageId: string,
+  deliveredAt: Date,
 ): Promise<void> {
   await applyIntentTransition(
     config,
@@ -249,7 +270,7 @@ async function confirmIntentDelivered(
     confirmDelivery({
       attemptNonce: attemptNonceFor(config, channelId),
       messageId,
-      deliveredAt: () => toIsoInstant(config.facts.now()),
+      deliveredAt: () => toIsoInstant(deliveredAt),
     }),
   );
 }
@@ -314,11 +335,11 @@ function stepsOwedTo(stored: NotificationIntent | null): AdoptionStep[] {
  * the lifecycle, so this is the only place those rows can still be finished —
  * and finishing them is the whole point of keeping the record.
  *
- * `beginSend` enforces the freshness deadline, which cannot fail on this path:
- * the delivery gate and the deadline both come from
- * `postmatchReportFreshnessDeadline`, so a pass that was allowed to deliver is
- * by construction inside the deadline its intent carries. The prematch path
- * does not use `deliverToChannels` at all.
+ * `beginSend` enforces the freshness deadline, and that guard stays exactly as
+ * the domain wrote it. It passes because the adopted send is given the instant
+ * it REALLY began — the claim row's own `claimedAt`, written immediately before
+ * the send ran — rather than the recovering pass's clock. A recovery can run
+ * hours after the deadline; the send it is adopting did not.
  *
  * Every step is separately guarded and separately fail-open, so a step that
  * cannot be applied is counted and the rest still run.
@@ -327,6 +348,7 @@ async function adoptCompletedDelivery(
   config: RecorderConfig,
   channelId: string,
   messageId: string,
+  send: ProvenSend,
 ): Promise<void> {
   const stored = await readIntent(config, channelId);
   if (stored === "unreadable") return;
@@ -339,10 +361,15 @@ async function adoptCompletedDelivery(
         await markIntentReady(config, channelId);
         break;
       case "send-started":
-        await beginIntentSend(config, channelId);
+        await beginIntentSend(config, channelId, send.startedAt);
         break;
       case "delivered":
-        await confirmIntentDelivered(config, channelId, messageId);
+        await confirmIntentDelivered(
+          config,
+          channelId,
+          messageId,
+          send.deliveredAt,
+        );
         break;
     }
   }
@@ -389,13 +416,23 @@ export function createChannelDeliveryRecorder(
         return;
       case "send-started":
         started.add(event.channelId);
-        await beginIntentSend(config, event.channelId);
+        await beginIntentSend(config, event.channelId, config.facts.now());
         return;
       case "delivered":
-        await confirmIntentDelivered(config, event.channelId, event.messageId);
+        await confirmIntentDelivered(
+          config,
+          event.channelId,
+          event.messageId,
+          config.facts.now(),
+        );
         return;
       case "already-delivered":
-        await adoptCompletedDelivery(config, event.channelId, event.messageId);
+        await adoptCompletedDelivery(
+          config,
+          event.channelId,
+          event.messageId,
+          event.send,
+        );
         return;
       case "failed": {
         if (!started.has(event.channelId)) return;

--- a/packages/scout-for-lol/packages/backend/src/durable/match/dualwrite.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/dualwrite.integration.test.ts
@@ -19,7 +19,10 @@ import { listReceipts } from "#src/database/durable/receipt-repository.ts";
 import { listTrackedAccounts } from "#src/database/durable/tracked-account-repository.ts";
 import { getIntent } from "#src/database/durable/intent-repository.ts";
 import { getWorkflowStart } from "#src/database/durable/workflow-start-repository.ts";
-import { scoutDurableDualwriteFailuresTotal } from "#src/metrics/durable.ts";
+import {
+  scoutDurableDualwriteFailuresTotal,
+  scoutDurableDualwriteRecordsTotal,
+} from "#src/metrics/durable.ts";
 import type { DurableFacts } from "#src/durable/match/durable-facts.ts";
 import {
   recordObservedMatch,
@@ -99,6 +102,37 @@ async function failureCount(writeKind: string): Promise<number> {
     metric.values.find((value) => value.labels.write_kind === writeKind)
       ?.value ?? 0
   );
+}
+
+/**
+ * Every `scout_durable_dualwrite_records_total` sample, keyed
+ * `write_kind:outcome`. Comparing two snapshots gives the exact multiset of
+ * facts one pass recorded, which is stronger than counting rows: it states
+ * both what was written and what the repository answered.
+ */
+type RecordedFacts = Record<string, number>;
+
+async function recordedFacts(): Promise<RecordedFacts> {
+  const metric = await scoutDurableDualwriteRecordsTotal.get();
+  const counts: RecordedFacts = {};
+  for (const sample of metric.values) {
+    const kind = String(sample.labels.write_kind);
+    const outcome = String(sample.labels.outcome);
+    counts[`${kind}:${outcome}`] = sample.value;
+  }
+  return counts;
+}
+
+function factsRecordedDuring(
+  before: RecordedFacts,
+  after: RecordedFacts,
+): RecordedFacts {
+  const delta: RecordedFacts = {};
+  for (const [key, value] of Object.entries(after)) {
+    const change = value - (before[key] ?? 0);
+    if (change > 0) delta[key] = change;
+  }
+  return delta;
 }
 
 async function seedRegisteredAccount(): Promise<{
@@ -316,6 +350,35 @@ describe("the fail-open boundary", () => {
     ).toBeNull();
   });
 
+  test("a delivered message id that cannot be a durable identity is counted, not thrown", async () => {
+    const id = matchId(9011);
+    const keyPrefix = `postmatch-discord:${id}`;
+    const record = createChannelDeliveryRecorder({
+      facts,
+      matchId: toRiotMatchId(id),
+      keyPrefix,
+      freshnessDeadline: FRESHNESS_DEADLINE,
+    });
+    const before = await failureCount("intent-delivered");
+
+    await record({ kind: "prepared", channelId: CHANNEL_ONE });
+    await record({ kind: "send-started", channelId: CHANNEL_ONE });
+    // The recorder takes whatever the send answered with. That message is
+    // already in Discord, so a value the durable tables cannot hold has to be
+    // counted here rather than thrown back at a delivery that succeeded.
+    await record({
+      kind: "delivered",
+      channelId: CHANNEL_ONE,
+      messageId: "not-a-snowflake",
+    });
+
+    expect(await failureCount("intent-delivered")).toBe(before + 1);
+    const stored = await getIntent(prisma, {
+      intentKey: intentKey(keyPrefix, CHANNEL_ONE),
+    });
+    expect(stored?.intent.state.kind).toBe("sending");
+  });
+
   test("a match id that cannot be a durable identity is counted, not thrown", async () => {
     const before = await failureCount("match-identity");
     const settled = await commitMatchSettlement({
@@ -473,6 +536,129 @@ describe("notification intents", () => {
     ).toEqual({
       deliveries: [{ channelId: CHANNEL_ONE, messageId: MESSAGE_ID }],
     });
+  });
+});
+
+const SECOND_MESSAGE_ID = "300000000000000002";
+
+/** The archive descriptor a receipted ingest hands the bridge. */
+const ARCHIVED_MATCH = {
+  key: "games/2026/09/12/NA1_9040/match.json",
+  digest: "c".repeat(64),
+};
+
+const DELIVERED_TO = [
+  { channel: CHANNEL_ONE, serverId: GUILD_ONE, messageId: MESSAGE_ID },
+  { channel: CHANNEL_TWO, serverId: GUILD_TWO, messageId: SECOND_MESSAGE_ID },
+];
+
+/**
+ * One match through every durable service the per-match flow uses.
+ *
+ * `delivery` is how the pass reaches Discord. A first pass runs the whole
+ * notification lifecycle; a reprocess does not, because the `ScoutEffectClaim`
+ * answers `completed` and the loop only confirms the delivery that claim names.
+ * Replaying the lifecycle instead would be a test of something v1 never does.
+ */
+async function runMatchPass(
+  id: string,
+  delivery: "sends" | "confirms-a-previous-send",
+): Promise<void> {
+  await requestMatchArchive({
+    facts,
+    match: {
+      matchId: id,
+      gameCreation: GAME_CREATION,
+      trackedPuuids: [REGISTERED_PUUID],
+      source: "postmatch_live",
+    },
+    archive: async () => ({
+      staged: true,
+      stored: true,
+      artifact: ARCHIVED_MATCH,
+    }),
+  });
+  await commitMatchSettlement({
+    facts,
+    matchId: id,
+    settle: async () => ({ announced: true }),
+    evidence: () => SETTLEMENT_EVIDENCE,
+  });
+  await runMatchProgressionStage({
+    facts,
+    matchId: id,
+    evidence: { participantCount: 10, trackedAccountCount: 1 },
+    advance: async () => "progressed",
+  });
+  await recordCursorAdvanced({ facts, matchId: id, puuid: REGISTERED_PUUID });
+
+  const record = createChannelDeliveryRecorder({
+    facts,
+    matchId: toRiotMatchId(id),
+    keyPrefix: `postmatch-discord:${id}`,
+    freshnessDeadline: FRESHNESS_DEADLINE,
+  });
+  for (const { channel, messageId } of DELIVERED_TO) {
+    if (delivery === "sends") {
+      await record({ kind: "prepared", channelId: channel });
+      await record({ kind: "send-started", channelId: channel });
+    }
+    await record({ kind: "delivered", channelId: channel, messageId });
+  }
+  await recordDeliveryReceipts({
+    facts,
+    kind: "reportDelivery",
+    matchId: id,
+    messagesByGuild: deliveredMessagesByGuild(
+      DELIVERED_TO,
+      new Map(DELIVERED_TO.map((entry) => [entry.channel, entry.messageId])),
+    ),
+  });
+}
+
+describe("a whole match pass", () => {
+  test("records each fact exactly once, and a replay re-applies none of them", async () => {
+    const id = matchId(9040);
+
+    const beforeFirst = await recordedFacts();
+    await runMatchPass(id, "sends");
+    const firstPass = factsRecordedDuring(beforeFirst, await recordedFacts());
+
+    expect(firstPass).toEqual({
+      "observation:applied": 1,
+      "tracked-accounts:applied": 1,
+      "receipt-settlement:applied": 1,
+      "receipt-progression:applied": 1,
+      "cursor-advanced:applied": 1,
+      "intent-created:applied": 2,
+      "intent-ready:applied": 2,
+      "intent-send-started:applied": 2,
+      "intent-delivered:applied": 2,
+      "receipt-report-delivery:applied": 2,
+    });
+
+    const beforeReplay = await recordedFacts();
+    await runMatchPass(id, "confirms-a-previous-send");
+    const replay = factsRecordedDuring(beforeReplay, await recordedFacts());
+
+    // Every answer is `already-applied`. A `conflict` here would mean two
+    // producers disagree about a fact, and reprocessing the same match with
+    // the same inputs is not disagreement — so a conflict on this path would
+    // be drift the parity dashboard reports that nobody can act on.
+    expect(replay).toEqual({
+      "observation:already-applied": 1,
+      "tracked-accounts:already-applied": 1,
+      "receipt-settlement:already-applied": 1,
+      "receipt-progression:already-applied": 1,
+      "cursor-advanced:already-applied": 1,
+      "intent-delivered:already-applied": 2,
+      "receipt-report-delivery:already-applied": 2,
+    });
+
+    const observation = await getObservation(prisma, {
+      matchId: toRiotMatchId(id),
+    });
+    expect(observation?.artifacts.match).toEqual(ARCHIVED_MATCH);
   });
 });
 

--- a/packages/scout-for-lol/packages/backend/src/durable/match/dualwrite.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/dualwrite.integration.test.ts
@@ -74,6 +74,16 @@ const CHANNEL_TWO = testChannelId("9002");
 const MESSAGE_ID = "300000000000000001";
 const SECOND_MESSAGE_ID = "300000000000000002";
 
+/**
+ * A send an earlier pass made, bracketed by its claim row. Both instants are
+ * BEFORE the freshness deadline, which is what lets `beginSend` accept an
+ * adoption that runs after it.
+ */
+const PROVEN_SEND = {
+  startedAt: new Date("2026-09-12T09:30:00.000Z"),
+  deliveredAt: new Date("2026-09-12T09:30:05.000Z"),
+};
+
 const facts: DurableFacts = { db: prisma, now: () => NOW };
 
 function matchId(gameId: number): string {
@@ -578,12 +588,13 @@ describe("adopting a delivery an earlier pass proved", () => {
       kind: "already-delivered",
       channelId: CHANNEL_ONE,
       messageId: MESSAGE_ID,
+      send: PROVEN_SEND,
     });
 
     expect(await storedIntentState(keyPrefix)).toEqual({
       kind: "delivered",
       messageId: MESSAGE_ID,
-      deliveredAt: NOW.toISOString(),
+      deliveredAt: PROVEN_SEND.deliveredAt.toISOString(),
     });
   });
 
@@ -610,12 +621,13 @@ describe("adopting a delivery an earlier pass proved", () => {
       kind: "already-delivered",
       channelId: CHANNEL_ONE,
       messageId: MESSAGE_ID,
+      send: PROVEN_SEND,
     });
 
     expect(await storedIntentState(keyPrefix)).toEqual({
       kind: "delivered",
       messageId: MESSAGE_ID,
-      deliveredAt: NOW.toISOString(),
+      deliveredAt: PROVEN_SEND.deliveredAt.toISOString(),
     });
   });
 
@@ -631,12 +643,13 @@ describe("adopting a delivery an earlier pass proved", () => {
       kind: "already-delivered",
       channelId: CHANNEL_ONE,
       messageId: MESSAGE_ID,
+      send: PROVEN_SEND,
     });
 
     expect(await storedIntentState(keyPrefix)).toEqual({
       kind: "delivered",
       messageId: MESSAGE_ID,
-      deliveredAt: NOW.toISOString(),
+      deliveredAt: PROVEN_SEND.deliveredAt.toISOString(),
     });
   });
 
@@ -651,12 +664,13 @@ describe("adopting a delivery an earlier pass proved", () => {
       kind: "already-delivered",
       channelId: CHANNEL_ONE,
       messageId: MESSAGE_ID,
+      send: PROVEN_SEND,
     });
 
     expect(await storedIntentState(keyPrefix)).toEqual({
       kind: "delivered",
       messageId: MESSAGE_ID,
-      deliveredAt: NOW.toISOString(),
+      deliveredAt: PROVEN_SEND.deliveredAt.toISOString(),
     });
   });
 
@@ -678,8 +692,11 @@ describe("adopting a delivery an earlier pass proved", () => {
       kind: "already-delivered",
       channelId: CHANNEL_ONE,
       messageId: SECOND_MESSAGE_ID,
+      send: PROVEN_SEND,
     });
 
+    // Still the message and the instant the ORIGINAL delivery recorded — the
+    // rejected adoption moved neither.
     expect(await storedIntentState(keyPrefix)).toEqual({
       kind: "delivered",
       messageId: MESSAGE_ID,
@@ -749,7 +766,12 @@ async function runMatchPass(
     }
     // The reprocess takes the completed-claim branch, which adopts the
     // delivery rather than replaying the lifecycle.
-    await record({ kind: "already-delivered", channelId: channel, messageId });
+    await record({
+      kind: "already-delivered",
+      channelId: channel,
+      messageId,
+      send: PROVEN_SEND,
+    });
   }
   await recordDeliveryReceipts({
     facts,

--- a/packages/scout-for-lol/packages/backend/src/durable/match/dualwrite.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/dualwrite.integration.test.ts
@@ -17,7 +17,12 @@ import {
 } from "#src/database/durable/observation-repository.ts";
 import { listReceipts } from "#src/database/durable/receipt-repository.ts";
 import { listTrackedAccounts } from "#src/database/durable/tracked-account-repository.ts";
-import { getIntent } from "#src/database/durable/intent-repository.ts";
+import {
+  getIntent,
+  upsertIntent,
+} from "#src/database/durable/intent-repository.ts";
+import { DiscordChannelIdSchema } from "@scout-for-lol/domain/identity/discord.ts";
+import { toIsoInstant } from "#src/durable/match/match-identity.ts";
 import { getWorkflowStart } from "#src/database/durable/workflow-start-repository.ts";
 import {
   scoutDurableDualwriteFailuresTotal,
@@ -38,7 +43,9 @@ import {
   deliveredMessagesByGuild,
   deliveryAttemptNonce,
   recordDeliveryReceipts,
+  type ChannelDeliveryRecorder,
 } from "#src/durable/match/delivery-intents.ts";
+import type { NotificationIntentState } from "@scout-for-lol/domain/notifications/intent.ts";
 import { withRecordedWorkflowStart } from "#src/durable/match/workflow-start-facts.ts";
 import {
   deliveryEvidenceCodec,
@@ -65,6 +72,7 @@ const GUILD_TWO = testGuildId("9002");
 const CHANNEL_ONE = testChannelId("9001");
 const CHANNEL_TWO = testChannelId("9002");
 const MESSAGE_ID = "300000000000000001";
+const SECOND_MESSAGE_ID = "300000000000000002";
 
 const facts: DurableFacts = { db: prisma, now: () => NOW };
 
@@ -78,6 +86,25 @@ function intentKey(
   channelId: string,
 ): NotificationIntentKey {
   return NotificationIntentKeySchema.parse(`${keyPrefix}:${channelId}`);
+}
+
+function deliveryRecorderFor(id: string): ChannelDeliveryRecorder {
+  return createChannelDeliveryRecorder({
+    facts,
+    matchId: toRiotMatchId(id),
+    keyPrefix: `postmatch-discord:${id}`,
+    freshnessDeadline: FRESHNESS_DEADLINE,
+  });
+}
+
+/** The state CHANNEL_ONE's stored intent ended up in. */
+async function storedIntentState(
+  keyPrefix: string,
+): Promise<NotificationIntentState | undefined> {
+  const stored = await getIntent(prisma, {
+    intentKey: intentKey(keyPrefix, CHANNEL_ONE),
+  });
+  return stored?.intent.state;
 }
 
 /**
@@ -539,7 +566,127 @@ describe("notification intents", () => {
   });
 });
 
-const SECOND_MESSAGE_ID = "300000000000000002";
+describe("adopting a delivery an earlier pass proved", () => {
+  test("adopts a delivery whose intent was never created", async () => {
+    // The run that sent the message ended before ANY of its fail-open writes
+    // landed, so the claim proves a delivery that has no row at all.
+    const id = matchId(9030);
+    const keyPrefix = `postmatch-discord:${id}`;
+    const record = deliveryRecorderFor(id);
+
+    await record({
+      kind: "already-delivered",
+      channelId: CHANNEL_ONE,
+      messageId: MESSAGE_ID,
+    });
+
+    expect(await storedIntentState(keyPrefix)).toEqual({
+      kind: "delivered",
+      messageId: MESSAGE_ID,
+      deliveredAt: NOW.toISOString(),
+    });
+  });
+
+  test("adopts a delivery whose intent stopped at pending", async () => {
+    // `intent-created` landed and `intent-ready` did not.
+    const id = matchId(9031);
+    const keyPrefix = `postmatch-discord:${id}`;
+    await upsertIntent(prisma, {
+      matchId: toRiotMatchId(id),
+      intent: {
+        key: intentKey(keyPrefix, CHANNEL_ONE),
+        target: {
+          kind: "channel",
+          channelId: DiscordChannelIdSchema.parse(CHANNEL_ONE),
+        },
+        freshnessDeadline: toIsoInstant(FRESHNESS_DEADLINE),
+        createdAt: toIsoInstant(NOW),
+        attemptCount: 0,
+        state: { kind: "pending" },
+      },
+    });
+
+    await deliveryRecorderFor(id)({
+      kind: "already-delivered",
+      channelId: CHANNEL_ONE,
+      messageId: MESSAGE_ID,
+    });
+
+    expect(await storedIntentState(keyPrefix)).toEqual({
+      kind: "delivered",
+      messageId: MESSAGE_ID,
+      deliveredAt: NOW.toISOString(),
+    });
+  });
+
+  test("adopts a delivery whose intent stopped at ready", async () => {
+    // The send happened and the claim completed, but `intent-send-started`
+    // never landed. Nothing else will ever move this row.
+    const id = matchId(9032);
+    const keyPrefix = `postmatch-discord:${id}`;
+    const record = deliveryRecorderFor(id);
+    await record({ kind: "prepared", channelId: CHANNEL_ONE });
+
+    await record({
+      kind: "already-delivered",
+      channelId: CHANNEL_ONE,
+      messageId: MESSAGE_ID,
+    });
+
+    expect(await storedIntentState(keyPrefix)).toEqual({
+      kind: "delivered",
+      messageId: MESSAGE_ID,
+      deliveredAt: NOW.toISOString(),
+    });
+  });
+
+  test("adopts a delivery whose intent stopped at sending", async () => {
+    const id = matchId(9033);
+    const keyPrefix = `postmatch-discord:${id}`;
+    const record = deliveryRecorderFor(id);
+    await record({ kind: "prepared", channelId: CHANNEL_ONE });
+    await record({ kind: "send-started", channelId: CHANNEL_ONE });
+
+    await record({
+      kind: "already-delivered",
+      channelId: CHANNEL_ONE,
+      messageId: MESSAGE_ID,
+    });
+
+    expect(await storedIntentState(keyPrefix)).toEqual({
+      kind: "delivered",
+      messageId: MESSAGE_ID,
+      deliveredAt: NOW.toISOString(),
+    });
+  });
+
+  test("adopting never overwrites a delivery recorded under another message", async () => {
+    const id = matchId(9034);
+    const keyPrefix = `postmatch-discord:${id}`;
+    const record = deliveryRecorderFor(id);
+    await record({ kind: "prepared", channelId: CHANNEL_ONE });
+    await record({ kind: "send-started", channelId: CHANNEL_ONE });
+    await record({
+      kind: "delivered",
+      channelId: CHANNEL_ONE,
+      messageId: MESSAGE_ID,
+    });
+
+    // Two producers naming different messages for one send is disagreement,
+    // not something to adopt. The first writer's evidence stands.
+    await record({
+      kind: "already-delivered",
+      channelId: CHANNEL_ONE,
+      messageId: SECOND_MESSAGE_ID,
+    });
+
+    expect(await storedIntentState(keyPrefix)).toEqual({
+      kind: "delivered",
+      messageId: MESSAGE_ID,
+      deliveredAt: NOW.toISOString(),
+    });
+  });
+});
 
 /** The archive descriptor a receipted ingest hands the bridge. */
 const ARCHIVED_MATCH = {
@@ -592,18 +739,17 @@ async function runMatchPass(
   });
   await recordCursorAdvanced({ facts, matchId: id, puuid: REGISTERED_PUUID });
 
-  const record = createChannelDeliveryRecorder({
-    facts,
-    matchId: toRiotMatchId(id),
-    keyPrefix: `postmatch-discord:${id}`,
-    freshnessDeadline: FRESHNESS_DEADLINE,
-  });
+  const record = deliveryRecorderFor(id);
   for (const { channel, messageId } of DELIVERED_TO) {
     if (delivery === "sends") {
       await record({ kind: "prepared", channelId: channel });
       await record({ kind: "send-started", channelId: channel });
+      await record({ kind: "delivered", channelId: channel, messageId });
+      continue;
     }
-    await record({ kind: "delivered", channelId: channel, messageId });
+    // The reprocess takes the completed-claim branch, which adopts the
+    // delivery rather than replaying the lifecycle.
+    await record({ kind: "already-delivered", channelId: channel, messageId });
   }
   await recordDeliveryReceipts({
     facts,

--- a/packages/scout-for-lol/packages/backend/src/durable/match/durable-facts.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/durable-facts.ts
@@ -90,8 +90,12 @@ export type DurableFacts = {
  * event per write per channel per match, drowning the errors that actually
  * stop work. `scout_durable_dualwrite_failures_total` is the signal an alert
  * watches, and it stays legible under exactly the outage that produces it.
+ *
+ * Exported for the reads a recorder has to make before it can decide what to
+ * write: those sit behind the same boundary as the writes they serve, and a
+ * broken one has to be reported the same way rather than thrown at the caller.
  */
-function reportDurableWriteFailure(
+export function reportDurableWriteFailure(
   kind: DurableWriteKind,
   error: unknown,
 ): void {

--- a/packages/scout-for-lol/packages/backend/src/durable/match/durable-facts.ts
+++ b/packages/scout-for-lol/packages/backend/src/durable/match/durable-facts.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { z } from "zod";
 import type { Db } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
@@ -28,12 +29,21 @@ const logger = createLogger("durable-dualwrite");
  * Every durable write the bridge performs, spelled out so the metric's
  * `write_kind` label can never grow unbounded. A new dual-write site adds a
  * member here rather than passing a free-form string.
+ *
+ * `raw-archive` and `lake-staging` are recorded by the receipted lake
+ * projection in `report-lake/` rather than by a service in this directory,
+ * but they share this list on purpose: one closed vocabulary is what keeps
+ * the label bounded and a parity dashboard's `write_kind` axis readable. A
+ * second enumeration next to the other producer would be two vocabularies for
+ * one metric.
  */
 export const DURABLE_WRITE_KINDS = [
   "match-identity",
   "observation",
   "tracked-accounts",
   "cursor-advanced",
+  "raw-archive",
+  "lake-staging",
   "receipt-settlement",
   "receipt-report-delivery",
   "receipt-prematch-delivery",
@@ -54,7 +64,8 @@ export type DurableWriteKind = (typeof DURABLE_WRITE_KINDS)[number];
  * repository that grows a new outcome shows up as a loud dual-write failure
  * instead of quietly widening a Prometheus label.
  */
-const DurableWriteOutcomeSchema = z.enum([
+export type DurableWriteOutcome = z.infer<typeof DurableWriteOutcomeSchema>;
+export const DurableWriteOutcomeSchema = z.enum([
   "applied",
   "already-applied",
   "adopted",
@@ -84,11 +95,56 @@ function reportDurableWriteFailure(
   kind: DurableWriteKind,
   error: unknown,
 ): void {
-  scoutDurableDualwriteFailuresTotal.inc({ write_kind: kind });
+  countDurableWriteFailure(kind);
   logger.error(
     `❌ Durable dual-write ${kind} failed; the authoritative v1 pipeline continues unaffected`,
     error,
   );
+}
+
+/**
+ * Count one THROWN durable write. Separated from the log so a producer with
+ * more context to report — the receipted lake projection names the receipt and
+ * the match it belongs to — meters through this module rather than reaching
+ * for the counter itself.
+ */
+export function countDurableWriteFailure(kind: DurableWriteKind): void {
+  scoutDurableDualwriteFailuresTotal.inc({ write_kind: kind });
+}
+
+/**
+ * Count one COMPLETED durable write by the repository's own answer, which is
+ * parsed here so no producer can widen the `outcome` label by passing a string
+ * the bridge does not recognise. A repository that grows a new outcome throws
+ * out of here and is counted as that write's failure instead.
+ */
+export function countDurableWrite(
+  kind: DurableWriteKind,
+  outcome: string,
+): DurableWriteOutcome {
+  const parsed = DurableWriteOutcomeSchema.parse(outcome);
+  scoutDurableDualwriteRecordsTotal.inc({ write_kind: kind, outcome: parsed });
+  return parsed;
+}
+
+/**
+ * Whether the code running right now is inside a {@link recordDurableWrite}
+ * callback.
+ *
+ * Both this wrapper and the receipted lake projection's own fail-open wrapper
+ * increment `scout_durable_dualwrite_records_total`, so a receipt recorded
+ * from inside a durable write would count one fact twice and silently inflate
+ * the parity signal. The two are sequential everywhere today; this is what
+ * makes a future nesting fail instead of drifting the metric.
+ *
+ * Tracked per async context rather than with a module-level flag because one
+ * process handles several matches at once: a shared flag would let one flow's
+ * durable write make an unrelated flow's receipt look nested.
+ */
+const durableWriteScope = new AsyncLocalStorage<true>();
+
+export function insideDurableWrite(): boolean {
+  return durableWriteScope.getStore() === true;
 }
 
 /**
@@ -105,9 +161,8 @@ export async function recordDurableWrite(
   write: (db: Db) => Promise<{ outcome: string }>,
 ): Promise<void> {
   try {
-    const result = await write(facts.db);
-    const outcome = DurableWriteOutcomeSchema.parse(result.outcome);
-    scoutDurableDualwriteRecordsTotal.inc({ write_kind: kind, outcome });
+    const result = await durableWriteScope.run(true, () => write(facts.db));
+    countDurableWrite(kind, result.outcome);
   } catch (error) {
     reportDurableWriteFailure(kind, error);
   }

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.test.ts
@@ -50,6 +50,7 @@ const COMPLETED_AT = new Date("2026-09-12T09:30:02.000Z");
 let claimResult: "execute" | "completed" = "execute";
 
 await vi.doMock("#src/temporal/effect-claims.ts", () => ({
+  DISCORD_CHANNEL_MESSAGE_EFFECT_KIND: "discord-channel-message",
   claimScoutEffect: () => Promise.resolve(claimResult),
   completeScoutEffectWithResult: () => Promise.resolve(),
   recordScoutEffectFailure: () => Promise.resolve(),

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.test.ts
@@ -161,7 +161,7 @@ describe("deliverToChannels", () => {
     expect(sentMessages).toEqual([]);
     expect(recorded).toEqual([
       {
-        kind: "delivered",
+        kind: "already-delivered",
         channelId,
         messageId: ALREADY_SENT_MESSAGE_ID,
       },

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.test.ts
@@ -45,14 +45,21 @@ await vi.doMock("#src/league/discord/channel.ts", () => ({
 }));
 
 const ALREADY_SENT_MESSAGE_ID = "300000000000000007";
+const CLAIMED_AT = new Date("2026-09-12T09:30:00.000Z");
+const COMPLETED_AT = new Date("2026-09-12T09:30:02.000Z");
 let claimResult: "execute" | "completed" = "execute";
 
 await vi.doMock("#src/temporal/effect-claims.ts", () => ({
   claimScoutEffect: () => Promise.resolve(claimResult),
   completeScoutEffectWithResult: () => Promise.resolve(),
   recordScoutEffectFailure: () => Promise.resolve(),
-  requireCompletedScoutEffectResult: () =>
-    Promise.resolve(ALREADY_SENT_MESSAGE_ID),
+  requireCompletedScoutEffectResult: (key: string) =>
+    Promise.resolve({
+      key,
+      resultId: ALREADY_SENT_MESSAGE_ID,
+      claimedAt: CLAIMED_AT,
+      completedAt: COMPLETED_AT,
+    }),
 }));
 
 const { channelsPassingQueueFilter, deliverToChannels } =
@@ -164,6 +171,8 @@ describe("deliverToChannels", () => {
         kind: "already-delivered",
         channelId,
         messageId: ALREADY_SENT_MESSAGE_ID,
+        // The claim's own bracket around the send, not this pass's clock.
+        send: { startedAt: CLAIMED_AT, deliveredAt: COMPLETED_AT },
       },
     ]);
     expect(delivery.messageIdsByChannel).toEqual(

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.test.ts
@@ -8,6 +8,7 @@ import type {
   SubscribedChannel,
   SubscribedChannelSubscription,
 } from "#src/database/index.ts";
+import type { ChannelDeliveryEvent } from "#src/durable/match/delivery-intents.ts";
 
 const sentMessages: MessageCreateOptions[] = [];
 let failReplyOnce = false;
@@ -41,6 +42,17 @@ await vi.doMock("#src/league/discord/channel.ts", () => ({
       id: `sent-message-${sentMessages.length.toString()}`,
     });
   },
+}));
+
+const ALREADY_SENT_MESSAGE_ID = "300000000000000007";
+let claimResult: "execute" | "completed" = "execute";
+
+await vi.doMock("#src/temporal/effect-claims.ts", () => ({
+  claimScoutEffect: () => Promise.resolve(claimResult),
+  completeScoutEffectWithResult: () => Promise.resolve(),
+  recordScoutEffectFailure: () => Promise.resolve(),
+  requireCompletedScoutEffectResult: () =>
+    Promise.resolve(ALREADY_SENT_MESSAGE_ID),
 }));
 
 const { channelsPassingQueueFilter, deliverToChannels } =
@@ -124,6 +136,39 @@ describe("deliverToChannels", () => {
     sentMessages.length = 0;
     failReplyOnce = false;
     failAll = false;
+    claimResult = "execute";
+  });
+
+  test("confirms the intent for a send an earlier run already completed", async () => {
+    claimResult = "completed";
+    const channelId = DiscordChannelIdSchema.parse("123456789012345678");
+    const recorded: ChannelDeliveryEvent[] = [];
+
+    const delivery = await deliverToChannels({
+      message: { content: "Game finished" },
+      channels: [{ channel: channelId, serverId: "123456789012345680" }],
+      logPrefix: "[test]",
+      sentryTags: {},
+      effectKeyPrefix: "postmatch-discord:NA1_1",
+      recordDelivery: (event) => {
+        recorded.push(event);
+        return Promise.resolve();
+      },
+    });
+
+    // The claim is the at-most-once guard, so nothing is sent again — but the
+    // intent that earlier run left behind is closed out rather than stranded.
+    expect(sentMessages).toEqual([]);
+    expect(recorded).toEqual([
+      {
+        kind: "delivered",
+        channelId,
+        messageId: ALREADY_SENT_MESSAGE_ID,
+      },
+    ]);
+    expect(delivery.messageIdsByChannel).toEqual(
+      new Map([[channelId, ALREADY_SENT_MESSAGE_ID]]),
+    );
   });
 
   test("replies to the matching prematch message per channel", async () => {

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.ts
@@ -152,13 +152,20 @@ export async function deliverToChannels(params: {
           // adopts the delivery from wherever the intent stopped; a row already
           // delivered under this message id answers `already-applied`, so the
           // ordinary replay stays quiet.
-          const messageId = await requireCompletedScoutEffectResult(effectKey);
+          const completed = await requireCompletedScoutEffectResult(effectKey);
           deliveredGuildIds.add(DiscordGuildIdSchema.parse(serverId));
-          messageIdsByChannel.set(channel, messageId);
+          messageIdsByChannel.set(channel, completed.resultId);
           await recordDelivery({
             kind: "already-delivered",
             channelId: channel,
-            messageId,
+            messageId: completed.resultId,
+            // The claim brackets the send it proves — taken immediately before
+            // it ran, completed immediately after it returned — so those are
+            // the instants to record, not this pass's clock.
+            send: {
+              startedAt: completed.claimedAt,
+              deliveredAt: completed.completedAt,
+            },
           });
           continue;
         }

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/bun";
 import {
   claimScoutEffect,
+  DISCORD_CHANNEL_MESSAGE_EFFECT_KIND,
   completeScoutEffectWithResult,
   recordScoutEffectFailure,
   requireCompletedScoutEffectResult,
@@ -141,7 +142,7 @@ export async function deliverToChannels(params: {
       if (effectKey !== undefined) {
         const claim = await claimScoutEffect({
           key: effectKey,
-          kind: "discord-channel-message",
+          kind: DISCORD_CHANNEL_MESSAGE_EFFECT_KIND,
         });
         if (claim === "completed") {
           // An earlier run already sent this message, but its intent writes are

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.ts
@@ -144,12 +144,22 @@ export async function deliverToChannels(params: {
           kind: "discord-channel-message",
         });
         if (claim === "completed") {
-          // An earlier run already sent this message and already recorded its
-          // intent; replaying the lifecycle here would only conflict with the
-          // delivered row that run wrote.
+          // An earlier run already sent this message, but its intent writes are
+          // fail-open, so that run may have ended between the send and the
+          // confirmation and left the intent in `ready` or `sending`. No later
+          // pass reaches the lifecycle below, so this is the only place that
+          // can still close it out: confirm the delivery the claim proves,
+          // naming the message it recorded. A row already delivered under that
+          // id is answered `already-applied`, so the ordinary replay stays
+          // quiet.
           const messageId = await requireCompletedScoutEffectResult(effectKey);
           deliveredGuildIds.add(DiscordGuildIdSchema.parse(serverId));
           messageIdsByChannel.set(channel, messageId);
+          await recordDelivery({
+            kind: "delivered",
+            channelId: channel,
+            messageId,
+          });
           continue;
         }
         effectClaimed = true;

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/notification-filters.ts
@@ -145,18 +145,18 @@ export async function deliverToChannels(params: {
         });
         if (claim === "completed") {
           // An earlier run already sent this message, but its intent writes are
-          // fail-open, so that run may have ended between the send and the
-          // confirmation and left the intent in `ready` or `sending`. No later
-          // pass reaches the lifecycle below, so this is the only place that
-          // can still close it out: confirm the delivery the claim proves,
-          // naming the message it recorded. A row already delivered under that
-          // id is answered `already-applied`, so the ordinary replay stays
-          // quiet.
+          // fail-open, so that run may have ended anywhere between minting the
+          // intent and confirming it — leaving the row missing, `pending`,
+          // `ready`, or `sending`. No later pass reaches the lifecycle below,
+          // so this is the only place that can still close it out. The recorder
+          // adopts the delivery from wherever the intent stopped; a row already
+          // delivered under this message id answers `already-applied`, so the
+          // ordinary replay stays quiet.
           const messageId = await requireCompletedScoutEffectResult(effectKey);
           deliveredGuildIds.add(DiscordGuildIdSchema.parse(serverId));
           messageIdsByChannel.set(channel, messageId);
           await recordDelivery({
-            kind: "delivered",
+            kind: "already-delivered",
             channelId: channel,
             messageId,
           });

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-delivery.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-delivery.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import {
+  MAX_DISCORD_ALERT_AGE_MS,
+  isPostmatchReportStale,
+  postmatchReportFreshnessDeadline,
+} from "#src/league/tasks/postmatch/match-report-delivery.ts";
+
+const GAME_CREATION = Date.parse("2026-09-12T09:00:00.000Z");
+
+describe("post-match report freshness", () => {
+  test("the delivery gate and the intent's deadline are the same instant", () => {
+    const deadline = postmatchReportFreshnessDeadline(GAME_CREATION);
+
+    // Both comparisons are STRICTLY after, so the deadline itself still
+    // delivers and `beginSend` still accepts it. A pass that clears this gate
+    // is therefore always inside the deadline its intent carries, which is
+    // what lets the completed-claim recovery adopt a proven delivery through
+    // `beginSend` without tripping the freshness guard.
+    expect(isPostmatchReportStale(GAME_CREATION, deadline)).toBe(false);
+    expect(
+      isPostmatchReportStale(GAME_CREATION, new Date(deadline.getTime() + 1)),
+    ).toBe(true);
+  });
+
+  test("the deadline is the match's own age limit, not the pass's", () => {
+    // Keyed to gameCreation rather than to when this pass happens to run, so
+    // every pass over one match agrees on the same instant.
+    expect(postmatchReportFreshnessDeadline(GAME_CREATION).getTime()).toBe(
+      GAME_CREATION + MAX_DISCORD_ALERT_AGE_MS,
+    );
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-delivery.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-delivery.ts
@@ -25,6 +25,7 @@ import {
   deliverToChannels,
 } from "#src/league/tasks/notification-filters.ts";
 import { liveDurableFacts } from "#src/durable/match/live-facts.ts";
+import { recoverCompletedPostmatchDeliveries } from "#src/league/tasks/postmatch/postmatch-delivery-recovery.ts";
 import {
   deliveredMessagesByGuild,
   recordDeliveryReceipts,
@@ -69,6 +70,31 @@ export async function deliverPostmatchReport(input: {
   prefetchedRankChanges?: PostmatchRankChanges | undefined;
 }): Promise<Map<DiscordChannelId, string>> {
   const matchId = MatchIdSchema.parse(input.matchData.metadata.matchId);
+  const effectKeyPrefix = `postmatch-discord:${matchId}`;
+  // Staleness is decided before anything is looked up, for two reasons: an old
+  // match should not pay for a channel query it cannot use, and recovery must
+  // not sit behind a return that depends on CURRENT subscriptions. A match
+  // whose channels were all removed after its report went out still has
+  // deliveries to finish recording, and the claim keys that prove them do not
+  // depend on who is subscribed now.
+  if (isPostmatchReportStale(input.matchData.info.gameCreation, new Date())) {
+    const matchAgeMs = Date.now() - input.matchData.info.gameCreation;
+    const ageHours = (matchAgeMs / (60 * 60 * 1000)).toFixed(1);
+    logger.info(
+      `[processMatch] ⏰ Skipping match ${matchId} — ${ageHours}h old (cutoff ${(MAX_DISCORD_ALERT_AGE_MS / (60 * 60 * 1000)).toString()}h)`,
+    );
+    // Too old to SEND is not too old to RECORD. The completed-claim branch in
+    // `deliverToChannels` never runs for a stale match, so this is the only
+    // pass that can still finish an intent an earlier send left unwritten.
+    await recoverCompletedPostmatchDeliveries({
+      matchId,
+      effectKeyPrefix,
+      freshnessDeadline: postmatchReportFreshnessDeadline(
+        input.matchData.info.gameCreation,
+      ),
+    });
+    return new Map();
+  }
   const playersInMatch = input.trackedPlayers.filter((player) =>
     input.matchData.metadata.participants.includes(
       player.league.leagueAccount.puuid,
@@ -96,14 +122,6 @@ export async function deliverPostmatchReport(input: {
     ),
     (id) => id,
   );
-  if (isPostmatchReportStale(input.matchData.info.gameCreation, new Date())) {
-    const matchAgeMs = Date.now() - input.matchData.info.gameCreation;
-    const ageHours = (matchAgeMs / (60 * 60 * 1000)).toFixed(1);
-    logger.info(
-      `[processMatch] ⏰ Skipping match ${matchId} — ${ageHours}h old (cutoff ${(MAX_DISCORD_ALERT_AGE_MS / (60 * 60 * 1000)).toString()}h)`,
-    );
-    return new Map();
-  }
   const message = await generateMatchReport(
     input.matchData,
     input.trackedPlayers,
@@ -125,7 +143,6 @@ export async function deliverPostmatchReport(input: {
     return new Map();
   }
   const facts = liveDurableFacts();
-  const effectKeyPrefix = `postmatch-discord:${matchId}`;
   const delivery = await deliverToChannels({
     message,
     channels: deliverChannels,

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-delivery.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-delivery.ts
@@ -32,7 +32,33 @@ import {
 } from "#src/durable/match/delivery-intents.ts";
 
 const logger = createLogger("postmatch-report-delivery");
-const MAX_DISCORD_ALERT_AGE_MS = 3 * 60 * 60 * 1000;
+export const MAX_DISCORD_ALERT_AGE_MS = 3 * 60 * 60 * 1000;
+
+/**
+ * The instant after which this match's report is stale.
+ *
+ * This is v1's own staleness rule and the notification intent's freshness
+ * deadline — ONE derivation, consumed by both, because the two must be the
+ * same instant. The delivery gate below refuses to send past it, and the
+ * intent's `beginSend` refuses to record a send started past it, so a pass
+ * that clears the gate is always inside the deadline. That is what lets the
+ * completed-claim recovery in `delivery-intents.ts` adopt a proven delivery
+ * through `beginSend` without tripping the freshness guard; two expressions of
+ * "3 hours" that could drift apart would quietly break it.
+ */
+export function postmatchReportFreshnessDeadline(gameCreation: number): Date {
+  return new Date(gameCreation + MAX_DISCORD_ALERT_AGE_MS);
+}
+
+/** Both this and `beginSend` compare STRICTLY after, so the deadline itself still delivers. */
+export function isPostmatchReportStale(
+  gameCreation: number,
+  now: Date,
+): boolean {
+  return (
+    now.getTime() > postmatchReportFreshnessDeadline(gameCreation).getTime()
+  );
+}
 
 /** Generate and deliver one non-silent post-match report. */
 export async function deliverPostmatchReport(input: {
@@ -70,8 +96,8 @@ export async function deliverPostmatchReport(input: {
     ),
     (id) => id,
   );
-  const matchAgeMs = Date.now() - input.matchData.info.gameCreation;
-  if (matchAgeMs > MAX_DISCORD_ALERT_AGE_MS) {
+  if (isPostmatchReportStale(input.matchData.info.gameCreation, new Date())) {
+    const matchAgeMs = Date.now() - input.matchData.info.gameCreation;
     const ageHours = (matchAgeMs / (60 * 60 * 1000)).toFixed(1);
     logger.info(
       `[processMatch] ⏰ Skipping match ${matchId} — ${ageHours}h old (cutoff ${(MAX_DISCORD_ALERT_AGE_MS / (60 * 60 * 1000)).toString()}h)`,
@@ -112,10 +138,11 @@ export async function deliverPostmatchReport(input: {
         facts,
         matchId,
         keyPrefix: effectKeyPrefix,
-        // v1's own staleness rule: a report older than this is never sent, so
-        // it is exactly the instant after which the intent is stale.
-        freshnessDeadline: new Date(
-          input.matchData.info.gameCreation + MAX_DISCORD_ALERT_AGE_MS,
+        // The same derivation the gate above used, so the instant a report
+        // stops being sendable and the instant its intent goes stale cannot
+        // drift apart.
+        freshnessDeadline: postmatchReportFreshnessDeadline(
+          input.matchData.info.gameCreation,
         ),
       }) ?? undefined,
   });

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-delivery.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-delivery.ts
@@ -71,28 +71,31 @@ export async function deliverPostmatchReport(input: {
 }): Promise<Map<DiscordChannelId, string>> {
   const matchId = MatchIdSchema.parse(input.matchData.metadata.matchId);
   const effectKeyPrefix = `postmatch-discord:${matchId}`;
-  // Staleness is decided before anything is looked up, for two reasons: an old
-  // match should not pay for a channel query it cannot use, and recovery must
-  // not sit behind a return that depends on CURRENT subscriptions. A match
-  // whose channels were all removed after its report went out still has
-  // deliveries to finish recording, and the claim keys that prove them do not
-  // depend on who is subscribed now.
+  // FIRST, and unconditionally. Every exit below is decided by whether a report
+  // may still be SENT — the match's age, which players are tracked, which
+  // channels are subscribed now, whether any survive their queue filter — and
+  // none of that bears on whether a send this pipeline ALREADY made still needs
+  // recording. A channel unsubscribed since its report went out is reachable
+  // from no other point in this function, and once the match is three hours old
+  // it is reachable from no later pass either. So recovery runs before the
+  // first of those exits rather than behind any of them.
+  //
+  // It cannot cause a resend: it only reads claims that are already COMPLETED,
+  // and `deliverToChannels` still takes its own claim before sending.
+  await recoverCompletedPostmatchDeliveries({
+    matchId,
+    effectKeyPrefix,
+    gameCreation: input.matchData.info.gameCreation,
+    freshnessDeadline: postmatchReportFreshnessDeadline(
+      input.matchData.info.gameCreation,
+    ),
+  });
   if (isPostmatchReportStale(input.matchData.info.gameCreation, new Date())) {
     const matchAgeMs = Date.now() - input.matchData.info.gameCreation;
     const ageHours = (matchAgeMs / (60 * 60 * 1000)).toFixed(1);
     logger.info(
       `[processMatch] ⏰ Skipping match ${matchId} — ${ageHours}h old (cutoff ${(MAX_DISCORD_ALERT_AGE_MS / (60 * 60 * 1000)).toString()}h)`,
     );
-    // Too old to SEND is not too old to RECORD. The completed-claim branch in
-    // `deliverToChannels` never runs for a stale match, so this is the only
-    // pass that can still finish an intent an earlier send left unwritten.
-    await recoverCompletedPostmatchDeliveries({
-      matchId,
-      effectKeyPrefix,
-      freshnessDeadline: postmatchReportFreshnessDeadline(
-        input.matchData.info.gameCreation,
-      ),
-    });
     return new Map();
   }
   const playersInMatch = input.trackedPlayers.filter((player) =>

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/persist-authoritative-match.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/persist-authoritative-match.integration.test.ts
@@ -1,0 +1,230 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import {
+  PlayerConfigEntrySchema,
+  RawMatchSchema,
+  type PlayerConfigEntry,
+  type RawMatch,
+} from "@scout-for-lol/data";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import { loadRawMatchFixture } from "#src/testing/raw-capture-fixtures.ts";
+import { testPuuid } from "#src/testing/test-ids.ts";
+import { MATCHES_STAGING_DIR } from "#src/report-lake/paths.ts";
+import {
+  getValidatedPutCommand,
+  mockSuccessfulPut,
+  resetS3TestState,
+  s3Mock,
+} from "#src/storage/s3-test-helpers.ts";
+import {
+  getObservation,
+  getProcessingState,
+} from "#src/database/durable/observation-repository.ts";
+import { listReceipts } from "#src/database/durable/receipt-repository.ts";
+import { listTrackedAccounts } from "#src/database/durable/tracked-account-repository.ts";
+import { toRiotMatchId } from "#src/durable/match/match-identity.ts";
+
+/**
+ * The live post-match ingest gate, end to end against the durable tables.
+ *
+ * Everything below the gate is real: the receipted archive builds its
+ * descriptor from the put the S3 client actually received, the lake staging
+ * writes real files, and the durable services write real rows. Only the object
+ * store's transport is mocked, because the archive's answer — the key it used
+ * and the digest of the bytes — is the thing these tests are about.
+ */
+
+const { prisma } = createTestDatabase("persist-authoritative-match");
+
+vi.doMock("#src/database/index.ts", async (importOriginal) => ({
+  ...(await importOriginal()),
+  prisma,
+}));
+
+const { persistAuthoritativeMatch } =
+  await import("#src/league/tasks/postmatch/match-history-polling-effects.ts");
+
+const TRACKED_PUUID = testPuuid("polled");
+
+const trackedPlayer: PlayerConfigEntry = PlayerConfigEntrySchema.parse({
+  alias: "Polled",
+  league: { leagueAccount: { puuid: TRACKED_PUUID, region: "AMERICA_NORTH" } },
+});
+
+let lakeDir: string;
+let matchFixture: RawMatch;
+
+/** The same payload under a fresh match id, so each test owns its rows. */
+function matchNumbered(gameId: number): RawMatch {
+  return RawMatchSchema.parse({
+    ...matchFixture,
+    metadata: { ...matchFixture.metadata, matchId: `NA1_${String(gameId)}` },
+  });
+}
+
+async function persist(match: RawMatch): Promise<void> {
+  await persistAuthoritativeMatch({
+    matchData: match,
+    matchId: match.metadata.matchId,
+    trackedPlayers: [trackedPlayer],
+    silent: false,
+  });
+}
+
+async function receiptKindsFor(matchId: string): Promise<string[]> {
+  const receipts = await listReceipts(prisma, {
+    matchId: toRiotMatchId(matchId),
+  });
+  return receipts.map((entry) => entry.receipt.kind);
+}
+
+beforeEach(async () => {
+  matchFixture = await loadRawMatchFixture();
+  lakeDir = await mkdtemp(path.join(tmpdir(), "persist-match-lake-"));
+  Bun.env["REPORT_LAKE_DIR"] = lakeDir;
+  resetS3TestState();
+  mockSuccessfulPut();
+});
+
+afterEach(async () => {
+  resetS3TestState();
+  await rm(lakeDir, { recursive: true, force: true });
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("the authoritative ingest gate", () => {
+  test("stamps the observation with the object the archive really wrote", async () => {
+    const match = matchNumbered(7001);
+
+    await persist(match);
+
+    const observation = await getObservation(prisma, {
+      matchId: toRiotMatchId(match.metadata.matchId),
+    });
+    // The columns this wave exists to fill: an identity taken from the put,
+    // not reconstructed from the key layout.
+    const put = getValidatedPutCommand();
+    expect(observation?.artifacts.match?.key).toBe(put.input.Key);
+    expect(observation?.artifacts.match?.digest).toBe(
+      put.input.Metadata?.["sha256"],
+    );
+
+    expect(
+      await listTrackedAccounts(prisma, {
+        matchId: toRiotMatchId(match.metadata.matchId),
+      }),
+    ).toHaveLength(1);
+
+    const claim = await prisma.scoutEffectClaim.findUniqueOrThrow({
+      where: { key: `raw-match-s3:${match.metadata.matchId}` },
+    });
+    expect(claim.state).toBe("COMPLETED");
+  });
+
+  test("records the archive and the lake projection as receipts", async () => {
+    const match = matchNumbered(7002);
+
+    await persist(match);
+
+    expect(await receiptKindsFor(match.metadata.matchId)).toEqual([
+      "raw-archive-match",
+      "lake-staging-match",
+    ]);
+  });
+
+  test("a second pass re-archives nothing and leaves the observation standing", async () => {
+    const match = matchNumbered(7003);
+    await persist(match);
+    const putsAfterFirstPass = s3Mock.calls().length;
+    const afterFirstPass = await getObservation(prisma, {
+      matchId: toRiotMatchId(match.metadata.matchId),
+    });
+
+    await persist(match);
+
+    // The effect claim is COMPLETED, so the archive is skipped entirely — but
+    // the observation and the account associations are still facts, and the
+    // cursor advance ahead needs their rows.
+    expect(s3Mock.calls()).toHaveLength(putsAfterFirstPass);
+    const state = await getProcessingState(prisma, {
+      matchId: toRiotMatchId(match.metadata.matchId),
+    });
+    expect(state?.owner).toEqual({ kind: "legacy-v1" });
+    expect(
+      await listTrackedAccounts(prisma, {
+        matchId: toRiotMatchId(match.metadata.matchId),
+      }),
+    ).toHaveLength(1);
+
+    // The second pass has no descriptor to offer. Its silence neither erases
+    // the identity the first pass stamped nor restamps the observation.
+    const afterSecondPass = await getObservation(prisma, {
+      matchId: toRiotMatchId(match.metadata.matchId),
+    });
+    expect(afterSecondPass).toEqual(afterFirstPass);
+    expect(afterSecondPass?.artifacts.match).not.toBeNull();
+  });
+
+  test("an archive completed by a run that recorded nothing still gets its observation", async () => {
+    const match = matchNumbered(7004);
+    // A previous run archived the match and completed its claim, then ended
+    // before the durable write. Nothing else will ever observe this match.
+    await prisma.scoutEffectClaim.create({
+      data: {
+        key: `raw-match-s3:${match.metadata.matchId}`,
+        kind: "raw-match-s3",
+        state: "COMPLETED",
+      },
+    });
+
+    await persist(match);
+
+    const observation = await getObservation(prisma, {
+      matchId: toRiotMatchId(match.metadata.matchId),
+    });
+    expect(observation).not.toBeNull();
+    // No archive ran this pass, so there is no artifact identity to stamp.
+    expect(observation?.artifacts.match).toBeNull();
+  });
+
+  test("a failed lake projection blocks the cursor and records no observation", async () => {
+    const match = matchNumbered(7005);
+    // Occupy the staging directory's path with a plain file so the scaffold's
+    // mkdir fails: the real way staging returns false, not a stubbed one.
+    await Bun.write(path.join(lakeDir, MATCHES_STAGING_DIR), "not a directory");
+
+    await expect(persist(match)).rejects.toThrow(
+      "cursor advancement is blocked",
+    );
+
+    // An observation row means the raw payload really did become canonical
+    // AND reached the lake, so a blocked pass must leave none.
+    expect(
+      await getObservation(prisma, {
+        matchId: toRiotMatchId(match.metadata.matchId),
+      }),
+    ).toBeNull();
+    // The archive itself happened, so its receipt stands; the projection's
+    // does not.
+    expect(await receiptKindsFor(match.metadata.matchId)).toEqual([
+      "raw-archive-match",
+    ]);
+    const claim = await prisma.scoutEffectClaim.findUniqueOrThrow({
+      where: { key: `raw-match-s3:${match.metadata.matchId}` },
+    });
+    expect(claim.state).toBe("AMBIGUOUS_OR_FAILED");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/postmatch-delivery-recovery.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/postmatch-delivery-recovery.integration.test.ts
@@ -5,13 +5,20 @@ import { createTestDatabase } from "#src/testing/test-database.ts";
 import { loadRawMatchFixture } from "#src/testing/raw-capture-fixtures.ts";
 import { testChannelId, testGuildId } from "#src/testing/test-ids.ts";
 import { getIntent } from "#src/database/durable/intent-repository.ts";
+import { z } from "zod";
+
+/** What `deliverToChannels` was actually asked to deliver to. */
+const DeliveryCallSchema = z.object({
+  channels: z.array(z.object({ channel: z.string() })),
+});
 
 /**
- * The hole this closes: a report too old to send is not too old to finish
- * recording. The delivery gate returns before `deliverToChannels`, so the
- * completed-claim branch that adopts an unfinished intent is unreachable once
- * a match goes stale — and an intent left behind by a send whose durable
- * writes were lost would strand forever.
+ * The hole these close: whether a report may still be SENT and whether a send
+ * already made still needs RECORDING are different questions, and every exit in
+ * `deliverPostmatchReport` answers only the first. An intent left unfinished by
+ * a send whose durable writes were lost is reachable from the delivery pass
+ * only while its channel is still eligible, and from no pass at all once the
+ * match is three hours old — so recovery runs before all of it.
  */
 
 const { prisma } = createTestDatabase("postmatch-delivery-recovery");
@@ -21,6 +28,7 @@ const GUILD = testGuildId("7701");
 const MESSAGE_ID = "300000000000000011";
 
 const deliverToChannels = vi.fn();
+const generateMatchReport = vi.fn();
 
 /** The channels subscribed RIGHT NOW, which a test can empty out. */
 const SUBSCRIBED = [
@@ -51,6 +59,15 @@ vi.doMock(
   }),
 );
 
+// Only so a FRESH match can reach the delivery step without rendering a report.
+vi.doMock(
+  "#src/league/tasks/postmatch/match-report-generator.ts",
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    generateMatchReport,
+  }),
+);
+
 const { deliverPostmatchReport } =
   await import("#src/league/tasks/postmatch/match-report-delivery.ts");
 
@@ -61,6 +78,32 @@ function staleMatch(gameId: number): RawMatch {
   return RawMatchSchema.parse({
     ...fixture,
     metadata: { ...fixture.metadata, matchId: `NA1_${String(gameId)}` },
+  });
+}
+
+/** The same, played an hour ago — well inside the three-hour send window. */
+function freshMatch(gameId: number): RawMatch {
+  return RawMatchSchema.parse({
+    ...fixture,
+    metadata: { ...fixture.metadata, matchId: `NA1_${String(gameId)}` },
+    info: { ...fixture.info, gameCreation: Date.now() - 60 * 60 * 1000 },
+  });
+}
+
+async function seedCompletedSend(
+  key: string,
+  sentAt: Date,
+  completedAt: Date,
+): Promise<void> {
+  await prisma.scoutEffectClaim.create({
+    data: {
+      key,
+      kind: "discord-channel-message",
+      state: "COMPLETED",
+      resultId: MESSAGE_ID,
+      claimedAt: sentAt,
+      completedAt,
+    },
   });
 }
 
@@ -79,6 +122,12 @@ async function deliver(match: RawMatch): Promise<number> {
 beforeEach(async () => {
   fixture = await loadRawMatchFixture();
   deliverToChannels.mockClear();
+  deliverToChannels.mockResolvedValue({
+    deliveredGuildIds: new Set(),
+    messageIdsByChannel: new Map(),
+  });
+  generateMatchReport.mockClear();
+  generateMatchReport.mockResolvedValue({ content: "report" });
   subscribedChannels = SUBSCRIBED;
 });
 
@@ -169,5 +218,40 @@ describe("a report that went stale before its intent was finished", () => {
         intentKey: NotificationIntentKeySchema.parse(effectKeyFor(match)),
       }),
     ).toBeNull();
+  });
+});
+
+describe("a still-sendable report whose earlier delivery is unfinished", () => {
+  test("adopts a claim for a channel that is no longer subscribed", async () => {
+    // On a FRESH replay the delivery pass visits only currently eligible
+    // channels, so a channel unsubscribed since its report went out is never
+    // revisited — and once the match is three hours old no pass reaches
+    // delivery at all. Recovery is the only thing that can still finish it.
+    const match = freshMatch(7704);
+    const departed = testChannelId("7799");
+    const departedKey = `postmatch-discord:${match.metadata.matchId}:${departed}`;
+    const sentAt = new Date(Date.now() - 50 * 60 * 1000);
+    const completedAt = new Date(sentAt.getTime() + 700);
+    await seedCompletedSend(departedKey, sentAt, completedAt);
+
+    await deliverPostmatchReport({ matchData: match, trackedPlayers: [] });
+
+    // Finished from its claim, at the instants that send really happened.
+    const stored = await getIntent(prisma, {
+      intentKey: NotificationIntentKeySchema.parse(departedKey),
+    });
+    expect(stored?.intent.state).toEqual({
+      kind: "delivered",
+      messageId: MESSAGE_ID,
+      deliveredAt: completedAt.toISOString(),
+    });
+
+    // Nothing was sent to it: the delivery pass only ever saw the channel that
+    // is still subscribed, which is otherwise unaffected.
+    expect(deliverToChannels).toHaveBeenCalledTimes(1);
+    const sentTo = DeliveryCallSchema.parse(
+      deliverToChannels.mock.calls[0]?.[0],
+    );
+    expect(sentTo.channels.map((entry) => entry.channel)).toEqual([CHANNEL]);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/postmatch-delivery-recovery.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/postmatch-delivery-recovery.integration.test.ts
@@ -1,0 +1,173 @@
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { RawMatchSchema, type RawMatch } from "@scout-for-lol/data";
+import { NotificationIntentKeySchema } from "@scout-for-lol/domain/identity/brands.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import { loadRawMatchFixture } from "#src/testing/raw-capture-fixtures.ts";
+import { testChannelId, testGuildId } from "#src/testing/test-ids.ts";
+import { getIntent } from "#src/database/durable/intent-repository.ts";
+
+/**
+ * The hole this closes: a report too old to send is not too old to finish
+ * recording. The delivery gate returns before `deliverToChannels`, so the
+ * completed-claim branch that adopts an unfinished intent is unreachable once
+ * a match goes stale — and an intent left behind by a send whose durable
+ * writes were lost would strand forever.
+ */
+
+const { prisma } = createTestDatabase("postmatch-delivery-recovery");
+
+const CHANNEL = testChannelId("7701");
+const GUILD = testGuildId("7701");
+const MESSAGE_ID = "300000000000000011";
+
+const deliverToChannels = vi.fn();
+
+/** The channels subscribed RIGHT NOW, which a test can empty out. */
+const SUBSCRIBED = [
+  {
+    channel: CHANNEL,
+    serverId: GUILD,
+    subscriptions: [
+      { subscriptionId: 1, playerId: 1, filters: null, isMuted: false },
+    ],
+  },
+];
+let subscribedChannels: typeof SUBSCRIBED = SUBSCRIBED;
+
+vi.doMock("#src/database/index.ts", async (importOriginal) => ({
+  ...(await importOriginal()),
+  prisma,
+  getChannelsSubscribedToPlayers: () => Promise.resolve(subscribedChannels),
+}));
+
+// Spied rather than stubbed wholesale: `channelsPassingQueueFilter` runs before
+// the staleness gate and must stay real. Reaching this at all would mean the
+// stale path tried to send something.
+vi.doMock(
+  "#src/league/tasks/notification-filters.ts",
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    deliverToChannels,
+  }),
+);
+
+const { deliverPostmatchReport } =
+  await import("#src/league/tasks/postmatch/match-report-delivery.ts");
+
+let fixture: RawMatch;
+
+/** The committed payload under a fresh id, so each test owns its rows. */
+function staleMatch(gameId: number): RawMatch {
+  return RawMatchSchema.parse({
+    ...fixture,
+    metadata: { ...fixture.metadata, matchId: `NA1_${String(gameId)}` },
+  });
+}
+
+function effectKeyFor(match: RawMatch): string {
+  return `postmatch-discord:${match.metadata.matchId}:${CHANNEL}`;
+}
+
+async function deliver(match: RawMatch): Promise<number> {
+  const delivered = await deliverPostmatchReport({
+    matchData: match,
+    trackedPlayers: [],
+  });
+  return delivered.size;
+}
+
+beforeEach(async () => {
+  fixture = await loadRawMatchFixture();
+  deliverToChannels.mockClear();
+  subscribedChannels = SUBSCRIBED;
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("a report that went stale before its intent was finished", () => {
+  test("finishes the intent from the claim, records the real send instants, and sends nothing", async () => {
+    // The fixture's game is years old, so every pass over it is past the
+    // three-hour deadline — exactly the case where no later pass could ever
+    // reach the completed-claim branch.
+    const match = staleMatch(7701);
+    const sentAt = new Date(match.info.gameCreation + 60 * 60 * 1000);
+    const completedAt = new Date(sentAt.getTime() + 1500);
+    // The send succeeded and its claim was completed; every durable intent
+    // write of that run was lost, so there is no intent row at all.
+    await prisma.scoutEffectClaim.create({
+      data: {
+        key: effectKeyFor(match),
+        kind: "discord-channel-message",
+        state: "COMPLETED",
+        resultId: MESSAGE_ID,
+        claimedAt: sentAt,
+        completedAt,
+      },
+    });
+
+    expect(await deliver(match)).toBe(0);
+
+    // Nothing new went out: the report is still too old to send.
+    expect(deliverToChannels).not.toHaveBeenCalled();
+
+    const stored = await getIntent(prisma, {
+      intentKey: NotificationIntentKeySchema.parse(effectKeyFor(match)),
+    });
+    // Delivered, carrying the instant the send was actually observed rather
+    // than this pass's clock — which is also what lets `beginSend`'s freshness
+    // guard accept an adoption running hours past the deadline.
+    expect(stored?.intent.state).toEqual({
+      kind: "delivered",
+      messageId: MESSAGE_ID,
+      deliveredAt: completedAt.toISOString(),
+    });
+    expect(stored?.intent.attemptCount).toBe(1);
+  });
+
+  test("adopts the delivery even when every channel has since been unsubscribed", async () => {
+    // Recovery must not sit behind a return that depends on CURRENT
+    // subscriptions: the send happened when the channel was subscribed, and
+    // the claim that proves it does not care who is subscribed now.
+    const match = staleMatch(7703);
+    const sentAt = new Date(match.info.gameCreation + 60 * 60 * 1000);
+    const completedAt = new Date(sentAt.getTime() + 900);
+    await prisma.scoutEffectClaim.create({
+      data: {
+        key: effectKeyFor(match),
+        kind: "discord-channel-message",
+        state: "COMPLETED",
+        resultId: MESSAGE_ID,
+        claimedAt: sentAt,
+        completedAt,
+      },
+    });
+    subscribedChannels = [];
+
+    expect(await deliver(match)).toBe(0);
+
+    expect(deliverToChannels).not.toHaveBeenCalled();
+    const stored = await getIntent(prisma, {
+      intentKey: NotificationIntentKeySchema.parse(effectKeyFor(match)),
+    });
+    expect(stored?.intent.state).toEqual({
+      kind: "delivered",
+      messageId: MESSAGE_ID,
+      deliveredAt: completedAt.toISOString(),
+    });
+  });
+
+  test("a stale match with no completed claim records nothing and sends nothing", async () => {
+    const match = staleMatch(7702);
+
+    expect(await deliver(match)).toBe(0);
+
+    expect(deliverToChannels).not.toHaveBeenCalled();
+    expect(
+      await getIntent(prisma, {
+        intentKey: NotificationIntentKeySchema.parse(effectKeyFor(match)),
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/postmatch-delivery-recovery.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/postmatch-delivery-recovery.ts
@@ -1,0 +1,77 @@
+import { listCompletedScoutEffects } from "#src/temporal/effect-claims.ts";
+import { tryCreateChannelDeliveryRecorder } from "#src/durable/match/delivery-intents.ts";
+import { liveDurableFacts } from "#src/durable/match/live-facts.ts";
+import { createLogger } from "#src/logger.ts";
+
+const logger = createLogger("postmatch-delivery-recovery");
+
+/**
+ * Finish the durable record of sends this match already made, when the report
+ * itself is too old to send.
+ *
+ * The delivery gate returns early for a stale match, so the completed-claim
+ * branch inside `deliverToChannels` — the one that adopts an intent an earlier
+ * pass left unfinished — is never reached. That is the hole this closes: a run
+ * whose Discord send succeeded but whose intent writes were lost leaves a row
+ * that only a later pass can finish, and if no pass arrives before the match
+ * goes stale, every later pass takes the early return and the row strands
+ * forever. Recovery therefore has to be independent of send eligibility.
+ *
+ * Nothing is sent here, and nothing can be: this only reads claims the
+ * pipeline already completed and records what they prove.
+ *
+ * The instants come from the claim row rather than from the message id's
+ * Discord snowflake. Both are real evidence, but they describe different
+ * moments: the snowflake says when Discord created the message, while
+ * `beginSend`'s guard is about when the SEND BEGAN, which is what `claimedAt`
+ * records — the claim is taken immediately before the send runs. Using the one
+ * row that also proves the delivery keeps the evidence to a single source.
+ */
+export async function recoverCompletedPostmatchDeliveries(args: {
+  matchId: string;
+  effectKeyPrefix: string;
+  freshnessDeadline: Date;
+}): Promise<void> {
+  try {
+    // Scoped to this match's own claim keys: a stale match with nothing to
+    // recover costs one indexed lookup that returns no rows, and this runs on
+    // ordinary polls.
+    const completed = await listCompletedScoutEffects(
+      `${args.effectKeyPrefix}:`,
+    );
+    if (completed.length === 0) return;
+
+    const record = tryCreateChannelDeliveryRecorder({
+      facts: liveDurableFacts(),
+      matchId: args.matchId,
+      keyPrefix: args.effectKeyPrefix,
+      freshnessDeadline: args.freshnessDeadline,
+    });
+    if (record === null) return;
+
+    for (const claim of completed) {
+      // The claim key is `<prefix>:<channelId>`, so the channel is the segment
+      // the prefix does not cover.
+      const channelId = claim.key.slice(args.effectKeyPrefix.length + 1);
+      await record({
+        kind: "already-delivered",
+        channelId,
+        messageId: claim.resultId,
+        send: {
+          startedAt: claim.claimedAt,
+          deliveredAt: claim.completedAt,
+        },
+      });
+    }
+    logger.info(
+      `[processMatch] 📓 Recorded ${completed.length.toString()} already-delivered notification intent(s) for stale match ${args.matchId}`,
+    );
+  } catch (error) {
+    // Recovery is bookkeeping for a report that is not going out either way.
+    // It must never change what the stale path does.
+    logger.error(
+      `[processMatch] ❌ Could not reconcile completed deliveries for stale match ${args.matchId}`,
+      error,
+    );
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/postmatch-delivery-recovery.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/postmatch-delivery-recovery.ts
@@ -1,4 +1,7 @@
-import { listCompletedScoutEffects } from "#src/temporal/effect-claims.ts";
+import {
+  listCompletedScoutEffects,
+  DISCORD_CHANNEL_MESSAGE_EFFECT_KIND,
+} from "#src/temporal/effect-claims.ts";
 import { tryCreateChannelDeliveryRecorder } from "#src/durable/match/delivery-intents.ts";
 import { liveDurableFacts } from "#src/durable/match/live-facts.ts";
 import { createLogger } from "#src/logger.ts";
@@ -6,19 +9,35 @@ import { createLogger } from "#src/logger.ts";
 const logger = createLogger("postmatch-delivery-recovery");
 
 /**
- * Finish the durable record of sends this match already made, when the report
- * itself is too old to send.
+ * How far outside the derived window a claim may still be recognised.
  *
- * The delivery gate returns early for a stale match, so the completed-claim
- * branch inside `deliverToChannels` — the one that adopts an intent an earlier
- * pass left unfinished — is never reached. That is the hole this closes: a run
- * whose Discord send succeeded but whose intent writes were lost leaves a row
- * that only a later pass can finish, and if no pass arrives before the match
- * goes stale, every later pass takes the early return and the row strands
- * forever. Recovery therefore has to be independent of send eligibility.
+ * Three clocks bound the window and none of them is the same one: Riot stamps
+ * `gameCreation`, the application decides staleness from its own clock, and
+ * `claimedAt` defaults to the database's `now()`. The cost of the window being
+ * a little too narrow is a delivery that can never be recovered — the bug this
+ * whole path exists to fix — while the cost of it being too wide is a few more
+ * index entries scanned, so it is deliberately generous.
+ */
+const CLAIM_WINDOW_SLACK_MS = 60 * 60 * 1000;
+
+/**
+ * Finish the durable record of sends this match already made, whatever the
+ * pipeline decides about sending now.
  *
- * Nothing is sent here, and nothing can be: this only reads claims the
- * pipeline already completed and records what they prove.
+ * `deliverToChannels` can adopt an unfinished intent only for a channel it is
+ * currently delivering to, and it is reached only when the report is still
+ * sendable at all. Everything in between — the match's age, the tracked
+ * players, the current subscriptions, the queue filters — gates SENDING, and a
+ * send that already happened is indifferent to all of it. A channel
+ * unsubscribed after its report went out, or a match that turned three hours
+ * old before anything retried it, would otherwise leave an intent that no code
+ * path could ever finish. So this runs first and unconditionally, and it is the
+ * one place that adopts completed claims regardless of eligibility.
+ *
+ * Nothing is sent here, and nothing can be: it only reads claims the pipeline
+ * already COMPLETED and records what they prove. `deliverToChannels` still
+ * takes its own claim before any send, so running this first cannot produce a
+ * duplicate message.
  *
  * The instants come from the claim row rather than from the message id's
  * Discord snowflake. Both are real evidence, but they describe different
@@ -30,15 +49,32 @@ const logger = createLogger("postmatch-delivery-recovery");
 export async function recoverCompletedPostmatchDeliveries(args: {
   matchId: string;
   effectKeyPrefix: string;
+  gameCreation: number;
   freshnessDeadline: Date;
 }): Promise<void> {
   try {
-    // Scoped to this match's own claim keys: a stale match with nothing to
-    // recover costs one indexed lookup that returns no rows, and this runs on
-    // ordinary polls.
-    const completed = await listCompletedScoutEffects(
-      `${args.effectKeyPrefix}:`,
-    );
+    // This runs on every pass, so the lookup has to be index-served. It is
+    // shaped for the `[kind, state, claimedAt]` index rather than for a prefix
+    // match on the primary key, which Postgres cannot serve from a btree under
+    // these databases' `en_US.utf8` collation and would turn into a sequential
+    // scan of every claim ever made. Measured over 20k claims: an index scan
+    // touching 17 buffers, the window narrowing to a few hundred entries and
+    // the key prefix filtering those down to this match's.
+    //
+    // The time window is sound by the invariant the delivery gate already
+    // enforces. `claimedAt` records when a send BEGAN, and a send can only
+    // begin while the report is still sendable — never before the game existed,
+    // never after `postmatchReportFreshnessDeadline`. So every claim this match
+    // could own was stamped inside that span, widened by the slack above
+    // because the three instants come from three different clocks.
+    const completed = await listCompletedScoutEffects({
+      kind: DISCORD_CHANNEL_MESSAGE_EFFECT_KIND,
+      keyPrefix: `${args.effectKeyPrefix}:`,
+      claimedFrom: new Date(args.gameCreation - CLAIM_WINDOW_SLACK_MS),
+      claimedUntil: new Date(
+        args.freshnessDeadline.getTime() + CLAIM_WINDOW_SLACK_MS,
+      ),
+    });
     if (completed.length === 0) return;
 
     const record = tryCreateChannelDeliveryRecorder({

--- a/packages/scout-for-lol/packages/backend/src/report-lake/durable-receipts.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/durable-receipts.ts
@@ -5,9 +5,11 @@ import { recordReceipt } from "#src/database/durable/receipt-repository.ts";
 import type { MatchProcessingReceiptRecord } from "#src/database/durable/receipt-row.ts";
 import { createLogger } from "#src/logger.ts";
 import {
-  scoutDurableDualwriteFailuresTotal,
-  scoutDurableDualwriteRecordsTotal,
-} from "#src/metrics/durable.ts";
+  countDurableWrite,
+  countDurableWriteFailure,
+  insideDurableWrite,
+  type DurableWriteKind,
+} from "#src/durable/match/durable-facts.ts";
 import { defineVersionedCodec } from "@scout-for-lol/domain/codec/versioned.ts";
 import {
   ArtifactDescriptorSchema,
@@ -177,32 +179,42 @@ export type ReceiptRecordOutcome = "recorded" | "conflict" | "failed";
  * and metered and nothing else.
  *
  * The two counters answer different questions, and keeping them apart is what
- * makes either usable. {@link scoutDurableDualwriteFailuresTotal} counts only
- * THROWN writes — the recorder itself is broken and the stored state is unknown,
- * which is worth paging on. {@link scoutDurableDualwriteRecordsTotal} counts
- * every completed write by its repository outcome, so a `conflict` stays visible
- * as drift without contaminating the alert.
+ * makes either usable. The failures counter counts only THROWN writes — the
+ * recorder itself is broken and the stored state is unknown, which is worth
+ * paging on. The records counter counts every completed write by its repository
+ * outcome, so a `conflict` stays visible as drift without contaminating the
+ * alert.
  *
  * Conflicts are a permanent feature of this table, not a transitional one: a
  * producer whose v1 operation is one-shot genuinely observes different evidence
  * on a replay, and reporting that honestly is better than fabricating agreement.
  * So a `conflict` must never reach the failures counter, whatever the
  * repository's replay equality happens to compare at the time.
+ *
+ * Both counters are reached through `durable-facts.ts` rather than incremented
+ * here: `write_kind` comes from the one closed set, and the repository's answer
+ * is parsed before it becomes a label, so this producer cannot widen either
+ * axis of a metric the other producer shares.
  */
 export async function recordReceiptFailOpen(args: {
   record: MatchProcessingReceiptRecord;
-  writeKind: string;
+  writeKind: DurableWriteKind;
   db?: Db;
 }): Promise<ReceiptRecordOutcome> {
+  if (insideDurableWrite()) {
+    // Both wrappers count a completed write, so nesting them would record one
+    // fact twice. The receipted doors run alongside the durable services, never
+    // inside them; a caller that nests them is a bug, not a degraded mode.
+    throw new Error(
+      `Refusing to record the ${args.record.receipt.kind} receipt for ${args.record.matchId} from inside a durable write: it would double-count scout_durable_dualwrite_records_total`,
+    );
+  }
   try {
-    const outcome = await recordReceipt(args.db ?? prisma, args.record);
-    scoutDurableDualwriteRecordsTotal.inc({
-      write_kind: args.writeKind,
-      outcome: outcome.outcome,
-    });
-    if (outcome.outcome === "conflict") {
+    const result = await recordReceipt(args.db ?? prisma, args.record);
+    countDurableWrite(args.writeKind, result.outcome);
+    if (result.outcome === "conflict") {
       logger.warn(
-        `Receipt ${args.record.receipt.kind} for ${args.record.matchId} disagrees with the recorded one (${outcome.reason}); the first writer's evidence stands`,
+        `Receipt ${args.record.receipt.kind} for ${args.record.matchId} disagrees with the recorded one (${result.reason}); the first writer's evidence stands`,
       );
       return "conflict";
     }
@@ -212,7 +224,7 @@ export async function recordReceiptFailOpen(args: {
       `Failed to record ${args.record.receipt.kind} receipt for ${args.record.matchId}; the v1 write stands`,
       error,
     );
-    scoutDurableDualwriteFailuresTotal.inc({ write_kind: args.writeKind });
+    countDurableWriteFailure(args.writeKind);
     return "failed";
   }
 }

--- a/packages/scout-for-lol/packages/backend/src/report-lake/receipted-archive.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/receipted-archive.test.ts
@@ -9,6 +9,7 @@ import {
   ArtifactKindSchema,
 } from "@scout-for-lol/domain/artifacts/descriptors.ts";
 import { matchProcessingReceiptIdentityKey } from "@scout-for-lol/domain/match-processing/states.ts";
+import { MATCH_RECEIPT_KINDS } from "#src/durable/match/receipt-evidence.ts";
 import {
   MatchProcessingReceiptRecordSchema,
   type MatchProcessingReceiptRecord,
@@ -215,5 +216,14 @@ describe("a full ingest receipts every one of its artifacts", () => {
     expect(new Set(RECEIPTED_LAKE_RECEIPT_KINDS).size).toBe(
       ARTIFACT_KINDS.length * 2,
     );
+  });
+
+  test("no receipt kind is owned by both the lake projection and the match bridge", () => {
+    // A shared kind would put two evidence shapes behind one receipt identity,
+    // and whichever producer wrote second would lose to an evidence mismatch.
+    const matchKinds: readonly string[] = Object.values(MATCH_RECEIPT_KINDS);
+    expect(
+      RECEIPTED_LAKE_RECEIPT_KINDS.filter((kind) => matchKinds.includes(kind)),
+    ).toEqual([]);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/report-lake/receipted-staging.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/receipted-staging.test.ts
@@ -18,6 +18,11 @@ import {
   scoutDurableDualwriteFailuresTotal,
   scoutDurableDualwriteRecordsTotal,
 } from "#src/metrics/durable.ts";
+import { prisma } from "#src/database/index.ts";
+import {
+  recordDurableWrite,
+  type DurableFacts,
+} from "#src/durable/match/durable-facts.ts";
 
 const mocks = vi.hoisted(() => ({
   recordReceipt: vi.fn(),
@@ -295,6 +300,33 @@ describe("receipted timeline staging", () => {
       fileCount: 4,
     });
     expect(recordedReceipt().matchId).toBe("NA1_5370969615");
+  });
+});
+
+describe("the receipt wrapper and the durable bridge", () => {
+  test("refuse to record one fact from inside the other", async () => {
+    const match = await loadRawMatchFixture();
+    const before = await recordsFor("lake-staging", "applied");
+    const facts: DurableFacts = { db: prisma, now: () => new Date() };
+    let refusal: unknown;
+
+    await recordDurableWrite(facts, "observation", async () => {
+      try {
+        await stageMatchReceipted(lakeDir, match, {
+          source: artifactDescriptorFixture("match"),
+        });
+      } catch (error) {
+        refusal = error;
+      }
+      return { outcome: "applied" };
+    });
+
+    // Both wrappers increment scout_durable_dualwrite_records_total, so a
+    // receipt recorded inside a durable write would report one projection as
+    // two recorded facts. The connector keeps them sequential; this is what
+    // makes a future nesting fail instead of silently inflating the counter.
+    expect(String(refusal)).toContain("double-count");
+    expect(await recordsFor("lake-staging", "applied")).toBe(before);
   });
 });
 

--- a/packages/scout-for-lol/packages/backend/src/report-lake/receipted-staging.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/receipted-staging.ts
@@ -30,11 +30,13 @@ import {
  * The receipted entry point into lake staging.
  *
  * This is a SECOND door onto the same `write*StagingFile` functions, not a
- * replacement for the first. The legacy boolean callers keep their exact
- * semantics — best-effort for timeline, prematch and rank history; a `false`
- * match staging result still blocks cursor advancement — because the contract
- * that staging must never fail ingest is what makes the nightly rebuild the
- * safety net rather than a second source of truth.
+ * replacement for the first. Rank history and the dev/test no-bucket path still
+ * go through the boolean one, and v1's own semantics are unchanged everywhere —
+ * best-effort for timeline and prematch; a `false` match staging result still
+ * blocks cursor advancement — because the contract that staging must never fail
+ * ingest is what makes the nightly rebuild the safety net rather than a second
+ * source of truth. Live ingest reaches this door through `report-store/store.ts`,
+ * which is where the throw below is turned back into that boolean.
  *
  * What changes on this path is who is allowed to be vague. A caller that asked
  * for a RECEIPTED write is asking for a durable claim that the projection

--- a/packages/scout-for-lol/packages/backend/src/report-store/live-ingest.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-store/live-ingest.ts
@@ -9,6 +9,7 @@ import {
   ingestMatch,
   ingestPrematch,
   ingestTimeline,
+  type MatchIngestResult,
 } from "#src/report-store/store.ts";
 import { createLogger } from "#src/logger.ts";
 
@@ -76,11 +77,16 @@ function recordFailure(
  * Thin metric wrappers over the S3-authoritative ingest. On failure they record
  * the failure metric and RE-THROW — the caller (e.g. the polling cursor gate)
  * decides how to react. A swallowed failure would silently lose the match.
+ *
+ * The match wrapper passes the ingest's whole answer through, artifact
+ * descriptor included, because the durable bridge above it stamps the
+ * observation with that identity. Summarising the result here is what left the
+ * observation's artifact columns NULL for every live match.
  */
 
 export async function recordMatchForReportStore(
   options: MatchIngestOptions,
-): Promise<{ staged: boolean; stored: boolean }> {
+): Promise<MatchIngestResult> {
   try {
     const result = await ingestMatch(
       options.match,

--- a/packages/scout-for-lol/packages/backend/src/report-store/store.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-store/store.test.ts
@@ -1,30 +1,110 @@
-import { expect, test, vi } from "vitest";
-import { RawMatchSchema } from "@scout-for-lol/data";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { z } from "zod";
+import { MATCHES_STAGING_DIR } from "#src/report-lake/paths.ts";
+import { loadRawMatchFixture } from "#src/testing/raw-capture-fixtures.ts";
+import {
+  getValidatedPutCommand,
+  mockSuccessfulPut,
+  resetS3TestState,
+  setS3TestBucket,
+} from "#src/storage/s3-test-helpers.ts";
 
-const saveMatchToS3 = vi.fn(() => Promise.resolve("skipped_no_bucket"));
-const writeMatchStagingFile = vi.fn(() => Promise.resolve(true));
+const mocks = vi.hoisted(() => ({ recordReceipt: vi.fn() }));
 
-vi.doMock("#src/storage/s3.ts", () => ({ saveMatchToS3 }));
-vi.doMock("#src/report-lake/paths.ts", () => ({
-  resolveLakeDir: () => "/test/report-lake",
+// The object store runs for real against a mocked S3 client, because the
+// descriptor this suite is about is built from what the put actually stored.
+// Only the receipt repository is stubbed; the durable table's own behaviour
+// belongs to the repository suites.
+vi.mock("#src/database/index.ts", () => ({ prisma: {} }));
+vi.mock("#src/database/durable/receipt-repository.ts", () => ({
+  recordReceipt: mocks.recordReceipt,
 }));
-vi.doMock("#src/report-lake/staging.ts", () => ({ writeMatchStagingFile }));
 
 const { ingestMatch } = await import("#src/report-store/store.ts");
-const match = RawMatchSchema.parse(
-  await Bun.file(
-    new URL(
-      "../league/model/__tests__/testdata/matches_2025_09_19_NA1_5370986469.json",
-      import.meta.url,
-    ),
-  ).json(),
-);
 
-test("preserves local staging while reporting unavailable S3 storage", async () => {
-  await expect(ingestMatch(match, [])).resolves.toEqual({
-    staged: true,
-    stored: false,
+let lakeDir: string;
+
+/**
+ * Read back what this ingest claimed, without the row codec: the architecture
+ * rules keep `report-store/` out of `database/`, and the codec's own contract
+ * is covered where the receipted doors are tested.
+ */
+const RecordedReceiptSchema = z.object({
+  receipt: z.object({ kind: z.string() }),
+});
+
+function receiptKinds(): string[] {
+  return mocks.recordReceipt.mock.calls.map(
+    (call) => RecordedReceiptSchema.parse(call[1]).receipt.kind,
+  );
+}
+
+beforeEach(async () => {
+  lakeDir = await mkdtemp(path.join(tmpdir(), "report-store-ingest-"));
+  Bun.env["REPORT_LAKE_DIR"] = lakeDir;
+  resetS3TestState();
+  mocks.recordReceipt.mockReset();
+  mocks.recordReceipt.mockResolvedValue({ outcome: "applied" });
+});
+
+afterEach(async () => {
+  resetS3TestState();
+  await rm(lakeDir, { recursive: true, force: true });
+});
+
+describe("match ingest", () => {
+  test("returns the descriptor of the object the archive actually wrote", async () => {
+    const match = await loadRawMatchFixture();
+    mockSuccessfulPut();
+
+    const result = await ingestMatch(match, []);
+
+    expect(result).toMatchObject({ staged: true, stored: true });
+    // The identity comes from the put itself — the key it used and the digest
+    // it stored as object metadata — so the bridge above can stamp the
+    // observation with evidence rather than a reconstructed key.
+    const put = getValidatedPutCommand();
+    expect(result.artifact?.key).toBe(put.input.Key);
+    expect(result.artifact?.digest).toBe(put.input.Metadata?.["sha256"]);
   });
-  expect(saveMatchToS3).toHaveBeenCalledOnce();
-  expect(writeMatchStagingFile).toHaveBeenCalledOnce();
+
+  test("records the archive and the lake projection as two receipts", async () => {
+    const match = await loadRawMatchFixture();
+    mockSuccessfulPut();
+
+    await ingestMatch(match, []);
+
+    expect(receiptKinds()).toEqual(["raw-archive-match", "lake-staging-match"]);
+  });
+
+  test("reports a failed staging write without throwing, and receipts nothing for it", async () => {
+    const match = await loadRawMatchFixture();
+    mockSuccessfulPut();
+    // Occupy the staging directory's path with a plain file so the scaffold's
+    // mkdir fails: the real way staging returns false, not a stubbed one.
+    await Bun.write(path.join(lakeDir, MATCHES_STAGING_DIR), "not a directory");
+
+    const result = await ingestMatch(match, []);
+
+    // A false match staging result is what blocks cursor advancement upstream,
+    // so the receipted door's throw must never reach this caller.
+    expect(result).toMatchObject({ staged: false, stored: true });
+    expect(receiptKinds()).toEqual(["raw-archive-match"]);
+  });
+
+  test("preserves local staging while reporting unavailable S3 storage", async () => {
+    const match = await loadRawMatchFixture();
+    setS3TestBucket(undefined);
+    mockSuccessfulPut();
+
+    const result = await ingestMatch(match, []);
+
+    expect(result).toEqual({ staged: true, stored: false });
+    // Nothing was archived, so there is no source object a staging receipt
+    // could name and no archive to attest to.
+    expect(mocks.recordReceipt).not.toHaveBeenCalled();
+  });
 });

--- a/packages/scout-for-lol/packages/backend/src/report-store/store.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-store/store.ts
@@ -3,39 +3,111 @@ import type {
   RawMatch,
   RawTimeline,
 } from "@scout-for-lol/data";
+import type { ArtifactDescriptor } from "@scout-for-lol/domain/artifacts/descriptors.ts";
 import { resolveLakeDir } from "#src/report-lake/paths.ts";
+import {
+  archiveMatchReceipted,
+  archivePrematchReceipted,
+  archiveTimelineReceipted,
+} from "#src/report-lake/receipted-archive.ts";
+import {
+  ReceiptedStagingError,
+  stageMatchReceipted,
+  stagePrematchReceipted,
+  stageTimelineReceipted,
+  type ReceiptedStagingResult,
+} from "#src/report-lake/receipted-staging.ts";
 import {
   writeMatchStagingFile,
   writePrematchStagingFile,
   writeTimelineStagingFiles,
 } from "#src/report-lake/staging.ts";
-import {
-  saveMatchToS3,
-  savePrematchDataToS3,
-  saveTimelineToS3,
-} from "#src/storage/s3.ts";
 
 /**
  * S3-authoritative ingest. S3 (SeaweedFS) is the canonical raw store — the
  * report lake rebuilds by enumerating it — so the S3 write is the must-succeed
  * step and throws on failure. The lake staging write is best-effort by design
- * (it logs + meters internally, never throws) since the compactor re-derives
- * the same rows from S3.
+ * since the compactor re-derives the same rows from S3.
+ *
+ * Both steps run through the receipted doors in `report-lake/`, so an ingest
+ * leaves durable evidence of what it archived and what it projected. That is
+ * the only thing that changed here: the receipted doors are the same archival
+ * and staging primitives with a stricter contract on top, and this module is
+ * where that contract is translated back into v1's.
  *
  * No SQLite match/prematch/timeline/fact writes happen here anymore; the
  * Stored and fact tables are unwritten (dropped in the follow-up PR).
  */
 
+/**
+ * What one match ingest did.
+ *
+ * `artifact` is the raw payload's durable identity — the key the put actually
+ * used and the digest of the exact bytes uploaded. It is present exactly when
+ * the canonical write happened, so the dual-write layer above can stamp the
+ * observation's artifact columns with an identity rather than reconstruct one
+ * from the key layout, which would be evidence of nothing.
+ */
+export type MatchIngestResult = {
+  staged: boolean;
+  stored: boolean;
+  artifact?: ArtifactDescriptor;
+};
+
+/**
+ * Run a receipted staging write and answer in v1's boolean.
+ *
+ * THIS IS WHERE THE TWO CONTRACTS MEET. The receipted door throws when the
+ * projection fails, because a caller asking for a durable claim must never get
+ * a receipt for staging files that do not exist. v1's callers decide something
+ * different with the same answer — a `false` match staging result blocks cursor
+ * advancement, while timeline and prematch staging are best-effort — and this
+ * wave must not change any of that, so the one failure the receipted door
+ * signals by throwing becomes the `false` it has always been.
+ *
+ * Only {@link ReceiptedStagingError} is translated. A source descriptor that
+ * does not describe what was staged is a broken internal contract, not a failed
+ * projection, and stays fatal.
+ */
+async function stagedForV1(
+  stage: () => Promise<ReceiptedStagingResult>,
+): Promise<boolean> {
+  try {
+    await stage();
+    return true;
+  } catch (error) {
+    if (error instanceof ReceiptedStagingError) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/**
+ * The dev/test no-bucket path stages through the unreceipted door on purpose.
+ * A lake-staging receipt identifies the projection by the S3 object its rows
+ * were derived from, and when nothing was archived there is no such object —
+ * so there is no honest claim to record, exactly as the archive itself records
+ * nothing.
+ */
 export async function ingestMatch(
   match: RawMatch,
   trackedPlayerAliases: string[],
-): Promise<{ staged: boolean; stored: boolean }> {
+): Promise<MatchIngestResult> {
   // Authoritative: throws on failure.
-  const storageStatus = await saveMatchToS3(match, trackedPlayerAliases);
-  // Best-effort lake staging so the DuckDB report engine sees this match
-  // before the next compaction; never throws.
-  const staged = await writeMatchStagingFile(resolveLakeDir(), match);
-  return { staged, stored: storageStatus === "saved" };
+  const archived = await archiveMatchReceipted(match, trackedPlayerAliases);
+  if (archived.status === "skipped_no_bucket") {
+    return {
+      staged: await writeMatchStagingFile(resolveLakeDir(), match),
+      stored: false,
+    };
+  }
+  // Lake staging so the DuckDB report engine sees this match before the next
+  // compaction; a failure is reported, never thrown.
+  const staged = await stagedForV1(() =>
+    stageMatchReceipted(resolveLakeDir(), match, { source: archived.artifact }),
+  );
+  return { staged, stored: true, artifact: archived.artifact };
 }
 
 export async function ingestTimeline(
@@ -43,8 +115,20 @@ export async function ingestTimeline(
   trackedPlayerAliases: string[],
   gameCreatedAt: Date,
 ): Promise<boolean> {
-  await saveTimelineToS3(timeline, trackedPlayerAliases, gameCreatedAt);
-  return writeTimelineStagingFiles(resolveLakeDir(), timeline, new Date());
+  const archived = await archiveTimelineReceipted(
+    timeline,
+    trackedPlayerAliases,
+    gameCreatedAt,
+  );
+  const lakeDir = resolveLakeDir();
+  if (archived.status === "skipped_no_bucket") {
+    return await writeTimelineStagingFiles(lakeDir, timeline, new Date());
+  }
+  return await stagedForV1(() =>
+    stageTimelineReceipted(lakeDir, timeline, new Date(), {
+      source: archived.artifact,
+    }),
+  );
 }
 
 export async function ingestPrematch(
@@ -53,7 +137,18 @@ export async function ingestPrematch(
   trackedPlayerAliases: string[],
 ): Promise<void> {
   // Authoritative: throws on failure (missing bucket is a graceful no-op).
-  await savePrematchDataToS3(gameInfo.gameId, gameInfo, trackedPlayerAliases);
-  // Best-effort lake staging; never throws.
-  await writePrematchStagingFile(resolveLakeDir(), gameInfo, observedAt);
+  const archived = await archivePrematchReceipted(
+    gameInfo,
+    trackedPlayerAliases,
+  );
+  const lakeDir = resolveLakeDir();
+  if (archived.status === "skipped_no_bucket") {
+    await writePrematchStagingFile(lakeDir, gameInfo, observedAt);
+    return;
+  }
+  await stagedForV1(() =>
+    stagePrematchReceipted(lakeDir, gameInfo, observedAt, {
+      source: archived.artifact,
+    }),
+  );
 }

--- a/packages/scout-for-lol/packages/backend/src/storage/s3-archive.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3-archive.test.ts
@@ -5,11 +5,7 @@ import {
 } from "#src/testing/raw-capture-fixtures.ts";
 import { Sha256DigestSchema } from "@scout-for-lol/domain/identity/brands.ts";
 import { ArtifactDescriptorSchema } from "@scout-for-lol/domain/artifacts/descriptors.ts";
-import {
-  archiveMatchToS3,
-  archiveTimelineToS3,
-  saveMatchToS3,
-} from "#src/storage/s3.ts";
+import { archiveMatchToS3, archiveTimelineToS3 } from "#src/storage/s3.ts";
 import {
   getValidatedPutCommand,
   mockSuccessfulPut,
@@ -91,13 +87,6 @@ describe("archived match descriptors", () => {
 
     expect(result).toEqual({ status: "skipped_no_bucket" });
     expect(s3Mock.calls()).toHaveLength(0);
-  });
-
-  test("leaves the legacy status-only signature untouched", async () => {
-    const match = await loadRawMatchFixture();
-    mockSuccessfulPut();
-
-    await expect(saveMatchToS3(match, [])).resolves.toBe("saved");
   });
 });
 

--- a/packages/scout-for-lol/packages/backend/src/storage/s3.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { RawMatchSchema, type RawMatch } from "@scout-for-lol/data";
-import { saveMatchToS3 } from "#src/storage/s3.ts";
+import { archiveMatchToS3 } from "#src/storage/s3.ts";
 import {
   getValidatedPutCommand,
   mockFailedPut,
@@ -160,7 +160,7 @@ describe("S3 match storage", () => {
     const match = await loadMatchFixture();
     mockSuccessfulPut();
 
-    await saveMatchToS3(match, ["Lord ARKΞV", "H6 Hadès"]);
+    await archiveMatchToS3(match, ["Lord ARKΞV", "H6 Hadès"]);
 
     expect(s3Mock.calls()).toHaveLength(1);
     const command = getValidatedPutCommand();
@@ -190,7 +190,9 @@ describe("S3 match storage", () => {
     setS3TestBucket(undefined);
     mockSuccessfulPut();
 
-    await expect(saveMatchToS3(match, [])).resolves.toBe("skipped_no_bucket");
+    await expect(archiveMatchToS3(match, [])).resolves.toEqual({
+      status: "skipped_no_bucket",
+    });
     expect(s3Mock.calls()).toHaveLength(0);
   });
 
@@ -198,7 +200,7 @@ describe("S3 match storage", () => {
     const match = await loadMatchFixture();
     mockFailedPut("S3 upload failed");
 
-    await expect(saveMatchToS3(match, [])).rejects.toThrow(
+    await expect(archiveMatchToS3(match, [])).rejects.toThrow(
       `Failed to save match ${match.metadata.matchId} to S3`,
     );
     expect(s3Mock.calls()).toHaveLength(3);

--- a/packages/scout-for-lol/packages/backend/src/storage/s3.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3.ts
@@ -33,6 +33,12 @@ export type PrematchPayloadSaveResult = {
  * The descriptor is built from what the put actually stored — the real key and
  * the digest of the exact bytes uploaded — so it is usable as durable evidence
  * rather than a restatement of intent.
+ *
+ * There is deliberately NO status-only wrapper over these functions. Two once
+ * existed, and every caller that went through them threw the descriptor away —
+ * which is why `MatchObservation`'s artifact columns were NULL for every live
+ * match until the receipted doors were wired up. A caller that only wants the
+ * status reads `.status`.
  */
 export type RawArchiveResult =
   | { status: "saved"; artifact: ArtifactDescriptor }
@@ -104,18 +110,6 @@ export async function archiveMatchToS3(
   return stored === undefined
     ? { status: "skipped_no_bucket" }
     : archived("match", stored);
-}
-
-/**
- * Save a League of Legends match to S3 storage
- * @returns whether the canonical write happened or S3 is unavailable
- */
-export async function saveMatchToS3(
-  match: RawMatch,
-  trackedPlayerAliases: string[],
-): Promise<"saved" | "skipped_no_bucket"> {
-  const result = await archiveMatchToS3(match, trackedPlayerAliases);
-  return result.status;
 }
 
 /**
@@ -351,16 +345,4 @@ export async function archiveTimelineToS3(
   return stored === undefined
     ? { status: "skipped_no_bucket" }
     : archived("timeline", stored);
-}
-
-/**
- * Save a match timeline to S3 storage
- * @returns Promise that resolves when the timeline is saved
- */
-export async function saveTimelineToS3(
-  timeline: RawTimeline,
-  trackedPlayerAliases: string[],
-  gameCreatedAt: Date,
-): Promise<void> {
-  await archiveTimelineToS3(timeline, trackedPlayerAliases, gameCreatedAt);
 }

--- a/packages/scout-for-lol/packages/backend/src/temporal/durability.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/durability.integration.test.ts
@@ -408,7 +408,14 @@ test("effect claims retain a provider result for retry projection", async () => 
     "discord-message-99",
     prisma,
   );
-  await expect(
-    requireCompletedScoutEffectResult("postmatch:42:channel:7", prisma),
-  ).resolves.toBe("discord-message-99");
+  const completed = await requireCompletedScoutEffectResult(
+    "postmatch:42:channel:7",
+    prisma,
+  );
+  expect(completed.resultId).toBe("discord-message-99");
+  // The claim also brackets the effect it proves, which is what a later pass
+  // recovering that effect records instead of its own clock.
+  expect(completed.claimedAt.getTime()).toBeLessThanOrEqual(
+    completed.completedAt.getTime(),
+  );
 });

--- a/packages/scout-for-lol/packages/backend/src/temporal/effect-claims.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/effect-claims.ts
@@ -4,6 +4,12 @@ import { scoutTemporalDuplicateEffectClaims } from "#src/metrics/platform/tempor
 
 const UniqueViolationSchema = z.object({ code: z.literal("P2002") });
 
+/**
+ * The effect kind every per-channel Discord send is claimed under. Named here
+ * so the claim site and the queries that look those claims up cannot drift.
+ */
+export const DISCORD_CHANNEL_MESSAGE_EFFECT_KIND = "discord-channel-message";
+
 export async function claimScoutEffect(
   input: {
     key: string;
@@ -120,24 +126,37 @@ export async function requireCompletedScoutEffectResult(
 }
 
 /**
- * Every completed effect under one key prefix.
+ * Completed effects of one kind, claimed within a window, under one key prefix.
  *
- * Scoped to a prefix rather than scanning, because the caller is a recovery
- * path that runs on ordinary polls: it asks only about the keys one match
- * could own, and a match with nothing to recover costs one indexed lookup that
- * returns no rows.
+ * The query is shaped for `ScoutEffectClaim`'s `[kind, state, claimedAt]`
+ * index, which carries all three of those as an index condition and leaves the
+ * key prefix as a cheap residual filter. The obvious formulation — a prefix
+ * match on the primary key alone — is NOT usable here: Postgres can only serve
+ * `LIKE 'prefix%'` from a btree under the C collation or a `text_pattern_ops`
+ * index, and these databases are initdb'd `en_US.utf8`, so it would degrade to
+ * a sequential scan on every call. The window is what keeps this bounded; the
+ * caller derives it and owns its correctness.
  *
- * Rows are parsed, not filtered. A COMPLETED claim under a prefix whose
- * completions all carry a result is expected to carry one, so a row that does
- * not is a broken contract and says so here, exactly as the single-key read
- * above does.
+ * Rows are parsed, not filtered. A COMPLETED claim of a kind whose completions
+ * all carry a result is expected to carry one, so a row that does not is a
+ * broken contract and says so here, exactly as the single-key read above does.
  */
 export async function listCompletedScoutEffects(
-  keyPrefix: string,
+  args: {
+    kind: string;
+    keyPrefix: string;
+    claimedFrom: Date;
+    claimedUntil: Date;
+  },
   database: ExtendedPrismaClient = prisma,
 ): Promise<CompletedScoutEffect[]> {
   const rows = await database.scoutEffectClaim.findMany({
-    where: { key: { startsWith: keyPrefix }, state: "COMPLETED" },
+    where: {
+      kind: args.kind,
+      state: "COMPLETED",
+      claimedAt: { gte: args.claimedFrom, lte: args.claimedUntil },
+      key: { startsWith: args.keyPrefix },
+    },
     select: {
       key: true,
       resultId: true,

--- a/packages/scout-for-lol/packages/backend/src/temporal/effect-claims.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/effect-claims.ts
@@ -76,18 +76,76 @@ export async function completeScoutEffectWithResult(
   await persistCompletedScoutEffect(key, resultId, database);
 }
 
+/**
+ * A side effect this pipeline already performed, and when it performed it.
+ *
+ * The two instants bracket the effect itself: the claim row is created
+ * immediately BEFORE the effect runs and completed immediately AFTER it
+ * returns, so `claimedAt` is this system's own record of when the effect began
+ * and `completedAt` of when it was observed to have happened. A later pass
+ * recovering the effect has no other first-party record of either.
+ */
+export type CompletedScoutEffect = {
+  key: string;
+  resultId: string;
+  claimedAt: Date;
+  completedAt: Date;
+};
+
+const CompletedScoutEffectSchema = z.object({
+  key: z.string(),
+  resultId: z.string(),
+  claimedAt: z.date(),
+  completedAt: z.date(),
+});
+
 export async function requireCompletedScoutEffectResult(
   key: string,
   database: ExtendedPrismaClient = prisma,
-): Promise<string> {
+): Promise<CompletedScoutEffect> {
   const claim = await database.scoutEffectClaim.findUniqueOrThrow({
     where: { key },
-    select: { state: true, resultId: true },
+    select: {
+      key: true,
+      state: true,
+      resultId: true,
+      claimedAt: true,
+      completedAt: true,
+    },
   });
   if (claim.state !== "COMPLETED" || claim.resultId === null) {
     throw new Error(`Completed effect ${key} has no durable result ID`);
   }
-  return claim.resultId;
+  return CompletedScoutEffectSchema.parse(claim);
+}
+
+/**
+ * Every completed effect under one key prefix.
+ *
+ * Scoped to a prefix rather than scanning, because the caller is a recovery
+ * path that runs on ordinary polls: it asks only about the keys one match
+ * could own, and a match with nothing to recover costs one indexed lookup that
+ * returns no rows.
+ *
+ * Rows are parsed, not filtered. A COMPLETED claim under a prefix whose
+ * completions all carry a result is expected to carry one, so a row that does
+ * not is a broken contract and says so here, exactly as the single-key read
+ * above does.
+ */
+export async function listCompletedScoutEffects(
+  keyPrefix: string,
+  database: ExtendedPrismaClient = prisma,
+): Promise<CompletedScoutEffect[]> {
+  const rows = await database.scoutEffectClaim.findMany({
+    where: { key: { startsWith: keyPrefix }, state: "COMPLETED" },
+    select: {
+      key: true,
+      resultId: true,
+      claimedAt: true,
+      completedAt: true,
+    },
+  });
+  return rows.map((row) => CompletedScoutEffectSchema.parse(row));
 }
 
 export async function recordScoutEffectFailure(


### PR DESCRIPTION
## Why

The Wave-3 closing review found the receipted lake projection merged **dormant** (P0): all six receipted archive/staging entry points had zero production callers, `saveMatchToS3` discarded the artifact descriptor it was handed, so `MatchObservation`'s artifact columns stayed permanently NULL and no `raw-archive-*`/`lake-staging-*` receipts were ever recorded. The dual-write soak that the V2 acceptance checklist depends on was producing no artifact evidence at all.

## What

- **Connector (P0)**: live ingest — polling, initial-history import, recovery backfill, and prematch — now routes through the receipted door. Descriptors flow from the actual S3 put back to the observation writer, which stamps `matchObjectKey`/`matchDigest`/timeline columns. One documented translation point (`stagedForV1` in `report-store/store.ts`) preserves v1 semantics exactly: match staging `false` still blocks cursor advancement, timeline/prematch stay best-effort, receipt recording is fail-open, and only `ReceiptedStagingError` is translated (broken internal contracts stay fatal). The no-bucket path deliberately keeps the unreceipted staging door — there is no archived object for a receipt to attest to.
- **One metrics vocabulary**: `recordReceiptFailOpen` now takes the closed `DurableWriteKind` (15 → 17 members) and counts through the same parsed-outcome helpers as the dual-write bridge. An `AsyncLocalStorage` guard refuses to record one fact from inside the other (double-count), with a test proving both the refusal and that the counter did not move. Async-context tracking, not a module flag: concurrent matches must not see each other's scopes.
- **Stranded-intent fix (P1)**: a `ScoutEffectClaim` answering `completed` now confirms the intent as delivered (it already holds the message id) instead of `continue`-ing past it — previously an intent from a crashed-after-send run stayed `ready`/`sending` forever. The delivered transition is replay-tolerant on identical message ids so ordinary reprocessing doesn't pollute the parity counter.
- **Observation replay identity** (extends #2845's `recordedAt` ruling): `observedAt` is observational metadata, excluded from replay comparison (first observer's instant stands); an incoming null artifact asserts nothing; a first artifact identity backfills stored NULLs; genuinely differing artifacts still conflict (`observation-differs`). The claim is spelled as a rest-omission so any new column joins replay identity automatically — new facts fail toward conflict, not silence. Documented across repository, schema comments (comments only, no DDL), and tests — the same three layers as `recordedAt`.
- **Dead wrappers deleted**: `saveMatchToS3`/`saveTimelineToS3` were the exact descriptor-discarding shape that caused the P0 and had zero callers left. `savePrematchDataToS3` and the image/svg exports keep their production callers and stay.
- **Docs retruthed**: the wiki's "receipted ingest" section and the backend README now describe the live wiring (present tense is finally true); a pre-existing test asserting that a wall-clock difference constitutes divergence was retargeted to a real divergence (`gameCreatedAt`).
- New coverage closing the review's top three gaps: an `ingestMatch` descriptor contract test (fails on main by construction), a full-pass dual-write multiset test (exact per-write_kind `records_total` deltas, replay yields `already-applied`, zero conflicts), and a five-case `persistAuthoritativeMatch` integration suite including induced staging failure.

## Verification

- `bunx turbo run typecheck test lint --filter=@scout-for-lol/backend --force`: 415 test files / 3955 tests green, architecture 1269 modules clean.
- Lane suites directly: 9 files / 104 tests green. `prisma validate` clean (schema diff is comments-only). Prettier, jscpd ratchet, directory file counts, docs-wiki build green. Pre-commit hook green.
- **Not run**: Buildkite (this PR's build), deployment layers, live runtime checks — receipts and artifact columns start populating only once this deploys to beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qRdG6fzJr3THzYzAJwTZB