### PR TITLE
chore(dotfiles): disable Codex memories

### DIFF
--- a/packages/dotfiles/private_dot_codex/private_config.toml
+++ b/packages/dotfiles/private_dot_codex/private_config.toml
@@ -116,13 +116,13 @@ cwd = "."
 enabled = false
 
 [features]
-memories = true
+memories = false
 js_repl = false
 
 hooks = true
 [memories]
-generate_memories = true
-use_memories = true
+generate_memories = false
+use_memories = false
 
 [desktop]
 appearanceTheme = "system"


### PR DESCRIPTION
## Why

Agent-generated long-term memory is no longer wanted. The stored memories were
deleted from the machine (`~/.codex/memories/` — including `raw_memories.md`,
`MEMORY.md`, `memory_summary.md`, and 256 rollout summaries — plus
`~/.codex/memories_1.sqlite`), but Codex would have regenerated them on the next
session while this config still opted in.

## What

Disable the Codex memories feature and both of its behaviors in the chezmoi
source for `~/.codex/config.toml`:

- `[features] memories = false`
- `[memories] generate_memories = false`
- `[memories] use_memories = false`

The equivalent Claude Code switch is `autoMemoryEnabled: false` in
`~/.claude/settings.json`, which chezmoi does not manage, so it has no
representation in this repository and is not part of this diff. It was set on the
machine alongside this change, and Claude Code's own auto-memory directories
(`~/.claude/projects/*/memory/`, 24 files) were deleted.

## Verification

- `bunx lefthook run pre-commit` passes on the staged path (prettier,
  directory-file-counts, and env-var-names skip — no matching files).
- `bun install --frozen-lockfile` clean in a fresh worktree off `main`.
- The same three keys were already set to `false` in the live
  `~/.codex/config.toml`, so `chezmoi diff` reports no drift for them.

Not verified:

- Buildkite CI on this head — not yet run at the time of writing.
- Whether the Codex desktop app rewrites these keys on next launch.
- Unrelated pre-existing drift: the source pins
  `model_reasoning_effort = "xhigh"` while the live file has `"high"`. This PR
  deliberately does not touch it, and a `chezmoi apply` of this file will still
  carry that hunk.
